### PR TITLE
🐛[Bug] Fix the issue where the copy button fails to function properly in server environments.

### DIFF
--- a/frontend/app/[locale]/chat/streaming/chatStreamFinalMessage.tsx
+++ b/frontend/app/[locale]/chat/streaming/chatStreamFinalMessage.tsx
@@ -80,17 +80,16 @@ export function ChatStreamFinalMessage({
 
   // Copy content to clipboard
   const handleCopyContent = () => {
-    const contentToCopy = message.finalAnswer || message.content;
-    if (contentToCopy !== undefined) {
-      navigator.clipboard.writeText(contentToCopy)
-        .then(() => {
-          setCopied(true);
-          setTimeout(() => setCopied(false), 2000);
-        })
-        .catch(err => {
-          console.error(t('chatStreamFinalMessage.copyFailed'), err);
-        });
-    }
+    if (!message.finalAnswer) return;
+
+    copyToClipboard(message.finalAnswer)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(err => {
+        console.error(t('chatStreamFinalMessage.copyFailed'), err);
+      });
   };
 
   // Handle thumbs up

--- a/frontend/app/[locale]/chat/streaming/chatStreamMessage.tsx
+++ b/frontend/app/[locale]/chat/streaming/chatStreamMessage.tsx
@@ -60,21 +60,16 @@ export function ChatStreamMessage({
   // Copy content to clipboard
   const handleCopyContent = () => {
     const contentToCopy = message.finalAnswer || message.content;
-    if (contentToCopy) {
-      // Handle newlines: trim leading/trailing newlines and normalize multiple consecutive newlines
-      const trimmedContent = contentToCopy
-        .replace(/^\n+|\n+$/g, '') // Remove leading and trailing newlines
-        .replace(/\n{3,}/g, '\n\n'); // Replace 3+ consecutive newlines with double newlines
+    if (!contentToCopy) return;
 
-      navigator.clipboard.writeText(trimmedContent)
-        .then(() => {
-          setCopied(true);
-          setTimeout(() => setCopied(false), 2000);
-        })
-        .catch(err => {
-          console.error(t('chatStreamMessage.copyFailed'), err);
-        });
-    }
+    copyToClipboard(contentToCopy)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(err => {
+        console.error(t('chatStreamMessage.copyFailed'), err);
+      });
   };
 
   // Handle likes

--- a/frontend/lib/clipboard.ts
+++ b/frontend/lib/clipboard.ts
@@ -1,0 +1,41 @@
+export async function copyToClipboard(text: string): Promise<void> {
+  // Normalize line breaks: trim blank lines at the start/end and collapse >2 line breaks
+  const normalizedText = text
+    .replace(/^\n+|\n+$/g, '')
+    .replace(/\n{3,}/g, '\n\n');
+
+  // Prefer modern Clipboard API when available & permitted
+  if (typeof navigator !== 'undefined' && navigator.clipboard && navigator.clipboard.writeText) {
+    try {
+      await navigator.clipboard.writeText(normalizedText);
+      return;
+    } catch (error) {
+      // Continue to fallback approach if Clipboard API is unavailable or permission is denied
+    }
+  }
+
+  // Fallback: use a hidden textarea + execCommand
+  return new Promise<void>((resolve, reject) => {
+    try {
+      const textArea = document.createElement('textarea');
+      textArea.value = normalizedText;
+      textArea.style.position = 'fixed';
+      textArea.style.left = '-9999px';
+      textArea.style.top = '0';
+      document.body.appendChild(textArea);
+      textArea.focus();
+      textArea.select();
+
+      const successful = document.execCommand('copy');
+      document.body.removeChild(textArea);
+
+      if (successful) {
+        resolve();
+      } else {
+        reject(new Error('execCommand failed'));
+      }
+    } catch (err) {
+      reject(err instanceof Error ? err : new Error(String(err)));
+    }
+  });
+}


### PR DESCRIPTION
🐛[Bug] Fix the issue where the copy button fails to function properly in server environments. #386

Verification outcomes (Env 154):
https://github.com/user-attachments/assets/bf2a3208-4f7b-4d8f-9dd4-49c95f60a49f

**Problem Identification**
When the Linux server is accessed via plain HTTP, the page is in a non-secure context, so the browser sets navigator.clipboard to undefined, and direct calls throw an error.
Some components call navigator.clipboard.writeText directly and lack a unified fallback mechanism.
**Solution Design**
1. Create a single helper function copyToClipboard(text) that:
       Encapsulates all browser differences and fallback logic; First tries the modern Clipboard API;If the API is unavailable or permission is denied, automatically falls back to the classic “hidden textarea + execCommand('copy')” method.
2. Lightly sanitize the text inside the helper, keeping behavior identical to the old code.
3. Components just call this helper, keeping business logic clean.

<img width="546" height="834" alt="复制按钮en" src="https://github.com/user-attachments/assets/ae802b4e-f84c-416f-ab4f-6649a637f2f6" />


