### PR TITLE
🐛 Bugfix: When file length exceed limits, not trunctated properly #519

### DIFF
--- a/backend/apps/file_management_app.py
+++ b/backend/apps/file_management_app.py
@@ -517,7 +517,7 @@ async def process_text_file(query, filename, file_content, tenant_id: str, langu
         if response.status_code == 200:
             result = response.json()
             raw_text = result.get("text", "")
-            logger.info(f"File processed successfully: {raw_text[100:]}...{raw_text[-100:]}， length: {len(raw_text)}")
+            logger.info(f"File processed successfully: {raw_text[:200]}...{raw_text[-200:]}...， length: {len(raw_text)}")
         else:
             error_detail = response.json().get('detail', '未知错误') if response.headers.get('content-type', '').startswith('application/json') else response.text
             logger.error(f"File processing failed (status code: {response.status_code}): {error_detail}")

--- a/backend/apps/file_management_app.py
+++ b/backend/apps/file_management_app.py
@@ -517,7 +517,7 @@ async def process_text_file(query, filename, file_content, tenant_id: str, langu
         if response.status_code == 200:
             result = response.json()
             raw_text = result.get("text", "")
-            logger.info(f"File processed successfully: {raw_text[:100]}...")
+            logger.info(f"File processed successfully: {raw_text[100:]}...{raw_text[-100:]}， length: {len(raw_text)}")
         else:
             error_detail = response.json().get('detail', '未知错误') if response.headers.get('content-type', '').startswith('application/json') else response.text
             logger.error(f"File processing failed (status code: {response.status_code}): {error_detail}")

--- a/backend/prompts/analyze_file.yaml
+++ b/backend/prompts/analyze_file.yaml
@@ -25,4 +25,4 @@ long_text_analysis:
     4. 避免冗余信息，专注于问题相关内容
     
   user_prompt: |
-    请仔细阅读并分析这段文本：{file_context} 
+    请仔细阅读并分析这段文本：

--- a/backend/prompts/analyze_file_en.yaml
+++ b/backend/prompts/analyze_file_en.yaml
@@ -25,4 +25,4 @@ long_text_analysis:
     4. Avoid redundant information, focus on question-relevant content
     
   user_prompt: |
-    Please carefully read and analyze this text: {file_context} 
+    Please carefully read and analyze this text:

--- a/backend/utils/attachment_utils.py
+++ b/backend/utils/attachment_utils.py
@@ -73,7 +73,8 @@ def convert_long_text_to_text(query: str, file_context: str, tenant_id: str, lan
         observer=MessageObserver(),
         model_id=get_model_name_from_config(secondary_model_config),
         api_base=secondary_model_config.get("base_url"),
-        api_key=secondary_model_config.get("api_key")
+        api_key=secondary_model_config.get("api_key"),
+        max_context_tokens=secondary_model_config.get("max_tokens")
     )
     
     # Load prompts from yaml file

--- a/frontend/app/[locale]/setup/modelSetup/model/ModelEditDialog.tsx
+++ b/frontend/app/[locale]/setup/modelSetup/model/ModelEditDialog.tsx
@@ -1,4 +1,4 @@
-import { Modal, Input, Select, Button, message } from 'antd'
+import { Modal, Input, Select, Button, App } from 'antd'
 import { useState, useEffect } from 'react'
 import { ModelOption, ModelType } from '@/types/config'
 import { modelService } from '@/services/modelService'
@@ -16,6 +16,7 @@ interface ModelEditDialogProps {
 
 export const ModelEditDialog = ({ isOpen, model, onClose, onSuccess }: ModelEditDialogProps) => {
   const { t } = useTranslation()
+  const { message } = App.useApp()
   const { updateModelConfig } = useConfig()
   const [form, setForm] = useState({
     type: "llm" as ModelType,

--- a/frontend/app/[locale]/setup/page.tsx
+++ b/frontend/app/[locale]/setup/page.tsx
@@ -32,7 +32,7 @@ export default function CreatePage() {
   const [isSavingConfig, setIsSavingConfig] = useState(false)
   const [isFromSecondPage, setIsFromSecondPage] = useState(false)
   const { user, isLoading: userLoading, openLoginModal } = useAuth()
-  const { confirm } = Modal
+  const { modal } = App.useApp()
   const { state: { knowledgeBases, selectedIds }, saveUserSelectedKnowledgeBases } = useKnowledgeBaseContext()
   const { t } = useTranslation()
   const [embeddingModalOpen, setEmbeddingModalOpen] = useState(false);
@@ -47,7 +47,7 @@ export default function CreatePage() {
     if (!userLoading) {
       if (!user) {
         // user not logged in, show login prompt
-        confirm({
+        modal.confirm({
           title: t('login.expired.title'),
           icon: <ExclamationCircleOutlined />,
           content: t('login.expired.content'),
@@ -74,7 +74,7 @@ export default function CreatePage() {
         setSelectedKey("2")
       }
     }
-  }, [user, userLoading, selectedKey, confirm, openLoginModal, router])
+  }, [user, userLoading, selectedKey, modal, openLoginModal, router])
 
   // Check the connection status when the page is initialized
   useEffect(() => {

--- a/frontend/components/auth/avatarDropdown.tsx
+++ b/frontend/components/auth/avatarDropdown.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useAuth } from "@/hooks/useAuth"
-import { Dropdown, Avatar, Spin, Button, Tag, ConfigProvider, Modal } from "antd"
+import { Dropdown, Avatar, Spin, Button, Tag, ConfigProvider, App } from "antd"
 import { UserOutlined, SettingOutlined, LogoutOutlined, UserSwitchOutlined, LoginOutlined, UserAddOutlined } from "@ant-design/icons"
 import { getRoleColor } from "@/lib/auth"
 import type { ItemType, MenuItemType } from "antd/es/menu/interface"
@@ -13,6 +13,7 @@ export function AvatarDropdown() {
   const { user, isLoading, logout, openLoginModal, openRegisterModal } = useAuth()
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const { t } = useTranslation('common');
+  const { modal } = App.useApp();
 
   if (isLoading) {
     return <Spin size="small" />
@@ -114,14 +115,14 @@ export function AvatarDropdown() {
       icon: <LogoutOutlined />,
       label: t('auth.logout'),
       onClick: () => {
-        Modal.confirm({
+        modal.confirm({
           title: t('auth.confirmLogout'),
           content: t('auth.confirmLogoutPrompt'),
           okText: t('auth.confirm'),
           cancelText: t('auth.cancel'),
           onOk: () => {
             logout();
-          }
+          },
         });
       },
     },

--- a/frontend/components/auth/sessionListeners.tsx
+++ b/frontend/components/auth/sessionListeners.tsx
@@ -2,12 +2,12 @@
 
 import { useEffect, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
-import { Modal } from 'antd';
+import { App } from 'antd';
 import { ExclamationCircleOutlined } from '@ant-design/icons';
 import { authService } from '@/services/authService';
 import { EVENTS } from '@/types/auth';
-import { useAuth } from '@/hooks/useAuth';
 import { useTranslation } from 'react-i18next';
+import { useAuth } from '@/hooks/useAuth';
 
 /**
  * 会话管理组件
@@ -18,6 +18,7 @@ export function SessionListeners() {
   const pathname = usePathname();
   const { t } = useTranslation('common');
   const { openLoginModal, setIsFromSessionExpired, logout } = useAuth();
+  const { modal } = App.useApp();
   const modalShownRef = useRef<boolean>(false);
 
   /**
@@ -36,7 +37,7 @@ export function SessionListeners() {
 
     modalShownRef.current = true;
 
-    Modal.confirm({
+    modal.confirm({
       title: t('login.expired.title'),
       icon: <ExclamationCircleOutlined />,
       content: t('login.expired.content'),
@@ -100,7 +101,7 @@ export function SessionListeners() {
       window.removeEventListener(EVENTS.SESSION_EXPIRED, handleSessionExpired as EventListener);
     };
   // 依赖数组中去掉 confirm，避免因函数引用变化导致重复注册
-  }, [router, pathname, openLoginModal, setIsFromSessionExpired]);
+  }, [router, pathname, openLoginModal, setIsFromSessionExpired, modal]);
 
   // 组件初次挂载时，如果发现本地已经没有 session，也立即弹窗
   useEffect(() => {

--- a/frontend/hooks/useAuth.ts
+++ b/frontend/hooks/useAuth.ts
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState, useEffect, useContext, createContext, type ReactNode } from "react"
+import { App } from "antd"
 import { authService } from "@/services/authService"
 import { getSessionFromStorage } from "@/lib/auth"
 import { configService } from "@/services/configService"
@@ -16,6 +17,7 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined)
 // 认证提供者组件
 export function AuthProvider({ children }: { children: (value: AuthContextType) => ReactNode }) {
   const { t } = useTranslation('common');
+  const { message } = App.useApp();
   const [user, setUser] = useState<User | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false)
@@ -202,7 +204,7 @@ export function AuthProvider({ children }: { children: (value: AuthContextType) 
     setIsRegisterModalOpen(false)
   }
 
-  const login = async (email: string, password: string, showSuccessMessage: boolean = true, message?: any) => {
+  const login = async (email: string, password: string, showSuccessMessage: boolean = true) => {
     try {
       setIsLoading(true)
       
@@ -257,7 +259,7 @@ export function AuthProvider({ children }: { children: (value: AuthContextType) 
     }
   }
 
-  const register = async (email: string, password: string, isAdmin?: boolean, inviteCode?: string, message?: any) => {
+  const register = async (email: string, password: string, isAdmin?: boolean, inviteCode?: string) => {
     try {
       setIsLoading(true)
       
@@ -308,7 +310,7 @@ export function AuthProvider({ children }: { children: (value: AuthContextType) 
     }
   }
 
-  const logout = async (message?: any) => {
+  const logout = async () => {
     try {
       setIsLoading(true)
       await authService.signOut()

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -89,7 +89,7 @@
         "cannotPreviewFileType": "Cannot preview this file type",
         "thisFileTypeCannotBePreviewed": "This file type cannot be previewed",
         "fileCountExceedsLimit": "File count exceeds limit. Maximum {{count}} files allowed",
-        "fileSizeExceedsLimit": "File \"{{name}}\" exceeds size limit. Maximum 100MB per file",
+        "fileSizeExceedsLimit": "File \"{{name}}\" exceeds size limit. Maximum 10MB per file",
         "unsupportedFileType": "File \"{{name}}\" is not a supported file type. Supported formats: images, documents (PDF, Word, Excel, PPT), text files, CSV/TSV, Markdown",
         "unsupportedFileTypeSimple": "Unsupported file type",
         "dragAndDropFilesHere": "Drag and drop files here to upload",

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -89,7 +89,7 @@
         "cannotPreviewFileType": "无法预览此文件类型",
         "thisFileTypeCannotBePreviewed": "此文件类型无法预览",
         "fileCountExceedsLimit": "文件数量超过限制，最多只能上传{{count}}个文件",
-        "fileSizeExceedsLimit": "文件\"{{name}}\"超过大小限制，单个文件最大100MB",
+        "fileSizeExceedsLimit": "文件\"{{name}}\"超过大小限制，单个文件最大10MB",
         "unsupportedFileType": "文件\"{{name}}\"不是支持的文件类型，支持的格式包括：图片、文档（PDF、Word、Excel、PPT）、纯文本、CSV/TSV、Markdown",
         "unsupportedFileTypeSimple": "不支持的文件类型",
         "dragAndDropFilesHere": "文件拖动到此处即可上传",

--- a/frontend/services/memoryService.ts
+++ b/frontend/services/memoryService.ts
@@ -1,8 +1,6 @@
 import { MemoryItem, MemoryGroup } from "@/types/memory"
 import i18next from 'i18next'
 import { API_ENDPOINTS, fetchWithErrorHandling } from "./api"
-
-import { message } from "antd"
 import { fetchWithAuth, getAuthHeaders } from '@/lib/auth';
 import { fetchAllAgents } from "./agentConfigService"
 
@@ -200,12 +198,9 @@ async function listMemories(memoryLevel: string, agentId?: string): Promise<{ it
   } catch (e) {
     console.error("listMemories error", e)
     if (e instanceof Error) {
-      const msg = e.message || ""
-      message.error(getFriendlyErrorMessage(msg))
-    } else {
-      message.error(i18next.t('memoryService.loadMemoryError'))
+      throw new Error(getFriendlyErrorMessage(e.message || ""))
     }
-    return { items: [], total: 0 }
+    throw new Error(i18next.t('memoryService.loadMemoryError'))
   }
 }
 
@@ -378,8 +373,7 @@ export async function deleteMemory(memoryId: string, memoryLevel: string, agentI
     const url = `${API_ENDPOINTS.memory.entry.delete(memoryId)}?${params.toString()}`
     
     const res = await requestJson(url, { method: "DELETE", headers: getAuthHeaders() })
-    const ok = res?.status === "success"
-    return ok
+    return res?.status === "success"
   } catch (e) {
     console.error("deleteMemory error", e)
     throw e

--- a/sdk/nexent/core/models/openai_long_context_model.py
+++ b/sdk/nexent/core/models/openai_long_context_model.py
@@ -1,8 +1,11 @@
 from smolagents.models import ChatMessage
 import tiktoken
+import logging
 
 from ..models import OpenAIModel
 from ..utils.observer import MessageObserver
+
+logger = logging.getLogger("openai_long_context_model")
 
 
 class OpenAILongContextModel(OpenAIModel):
@@ -56,10 +59,14 @@ class OpenAILongContextModel(OpenAIModel):
         """
         tokenizer = self._get_tokenizer()
         if tokenizer:
-            return len(tokenizer.encode(text))
+            token_count = len(tokenizer.encode(text))
+            logger.debug(f"Token count using tiktoken: {token_count} tokens for text length {len(text)}")
+            return token_count
         else:
             # Simple character count estimation (approximately 4 characters = 1 token)
-            return len(text) // 4
+            estimated_tokens = len(text) // 4
+            logger.debug(f"Token count using estimation: {estimated_tokens} tokens for text length {len(text)} (4 chars ≈ 1 token)")
+            return estimated_tokens
     
     def truncate_text(self, text: str, max_tokens: int) -> str:
         """
@@ -72,49 +79,65 @@ class OpenAILongContextModel(OpenAIModel):
         Returns:
             str: Truncated text
         """
-        if self.count_tokens(text) <= max_tokens:
+        original_tokens = self.count_tokens(text)
+        logger.info(f"Starting text truncation: original_tokens={original_tokens}, max_tokens={max_tokens}, strategy={self.truncation_strategy}, text_length={len(text)}")
+        
+        if original_tokens <= max_tokens:
+            logger.debug(f"No truncation needed: original_tokens ({original_tokens}) <= max_tokens ({max_tokens})")
             return text
 
         tokenizer = self._get_tokenizer()
+        
         if tokenizer:
+            logger.debug("Using tiktoken tokenizer for precise truncation")
             # Use tiktoken for precise truncation
             tokens = tokenizer.encode(text)
             if len(tokens) <= max_tokens:
+                logger.debug(f"Token count within limit after encoding: {len(tokens)} <= {max_tokens}")
                 return text
             
             if self.truncation_strategy == "start":
                 # Only keep the beginning part
+                logger.info(f"Truncating with 'start' strategy: keeping first {max_tokens} tokens")
                 truncated_tokens = tokens[:max_tokens]
-                return tokenizer.decode(truncated_tokens)
+                truncated_text = tokenizer.decode(truncated_tokens)
             elif self.truncation_strategy == "middle":
                 # Keep the beginning and end,
                 half_tokens = max_tokens // 2
                 start_tokens = tokens[:half_tokens]
                 end_tokens = tokens[-(max_tokens - half_tokens):]
                 truncated_tokens = start_tokens + end_tokens
-                return tokenizer.decode(truncated_tokens)
+                truncated_text = tokenizer.decode(truncated_tokens)
             else:
                 # Only keep the end part
+                logger.info(f"Truncating with 'end' strategy: keeping last {max_tokens} tokens")
                 truncated_tokens = tokens[-max_tokens:]
-                return tokenizer.decode(truncated_tokens)
+                truncated_text = tokenizer.decode(truncated_tokens)
         else:
+            logger.warning("tiktoken not available, using character count estimation for truncation")
             # Use character count for estimation truncation
             estimated_chars = max_tokens * 4
             if len(text) <= estimated_chars:
+                logger.debug(f"Text length within estimated limit: {len(text)} <= {estimated_chars} chars")
                 return text
             
             if self.truncation_strategy == "start":
                 # Only keep the beginning part
-                return text[:estimated_chars]
+                logger.info(f"Truncating with 'start' strategy (char estimation): keeping first {estimated_chars} characters")
+                truncated_text = text[:estimated_chars]
             elif self.truncation_strategy == "middle":
                 # Keep the beginning and end
                 half_chars = estimated_chars // 2
                 start_text = text[:half_chars]
                 end_text = text[-(estimated_chars - half_chars):]
-                return start_text + "\n\n[Content truncated...]\n\n" + end_text
+                truncated_text = start_text + "\n\n[Content truncated...]\n\n" + end_text
             else:  # end
                 # Only keep the end part
-                return text[-estimated_chars:]
+                logger.info(f"Truncating with 'end' strategy (char estimation): keeping last {estimated_chars} characters")
+                truncated_text = text[-estimated_chars:]
+
+        logger.info(f"Truncation completed: {len(text)} -> {len(truncated_text)}")
+        return truncated_text
     
     def prepare_long_text_message(self, text_content: str, system_prompt: str, user_prompt: str):
         """
@@ -128,21 +151,32 @@ class OpenAILongContextModel(OpenAIModel):
         Returns:
             List[Dict[str, Any]]: Prepared message list
         """
+        logger.info("Preparing long text message with automatic truncation")
+        
         # Calculate the token number of the system prompt and user prompt
         system_tokens = self.count_tokens(system_prompt)
         user_prompt_tokens = self.count_tokens(user_prompt)
+        content_tokens = self.count_tokens(text_content)
+        
+        logger.info(f"Token breakdown: system={system_tokens}, user_prompt={user_prompt_tokens}, content={content_tokens}, max_context={self.max_context_tokens}")
+        logger.debug(f"Text lengths: system={len(system_prompt)}, user_prompt={len(user_prompt)}, content={len(text_content)}")
         
         # Reserve tokens for text content
         available_tokens = self.max_context_tokens - system_tokens - user_prompt_tokens - 100  # Reserve 100 tokens as buffer
         
         # Truncate the text content
         truncated_text = self.truncate_text(text_content, available_tokens)
+        final_content_tokens = self.count_tokens(truncated_text)
+        logger.info(f"Content truncation result: {content_tokens} -> {final_content_tokens} tokens")
         
         # Build messages
         messages = [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": f"{user_prompt}\n\n{truncated_text}"}
         ]
+        
+        total_message_tokens = system_tokens + user_prompt_tokens + final_content_tokens
+        logger.info(f"Message preparation completed: total_tokens={total_message_tokens}, messages_count={len(messages)}")
         
         return messages
 
@@ -158,5 +192,17 @@ class OpenAILongContextModel(OpenAIModel):
         Returns:
             ChatMessage: Model returned message
         """
-        messages = self.prepare_long_text_message(text_content, system_prompt, user_prompt)
-        return self(messages=messages)
+        logger.info("Starting long text analysis")
+        logger.debug(f"Input parameters: content_length={len(text_content)}, system_prompt_length={len(system_prompt)}, user_prompt_length={len(user_prompt)}")
+        
+        try:
+            messages = self.prepare_long_text_message(text_content, system_prompt, user_prompt)
+            logger.info("Messages prepared successfully, calling model for analysis")
+            
+            result = self(messages=messages)
+            logger.info("Long text analysis completed successfully")
+            return result
+            
+        except Exception as e:
+            logger.error(f"Error during long text analysis: {str(e)}")
+            raise

--- a/test/sdk/core/models/test_openai_long_context_model.py
+++ b/test/sdk/core/models/test_openai_long_context_model.py
@@ -1,0 +1,225 @@
+import pytest
+import sys
+from unittest.mock import MagicMock, patch
+
+mock_smolagents = MagicMock()
+mock_models_module = MagicMock()
+
+
+class MockOpenAIServerModel:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class MockChatMessage:
+    def __init__(self, content="", role="user"):
+        self.content = content
+        self.role = role
+        self.raw = MagicMock()
+
+
+mock_models_module.OpenAIServerModel = MockOpenAIServerModel
+mock_models_module.ChatMessage = MockChatMessage
+mock_smolagents.models = mock_models_module
+
+with patch.dict("sys.modules", {
+    "smolagents": mock_smolagents,
+    "smolagents.models": mock_models_module,
+}):
+    from sdk.nexent.core.models.openai_long_context_model import OpenAILongContextModel
+    from sdk.nexent.core.utils.observer import MessageObserver
+
+
+@pytest.fixture
+def mock_observer():
+    return MagicMock(spec=MessageObserver)
+
+
+@pytest.fixture
+def long_context_model(mock_observer):
+    model = OpenAILongContextModel(
+        observer=mock_observer,
+        temperature=0.5,
+        top_p=0.95,
+        max_context_tokens=128000,
+        truncation_strategy="start"
+    )
+    model.model_id = "test-model"
+    return model
+
+
+@pytest.fixture
+def mock_tokenizer():
+    mock_enc = MagicMock()
+    mock_enc.encode.return_value = list(range(1, 11))
+    mock_enc.decode.return_value = "decoded text"
+    return mock_enc
+
+
+def test_init_default_values(mock_observer):
+    model = OpenAILongContextModel(observer=mock_observer)
+    assert model.max_context_tokens == 128000
+    assert model.truncation_strategy == "start"
+    assert model._tokenizer is None
+
+
+def test_init_custom_values(mock_observer):
+    model = OpenAILongContextModel(observer=mock_observer, max_context_tokens=64000, truncation_strategy="middle")
+    assert model.max_context_tokens == 64000
+    assert model.truncation_strategy == "middle"
+
+
+def test_init_invalid_truncation_strategy(mock_observer):
+    with pytest.raises(ValueError, match="truncation_strategy must be 'start', 'middle' or 'end'"):
+        OpenAILongContextModel(observer=mock_observer, truncation_strategy="invalid")
+
+
+def test_get_tokenizer_success(long_context_model, mock_tokenizer):
+    with patch.object(long_context_model, '_get_tokenizer', return_value=mock_tokenizer):
+        result = long_context_model._get_tokenizer()
+        assert result == mock_tokenizer
+
+
+def test_get_tokenizer_import_error(long_context_model):
+    with patch.object(long_context_model, '_get_tokenizer', return_value=None):
+        result = long_context_model._get_tokenizer()
+        assert result is None
+
+
+def test_get_tokenizer_cached(long_context_model, mock_tokenizer):
+    long_context_model._tokenizer = mock_tokenizer
+    assert long_context_model._get_tokenizer() == mock_tokenizer
+
+
+def test_count_tokens_with_tiktoken(long_context_model, mock_tokenizer):
+    with patch.object(long_context_model, '_get_tokenizer', return_value=mock_tokenizer):
+        mock_tokenizer.encode.return_value = [1, 2, 3, 4, 5]
+        assert long_context_model.count_tokens("test text") == 5
+
+
+def test_count_tokens_without_tiktoken(long_context_model):
+    long_context_model._tokenizer = None
+    with patch.object(long_context_model, '_get_tokenizer', return_value=None):
+        result = long_context_model.count_tokens("a" * 20)
+        assert result == 5
+
+
+def test_truncate_text_no_truncation_needed(long_context_model):
+    long_context_model.count_tokens = MagicMock(return_value=10)
+    assert long_context_model.truncate_text("short text", 20) == "short text"
+
+
+@patch("sdk.nexent.core.models.openai_long_context_model.logging.getLogger")
+def test_truncate_text_start_strategy_with_tiktoken(mock_logger, long_context_model, mock_tokenizer):
+    with patch.object(long_context_model, '_get_tokenizer', return_value=mock_tokenizer):
+        long_context_model.count_tokens = MagicMock(return_value=100)
+        mock_tokenizer.encode.return_value = list(range(1, 11))
+        assert long_context_model.truncate_text("long text", 5) == "decoded text"
+
+
+@patch("sdk.nexent.core.models.openai_long_context_model.logging.getLogger")
+def test_truncate_text_middle_strategy_with_tiktoken(mock_logger, long_context_model, mock_tokenizer):
+    with patch.object(long_context_model, '_get_tokenizer', return_value=mock_tokenizer):
+        long_context_model.truncation_strategy = "middle"
+        long_context_model.count_tokens = MagicMock(return_value=100)
+        mock_tokenizer.encode.return_value = list(range(1, 11))
+        long_context_model.truncate_text("long text", 6)
+        mock_tokenizer.decode.assert_called_once_with([1, 2, 3, 8, 9, 10])
+
+
+@patch("sdk.nexent.core.models.openai_long_context_model.logging.getLogger")
+def test_truncate_text_end_strategy_with_tiktoken(mock_logger, long_context_model, mock_tokenizer):
+    with patch.object(long_context_model, '_get_tokenizer', return_value=mock_tokenizer):
+        long_context_model.truncation_strategy = "end"
+        long_context_model.count_tokens = MagicMock(return_value=100)
+        mock_tokenizer.encode.return_value = list(range(1, 11))
+        long_context_model.truncate_text("long text", 5)
+        mock_tokenizer.decode.assert_called_once_with([6, 7, 8, 9, 10])
+
+
+@patch("sdk.nexent.core.models.openai_long_context_model.logging.getLogger")
+def test_truncate_text_without_tiktoken_start_strategy(mock_logger, long_context_model):
+    with patch.object(long_context_model, '_get_tokenizer', return_value=None):
+        long_context_model.count_tokens = MagicMock(return_value=100)
+        result = long_context_model.truncate_text("x" * 100, 10)
+        assert result == "x" * 40
+
+
+@patch("sdk.nexent.core.models.openai_long_context_model.logging.getLogger")
+def test_truncate_text_without_tiktoken_middle_strategy(mock_logger, long_context_model):
+    with patch.object(long_context_model, '_get_tokenizer', return_value=None):
+        long_context_model.truncation_strategy = "middle"
+        long_context_model.count_tokens = MagicMock(return_value=100)
+        result = long_context_model.truncate_text("abcdefghij" * 5, 10)
+        assert "[Content truncated...]" in result
+
+
+@patch("sdk.nexent.core.models.openai_long_context_model.logging.getLogger")
+def test_truncate_text_without_tiktoken_end_strategy(mock_logger, long_context_model):
+    with patch.object(long_context_model, '_get_tokenizer', return_value=None):
+        long_context_model.count_tokens = MagicMock(return_value=100)
+        text = "abcdefghij" * 5
+        result = long_context_model.truncate_text(text, 10)
+        assert result == text[-40:]
+
+
+def test_prepare_long_text_message(long_context_model):
+    long_context_model.count_tokens = MagicMock(side_effect=[50, 30, 1000, 800])
+    long_context_model.truncate_text = MagicMock(return_value="truncated content")
+    result = long_context_model.prepare_long_text_message("very long content", "system prompt", "user prompt")
+    assert len(result) == 2
+    assert result[0]["role"] == "system"
+    assert "truncated content" in result[1]["content"]
+
+
+def test_prepare_long_text_message_no_truncation_needed(long_context_model):
+    long_context_model.count_tokens = MagicMock(side_effect=[50, 30, 100, 100])
+    long_context_model.truncate_text = MagicMock(return_value="original content")
+    result = long_context_model.prepare_long_text_message("short content", "system prompt", "user prompt")
+    assert len(result) == 2
+    long_context_model.truncate_text.assert_called_once()
+
+
+def test_analyze_long_text_exception(long_context_model):
+    long_context_model.prepare_long_text_message = MagicMock(side_effect=Exception("test error"))
+    with pytest.raises(Exception, match="test error"):
+        long_context_model.analyze_long_text("t", "sp", "up")
+
+
+def test_edge_cases(long_context_model):
+    long_context_model.count_tokens = MagicMock(return_value=0)
+    assert long_context_model.truncate_text("", 100) == ""
+
+    long_context_model.count_tokens = MagicMock(return_value=10)
+    assert len(long_context_model.truncate_text("test", 1)) > 0
+
+    long_context_model.count_tokens = MagicMock(return_value=100)
+    assert long_context_model.truncate_text("test", 100) == "test"
+
+
+def test_token_calculation_accuracy(long_context_model):
+    with patch.object(long_context_model, '_get_tokenizer', return_value=None):
+        short_text = "Hello world"
+        assert long_context_model.count_tokens(short_text) == len(short_text) // 4
+
+        long_text = "This is a much longer text for estimation"
+        assert long_context_model.count_tokens(long_text) == len(long_text) // 4
+
+
+def test_truncation_strategies_comparison(long_context_model):
+    with patch.object(long_context_model, '_get_tokenizer', return_value=None):
+        long_context_model.count_tokens = MagicMock(return_value=100)
+        text = "This is a very long text for truncation strategy test"
+
+        long_context_model.truncation_strategy = "start"
+        start_result = long_context_model.truncate_text(text, 10)
+
+        long_context_model.truncation_strategy = "end"
+        end_result = long_context_model.truncate_text(text, 10)
+
+        long_context_model.truncation_strategy = "middle"
+        middle_result = long_context_model.truncate_text(text, 10)
+
+        assert start_result != end_result
+        assert start_result != middle_result
+        assert end_result != middle_result


### PR DESCRIPTION
问题现象：内容较多的文件均会返回token过多的报错
问题根因：在user prompt中重复添加了原始文本，导致截断策略未生效
修改内容：删除user prompt中的替换符，增加定位日志
验证截图：
<img width="1576" height="478" alt="image" src="https://github.com/user-attachments/assets/e0aef54e-502f-4261-87a8-4673240b5ea2" />
<img width="1562" height="328" alt="image" src="https://github.com/user-attachments/assets/13f8ad17-c2a1-4cd8-8e48-b9e1e7e59672" />
<img width="767" height="303" alt="image" src="https://github.com/user-attachments/assets/8559e0cb-06ae-4cf0-ba07-d4efb01ac5e1" />
