### PR TITLE
 🐛 fix bug: modify the display logic of sub agent

### DIFF
--- a/frontend/app/[locale]/setup/agentSetup/components/CollaborativeAgentDisplay.tsx
+++ b/frontend/app/[locale]/setup/agentSetup/components/CollaborativeAgentDisplay.tsx
@@ -233,13 +233,8 @@ export default function CollaborativeAgentDisplay({
               onClose={() => handleRemoveCollaborativeAgent(Number(agent.id))}
               closeIcon={<CloseOutlined className="text-xs" />}
             >
-              <span className="flex items-baseline">
-                {agent.display_name && (
-                  <span className="text-base leading-none">{agent.display_name}</span>
-                )}
-                <span className={`leading-none ${agent.display_name ? 'ml-2 text-sm' : 'text-base'}`}>
-                  {agent.name}
-                </span>
+              <span className="text-base leading-none">
+                {agent.display_name || agent.name}
               </span>
             </Tag>
           ))}


### PR DESCRIPTION
#852 Modify the display logic of sub agent
The display area only displays display_name, and if it doesn't exist, it displays agent_name
<img width="578" height="208" alt="image" src="https://github.com/user-attachments/assets/4bafb7d0-7105-4f26-96c1-c9a8641659a6" />
