### PR TITLE
🐛The tool should be automatically refresh when empty #506

### DIFF
--- a/frontend/app/[locale]/setup/agentSetup/AgentConfig.tsx
+++ b/frontend/app/[locale]/setup/agentSetup/AgentConfig.tsx
@@ -51,28 +51,29 @@ export default function AgentConfig() {
   const [editingAgent, setEditingAgent] = useState<any>(null)
 
   // Only auto scan once flag
-  const hasAutoScanned = useRef(false);
+  const hasAutoScanned = useRef(false)
 
   // Load tools when page is loaded
   useEffect(() => {
     const loadTools = async () => {
       try {
-        const result = await fetchTools();
+        const result = await fetchTools()
         if (result.success) {
-          setTools(result.data);
+          setTools(result.data)
           // If the tool list is empty and auto scan hasn't been triggered, trigger scan once
           if (result.data.length === 0 && !hasAutoScanned.current) {
-            hasAutoScanned.current = true;
+            hasAutoScanned.current = true
             // Mark as auto scanned
-            const scanResult = await updateToolList();
+            const scanResult = await updateToolList()
             if (!scanResult.success) {
-              message.error(t('toolManagement.message.refreshFailed'));
+              message.error(t('toolManagement.message.refreshFailed'))
+              return
             }
-            message.success(t('toolManagement.message.refreshSuccess'));
+            message.success(t('toolManagement.message.refreshSuccess'))
             // After scan, fetch the tool list again
-            const reFetch = await fetchTools();
+            const reFetch = await fetchTools()
             if (reFetch.success) {
-              setTools(reFetch.data);
+              setTools(reFetch.data)
             }
           }
         } else {

--- a/frontend/app/[locale]/setup/agentSetup/AgentConfig.tsx
+++ b/frontend/app/[locale]/setup/agentSetup/AgentConfig.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import BusinessLogicConfig from './AgentManagementConfig'
 import SystemPromptDisplay from './components/SystemPromptDisplay'
@@ -9,6 +9,7 @@ import GuideSteps from './components/GuideSteps'
 import { Row, Col, Drawer, message } from 'antd'
 import { fetchTools, fetchAgentList } from '@/services/agentConfigService'
 import { OpenAIModel } from '@/app/setup/agentSetup/ConstInterface'
+import { updateToolList } from '@/services/mcpService'
 import '../../i18n'
 
 // Layout Height Constant Configuration
@@ -49,13 +50,31 @@ export default function AgentConfig() {
   const [isEditingAgent, setIsEditingAgent] = useState(false)
   const [editingAgent, setEditingAgent] = useState<any>(null)
 
-  // load tools when page is loaded
+  // Only auto scan once flag
+  const hasAutoScanned = useRef(false);
+
+  // Load tools when page is loaded
   useEffect(() => {
     const loadTools = async () => {
       try {
-        const result = await fetchTools()
+        const result = await fetchTools();
         if (result.success) {
-          setTools(result.data)
+          setTools(result.data);
+          // If the tool list is empty and auto scan hasn't been triggered, trigger scan once
+          if (result.data.length === 0 && !hasAutoScanned.current) {
+            hasAutoScanned.current = true;
+            // Mark as auto scanned
+            const scanResult = await updateToolList();
+            if (!scanResult.success) {
+              message.error(t('toolManagement.message.refreshFailed'));
+            }
+            message.success(t('toolManagement.message.refreshSuccess'));
+            // After scan, fetch the tool list again
+            const reFetch = await fetchTools();
+            if (reFetch.success) {
+              setTools(reFetch.data);
+            }
+          }
         } else {
           message.error(result.message)
         }

--- a/frontend/app/[locale]/setup/agentSetup/AgentManagementConfig.tsx
+++ b/frontend/app/[locale]/setup/agentSetup/AgentManagementConfig.tsx
@@ -419,7 +419,6 @@ function ToolPool({
       // 第二步：获取最新的工具列表
       const fetchResult = await fetchTools();
       if (fetchResult.success) {
-        message.success(t('toolManagement.message.refreshSuccess'));
         // 调用父组件的刷新回调，更新工具列表状态
         if (onToolsRefresh) {
           onToolsRefresh();


### PR DESCRIPTION
#506 🐛[Improvement] The tool should be automatically refresh when empty.
1、去除打印两次“工具列表已刷新”逻辑；
2、首次进入Agent配置页面获取工具列表为空时，调用/tool/scan_tool接口更新工具列表。
修改前：
![img_v3_02o6_14f57c42-e35c-478c-bc7b-02d757eb90ag](https://github.com/user-attachments/assets/bf2bd0ea-c521-4ef8-ac6b-f47be230828f)
修改后：
![img_v3_02o6_3bd033b6-783d-4752-8167-8632168af4ag](https://github.com/user-attachments/assets/5e1ceffd-9608-4956-8b92-fa3438663d95)
