### PR TITLE
🐛[Bug] Some model configurations are still read from env

### DIFF
--- a/backend/apps/conversation_management_app.py
+++ b/backend/apps/conversation_management_app.py
@@ -17,6 +17,7 @@ from services.conversation_management_service import (
     update_message_opinion_service
 )
 from database.conversation_db import get_message_id_by_index
+from utils.auth_utils import get_current_user_info
 
 router = APIRouter(prefix="/conversation")
 
@@ -177,7 +178,8 @@ async def generate_conversation_title_endpoint(request: GenerateTitleRequest, au
         ConversationResponse object containing generated title
     """
     try:
-        title = generate_conversation_title_service(request.conversation_id, request.history)
+        user_id, tenant_id, language = get_current_user_info(authorization=authorization)
+        title = generate_conversation_title_service(request.conversation_id, request.history,tenant_id=tenant_id)
         return ConversationResponse(code=0, message="success", data=title)
     except Exception as e:
         logging.error(f"Failed to generate conversation title: {str(e)}")

--- a/backend/apps/knowledge_app.py
+++ b/backend/apps/knowledge_app.py
@@ -5,7 +5,7 @@ from consts.model import ChangeSummaryRequest
 from fastapi.responses import StreamingResponse
 from nexent.vector_database.elasticsearch_core import ElasticSearchCore
 from services.elasticsearch_service import ElasticSearchService, get_es_core
-from utils.auth_utils import get_current_user_id
+from utils.auth_utils import get_current_user_info, get_current_user_id
 router = APIRouter(prefix="/summary")
 
 @router.post("/{index_name}/auto_summary")
@@ -17,14 +17,15 @@ async def auto_summary(
     ):
     """Summary Elasticsearch index_name by model"""
     try:
-        user_id = get_current_user_id(authorization)
+        user_id, tenant_id, language = get_current_user_info(authorization=authorization)
         service = ElasticSearchService()
 
         return await service.summary_index_name(
             index_name=index_name,
             batch_size=batch_size,
             es_core=es_core,
-            user_id=user_id
+            user_id=user_id,
+            tenant_id=tenant_id
         )
     except Exception as e:
         return StreamingResponse(

--- a/backend/apps/knowledge_summary_app.py
+++ b/backend/apps/knowledge_summary_app.py
@@ -23,7 +23,7 @@ async def auto_summary(
     ):
     """Summary Elasticsearch index_name by model"""
     try:
-        user_id, _, language = get_current_user_info(authorization, http_request)
+        user_id, tenant_id, language = get_current_user_info(authorization, http_request)
         logger.info(f"Start summary for {index_name}, language: {language}")
         service = ElasticSearchService()
 
@@ -32,6 +32,7 @@ async def auto_summary(
             batch_size=batch_size,
             es_core=es_core,
             user_id=user_id,
+            tenant_id=tenant_id,
             language=language
         )
     except Exception as e:

--- a/backend/services/conversation_management_service.py
+++ b/backend/services/conversation_management_service.py
@@ -15,6 +15,7 @@ from database.conversation_db import create_conversation_message, create_source_
     get_source_images_by_conversation, get_source_searches_by_message, get_source_searches_by_conversation, \
     delete_conversation, get_conversation, create_conversation, update_message_opinion
 
+from utils.config_utils import tenant_config_manager,get_model_name_from_config
 
 logger = logging.getLogger("conversation_management_service")
 
@@ -222,7 +223,7 @@ def extract_user_messages(history: List[Dict[str, str]]) -> str:
     return content
 
 
-def call_llm_for_title(content: str) -> str:
+def call_llm_for_title(content: str, tenant_id: str) -> str:
     """
     Call LLM to generate a title
 
@@ -235,9 +236,11 @@ def call_llm_for_title(content: str) -> str:
     with open('backend/prompts/utils/generate_title.yaml', "r", encoding="utf-8") as f:
         prompt_template = yaml.safe_load(f)
 
+    model_config = tenant_config_manager.get_model_config(key="LLM_ID", tenant_id=tenant_id)
+
     # Create OpenAIServerModel instance
-    llm = OpenAIServerModel(model_id=os.getenv('LLM_MODEL_NAME'), api_base=os.getenv('LLM_MODEL_URL'),
-        api_key=os.getenv('LLM_API_KEY'), temperature=0.7, top_p=0.95)
+    llm = OpenAIServerModel(model_id=get_model_name_from_config(model_config) if model_config.get("model_name") else "", api_base=model_config.get("base_url", ""),
+        api_key=model_config.get("api_key", ""), temperature=0.7, top_p=0.95)
 
     # Build messages
     compiled_template = Template(prompt_template["USER_PROMPT"], undefined=StrictUndefined)
@@ -611,7 +614,7 @@ def get_sources_service(conversation_id: Optional[int], message_id: Optional[int
         }
 
 
-def generate_conversation_title_service(conversation_id: int, history: List[Dict[str, str]]) -> str:
+def generate_conversation_title_service(conversation_id: int, history: List[Dict[str, str]], tenant_id: str) -> str:
     """
     Generate conversation title
 
@@ -627,7 +630,7 @@ def generate_conversation_title_service(conversation_id: int, history: List[Dict
         content = extract_user_messages(history)
 
         # Call LLM to generate title
-        title = call_llm_for_title(content)
+        title = call_llm_for_title(content, tenant_id)
 
         # Update conversation title
         update_conversation_title(conversation_id, title)

--- a/backend/services/elasticsearch_service.py
+++ b/backend/services/elasticsearch_service.py
@@ -24,7 +24,7 @@ from fastapi import HTTPException, Query, Body, Path, Depends
 from fastapi.responses import StreamingResponse
 from consts.const import ES_API_KEY, ES_HOST
 from consts.model import SearchRequest, HybridSearchRequest
-from utils.config_utils import config_manager
+from utils.config_utils import config_manager, tenant_config_manager, get_model_name_from_config
 from utils.file_management_utils import get_all_files_status, get_file_size
 from database.knowledge_db import create_knowledge_record, get_knowledge_record, update_knowledge_record, delete_knowledge_record
 
@@ -32,13 +32,14 @@ from database.knowledge_db import create_knowledge_record, get_knowledge_record,
 logger = logging.getLogger("elasticsearch_service")
 
 
-def generate_knowledge_summary_stream(keywords: str, language: str) -> Generator:
+def generate_knowledge_summary_stream(keywords: str, language: str, tenant_id: str) -> Generator:
     """
     Generate a knowledge base summary based on keywords
 
     Args:
         keywords: Keywords that frequently appear in the knowledge base content
         language: Language of the knowledge base content
+        tenant_id: The tenant ID for configuration
 
     Returns:
         str:  Generate a knowledge base summary
@@ -55,14 +56,17 @@ def generate_knowledge_summary_stream(keywords: str, language: str) -> Generator
     messages = [{"role": "system", "content": prompts['system_prompt']},
         {"role": "user", "content": prompts['user_prompt'].format(content=keywords)}]
 
+    # Get model configuration from tenant config manager
+    model_config = tenant_config_manager.get_model_config(key="LLM_SECONDARY_ID", tenant_id=tenant_id)
+    
     # initialize OpenAI client
-    client = OpenAI(api_key=os.getenv('LLM_SECONDARY_API_KEY'),
-                    base_url=os.getenv('LLM_SECONDARY_MODEL_URL'))
+    client = OpenAI(api_key=model_config.get('api_key', ""),
+                    base_url=model_config.get('base_url', ""))
 
     try:
         # Create stream chat completion request
         stream = client.chat.completions.create(
-            model=os.getenv('LLM_SECONDARY_MODEL_NAME'),  # can change model as needed
+            model=get_model_name_from_config(model_config) if model_config.get("model_name") else "",  # use model name from config
             messages=messages,
             stream=True  # enable stream output
         )
@@ -676,6 +680,7 @@ class ElasticSearchService:
             batch_size: int = Query(1000, description="Number of documents to retrieve per batch"),
             es_core: ElasticSearchCore = Depends(get_es_core),
             user_id: Optional[str] = Body(None, description="ID of the user delete the knowledge base"),
+            tenant_id: Optional[str] = Body(None, description="ID of the tenant"),
             language: str = 'zh'
     ):
         try:
@@ -690,7 +695,7 @@ class ElasticSearchService:
             async def generate_summary():
                 token_join = []
                 try:
-                    for new_token in generate_knowledge_summary_stream(keywords_for_summary, language):
+                    for new_token in generate_knowledge_summary_stream(keywords_for_summary, language,tenant_id):
                         if new_token == "END":
                             break
                         else:


### PR DESCRIPTION
1. Modify the original model configuration that used os.getenv to read from the database instead.
2. However, for the creation of ES instances, retain the embedding model API key configuration in the environment variables.
Related interfaces test：
![image](https://github.com/user-attachments/assets/72364132-9394-4fd9-a58d-0cb645a8cb74)

![image](https://github.com/user-attachments/assets/93cec2e3-324a-4c18-8cd3-06099d54dc51)

![image](https://github.com/user-attachments/assets/740040c5-e386-4b04-ad1b-a2d183c72176)



