### PR TITLE
🐛[release]Fixed two issues:Export failure in knowledge-base-equipped agents Knowledge base retrieval tool returning content when no KB is selected #564 #557

### DIFF
--- a/backend/services/agent_service.py
+++ b/backend/services/agent_service.py
@@ -172,6 +172,12 @@ async def export_agent_impl(agent_id: int, authorization: str = Header(None)):
     user_id, tenant_id = get_current_user_id(authorization)
 
     tool_list = await create_tool_config_list(agent_id=agent_id, tenant_id=tenant_id, user_id=user_id)
+
+    # Check if any tool is KnowledgeBaseSearchTool and set its metadata to empty dict
+    for tool in tool_list:
+        if tool.class_name == "KnowledgeBaseSearchTool":
+            tool.metadata = {}
+    
     agent_info_in_db = search_agent_info_by_agent_id(agent_id=agent_id, tenant_id=tenant_id, user_id=user_id)
 
     agent_info = ExportAndImportAgentInfo(name=agent_info_in_db["name"],

--- a/sdk/nexent/core/tools/knowledge_base_search_tool.py
+++ b/sdk/nexent/core/tools/knowledge_base_search_tool.py
@@ -59,6 +59,9 @@ class KnowledgeBaseSearchTool(Tool):
         card_content = [{"icon": "search", "text": query}]
         self.observer.add_message("", ProcessType.CARD, json.dumps(card_content, ensure_ascii=False))
 
+        if len(self.index_names) == 0:
+            return json.dumps("No knowledge base selected. No relevant information found.", ensure_ascii=False)
+
         if search_mode=="hybrid":
             kb_search_data = self.es_search_hybrid(query=query)
         elif search_mode=="accurate":


### PR DESCRIPTION
1. Successful import/export of KB-enabled agents
2. Zero results returned when no knowledge base is selected
#564 #557


Tenant B successfully imported the agent exported from Tenant A（The two tenants are using different embedding models）：
![img_v3_02oa_dae669b7-3986-4c57-bdd9-f3191231a6eg](https://github.com/user-attachments/assets/529bb088-b588-4f40-97eb-6231c18485e4)


Debugging procedure when importing agents with no knowledge base selected：
![img_v3_02oa_80b69bcf-9fa3-4c8b-90b7-e4985fcd926g](https://github.com/user-attachments/assets/dcbc7338-00d4-487e-9368-a57c778ad281)

When importing an agent with a knowledge base selected, the response is as follows(The knowledge base was successfully created and stored in the database):
<img width="1765" height="592" alt="image" src="https://github.com/user-attachments/assets/0e326250-dc82-4384-a924-99775b4fa3e2" />

![img_v3_02oa_83cbd589-642d-4f17-b59d-c081a40ec7fg](https://github.com/user-attachments/assets/d94d5f15-d3a8-46ff-975e-e78a2eba412f)


