### PR TITLE
🐛Regular users cannot save configurations #358

### DIFF
--- a/backend/apps/config_sync_app.py
+++ b/backend/apps/config_sync_app.py
@@ -19,14 +19,14 @@ logger = logging.getLogger("app config")
 
 def handle_model_config(tenant_id: str, user_id: str, config_key: str, model_id: int, tenant_config_dict: dict) -> None:
     """
-    处理模型配置的更新、删除和设置操作
+    Handle model configuration updates, deletions, and settings operations
 
     Args:
-        tenant_id: 租户ID
-        user_id: 用户ID
-        config_key: 配置键名
-        model_id: 模型ID
-        tenant_config_dict: 租户配置字典
+        tenant_id: Tenant ID
+        user_id: User ID
+        config_key: Configuration key name
+        model_id: Model ID
+        tenant_config_dict: Tenant configuration dictionary
     """
     if not model_id and config_key in tenant_config_dict:
         tenant_config_manager.delete_single_config(tenant_id, config_key)

--- a/backend/apps/config_sync_app.py
+++ b/backend/apps/config_sync_app.py
@@ -6,13 +6,47 @@ from fastapi.responses import JSONResponse
 from typing import Optional
 
 from consts.model import GlobalConfig
-from utils.config_utils import config_manager, get_env_key, safe_value, safe_list, tenant_config_manager, get_model_name_from_config
+from utils.config_utils import config_manager, get_env_key, safe_value, safe_list, tenant_config_manager, \
+    get_model_name_from_config
 from utils.auth_utils import get_current_user_id
 from database.model_management_db import get_model_id_by_display_name
+
 router = APIRouter(prefix="/config")
 
 # Get logger instance
 logger = logging.getLogger("app config")
+
+
+def handle_model_config(tenant_id: str, user_id: str, config_key: str, model_id: int, tenant_config_dict: dict) -> None:
+    """
+    处理模型配置的更新、删除和设置操作
+
+    Args:
+        tenant_id: 租户ID
+        user_id: 用户ID
+        config_key: 配置键名
+        model_id: 模型ID
+        tenant_config_dict: 租户配置字典
+    """
+    if not model_id and config_key in tenant_config_dict:
+        tenant_config_manager.delete_single_config(tenant_id, config_key)
+    elif config_key in tenant_config_dict:
+        try:
+            existing_model_id = int(tenant_config_dict[config_key]) if tenant_config_dict[config_key] else None
+            if existing_model_id == model_id:
+                tenant_config_manager.update_single_config(tenant_id, config_key)
+            else:
+                tenant_config_manager.delete_single_config(tenant_id, config_key)
+                if model_id:
+                    tenant_config_manager.set_single_config(user_id, tenant_id, config_key, model_id)
+        except (ValueError, TypeError):
+            tenant_config_manager.delete_single_config(tenant_id, config_key)
+            if model_id:
+                tenant_config_manager.set_single_config(user_id, tenant_id, config_key, model_id)
+    else:
+        if model_id:
+            tenant_config_manager.set_single_config(user_id, tenant_id, config_key, model_id)
+
 
 @router.post("/save_config")
 async def save_config(config: GlobalConfig, authorization: Optional[str] = Header(None)):
@@ -30,18 +64,17 @@ async def save_config(config: GlobalConfig, authorization: Optional[str] = Heade
         for key, value in config_dict.get("app", {}).items():
             env_key = get_env_key(key)
             env_config[env_key] = safe_value(value)
-            
+
             # Check if the key exists and has the same value in tenant_config_dict
             if env_key in tenant_config_dict and tenant_config_dict[env_key] == safe_value(value):
-                tenant_config_manager.update_single_config(user_id, tenant_id, env_key, safe_value(value))
+                tenant_config_manager.update_single_config(tenant_id, env_key)
             elif env_key in tenant_config_dict and env_config[env_key] == '':
-                tenant_config_manager.delete_single_config(user_id, tenant_id, env_key)
+                tenant_config_manager.delete_single_config(tenant_id, env_key)
             elif env_key in tenant_config_dict:
-                tenant_config_manager.delete_single_config(user_id, tenant_id, env_key)
+                tenant_config_manager.delete_single_config(tenant_id, env_key)
                 tenant_config_manager.set_single_config(user_id, tenant_id, env_key, safe_value(value))
             else:
                 tenant_config_manager.set_single_config(user_id, tenant_id, env_key, safe_value(value))
-
 
         # Process model configuration
         for model_type, model_config in config_dict.get("models", {}).items():
@@ -57,16 +90,7 @@ async def save_config(config: GlobalConfig, authorization: Optional[str] = Heade
             if not model_name:
                 continue
 
-            # Check if the key exists and has the same value in tenant_config_dict
-            if not model_id and config_key in tenant_config_dict:
-                tenant_config_manager.delete_single_config(user_id, tenant_id, config_key)
-            elif config_key in tenant_config_dict and int(tenant_config_dict[config_key]) == model_id:
-                tenant_config_manager.update_single_config(user_id, tenant_id, config_key, model_id)
-            elif config_key in tenant_config_dict:
-                tenant_config_manager.delete_single_config(user_id, tenant_id, config_key)
-                tenant_config_manager.set_single_config(user_id, tenant_id, config_key, model_id)
-            else:
-                tenant_config_manager.set_single_config(user_id, tenant_id, config_key, model_id)
+            handle_model_config(tenant_id, user_id, config_key, model_id, tenant_config_dict)
 
             model_prefix = get_env_key(model_type)
 

--- a/backend/apps/tenant_config_app.py
+++ b/backend/apps/tenant_config_app.py
@@ -6,7 +6,7 @@ from typing import Optional, List
 from services.tenant_config_service import get_selected_knowledge_list, update_selected_knowledge
 from fastapi.responses import JSONResponse
 
-from utils.user_utils import get_user_info
+from utils.auth_utils import get_current_user_id
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("tenant config app")
@@ -19,7 +19,7 @@ def load_knowledge_list(
     authorization: Optional[str] = Header(None)
 ):
     try:
-        user_id, tenant_id = get_user_info()
+        user_id, tenant_id = get_current_user_id(authorization)
         selected_knowledge_info = get_selected_knowledge_list(tenant_id=tenant_id, user_id=user_id)
         
         kb_name_list = [item["index_name"] for item in selected_knowledge_info]
@@ -66,7 +66,7 @@ def update_knowledge_list(
     knowledge_list: List[str] = Body(None)
 ):
     try:
-        user_id, tenant_id = get_user_info()
+        user_id, tenant_id = get_current_user_id(authorization)
         result = update_selected_knowledge(tenant_id=tenant_id, user_id=user_id, index_name_list=knowledge_list)
         if result:
             return JSONResponse(

--- a/backend/database/tenant_config_db.py
+++ b/backend/database/tenant_config_db.py
@@ -43,15 +43,18 @@ def get_tenant_config_info(tenant_id: str, user_id: str, select_key: str):
 def get_single_config_info(tenant_id: str, user_id: str, select_key: str):
     with get_db_session() as session:
         result = session.query(TenantConfig).filter(TenantConfig.tenant_id == tenant_id,
-                                                    TenantConfig.user_id == user_id,
                                                     TenantConfig.config_key == select_key,
                                                     TenantConfig.delete_flag == "N").first()
-        record_info = {
+
+        if result:
+            record_info = {
                 "config_value": result.config_value,
                 "tenant_config_id": result.tenant_config_id
             }
 
-        return record_info
+            return record_info
+        else:
+            return {}
 
 
 def insert_config(insert_data: Dict[str, Any]):

--- a/backend/utils/config_utils.py
+++ b/backend/utils/config_utils.py
@@ -230,13 +230,13 @@ class TenantConfigManager:
         # Clear cache for this tenant after setting new config
         self.clear_cache(tenant_id)
 
-    def delete_single_config(self, user_id: str | None = None, tenant_id: str | None = None, key: str | None = None, ):
+    def delete_single_config(self, tenant_id: str | None = None, key: str | None = None, ):
         """Delete configuration value in database"""
         if tenant_id is None:
             print(f"Warning: No tenant_id specified when deleting config for key: {key}")
             return
 
-        existing_config = get_single_config_info(tenant_id, user_id, key)
+        existing_config = get_single_config_info(tenant_id, key)
         print(existing_config)
         if existing_config:
             print(f"Deleting config for key: {key}")
@@ -245,14 +245,13 @@ class TenantConfigManager:
             self.clear_cache(tenant_id)
             return
 
-    def update_single_config(self, user_id: str | None = None, tenant_id: str | None = None, key: str | None = None,
-                             value: str | None = None, ):
+    def update_single_config(self, tenant_id: str | None = None, key: str | None = None):
         """Update configuration value in database"""
         if tenant_id is None:
             print(f"Warning: No tenant_id specified when updating config for key: {key}")
             return
 
-        existing_config = get_single_config_info(tenant_id, user_id, key)
+        existing_config = get_single_config_info(tenant_id, key)
         if existing_config:
             update_data = {
                 "updated_by": tenant_id,

--- a/frontend/app/setup/knowledgeBaseSetup/KnowledgeBaseManager.tsx
+++ b/frontend/app/setup/knowledgeBaseSetup/KnowledgeBaseManager.tsx
@@ -197,6 +197,17 @@ function DataConfig({ isActive }: DataConfigProps) {
     savedKnowledgeBasesRef.current = kbState.knowledgeBases;
   }, [kbState.selectedIds, kbState.knowledgeBases]);
 
+    // 获取授权头的辅助函数
+const getAuthHeaders = () => {
+  const session = typeof window !== "undefined" ? localStorage.getItem("session") : null;
+  const sessionObj = session ? JSON.parse(session) : null;
+  return {
+    'Content-Type': 'application/json',
+    'User-Agent': 'AgentFrontEnd/1.0',
+    ...(sessionObj?.access_token && { "Authorization": `Bearer ${sessionObj.access_token}` }),
+  };
+};
+
   // 组件卸载时的保存逻辑
   useEffect(() => {
     return () => {
@@ -213,7 +224,7 @@ function DataConfig({ isActive }: DataConfigProps) {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
-              'Authorization': localStorage.getItem('token') || '',
+              ...getAuthHeaders()
             },
             body: JSON.stringify(selectedKbNames),
             keepalive: true

--- a/frontend/services/userConfigService.ts
+++ b/frontend/services/userConfigService.ts
@@ -55,7 +55,7 @@ export class UserConfigService {
       const response = await fetch(API_ENDPOINTS.tenantConfig.updateKnowledgeList, {
         method: 'POST',
         headers: getAuthHeaders(),
-        body: JSON.stringify(knowledgeList),
+        body: JSON.stringify({ knowledge_list: knowledgeList }),
       });
 
       if (!response.ok) {

--- a/frontend/services/userConfigService.ts
+++ b/frontend/services/userConfigService.ts
@@ -7,6 +7,19 @@ export interface UserKnowledgeConfig {
   selectedKbSources: string[];
 }
 
+// 获取授权头的辅助函数
+const getAuthHeaders = () => {
+  const session = typeof window !== "undefined" ? localStorage.getItem("session") : null;
+  const sessionObj = session ? JSON.parse(session) : null;
+
+  return {
+    'Content-Type': 'application/json',
+    'User-Agent': 'AgentFrontEnd/1.0',
+    ...(sessionObj?.access_token && { "Authorization": `Bearer ${sessionObj.access_token}` }),
+  };
+};
+
+
 export class UserConfigService {
   // 获取用户选中的知识库列表
   async loadKnowledgeList(): Promise<UserKnowledgeConfig | null> {
@@ -14,10 +27,7 @@ export class UserConfigService {
     try {
       const response = await fetch(API_ENDPOINTS.tenantConfig.loadKnowledgeList, {
         method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': localStorage.getItem('token') || '',
-        },
+        headers: getAuthHeaders(),
       });
 
       if (!response.ok) {
@@ -44,10 +54,7 @@ export class UserConfigService {
     try {
       const response = await fetch(API_ENDPOINTS.tenantConfig.updateKnowledgeList, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': localStorage.getItem('token') || '',
-        },
+        headers: getAuthHeaders(),
         body: JSON.stringify(knowledgeList),
       });
 


### PR DESCRIPTION
🐛Regular users cannot save configurations #358
"1. Model configuration and loading, only filter by tenant_id, remove the filtering of user_id
2. Null pointer fix"
3. Adjust the trigger logic of the "Save Configuration" button on knowledge base related pages
4.Modify some knowledge base related APIs

admin:

https://github.com/user-attachments/assets/68d9b31f-2c61-4d90-9606-8159190fb37f

user:

https://github.com/user-attachments/assets/688481c5-4c05-4652-b696-82f7f48000cc

