### PR TITLE
🐛Missing tag styles in model config page (EN mode)

### DIFF
--- a/frontend/app/[locale]/setup/modelSetup/model/ModelListCard.tsx
+++ b/frontend/app/[locale]/setup/modelSetup/model/ModelListCard.tsx
@@ -80,7 +80,7 @@ const getSourceTagStyle = (source: string): React.CSSProperties => {
       backgroundColor: '#e6f7ff',
       borderColor: '#91d5ff',
     };
-  } else if (source === "自定义") {
+  } else if (source === "自定义" || source === "Custom") {
     return {
       ...baseStyle,
       color: '#722ed1',


### PR DESCRIPTION
[Bug] 英文模式下模型配置页面Tag样式丢失
 #923 

<img width="671" height="199" alt="image" src="https://github.com/user-attachments/assets/dc8fcbc7-fd02-4df2-ac1f-524a3ab44d96" />
