### PR TITLE
fix: should return model_output if no code block output

### DIFF
--- a/sdk/nexent/core/agents/code_agent.py
+++ b/sdk/nexent/core/agents/code_agent.py
@@ -1,4 +1,5 @@
 import os
+import re
 import time
 from collections import deque
 from typing import Union, Any, Optional, List, Dict, Generator
@@ -47,7 +48,9 @@ class CoreAgent(CodeAgent):
             raise AgentGenerationError(f"Error in generating model output:\n{e}", self.logger) from e
 
         self.logger.log_markdown(content=model_output, title="Output message of the LLM:", level=LogLevel.DEBUG, )
-
+        code_block_pattern = r"```(?:py|python)?\n(.*?)\n```"
+        if not re.search(code_block_pattern, model_output, re.DOTALL):
+            return model_output
         # Parse
         try:
             code_action = fix_final_answer_code(parse_code_blobs(model_output))


### PR DESCRIPTION
我的提示词中有句: 在思考结束后，当你认为可以回答用户问题，那么可以不生成代码，直接生成最终回答给到用户并停止循环。
因此会碰到一个问题就是: 
大模型返回的结果中不包含代码块,这时候咱们的agent会报错,提交pr修复这个问题