### PR TITLE
🐛 When the page is loaded for the first time, the Agent name should be displayed.

### DIFF
--- a/frontend/app/[locale]/setup/agentSetup/AgentConfig.tsx
+++ b/frontend/app/[locale]/setup/agentSetup/AgentConfig.tsx
@@ -362,6 +362,7 @@ export default function AgentConfig() {
         if (!isEditingAgent) {
           setAgentName('');
           setAgentDescription('');
+          setAgentDisplayName('');
         }
       } else {
         message.error(result.message || t('agent.error.fetchAgentList'));
@@ -485,6 +486,7 @@ export default function AgentConfig() {
       // When stopping editing, clear name description box
       setAgentName('')
       setAgentDescription('')
+      setAgentDisplayName('')
     }
   }
 

--- a/frontend/app/[locale]/setup/agentSetup/AgentManagementConfig.tsx
+++ b/frontend/app/[locale]/setup/agentSetup/AgentManagementConfig.tsx
@@ -575,13 +575,15 @@ export default function BusinessLogicConfig({
       setIsCreatingNewAgent(false);
 
       // First set right-side name description box data to ensure immediate display
-      console.log('Setting agent name and description in handleEditAgent:', agentDetail.name, agentDetail.description);
+      console.log('Setting agent name and description in handleEditAgent:', agentDetail.name, agentDetail.description, agentDetail.display_name);
       console.log('setAgentName function exists:', !!setAgentName);
       console.log('setAgentDescription function exists:', !!setAgentDescription);
+      console.log('setAgentDisplayName function exists:', !!setAgentDisplayName);
 
       setAgentName?.(agentDetail.name || '');
       setAgentDescription?.(agentDetail.description || '');
-      console.log('setAgentName and setAgentDescription called');
+      setAgentDisplayName?.(agentDetail.display_name || '');
+      console.log('setAgentName, setAgentDescription and setAgentDisplayName called');
 
       // Notify external editing state change (use complete data)
       onEditingStateChange?.(true, agentDetail);

--- a/frontend/app/[locale]/setup/agentSetup/AgentManagementConfig.tsx
+++ b/frontend/app/[locale]/setup/agentSetup/AgentManagementConfig.tsx
@@ -575,15 +575,12 @@ export default function BusinessLogicConfig({
       setIsCreatingNewAgent(false);
 
       // First set right-side name description box data to ensure immediate display
-      console.log('Setting agent name and description in handleEditAgent:', agentDetail.name, agentDetail.description, agentDetail.display_name);
       console.log('setAgentName function exists:', !!setAgentName);
       console.log('setAgentDescription function exists:', !!setAgentDescription);
-      console.log('setAgentDisplayName function exists:', !!setAgentDisplayName);
 
       setAgentName?.(agentDetail.name || '');
       setAgentDescription?.(agentDetail.description || '');
       setAgentDisplayName?.(agentDetail.display_name || '');
-      console.log('setAgentName, setAgentDescription and setAgentDisplayName called');
 
       // Notify external editing state change (use complete data)
       onEditingStateChange?.(true, agentDetail);


### PR DESCRIPTION
#776 🐛 When the page is loaded for the first time, the Agent name should be displayed.

自验证结果：
1、自动回填Agent名称和Agent描述，简化用户操作：
<img width="1635" height="1004" alt="image" src="https://github.com/user-attachments/assets/1de19cc0-3189-414c-b2f2-f59cfba59c94" />

2、英文界面同样适配：
<img width="1829" height="1028" alt="image" src="https://github.com/user-attachments/assets/bea0b587-26aa-4d97-9c3d-8eba1df5029c" />

3、问答界面展示Agent名称
<img width="1777" height="971" alt="image" src="https://github.com/user-attachments/assets/3bae14c6-3697-4d7c-bd70-6492d869d959" />