### PR TITLE
🐛 Fix syntax error in deploy script

### DIFF
--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -293,6 +293,7 @@ install() {
       echo "" >> .env
       echo "ELASTICSEARCH_API_KEY=$ELASTICSEARCH_API_KEY" >> .env
     fi
+  fi
 
   wait_for_elasticsearch_healthy || {
     echo "❌ ERROR Elasticsearch health check failed"


### PR DESCRIPTION
Execute successfully
<img width="558" height="418" alt="image" src="https://github.com/user-attachments/assets/9911f768-4979-4606-987b-cf02e3642d80" />
