### PR TITLE
🐛 [Bug] the return button on the delete model interface is not displayed correctly. #446

### DIFF
--- a/frontend/app/[locale]/setup/modelSetup/model/ModelDeleteDialog.tsx
+++ b/frontend/app/[locale]/setup/modelSetup/model/ModelDeleteDialog.tsx
@@ -246,7 +246,7 @@ export const ModelDeleteDialog = ({
                   clipRule="evenodd"
                 />
               </svg>
-              {t('common.button.back')}
+              {t('common.back')}
             </button>
           </div>
 


### PR DESCRIPTION
#446 [Bug] 按钮显示不正确
修改前：
![image](https://github.com/user-attachments/assets/c3622cb4-0ae0-4fce-9a48-ef8482b56c60)
修改后：
中文页面：
![image](https://github.com/user-attachments/assets/85b9e58b-80df-4f8d-8fd7-5e1e9f9b56da)
英文页面：
![image](https://github.com/user-attachments/assets/6016942a-358c-4bf7-8c40-21d22c175460)
