### PR TITLE
🐛 Fix expand modal state synchronization issues

### DIFF
--- a/frontend/app/[locale]/setup/agentSetup/components/AgentConfigurationSection.tsx
+++ b/frontend/app/[locale]/setup/agentSetup/components/AgentConfigurationSection.tsx
@@ -132,19 +132,8 @@ export default function AgentConfigurationSection({
 
   // Optimized click handlers using useCallback
   const handleSegmentClick = useCallback((segment: string) => {
-    // Before switching segments, ensure current local state is synced to parent
-    // This handles cases where user input debouncing might delay the update
-    if (activeSegment === 'duty' && onDutyContentChange) {
-      onDutyContentChange(localDutyContent);
-    } else if (activeSegment === 'constraint' && onConstraintContentChange) {
-      onConstraintContentChange(localConstraintContent);
-    } else if (activeSegment === 'few-shots' && onFewShotsContentChange) {
-      onFewShotsContentChange(localFewShotsContent);
-    }
-    
     setActiveSegment(segment);
-  }, [activeSegment, localDutyContent, localConstraintContent, localFewShotsContent, 
-      onDutyContentChange, onConstraintContentChange, onFewShotsContentChange]);
+  }, []);
 
   // Set default active segment when entering edit mode
   useEffect(() => {

--- a/frontend/app/[locale]/setup/agentSetup/components/AgentSelector.tsx
+++ b/frontend/app/[locale]/setup/agentSetup/components/AgentSelector.tsx
@@ -1,12 +1,12 @@
 "use client"
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { Card, List, Avatar, Typography, Spin, Empty, message } from 'antd'
 import { UserOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
-import { fetchAllAgentsBasicInfo } from '@/services/agentConfigService'
+import { fetchAllAgents } from '@/services/agentConfigService'
 
-const { Text, Title } = Typography
+const { Text } = Typography
 
 interface AgentBasicInfo {
   agent_id: number
@@ -27,15 +27,15 @@ export default function AgentSelector({ onAgentSelect, selectedAgentId }: AgentS
   const [selectedAgent, setSelectedAgent] = useState<AgentBasicInfo | null>(null)
 
   // Get basic information of all agents
-  const loadAgents = async () => {
+  const loadAgents = useCallback(async () => {
     setLoading(true)
     try {
-      const result = await fetchAllAgentsBasicInfo()
+      const result = await fetchAllAgents()
       if (result.success) {
         setAgents(result.data)
         // If there is a pre-selected agent, set selected state
         if (selectedAgentId) {
-          const preSelectedAgent = result.data.find(agent => agent.agent_id === selectedAgentId)
+          const preSelectedAgent = result.data.find((agent: AgentBasicInfo) => agent.agent_id === selectedAgentId)
           if (preSelectedAgent) {
             setSelectedAgent(preSelectedAgent)
           }
@@ -49,11 +49,11 @@ export default function AgentSelector({ onAgentSelect, selectedAgentId }: AgentS
     } finally {
       setLoading(false)
     }
-  }
+  }, [selectedAgentId, t])
 
   useEffect(() => {
     loadAgents()
-  }, [])
+  }, [loadAgents])
 
   const handleAgentClick = (agent: AgentBasicInfo) => {
     setSelectedAgent(agent)

--- a/frontend/app/[locale]/setup/agentSetup/components/PromptManager.tsx
+++ b/frontend/app/[locale]/setup/agentSetup/components/PromptManager.tsx
@@ -65,7 +65,7 @@ export function SimplePromptEditor({ value, onChange, height = '100%' }: SimpleP
   , [editorKey]) // 只在editorKey改变时重新创建
 
   return (
-    <div className="milkdown-editor-container" style={{ height, overflow: 'hidden' }}>
+    <div className="milkdown-editor-container" style={{ height }}>
       <Milkdown key={editorKey} />
     </div>
   )
@@ -85,8 +85,21 @@ function ExpandEditModal({ open, title, content, index, onClose, onSave }: Expan
   const { t } = useTranslation('common')
   const [editContent, setEditContent] = useState(content)
 
+  // 当 content 或 open 状态变化时，更新编辑内容
+  useEffect(() => {
+    if (open) {
+      // 当模态框打开时，总是使用最新的 content
+      setEditContent(content)
+    }
+  }, [content, open])
+
   const handleSave = () => {
     onSave(editContent)
+    onClose()
+  }
+
+  const handleClose = () => {
+    // 关闭时不保存更改，直接关闭
     onClose()
   }
 
@@ -128,7 +141,7 @@ function ExpandEditModal({ open, title, content, index, onClose, onSave }: Expan
       }
       open={open}
       closeIcon={null}
-      onCancel={handleSave}
+      onCancel={handleClose}
       footer={null}
       width={1000}
       styles={{
@@ -558,11 +571,7 @@ export default function PromptManager({
 
       {/* 展开编辑模态框 */}
       <ExpandEditModal
-        key={
-          expandIndex === 2 ? dutyContent :
-          expandIndex === 3 ? constraintContent :
-          expandIndex === 4 ? fewShotsContent : 'default'
-        }
+        key={`expand-modal-${expandIndex}-${expandModalOpen ? 'open' : 'closed'}`}
         title={expandIndex === 1 ? t('systemPrompt.expandEdit.backgroundInfo') : expandIndex === 2 ? t('systemPrompt.card.duty.title') : expandIndex === 3 ? t('systemPrompt.card.constraint.title') : t('systemPrompt.card.fewShots.title')}
         open={expandModalOpen}
         content={


### PR DESCRIPTION
🐛 Problem Description
## The ExpandEditModal component in the Agent Setup page had several state synchronization issues:
1. Stale content display: When switching between different prompt sections (duty, constraint, few-shots) using the segmented controller, the expand modal would show outdated content from the previously viewed section
2. Component reuse issues: The modal component was being reused with the same key, preventing proper reinitialization when switching between different content sections
3. Inconsistent save/cancel behavior: Both the close button and clicking outside the modal would save changes, providing no way to cancel edits