### PR TITLE
[Bug] Agent页面按钮鼠标悬浮时会有不合适的边框颜色

### DIFF
--- a/frontend/app/[locale]/setup/agentSetup/components/AgentConfigurationSection.tsx
+++ b/frontend/app/[locale]/setup/agentSetup/components/AgentConfigurationSection.tsx
@@ -20,8 +20,6 @@ export interface AgentConfigurationSectionProps {
   agentDescription?: string;
   onAgentNameChange?: (name: string) => void;
   onAgentDescriptionChange?: (description: string) => void;
-  agentDisplayName?: string;
-  onAgentDisplayNameChange?: (displayName: string) => void;
   isEditingMode?: boolean;
   mainAgentModel?: string;
   mainAgentMaxStep?: number;
@@ -55,8 +53,6 @@ export default function AgentConfigurationSection({
   agentDescription = '',
   onAgentNameChange,
   onAgentDescriptionChange,
-  agentDisplayName = '',
-  onAgentDisplayNameChange,
   isEditingMode = false,
   mainAgentModel = '',
   mainAgentMaxStep = 5,
@@ -188,21 +184,6 @@ export default function AgentConfigurationSection({
   // Render individual content sections
   const renderAgentInfo = () => (
     <div className="p-4 agent-info-content">
-      {/* Agent Display Name */}
-      <div className="mb-2">
-        <label className="block text-sm font-medium text-gray-700 mb-1">
-          {t('agent.displayName')}:
-        </label>
-        <input
-          type="text"
-          value={agentDisplayName}
-          onChange={(e) => onAgentDisplayNameChange?.(e.target.value)}
-          placeholder={t('agent.displayNamePlaceholder')}
-          className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 box-border"
-          disabled={!isEditingMode}
-        />
-      </div>
-      
       {/* Agent Name */}
       <div className="mb-2">
         <label className="block text-sm font-medium text-gray-700 mb-1">
@@ -566,6 +547,26 @@ export default function AgentConfigurationSection({
             margin-top: 8px;
             font-size: 14px;
             color: #666;
+          }
+
+          /* Fix Ant Design button hover border color issues - ensure consistent color scheme */
+          .responsive-button.ant-btn:hover {
+            border-color: inherit !important;
+          }
+          
+          /* Blue button: hover background blue-600, border should also be blue-600 */
+          .bg-blue-500.hover\\:bg-blue-600.border-blue-500.hover\\:border-blue-600.ant-btn:hover {
+            border-color: #2563eb !important; /* blue-600 */
+          }
+          
+          /* Green button: hover background green-600, border should also be green-600 */
+          .bg-green-500.hover\\:bg-green-600.border-green-500.hover\\:border-green-600.ant-btn:hover {
+            border-color: #16a34a !important; /* green-600 */
+          }
+          
+          /* Red button: hover background red-600, border should also be red-600 */
+          .bg-red-500.hover\\:bg-red-600.border-red-500.hover\\:border-red-600.ant-btn:hover {
+            border-color: #dc2626 !important; /* red-600 */
           }
         `}</style>
         


### PR DESCRIPTION
[[](url)](https://github.com/ModelEngine-Group/nexent/issues/936)
以下是修改后鼠标悬浮时的状态。
原代码受ant design格式的影响，由于代码中固定了悬浮色，但边框色沿用了原按钮的颜色。
针对现有样式部分添加必要的CSS规则
删除了修改后原格式中沿用的无关变量agentDisplayName，onAgentDisplayNameChange(未在其他出引用)
<img width="234" height="67" alt="image" src="https://github.com/user-attachments/assets/72228666-b927-4550-827b-31b7589fc30d" />
<img width="106" height="47" alt="image" src="https://github.com/user-attachments/assets/45cb3775-3170-43b9-9069-3a9eb0fbc673" />
<img width="114" height="53" alt="image" src="https://github.com/user-attachments/assets/bbffd370-b354-4251-974f-1c1c840f655b" />
