### PR TITLE
♻️ Unify all prompt template reading functions into one

### DIFF
--- a/backend/agents/create_agent_info.py
+++ b/backend/agents/create_agent_info.py
@@ -11,7 +11,7 @@ from database.agent_db import search_agent_info_by_agent_id, search_tools_for_su
     query_or_create_main_agent_id, query_sub_agents_id_list
 from services.elasticsearch_service import ElasticSearchService, elastic_core, get_embedding_model
 from services.tenant_config_service import get_selected_knowledge_list
-from utils.prompt_template_utils import get_prompt_template_path
+from utils.prompt_template_utils import get_agent_prompt_template
 from utils.config_utils import config_manager, tenant_config_manager, get_model_name_from_config
 from smolagents.agents import populate_template
 from smolagents.utils import BASE_BUILTIN_MODULES
@@ -63,10 +63,8 @@ async def create_agent_config(agent_id, tenant_id, user_id, language: str = 'zh'
     constraint_prompt = agent_info.get("constraint_prompt", "")
     few_shots_prompt = agent_info.get("few_shots_prompt", "")
     
-    # Get template path
-    prompt_template_path = get_prompt_template_path(is_manager=len(managed_agents) > 0, language=language)
-    with open(prompt_template_path, "r", encoding="utf-8") as file:
-        prompt_template = yaml.safe_load(file)
+    # Get template content
+    prompt_template = get_agent_prompt_template(is_manager=len(managed_agents) > 0, language=language)
 
     # Get app information
     default_app_description = 'Nexent 是一个开源智能体SDK和平台' if language == 'zh' else 'Nexent is an open-source agent SDK and platform'
@@ -229,9 +227,7 @@ async def prepare_prompt_templates(is_manager: bool, system_prompt: str, languag
     Returns:
         dict: Prompt template configuration
     """
-    prompt_template_path = get_prompt_template_path(is_manager, language)
-    with open(prompt_template_path, "r", encoding="utf-8") as f:
-        prompt_templates = yaml.safe_load(f)
+    prompt_templates = get_agent_prompt_template(is_manager, language)
     prompt_templates["system_prompt"] = system_prompt
     return prompt_templates
 

--- a/backend/apps/conversation_management_app.py
+++ b/backend/apps/conversation_management_app.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Dict, Any, Optional
 
-from fastapi import HTTPException, APIRouter, Header
+from fastapi import HTTPException, APIRouter, Header, Request
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel
 
@@ -176,7 +176,9 @@ async def get_sources_endpoint(request: Dict[str, Any], authorization: Optional[
 
 
 @router.post("/generate_title", response_model=ConversationResponse)
-async def generate_conversation_title_endpoint(request: GenerateTitleRequest, authorization: Optional[str] = Header(None)):
+async def generate_conversation_title_endpoint(request: GenerateTitleRequest, 
+                                            http_request: Request,
+                                            authorization: Optional[str] = Header(None)):
     """
     Generate conversation title
 
@@ -190,8 +192,8 @@ async def generate_conversation_title_endpoint(request: GenerateTitleRequest, au
         ConversationResponse object containing generated title
     """
     try:
-        user_id, tenant_id, language = get_current_user_info(authorization=authorization)
-        title = generate_conversation_title_service(request.conversation_id, request.history, user_id,tenant_id=tenant_id)
+        user_id, tenant_id, language = get_current_user_info(authorization=authorization, request=http_request)
+        title = generate_conversation_title_service(request.conversation_id, request.history, user_id, tenant_id=tenant_id, language=language)
         return ConversationResponse(code=0, message="success", data=title)
     except Exception as e:
         logging.error(f"Failed to generate conversation title: {str(e)}")

--- a/backend/prompts/utils/generate_title.yaml
+++ b/backend/prompts/utils/generate_title.yaml
@@ -1,22 +1,22 @@
 SYSTEM_PROMPT: |-
-  Please generate a concise and accurate title (no more than 12 characters) for the following conversation, highlighting the core theme or key information. The title should be natural and fluent, avoiding forced keyword stacking.
+  请为以下对话生成一个简洁准确的标题（不超过12个字符），突出核心主题或关键信息。标题应该自然流畅，避免强制堆砌关键词。
 
-  **Title Generation Requirements:**
-  1. If the conversation involves specific questions, the title should summarize the essence of the question (e.g., 'How to solve XX issue?');
-  2. If the conversation is about knowledge sharing, the title should highlight the core knowledge point (e.g., 'Key Steps of Photosynthesis');
-  3. Avoid using generic terms like 'Q&A' or 'Consultation', prioritize domain specificity;
-  4. The title language should match the conversation language.
+  **标题生成要求：**
+  1. 如果对话涉及具体问题，标题应该概括问题的本质（例如：'如何解决XX问题？'）；
+  2. 如果对话是关于知识分享，标题应该突出核心知识点（例如：'光合作用关键步骤'）；
+  3. 避免使用'问答'或'咨询'等通用术语，优先考虑领域特异性；
+  4. 标题语言应与对话语言保持一致。
 
-  **Examples:**
-  - Conversation: User asking about multiple methods for Python list deduplication → Title: Python List Deduplication Techniques
-  - Conversation: Discussion about factors affecting new energy vehicle battery life → Title: Factors Affecting EV Battery Life
-  - Conversation: hello → Title: hello
+  **示例：**
+  - 对话：用户询问Python列表去重的多种方法 → 标题：Python列表去重技巧
+  - 对话：讨论影响新能源汽车电池寿命的因素 → 标题：影响电动车电池寿命的因素
+  - 对话：hello → 标题：hello
 
-  Please output only the generated title without additional explanation.
+  请只输出生成的标题，不要添加额外解释。
 
 
 USER_PROMPT: |-
-  Please generate a concise title (no more than 12 characters) based on the following conversation:
+  请根据以下对话生成一个简洁的标题（不超过12个字符）：
   {{ content }}
   
-  Title：
+  标题：

--- a/backend/prompts/utils/generate_title_en.yaml
+++ b/backend/prompts/utils/generate_title_en.yaml
@@ -1,0 +1,22 @@
+SYSTEM_PROMPT: |-
+  Please generate a concise and accurate title (no more than 12 characters) for the following conversation, highlighting the core theme or key information. The title should be natural and fluent, avoiding forced keyword stacking.
+
+  **Title Generation Requirements:**
+  1. If the conversation involves specific questions, the title should summarize the essence of the question (e.g., 'How to solve XX issue?');
+  2. If the conversation is about knowledge sharing, the title should highlight the core knowledge point (e.g., 'Key Steps of Photosynthesis');
+  3. Avoid using generic terms like 'Q&A' or 'Consultation', prioritize domain specificity;
+  4. The title language should match the conversation language.
+
+  **Examples:**
+  - Conversation: User asking about multiple methods for Python list deduplication → Title: Python List Deduplication Techniques
+  - Conversation: Discussion about factors affecting new energy vehicle battery life → Title: Factors Affecting EV Battery Life
+  - Conversation: hello → Title: hello
+
+  Please output only the generated title without additional explanation.
+
+
+USER_PROMPT: |-
+  Please generate a concise title (no more than 12 characters) based on the following conversation:
+  {{ content }}
+  
+  Title: 

--- a/backend/services/conversation_management_service.py
+++ b/backend/services/conversation_management_service.py
@@ -18,6 +18,7 @@ from utils.config_utils import tenant_config_manager,get_model_name_from_config
 from utils.auth_utils import get_current_user_id_from_token
 from nexent.core.utils.observer import ProcessType
 from utils.str_utils import remove_think_tags, add_no_think_token
+from utils.prompt_template_utils import get_generate_title_prompt_template
 
 logger = logging.getLogger("conversation_management_service")
 
@@ -228,18 +229,19 @@ def extract_user_messages(history: List[Dict[str, str]]) -> str:
     return content
 
 
-def call_llm_for_title(content: str, tenant_id: str) -> str:
+def call_llm_for_title(content: str, tenant_id: str, language: str = 'zh') -> str:
     """
     Call LLM to generate a title
 
     Args:
         content: Conversation content
+        tenant_id: Tenant ID
+        language: Language code ('zh' for Chinese, 'en' for English)
 
     Returns:
         str: Generated title
     """
-    with open('backend/prompts/utils/generate_title.yaml', "r", encoding="utf-8") as f:
-        prompt_template = yaml.safe_load(f)
+    prompt_template = get_generate_title_prompt_template(language=language)
 
     model_config = tenant_config_manager.get_model_config(key="LLM_ID", tenant_id=tenant_id)
 
@@ -626,7 +628,7 @@ def get_sources_service(conversation_id: Optional[int], message_id: Optional[int
         }
 
 
-def generate_conversation_title_service(conversation_id: int, history: List[Dict[str, str]], user_id: str, tenant_id: str) -> str:
+def generate_conversation_title_service(conversation_id: int, history: List[Dict[str, str]], user_id: str, tenant_id: str, language: str = 'zh') -> str:
     """
     Generate conversation title
 
@@ -634,6 +636,8 @@ def generate_conversation_title_service(conversation_id: int, history: List[Dict
         conversation_id: Conversation ID
         history: Conversation history list
         user_id: User ID
+        tenant_id: Tenant ID
+        language: Language code ('zh' for Chinese, 'en' for English)
 
     Returns:
         str: Generated title
@@ -643,7 +647,7 @@ def generate_conversation_title_service(conversation_id: int, history: List[Dict
         content = extract_user_messages(history)
 
         # Call LLM to generate title
-        title = call_llm_for_title(content, tenant_id)
+        title = call_llm_for_title(content, tenant_id, language)
 
         # Update conversation title
         update_conversation_title(conversation_id, title, user_id)

--- a/backend/services/elasticsearch_service.py
+++ b/backend/services/elasticsearch_service.py
@@ -26,6 +26,7 @@ from fastapi.responses import StreamingResponse
 from consts.const import ES_API_KEY, ES_HOST
 from utils.config_utils import tenant_config_manager, get_model_name_from_config
 from utils.file_management_utils import get_all_files_status, get_file_size
+from utils.prompt_template_utils import get_knowledge_summary_prompt_template
 from database.knowledge_db import create_knowledge_record, get_knowledge_record, update_knowledge_record, delete_knowledge_record
 from database.attachment_db import delete_file
 
@@ -49,10 +50,7 @@ def generate_knowledge_summary_stream(keywords: str, language: str, tenant_id: s
     load_dotenv()
 
     # Load prompt words based on language
-    template_file = 'backend/prompts/knowledge_summary_agent.yaml' if language == 'zh' else 'backend/prompts/knowledge_summary_agent_en.yaml'
-    with open(template_file, 'r', encoding='utf-8') as f:
-        prompts = yaml.safe_load(f)
-    logger.info(f"Generating knowledge with template: {template_file}")
+    prompts = get_knowledge_summary_prompt_template(language)
     # Build messages
     messages: List[ChatCompletionMessageParam] = [
         {"role": "system", "content": prompts['system_prompt']},

--- a/backend/services/prompt_service.py
+++ b/backend/services/prompt_service.py
@@ -10,7 +10,7 @@ from consts.model import AgentInfoRequest
 from database.agent_db import update_agent, \
     query_tools_by_ids, query_sub_agents_id_list, search_agent_info_by_agent_id
 from services.agent_service import get_enable_tool_id_by_agent_id
-from utils.prompt_template_utils import get_prompt_generate_config_path
+from utils.prompt_template_utils import get_prompt_generate_prompt_template
 from utils.config_utils import tenant_config_manager, get_model_name_from_config
 from utils.auth_utils import get_current_user_info
 from fastapi import Header, Request
@@ -110,9 +110,7 @@ def generate_and_save_system_prompt_impl(agent_id: int, task_description: str, a
 
 
 def generate_system_prompt(sub_agent_info_list, task_description, tool_info_list, tenant_id: str, language: str = 'zh'):
-    prompt_config_path = get_prompt_generate_config_path(language)
-    with open(prompt_config_path, "r", encoding="utf-8") as f:
-        prompt_for_generate = yaml.safe_load(f)
+    prompt_for_generate = get_prompt_generate_prompt_template(language)
 
     # Add app information to the template variables
     content = join_info_for_generate_system_prompt(prompt_for_generate, sub_agent_info_list, task_description,

--- a/backend/utils/attachment_utils.py
+++ b/backend/utils/attachment_utils.py
@@ -2,25 +2,12 @@ import yaml
 from typing import Union, BinaryIO
 
 from utils.config_utils import tenant_config_manager, get_model_name_from_config
+from utils.prompt_template_utils import get_analyze_file_prompt_template
 
 from nexent.core.models.openai_vlm import OpenAIVLModel
 from nexent.core.models.openai_long_context_model import OpenAILongContextModel
 from nexent.core import MessageObserver
 
-
-def load_analyze_prompts(language: str = 'zh'):
-    """
-    Load analyze file prompts from yaml file based on language
-    
-    Args:
-        language: Language code ('zh' for Chinese, 'en' for English)
-        
-    Returns:
-        dict: Loaded prompts configuration
-    """
-    template_file = 'backend/prompts/analyze_file.yaml' if language == 'zh' else 'backend/prompts/analyze_file_en.yaml'
-    with open(template_file, 'r', encoding='utf-8') as f:
-        return yaml.safe_load(f)
 
 
 def convert_image_to_text(query: str, image_input: Union[str, BinaryIO], tenant_id: str, language: str = 'zh'):
@@ -49,7 +36,7 @@ def convert_image_to_text(query: str, image_input: Union[str, BinaryIO], tenant_
         )
     
     # Load prompts from yaml file
-    prompts = load_analyze_prompts(language)
+    prompts = get_analyze_file_prompt_template(language)
     system_prompt = prompts['image_analysis']['system_prompt'].format(query=query)
     
     return image_to_text_model.analyze_image(image_input=image_input, system_prompt=system_prompt).content
@@ -77,7 +64,7 @@ def convert_long_text_to_text(query: str, file_context: str, tenant_id: str, lan
     )
     
     # Load prompts from yaml file
-    prompts = load_analyze_prompts(language)
+    prompts = get_analyze_file_prompt_template(language)
     system_prompt = prompts['long_text_analysis']['system_prompt'].format(query=query)
     user_prompt = prompts['long_text_analysis']['user_prompt'].format(file_context=file_context)
 

--- a/backend/utils/prompt_template_utils.py
+++ b/backend/utils/prompt_template_utils.py
@@ -1,37 +1,154 @@
-def get_prompt_template_path(is_manager: bool, language: str = 'zh') -> str:
+import yaml
+from typing import Dict, Any
+import logging
+logger = logging.getLogger("prompt_template_utils")
+
+
+def get_prompt_template(template_type: str, language: str = 'zh', **kwargs) -> Dict[str, Any]:
     """
-    Get the prompt template path based on the agent type and language
+    Get prompt template
     
     Args:
-        is_manager: Whether it is a manager mode
+        template_type: Template type, supports the following values:
+            - 'prompt_generate': Prompt generation template
+            - 'agent': Agent template including manager and managed agents
+            - 'knowledge_summary': Knowledge summary template
+            - 'analyze_file': File analysis template
+            - 'prompt_fine_tune': Prompt fine-tuning template
+            - 'generate_title': Title generation template
+        language: Language code ('zh' or 'en')
+        **kwargs: Additional parameters, for agent type need to pass is_manager parameter
+        
+    Returns:
+        dict: Loaded prompt template
+    """
+    logger.info(f"Getting prompt template for type: {template_type}, language: {language}")
+    
+    # Define template path mapping
+    template_paths = {
+        'prompt_generate': {
+            'zh': 'backend/prompts/utils/prompt_generate.yaml',
+            'en': 'backend/prompts/utils/prompt_generate_en.yaml'
+        },
+        'agent': {
+            'zh': {
+                'manager': 'backend/prompts/manager_system_prompt_template.yaml',
+                'managed': 'backend/prompts/managed_system_prompt_template.yaml'
+            },
+            'en': {
+                'manager': 'backend/prompts/manager_system_prompt_template_en.yaml',
+                'managed': 'backend/prompts/managed_system_prompt_template_en.yaml'
+            }
+        },
+        'knowledge_summary': {
+            'zh': 'backend/prompts/knowledge_summary_agent.yaml',
+            'en': 'backend/prompts/knowledge_summary_agent_en.yaml'
+        },
+        'analyze_file': {
+            'zh': 'backend/prompts/analyze_file.yaml',
+            'en': 'backend/prompts/analyze_file_en.yaml'
+        },
+        'prompt_fine_tune': {
+            'zh': 'backend/prompts/utils/prompt_fine_tune.yaml',
+            'en': 'backend/prompts/utils/prompt_fine_tune_en.yaml'
+        },
+        'generate_title': {
+            'zh': 'backend/prompts/utils/generate_title.yaml',
+            'en': 'backend/prompts/utils/generate_title_en.yaml'
+        }
+    }
+    
+    if template_type not in template_paths:
+        raise ValueError(f"Unsupported template type: {template_type}")
+    
+    # Get template path
+    if template_type == 'agent':
+        is_manager = kwargs.get('is_manager', False)
+        agent_type = 'manager' if is_manager else 'managed'
+        template_path = template_paths[template_type][language][agent_type]
+    else:
+        template_path = template_paths[template_type][language]
+    
+    # Read and return template content
+    with open(template_path, 'r', encoding='utf-8') as f:
+        return yaml.safe_load(f)
+
+
+# For backward compatibility, keep original function names as wrapper functions
+def get_prompt_generate_prompt_template(language: str = 'zh') -> Dict[str, Any]:
+    """
+    Get prompt generation prompt template
+    
+    Args:
         language: Language code ('zh' or 'en')
         
     Returns:
-        str: Prompt template file path
+        dict: Loaded prompt template configuration
     """
-    if language == 'en':
-        if is_manager:
-            return "backend/prompts/manager_system_prompt_template_en.yaml"
-        else:
-            return "backend/prompts/managed_system_prompt_template_en.yaml"
-    else:  # Default to Chinese
-        if is_manager:
-            return "backend/prompts/manager_system_prompt_template.yaml"
-        else:
-            return "backend/prompts/managed_system_prompt_template.yaml"
+    return get_prompt_template('prompt_generate', language)
 
 
-def get_prompt_generate_config_path(language: str = 'zh') -> str:
+def get_agent_prompt_template(is_manager: bool, language: str = 'zh') -> Dict[str, Any]:
     """
-    Get the prompt generation configuration file path based on the language
+    Get agent prompt template
+    
+    Args:
+        is_manager: Whether it is manager mode
+        language: Language code ('zh' or 'en')
+        
+    Returns:
+        dict: Loaded prompt template configuration
+    """
+    return get_prompt_template('agent', language, is_manager=is_manager)
+
+
+def get_knowledge_summary_prompt_template(language: str = 'zh') -> Dict[str, Any]:
+    """
+    Get knowledge summary prompt template
     
     Args:
         language: Language code ('zh' or 'en')
         
     Returns:
-        str: Prompt generation configuration file path
+        dict: Loaded prompt template configuration
     """
-    if language == 'en':
-        return 'backend/prompts/utils/prompt_generate_en.yaml'
-    else:  # Default to Chinese
-        return 'backend/prompts/utils/prompt_generate.yaml'
+    return get_prompt_template('knowledge_summary', language)
+
+
+def get_analyze_file_prompt_template(language: str = 'zh') -> Dict[str, Any]:
+    """
+    Get file analysis prompt template
+    
+    Args:
+        language: Language code ('zh' or 'en')
+        
+    Returns:
+        dict: Loaded prompt template configuration
+    """
+    return get_prompt_template('analyze_file', language)
+
+
+def get_prompt_fine_tune_prompt_template(language: str = 'zh') -> Dict[str, Any]:
+    """
+    Get prompt fine-tuning template
+    
+    Args:
+        language: Language code ('zh' or 'en')
+        
+    Returns:
+        dict: Loaded prompt template configuration
+    """
+    return get_prompt_template('prompt_fine_tune', language)
+
+
+def get_generate_title_prompt_template(language: str = 'zh') -> Dict[str, Any]:
+    """
+    Get title generation prompt template
+    
+    Args:
+        language: Language code ('zh' or 'en')
+        
+    Returns:
+        dict: Loaded prompt template configuration
+    """
+    return get_prompt_template('generate_title', language)


### PR DESCRIPTION
Unify all prompt template reading functions into one.

Validations:
All prompt templates are used correctly (both en and zh), including generating title, generating prompt, analyzing file, summary knowledge, managed/manager agents.

<img width="1947" height="785" alt="image" src="https://github.com/user-attachments/assets/f0a5d4ab-3d73-4411-8539-c838cf68ba21" />

#468 

