### PR TITLE
🐛 [Request] Support theme change to adapt to the Dark/Light mode of the broswer #442

### DIFF
--- a/frontend/components/ui/markdownRenderer.tsx
+++ b/frontend/components/ui/markdownRenderer.tsx
@@ -390,6 +390,10 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   return (
     <>
       <style jsx global>{`
+        .markdown-body,
+        .task-message-content {
+          color: hsl(var(--foreground)) !important;
+        }
         .markdown-body {
           background: transparent !important;
           min-height: 1em;


### PR DESCRIPTION
#442  [Request] Support theme change to adapt to the Dark/Light mode of the broswer.
为内容区强制指定字体颜色，避免因外部主题或浏览器深色模式导致字体消失。
修改前深色模式下：
<img width="939" height="643" alt="image" src="https://github.com/user-attachments/assets/c7c5d13f-fb53-44b7-a509-cc59e0fbcdb6" />
修改后深色模式下：
<img width="1323" height="840" alt="image" src="https://github.com/user-attachments/assets/588a06b1-dab6-4d02-941c-9c6ab5341d37" />
修改后浅色模式下：
<img width="1312" height="857" alt="image" src="https://github.com/user-attachments/assets/fcb57039-d701-402e-b489-5a54e5558ea2" />

