### PR TITLE
🐛 Switching conversations don't automatically slide to the bottom.

### DIFF
--- a/frontend/app/[locale]/chat/internal/chatInterface.tsx
+++ b/frontend/app/[locale]/chat/internal/chatInterface.tsx
@@ -903,6 +903,11 @@ export function ChatInterface() {
 
             // Trigger scroll to bottom
             setShouldScrollToBottom(true);
+            
+            // Reset shouldScrollToBottom after a delay to ensure scrolling completes.
+            setTimeout(() => {
+              setShouldScrollToBottom(false);
+            }, 1000);
 
             // Refresh history list
             fetchConversationList().catch(err => {
@@ -934,6 +939,12 @@ export function ChatInterface() {
         // 缓存有内容，正常显示
         setIsLoadingHistoricalConversation(false);
         setIsLoading(false); // 确保 isLoading 状态也被重置
+        
+        // For cases where there are cached messages, also trigger scrolling to the bottom.
+        setShouldScrollToBottom(true);
+        setTimeout(() => {
+          setShouldScrollToBottom(false);
+        }, 1000);
       }
     }
 
@@ -1013,6 +1024,11 @@ export function ChatInterface() {
 
           // Trigger scroll to bottom
           setShouldScrollToBottom(true);
+          
+          // Reset shouldScrollToBottom after a delay to ensure scrolling completes.
+          setTimeout(() => {
+            setShouldScrollToBottom(false);
+          }, 1000);
 
           // Refresh history list
           fetchConversationList().catch(err => {

--- a/frontend/app/[locale]/chat/streaming/chatStreamMain.tsx
+++ b/frontend/app/[locale]/chat/streaming/chatStreamMain.tsx
@@ -279,11 +279,13 @@ export function ChatStreamMain({
         setShowTopFade(false);
       }
 
-      // Control autoScroll based on user's scroll position
-      if (distanceToBottom < 50) {
-        setAutoScroll(true);
-      } else if (distanceToBottom > 80) { 
-        setAutoScroll(false);
+      // Only if shouldScrollToBottom is false does autoScroll adjust based on user scroll position.
+      if (!shouldScrollToBottom) {
+        if (distanceToBottom < 50) {
+          setAutoScroll(true);
+        } else if (distanceToBottom > 80) { 
+          setAutoScroll(false);
+        }
       }
     };
     
@@ -296,7 +298,7 @@ export function ChatStreamMain({
     return () => {
       scrollAreaElement.removeEventListener('scroll', handleScroll);
     };
-  }, []);
+  }, [shouldScrollToBottom]);
 
   // Scroll to bottom function
   const scrollToBottom = (smooth = false) => {
@@ -322,17 +324,11 @@ export function ChatStreamMain({
   useEffect(() => {
     if (shouldScrollToBottom && processedMessages.finalMessages.length > 0) {
       setAutoScroll(true);
+      scrollToBottom(false);
+
       setTimeout(() => {
         scrollToBottom(false);
-        
-        setTimeout(() => {
-          scrollToBottom(false);
-        }, 300);
-        
-        setTimeout(() => {
-          scrollToBottom(false);
-        }, 800);
-      }, 100);
+      }, 300);
     }
   }, [shouldScrollToBottom, processedMessages.finalMessages.length]);
 
@@ -345,12 +341,12 @@ export function ChatStreamMain({
       const { scrollTop, scrollHeight, clientHeight } = scrollAreaElement as HTMLElement;
       const distanceToBottom = scrollHeight - scrollTop - clientHeight;
       
-      // Only auto-scroll if user is near the bottom (within 50px)
-      if (distanceToBottom < 50) {
+      // When shouldScrollToBottom is true, force scroll to the bottom, regardless of distance.
+      if (shouldScrollToBottom || distanceToBottom < 50) {
         scrollToBottom();
       }
     }
-  }, [processedMessages.finalMessages.length, processedMessages.conversationGroups.size, autoScroll]);
+  }, [processedMessages.finalMessages.length, processedMessages.conversationGroups.size, autoScroll, shouldScrollToBottom]);
 
   // Scroll to bottom when task messages are updated
   useEffect(() => {
@@ -361,12 +357,12 @@ export function ChatStreamMain({
       const { scrollTop, scrollHeight, clientHeight } = scrollAreaElement as HTMLElement;
       const distanceToBottom = scrollHeight - scrollTop - clientHeight;
       
-      // Only auto-scroll if user is near the bottom (within 150px)
-      if (distanceToBottom < 150) {
+      // When shouldScrollToBottom is true, force scroll to the bottom, regardless of distance.
+      if (shouldScrollToBottom || distanceToBottom < 150) {
         scrollToBottom();
       }
     }
-  }, [processedMessages.taskMessages.length, isStreaming, autoScroll]);
+  }, [processedMessages.taskMessages.length, isStreaming, autoScroll, shouldScrollToBottom]);
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden relative custom-scrollbar">


### PR DESCRIPTION
#706 🐛 Switching conversations don't automatically slide to the bottom.
自测结果：
<img width="1929" height="914" alt="image" src="https://github.com/user-attachments/assets/19de03ab-9d59-4fc3-a1e5-aa94aa803e7f" />
