### PR TITLE
🐛 Bugfix: scroll tracking lost #289 & two scroll bars will appear #286

### DIFF
--- a/frontend/app/chat/internal/chatInterface.tsx
+++ b/frontend/app/chat/internal/chatInterface.tsx
@@ -232,6 +232,9 @@ export function ChatInterface() {
     // Add initial AI reply message (will show loading state)
     setMessages(prevMessages => [...prevMessages, initialAssistantMessage])
 
+    // 发送消息后自动滚动到底部
+    setShouldScrollToBottom(true);
+
     setIsLoading(true)
     setIsStreaming(true) // Set streaming state to true
 
@@ -603,6 +606,9 @@ export function ChatInterface() {
 
     // Wait for all state updates to complete
     await new Promise(resolve => setTimeout(resolve, 0));
+
+    // 确保新对话时滚动到底部
+    setShouldScrollToBottom(true);
   }
 
   const fetchConversationList = async () => {

--- a/frontend/app/chat/streaming/taskWindow.tsx
+++ b/frontend/app/chat/streaming/taskWindow.tsx
@@ -645,7 +645,22 @@ export function TaskWindow({
   const [contentHeight, setContentHeight] = useState(0)
   const contentRef = useRef<HTMLDivElement>(null)
   
+  // Add new refs for dynamic threshold calculation
+  const prevContentHeightRef = useRef(0)
+  const lastScrollTimeRef = useRef(Date.now())
+  
   const { hasMessages, hasVisibleMessages, groupedMessages } = useChatTaskMessage(messages as ChatMessageType[]);
+
+  // The function of scrolling to the bottom - defined early to avoid hoisting issues
+  const scrollToBottom = () => {
+    const scrollAreaElement = scrollAreaRef.current?.querySelector('[data-radix-scroll-area-viewport]');
+    if (!scrollAreaElement) return;
+    
+    // Use requestAnimationFrame to optimize performance
+    requestAnimationFrame(() => {
+      (scrollAreaElement as HTMLElement).scrollTop = (scrollAreaElement as HTMLElement).scrollHeight;
+    });
+  };
 
   // calculate the content height
   useEffect(() => {
@@ -654,6 +669,28 @@ export function TaskWindow({
       setContentHeight(height)
     }
   }, [isExpanded, groupedMessages, messages])
+
+  // Dynamic threshold calculation based on content growth
+  const calculateDynamicThreshold = (baseThreshold: number) => {
+    const contentGrowth = contentHeight - prevContentHeightRef.current;
+    const currentTime = Date.now();
+    const timeDiff = currentTime - lastScrollTimeRef.current;
+    
+    // If content grew significantly (more than 200px) in a short time (less than 1 second)
+    if (contentGrowth > 200 && timeDiff < 1000) {
+      // Increase threshold proportionally to content growth, but cap it at reasonable limits
+      const dynamicThreshold = Math.min(baseThreshold + contentGrowth * 0.8, 400);
+      return dynamicThreshold;
+    }
+    
+    // If content grew moderately (50-200px)
+    if (contentGrowth > 50) {
+      const dynamicThreshold = Math.min(baseThreshold + contentGrowth * 0.5, 250);
+      return dynamicThreshold;
+    }
+    
+    return baseThreshold;
+  };
 
   // Listen for message changes and automatically scroll to the bottom (only when user allows it)
   useEffect(() => {
@@ -664,15 +701,22 @@ export function TaskWindow({
       const { scrollTop, scrollHeight, clientHeight } = scrollAreaElement as HTMLElement;
       const distanceToBottom = scrollHeight - scrollTop - clientHeight;
       
-      // Only auto-scroll if user is near the bottom (within 150px)
-      if (distanceToBottom < 150) {
+      // Use dynamic threshold for auto-scroll
+      const dynamicThreshold = calculateDynamicThreshold(150);
+      
+      // Only auto-scroll if user is near the bottom (within dynamic threshold)
+      if (distanceToBottom < dynamicThreshold) {
         // Use requestAnimationFrame to avoid too frequent updates
         requestAnimationFrame(() => {
           scrollToBottom();
         });
       }
+      
+      // Update tracking refs after scroll decision
+      prevContentHeightRef.current = contentHeight;
+      lastScrollTimeRef.current = Date.now();
     }
-  }, [messages.length, isExpanded, autoScroll]);
+  }, [messages.length, isExpanded, autoScroll, contentHeight]);
 
   // Auto-scroll during streaming when user allows it
   useEffect(() => {
@@ -683,12 +727,19 @@ export function TaskWindow({
       const { scrollTop, scrollHeight, clientHeight } = scrollAreaElement as HTMLElement;
       const distanceToBottom = scrollHeight - scrollTop - clientHeight;
       
-      // Only auto-scroll during streaming if user is near the bottom (within 150px)
-      if (distanceToBottom < 50) {
+      // Use dynamic threshold for streaming auto-scroll (more sensitive base threshold)
+      const dynamicThreshold = calculateDynamicThreshold(50);
+      
+      // Only auto-scroll during streaming if user is near the bottom (within dynamic threshold)
+      if (distanceToBottom < dynamicThreshold) {
         scrollToBottom();
       }
+      
+      // Update tracking refs after scroll decision
+      prevContentHeightRef.current = contentHeight;
+      lastScrollTimeRef.current = Date.now();
     }
-  }, [messages, autoScroll, isStreaming, isExpanded]);
+  }, [messages, autoScroll, isStreaming, isExpanded, contentHeight]);
 
   // Handle the scrolling event of the scroll area
   useEffect(() => {
@@ -729,17 +780,6 @@ export function TaskWindow({
       }
     }
   }, [messages, isStreaming]);
-
-  // The function of scrolling to the bottom
-  const scrollToBottom = () => {
-    const scrollAreaElement = scrollAreaRef.current?.querySelector('[data-radix-scroll-area-viewport]');
-    if (!scrollAreaElement) return;
-    
-    // Use requestAnimationFrame to optimize performance
-    requestAnimationFrame(() => {
-      (scrollAreaElement as HTMLElement).scrollTop = (scrollAreaElement as HTMLElement).scrollHeight;
-    });
-  };
 
   // Use the processor to render the message content
   const renderMessageContent = (message: any) => {
@@ -871,6 +911,7 @@ export function TaskWindow({
         </div>
         
         {isExpanded && (
+          
           <div className="px-4" style={{ height: `${actualContentHeight}px` }}>
             {needsScroll ? (
               <ScrollArea className="h-full" ref={scrollAreaRef}>

--- a/frontend/app/setup/agentSetup/components/GuideSteps.tsx
+++ b/frontend/app/setup/agentSetup/components/GuideSteps.tsx
@@ -102,10 +102,8 @@ export default function GuideSteps({
 
   return (
     <div className="h-[65vh]">
-      <div className="mb-4">
-        <h2 className="text-xl font-bold">{isCreatingNewAgent ? '新建Agent' : '主Agent配置'}</h2>
-      </div>
       <div className="flex-1 flex flex-col h-full overflow-y-auto overflow-x-hidden">
+        <h2 className="text-xl font-bold mb-4">{isCreatingNewAgent ? '新建Agent' : '主Agent配置'}</h2>
         <Steps
           direction="vertical"
           current={step}


### PR DESCRIPTION
#289 
问题根因：当前自动滚动时根据滚动条距离页面底部的距离判断，小于设定的阈值才自动滚动，否则保持不动。当后端一次传输大量消息时会将滚动条上移至超出阈值的位置，导致无法自动滚动。
修改方案：根据内容长度动态设定阈值

#286 
将浏览器缩小后只展示一个滚动条
![image](https://github.com/user-attachments/assets/b0fa25dd-f5cb-46a6-90e3-defdb9199f1b)
