### PR TITLE
🐛 Bugfix: When terminating a conversation, disconnect the agent run i…

### DIFF
--- a/frontend/app/chat/internal/chatInterface.tsx
+++ b/frontend/app/chat/internal/chatInterface.tsx
@@ -250,11 +250,11 @@ export function ChatInterface() {
       timeoutRef.current = setTimeout(async () => {
         if (abortControllerRef.current && !abortControllerRef.current.signal.aborted) {
           try {
-            // 立刻断开agent_run连接
+            // Stop agent_run immediately
             abortControllerRef.current.abort('请求超时');
             console.log('请求超过120秒已自动取消');
             
-            // 立刻更新前端状态
+            // Update frontend state immediately
             setIsLoading(false);
             setIsStreaming(false);
             setMessages(prev => {
@@ -853,7 +853,7 @@ export function ChatInterface() {
 
   // Add conversation stop handling function
   const handleStop = async () => {
-    // 立刻断开agent_run连接
+    // stop agent_run immediately
     if (abortControllerRef.current) {
       try {
         abortControllerRef.current.abort('用户手动停止');
@@ -869,7 +869,7 @@ export function ChatInterface() {
       timeoutRef.current = null;
     }
 
-    // 立刻更新前端状态
+    // Immediately update frontend state
     setIsStreaming(false);
     setIsLoading(false);
 


### PR DESCRIPTION
问题根因：终止对话会等待agent_run接口返回的final_answer，但由于界面展示的逻辑是单纯根据agent_run接口返回的信息渲染内容，导致旧界面对话的final_answer出现在新界面。
修改方案：终止对话时，优先断开与agent_run接口的连接，这样不会影响后续界面的展示。