### PR TITLE
[release]🐛 fix bug: MCP status indicator stays green when mcp server is unavailable

### DIFF
--- a/frontend/app/[locale]/setup/agentSetup/components/McpConfigModal.tsx
+++ b/frontend/app/[locale]/setup/agentSetup/components/McpConfigModal.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react'
 import { Modal, Button, Input, Table, Space, Typography, Card, Divider, Tag, Tooltip, App } from 'antd'
 import { DeleteOutlined, EyeOutlined, PlusOutlined, LoadingOutlined, ExpandAltOutlined, CompressOutlined, RedoOutlined } from '@ant-design/icons'
-import { getMcpServerList, addMcpServer, deleteMcpServer, getMcpTools, updateToolList, recoverMcpServers, McpServer, McpTool } from '@/services/mcpService'
+import { getMcpServerList, addMcpServer, deleteMcpServer, getMcpTools, updateToolList, recoverMcpServers, checkMcpServerHealth, McpServer, McpTool } from '@/services/mcpService'
 import { useTranslation } from 'react-i18next'
 
 const { Text, Title } = Typography
@@ -197,23 +197,15 @@ export default function McpConfigModal({ visible, onCancel }: McpConfigModalProp
     message.info(t('mcpConfig.message.healthChecking', { name: server.service_name }))
     setHealthCheckLoading((prev) => ({ ...prev, [key]: true }))
     try {
-      const response = await fetch(`/api/mcp/healthcheck?mcp_url=${encodeURIComponent(server.mcp_url)}&service_name=${encodeURIComponent(server.service_name)}`, {
-        headers: { ...((window as any).authHeaders || {}) }
-      })
-      if (response.ok) {
-        const data = await response.json()
-        if (data.status === 'success' || response.status === 200) {
-          message.success(t('mcpConfig.message.healthCheckSuccess'))
-          await loadServerList()
-        } else {
-          message.error(t('mcpConfig.message.healthCheckFailed'))
-          await loadServerList()
-        }
+      const result = await checkMcpServerHealth(server.mcp_url, server.service_name)
+      if (result.success) {
+        message.success(t('mcpConfig.message.healthCheckSuccess'))
+        await loadServerList()
       } else {
-        message.error(t('mcpConfig.message.healthCheckFailed'))
+        message.error(result.message || t('mcpConfig.message.healthCheckFailed'))
         await loadServerList()
       }
-    } catch (e) {
+    } catch (error) {
       message.error(t('mcpConfig.message.healthCheckFailed'))
       await loadServerList()
     } finally {

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -116,6 +116,7 @@ export const API_ENDPOINTS = {
     delete: `${API_BASE_URL}/mcp/`,
     list: `${API_BASE_URL}/mcp/list`,
     recover: `${API_BASE_URL}/mcp/recover`,
+    healthcheck: `${API_BASE_URL}/mcp/healthcheck`,
   },
   memory: {
     // ---------------- Memory configuration ----------------

--- a/frontend/services/mcpService.ts
+++ b/frontend/services/mcpService.ts
@@ -369,7 +369,7 @@ export const recoverMcpServers = async () => {
 };
 
 /**
- * 检查MCP服务器健康状态
+ * checkMcpServerHealth
  */
 export const checkMcpServerHealth = async (mcpUrl: string, serviceName: string) => {
   try {

--- a/frontend/services/mcpService.ts
+++ b/frontend/services/mcpService.ts
@@ -367,3 +367,40 @@ export const recoverMcpServers = async () => {
     };
   }
 };
+
+/**
+ * 检查MCP服务器健康状态
+ */
+export const checkMcpServerHealth = async (mcpUrl: string, serviceName: string) => {
+  try {
+    const response = await fetch(
+      `${API_ENDPOINTS.mcp.healthcheck}?mcp_url=${encodeURIComponent(mcpUrl)}&service_name=${encodeURIComponent(serviceName)}`,
+      {
+        headers: getAuthHeaders(),
+      }
+    );
+
+    const data = await response.json();
+    
+    if (response.ok && data.status === 'success') {
+      return {
+        success: true,
+        data: data,
+        message: data.message || t('mcpService.message.healthCheckSuccess')
+      };
+    } else {
+      return {
+        success: false,
+        data: null,
+        message: data.message || t('mcpService.message.healthCheckFailed')
+      };
+    }
+  } catch (error) {
+    console.error(t('mcpService.debug.healthCheckFailed'), error);
+    return {
+      success: false,
+      data: null,
+      message: t('mcpService.message.networkError')
+    };
+  }
+};


### PR DESCRIPTION
#898 
The problem is that the mcp/healthcheck interface does not pass in the authentication information correctly.
<img width="1031" height="639" alt="image" src="https://github.com/user-attachments/assets/e1a3d836-cda3-45dd-b140-8033a3fd0b3f" />
