### PR TITLE
Update conversation_db.py

### DIFF
--- a/backend/database/conversation_db.py
+++ b/backend/database/conversation_db.py
@@ -319,8 +319,7 @@ def rename_conversation(conversation_id: int, new_title: str, user_id: Optional[
 
         # Prepare update data
         update_data = {
-            "conversation_title": new_title,
-            "update_time": func.current_timestamp()  # Use the database's CURRENT_TIMESTAMP function
+            "conversation_title": new_title
         }
         if user_id:
             update_data = add_update_tracking(update_data, user_id)

--- a/backend/database/conversation_db.py
+++ b/backend/database/conversation_db.py
@@ -319,7 +319,8 @@ def rename_conversation(conversation_id: int, new_title: str, user_id: Optional[
 
         # Prepare update data
         update_data = {
-            "conversation_title": new_title
+            "conversation_title": new_title,
+            "update_time": func.current_timestamp()  
         }
         if user_id:
             update_data = add_update_tracking(update_data, user_id)

--- a/frontend/app/[locale]/chat/layout/chatLeftSidebar.tsx
+++ b/frontend/app/[locale]/chat/layout/chatLeftSidebar.tsx
@@ -85,7 +85,7 @@ const categorizeDialogs = (dialogs: ConversationListItem[]) => {
   const olderDialogs: ConversationListItem[] = []
   
   dialogs.forEach(dialog => {
-    const dialogTime = dialog.update_time || dialog.create_time
+    const dialogTime = dialog.create_time
     
     if (dialogTime >= today) {
       todayDialogs.push(dialog)


### PR DESCRIPTION
Fix bug:[Bug] Modify dialog title should not change its time #785
列表分类(最近，三天前，七天前)由up_time控制，当用户仅仅修改历史标题的时候不改变update_time的值，解决修改标题修改对话时间的问题