### PR TITLE
[release]🐛 创建子agent时，需要清空提示词内容 #641

### DIFF
--- a/frontend/app/[locale]/setup/agentSetup/AgentManagementConfig.tsx
+++ b/frontend/app/[locale]/setup/agentSetup/AgentManagementConfig.tsx
@@ -774,7 +774,7 @@ export default function BusinessLogicConfig({
     try {
       const result = await getCreatingSubAgentId(mainAgentId);
       if (result.success && result.data) {
-        const { agentId, enabledToolIds, modelName, maxSteps, businessDescription, prompt } = result.data;
+        const { agentId, enabledToolIds, modelName, maxSteps, businessDescription, dutyPrompt, constraintPrompt, fewShotsPrompt } = result.data;
         
         // Update the main agent ID
         setMainAgentId(agentId);
@@ -792,9 +792,17 @@ export default function BusinessLogicConfig({
         if (businessDescription) {
           setBusinessLogic(businessDescription);
         }
-        // Update the system prompt
-        if (prompt) {
-          setSystemPrompt(prompt);
+        // Update the duty prompt
+        if (setDutyContent) {
+          setDutyContent(dutyPrompt || '');
+        }
+        // Update the constraint prompt
+        if (setConstraintContent) {
+          setConstraintContent(constraintPrompt || '');
+        }
+        // Update the few shots prompt
+        if (setFewShotsContent) {
+          setFewShotsContent(fewShotsPrompt || '');
         }
       } else {
         message.error(result.message || t('businessLogic.config.error.agentIdFailed'));

--- a/frontend/services/agentConfigService.ts
+++ b/frontend/services/agentConfigService.ts
@@ -163,7 +163,9 @@ export const getCreatingSubAgentId = async (mainAgentId: string | null) => {
         modelName: data.model_name,
         maxSteps: data.max_steps,
         businessDescription: data.business_description,
-        prompt: data.prompt
+        dutyPrompt: data.duty_prompt,
+        constraintPrompt: data.constraint_prompt,
+        fewShotsPrompt: data.few_shots_prompt
       },
       message: ''
     };


### PR DESCRIPTION
#641 🐛 创建子agent时，需要清空提示词内容
修改前：
<img width="324" height="148" alt="image" src="https://github.com/user-attachments/assets/74baec39-c285-4eae-a09b-c7884963105a" />
修改后：
<img width="1519" height="726" alt="image" src="https://github.com/user-attachments/assets/51fa403d-5d75-4705-bad3-6705cb80a8e6" />
