### PR TITLE
🐛 点击放大按钮，修改提示词，点击关闭后未在卡片中正确展示

### DIFF
--- a/frontend/app/[locale]/setup/agentSetup/components/SystemPromptDisplay.tsx
+++ b/frontend/app/[locale]/setup/agentSetup/components/SystemPromptDisplay.tsx
@@ -273,6 +273,21 @@ export default function SystemPromptDisplay({
 
   // Handle close expanded modal
   const handleCloseExpandedModal = () => {
+    // 关闭前先保存修改的内容
+    switch (expandIndex) {
+      case 1:
+        setLocalDutyContent(expandContent);
+        onDutyContentChange?.(expandContent);
+        break;
+      case 2:
+        setLocalConstraintContent(expandContent);
+        onConstraintContentChange?.(expandContent);
+        break;
+      case 3:
+        setLocalFewShotsContent(expandContent);
+        onFewShotsContentChange?.(expandContent);
+        break;
+    }
     setExpandModalOpen(false)
   }
 


### PR DESCRIPTION
#615 🐛 点击放大按钮，修改提示词，点击关闭后未在卡片中正确展示
<img width="1147" height="306" alt="image" src="https://github.com/user-attachments/assets/ff87f789-b0d3-4136-93ae-03b71ea345d3" />
