### PR TITLE
[release]🐛 When there are no reasoning_content fields in the access model, you need to process them. #903

### DIFF
--- a/sdk/nexent/core/models/openai_llm.py
+++ b/sdk/nexent/core/models/openai_llm.py
@@ -37,7 +37,7 @@ class OpenAIModel(OpenAIServerModel):
             self.observer.current_mode = ProcessType.MODEL_OUTPUT_THINKING
             for chunk in current_request:
                 new_token = chunk.choices[0].delta.content
-                reasoning_content = chunk.choices[0].delta.reasoning_content
+                reasoning_content = getattr(chunk.choices[0].delta, 'reasoning_content', None)
 
                 # Handle reasoning_content if it exists and is not null
                 if reasoning_content is not None:


### PR DESCRIPTION
🐛 When there are no reasoning_content fields in the access model, you need to process them. #903 
有的模型没有reasoning_content字段。

修改前：
<img width="1027" height="379" alt="image" src="https://github.com/user-attachments/assets/306c3680-b22d-4119-a398-869ce203e6ab" />

修改后对接qwen-max模型问答成功：
<img width="2553" height="1192" alt="image" src="https://github.com/user-attachments/assets/15f0dcf8-8c77-468d-88e7-5bfe677c2b8a" />