### PR TITLE
🐛 fix bug: the title of historical conversation cannot be modified and deleted.

### DIFF
--- a/frontend/app/[locale]/chat/layout/chatLeftSidebar.tsx
+++ b/frontend/app/[locale]/chat/layout/chatLeftSidebar.tsx
@@ -207,13 +207,22 @@ export function ChatSidebar({
             ) : (
               // Display mode
               <>
-                <Button
-                  variant="ghost"
-                  className="flex-1 justify-start text-left hover:bg-transparent min-w-0"
-                  onClick={() => onDialogClick(dialog)}
-                >
-                  <span className="truncate block text-base font-normal text-gray-800 tracking-wide font-sans">{dialog.conversation_title}</span>
-                </Button>
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        className="flex-1 justify-start text-left hover:bg-transparent min-w-0 max-w-[250px]"
+                        onClick={() => onDialogClick(dialog)}
+                      >
+                        <span className="truncate block text-base font-normal text-gray-800 tracking-wide font-sans">{dialog.conversation_title}</span>
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="right" className="max-w-xs">
+                      <p className="break-words">{dialog.conversation_title}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
                 
                 <DropdownMenu 
                   open={openDropdownId === dialog.conversation_id.toString()} 

--- a/frontend/app/[locale]/chat/layout/chatLeftSidebar.tsx
+++ b/frontend/app/[locale]/chat/layout/chatLeftSidebar.tsx
@@ -232,7 +232,7 @@ export function ChatSidebar({
                     <Button 
                       variant="ghost" 
                       size="icon" 
-                      className="h-6 w-6 flex-shrink-0 opacity-0 group-hover:opacity-100 hover:bg-slate-100 hover:border hover:border-slate-200 mr-1"
+                      className="h-6 w-6 flex-shrink-0 opacity-0 group-hover:opacity-100 hover:bg-slate-100 hover:border hover:border-slate-200 mr-1 focus:outline-none focus:ring-0"
                     >
                       <MoreHorizontal className="h-4 w-4" />
                     </Button>


### PR DESCRIPTION
#396 
当历史对话标题过长时，容器会被撑开，影响悬浮提示框的正常显示。从而无法修改历史对话标题和删除历史对话
![img_v3_02nl_1e029554-2e77-4a3b-916f-9d6a4daf13bg](https://github.com/user-attachments/assets/bb7ea363-af88-431d-93b8-ecd419cd0f30)

主要修改：限制标题显示区域的最大宽度为 250px，过长会被截断，展示省略号

![image](https://github.com/user-attachments/assets/bbb384a9-1425-4ebb-ae00-c6c7c76e5de1)
