### PR TITLE
🐛 Additional bugfix: The conversation cannot be interrupted during file parsing #648

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -30,6 +30,7 @@
         "fileParsed": "File {{filename}} has been parsed successfully",
         "fileParsingComplete": "File parsing complete",
         "fileProcessingFailed": "File processing failed: {{error}}",
+        "filePreprocessingStopped": "File parsing stopped",
         "userCancelledRequest": "User canceled the request",
         "conversationStopped": "Conversation stopped",
         "errorProcessingRequest": "An error occurred while processing the request",

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -30,6 +30,7 @@
         "fileParsed": "文件 {{filename}} 已解析完成",
         "fileParsingComplete": "文件解析完成",
         "fileProcessingFailed": "文件处理失败: {{error}}",
+        "filePreprocessingStopped": "文件解析已停止",
         "userCancelledRequest": "用户取消了请求",
         "conversationStopped": "对话已停止",
         "errorProcessingRequest": "处理请求时发生错误",


### PR DESCRIPTION
🐛 Additional bugfix: The conversation cannot be interrupted during file parsing #648
修复了一个国际化提示未展示问题
<img width="801" height="283" alt="image" src="https://github.com/user-attachments/assets/9ede1f3d-105b-483c-844e-41ceaec469c5" />

<img width="853" height="698" alt="image" src="https://github.com/user-attachments/assets/c00c7ef0-1c53-4a22-8a8a-0845bdc9edef" />
