### PR TITLE
[release]🐛 fix bug: elasticsearch cannot retrieve.

### DIFF
--- a/sdk/nexent/vector_database/elasticsearch_core.py
+++ b/sdk/nexent/vector_database/elasticsearch_core.py
@@ -641,7 +641,7 @@ class ElasticSearchCore:
         index_pattern = ",".join(index_names)
 
         # Get query embedding
-        query_embedding = self.embedding_model.get_embeddings(query_text)
+        query_embedding = self.embedding_model.get_embeddings(query_text)[0]
         
         # Prepare the search query
         search_query = {


### PR DESCRIPTION
修复本地检索工具无法正常检索的bug，问题在于embedding之后es检索表达式不正确