### PR TITLE
[Bug] Agent页面按钮鼠标悬浮时会有不合适的边框颜色 #936

### DIFF
--- a/frontend/app/[locale]/setup/agentSetup/components/AgentConfigurationSection.tsx
+++ b/frontend/app/[locale]/setup/agentSetup/components/AgentConfigurationSection.tsx
@@ -611,7 +611,7 @@ export default function AgentConfigurationSection({
               size="middle"
               icon={<BugOutlined />}
               onClick={onDebug}
-              className="bg-blue-500 hover:bg-blue-600 border-blue-500 hover:border-blue-600 responsive-button"
+              className="bg-blue-500 hover:bg-blue-600 responsive-button"
               title={t('systemPrompt.button.debug')}
             >
               {t('systemPrompt.button.debug')}
@@ -625,7 +625,7 @@ export default function AgentConfigurationSection({
                   size="middle"
                   icon={<UploadOutlined />}
                   onClick={onExportAgent}
-                  className="bg-green-500 hover:bg-green-600 border-green-500 hover:border-green-600 responsive-button"
+                  className="bg-green-500 hover:bg-green-600 responsive-button"
                   title={t('agent.contextMenu.export')}
                 >
                   {t('agent.contextMenu.export')}
@@ -636,7 +636,7 @@ export default function AgentConfigurationSection({
                   size="middle"
                   icon={<DeleteOutlined />}
                   onClick={handleDeleteClick}
-                  className="bg-red-500 hover:bg-red-600 border-red-500 hover:border-red-600 responsive-button"
+                  className="bg-red-500 hover:bg-red-600 responsive-button"
                   title={t('agent.contextMenu.delete')}
                 >
                   {t('agent.contextMenu.delete')}
@@ -652,7 +652,7 @@ export default function AgentConfigurationSection({
                 icon={<SaveOutlined />}
                 onClick={onSaveAgent}
                 disabled={!canActuallySave}
-                className="bg-green-500 hover:bg-green-600 border-green-500 hover:border-green-600 disabled:opacity-50 disabled:cursor-not-allowed responsive-button"
+                className="bg-green-500 hover:bg-green-600 disabled:opacity-50 disabled:cursor-not-allowed responsive-button"
                 title={(() => {
                   if (agentNameError) {
                     return agentNameError;
@@ -673,7 +673,7 @@ export default function AgentConfigurationSection({
                 icon={<SaveOutlined />}
                 onClick={onSaveAgent}
                 disabled={!canActuallySave}
-                className="bg-green-500 hover:bg-green-600 border-green-500 hover:border-green-600 disabled:opacity-50 disabled:cursor-not-allowed responsive-button"
+                className="bg-green-500 hover:bg-green-600 disabled:opacity-50 disabled:cursor-not-allowed responsive-button"
                 title={(() => {
                   if (agentNameError) {
                     return agentNameError;


### PR DESCRIPTION
按钮使用了 type="primary"，这是Ant Design的按钮类型
在className中显式设置了 hover:border-* 样式
这些hover边框样式与Ant Design的默认样式冲突，导致显示不合适的边框颜色

移除了所有按钮className中的 border-* 和 hover:border-* 样式，保留了必要的背景色和悬浮背景色变化。
我只移除了有问题的边框样式。
<img width="267" height="73" alt="image" src="https://github.com/user-attachments/assets/28665294-dc9f-43bf-a320-0e876a778241" />
<img width="105" height="48" alt="image" src="https://github.com/user-attachments/assets/c46eb6c3-522b-487b-b07b-3c579d528ec6" />
<img width="110" height="50" alt="image" src="https://github.com/user-attachments/assets/9432eb07-e1d1-4e29-8a17-1b01f1191623" />
