### PR TITLE
✨Frontend citation ground color coordinate with search tools

### DIFF
--- a/sdk/nexent/core/tools/create_directory_tool.py
+++ b/sdk/nexent/core/tools/create_directory_tool.py
@@ -6,6 +6,7 @@ from pydantic import Field
 from smolagents.tools import Tool
 
 from ..utils.observer import MessageObserver, ProcessType
+from ..utils.tools_common_message import ToolSign
 
 logger = logging.getLogger("create_directory_tool")
 
@@ -25,7 +26,7 @@ class CreateDirectoryTool(Tool):
     }
     output_type = "string"
 
-    tool_sign = "f"  # File operation tool identifier
+    tool_sign = ToolSign.FILE_OPERATION.value  # File operation tool identifier
 
     def __init__(self, 
                  init_path: str = Field(description="Initial workspace path", default="/mnt/nexent"),

--- a/sdk/nexent/core/tools/create_file_tool.py
+++ b/sdk/nexent/core/tools/create_file_tool.py
@@ -6,6 +6,7 @@ from pydantic import Field
 from smolagents.tools import Tool
 
 from ..utils.observer import MessageObserver, ProcessType
+from ..utils.tools_common_message import ToolSign
 
 logger = logging.getLogger("create_file_tool")
 
@@ -27,7 +28,7 @@ class CreateFileTool(Tool):
     }
     output_type = "string"
 
-    tool_sign = "f"  # File operation tool identifier
+    tool_sign = ToolSign.FILE_OPERATION.value  # File operation tool identifier
 
     def __init__(self, 
                  init_path: str = Field(description="Initial workspace path", default="/mnt/nexent"),

--- a/sdk/nexent/core/tools/delete_directory_tool.py
+++ b/sdk/nexent/core/tools/delete_directory_tool.py
@@ -7,6 +7,7 @@ from pydantic import Field
 from smolagents.tools import Tool
 
 from ..utils.observer import MessageObserver, ProcessType
+from ..utils.tools_common_message import ToolSign
 
 logger = logging.getLogger("delete_directory_tool")
 
@@ -25,7 +26,7 @@ class DeleteDirectoryTool(Tool):
     }
     output_type = "string"
 
-    tool_sign = "f"  # File operation tool identifier
+    tool_sign = ToolSign.FILE_OPERATION.value  # File operation tool identifier
 
     def __init__(self, 
                  init_path: str = Field(description="Initial workspace path", default="/mnt/nexent"),

--- a/sdk/nexent/core/tools/delete_file_tool.py
+++ b/sdk/nexent/core/tools/delete_file_tool.py
@@ -6,6 +6,7 @@ from pydantic import Field
 from smolagents.tools import Tool
 
 from ..utils.observer import MessageObserver, ProcessType
+from ..utils.tools_common_message import ToolSign
 
 logger = logging.getLogger("delete_file_tool")
 
@@ -24,7 +25,7 @@ class DeleteFileTool(Tool):
     }
     output_type = "string"
 
-    tool_sign = "f"  # File operation tool identifier
+    tool_sign = ToolSign.FILE_OPERATION.value  # File operation tool identifier
 
     def __init__(self, 
                  init_path: str = Field(description="Initial workspace path", default="/mnt/nexent"),

--- a/sdk/nexent/core/tools/exa_search_tool.py
+++ b/sdk/nexent/core/tools/exa_search_tool.py
@@ -8,7 +8,7 @@ from smolagents.tools import Tool
 from pydantic import Field
 
 from ..utils.observer import MessageObserver, ProcessType
-from ..utils.tools_common_message import SearchResultTextMessage
+from ..utils.tools_common_message import SearchResultTextMessage, ToolSign
 
 # Get logger instance
 logger = logging.getLogger("exa_search_tool")
@@ -22,7 +22,7 @@ class ExaSearchTool(Tool):
 
     inputs = {"query": {"type": "string", "description": "The search query to perform."}}
     output_type = "string"
-    tool_sign = "b"  # Used to distinguish different index sources in summary
+    tool_sign = ToolSign.EXA_SEARCH.value  # Used to distinguish different index sources in summary
 
     def __init__(self, exa_api_key:str=Field(description="EXA API key"),
                  observer: MessageObserver=Field(description="Message observer", default=None, exclude=True),

--- a/sdk/nexent/core/tools/knowledge_base_search_tool.py
+++ b/sdk/nexent/core/tools/knowledge_base_search_tool.py
@@ -6,7 +6,7 @@ import requests
 from smolagents.tools import Tool
 
 from ..utils.observer import MessageObserver, ProcessType
-from ..utils.tools_common_message import SearchResultTextMessage
+from ..utils.tools_common_message import SearchResultTextMessage, ToolSign
 from pydantic import Field
 from ...vector_database.elasticsearch_core import ElasticSearchCore
 from ..models.embedding_model import BaseEmbedding
@@ -29,7 +29,7 @@ class KnowledgeBaseSearchTool(Tool):
               "index_names": {"type": "array", "description": "The list of knowledge base index names to search. If not provided, will search all available knowledge bases.", "nullable": True}}
     output_type = "string"
 
-    tool_sign = "a"  # Used to distinguish different index sources for summaries
+    tool_sign = ToolSign.KNOWLEDGE_BASE.value  # Used to distinguish different index sources for summaries
 
     def __init__(self, top_k: int = Field(description="Maximum number of search results", default=5),
                        index_names: List[str] = Field(description="The list of index names to search", default=None, exclude=True) ,

--- a/sdk/nexent/core/tools/linkup_search_tool.py
+++ b/sdk/nexent/core/tools/linkup_search_tool.py
@@ -7,7 +7,7 @@ from smolagents.tools import Tool
 from pydantic import Field
 
 from ..utils.observer import MessageObserver, ProcessType
-from ..utils.tools_common_message import SearchResultTextMessage
+from ..utils.tools_common_message import SearchResultTextMessage, ToolSign
 
 logger = logging.getLogger("linkup_search_tool")
 
@@ -20,7 +20,7 @@ class LinkupSearchTool(Tool):
     )
     inputs = {"query": {"type": "string", "description": "The search query to perform."}}
     output_type = "string"
-    tool_sign = "c"  # Used to distinguish different index sources in summary
+    tool_sign = ToolSign.LINKUP_SEARCH.value  # Used to distinguish different index sources in summary
 
     def __init__(
         self,

--- a/sdk/nexent/core/tools/linkup_search_tool.py
+++ b/sdk/nexent/core/tools/linkup_search_tool.py
@@ -20,7 +20,7 @@ class LinkupSearchTool(Tool):
     )
     inputs = {"query": {"type": "string", "description": "The search query to perform."}}
     output_type = "string"
-    tool_sign = "l"  # Used to distinguish different index sources in summary
+    tool_sign = "c"  # Used to distinguish different index sources in summary
 
     def __init__(
         self,

--- a/sdk/nexent/core/tools/list_directory_tool.py
+++ b/sdk/nexent/core/tools/list_directory_tool.py
@@ -6,6 +6,7 @@ from pydantic import Field
 from smolagents.tools import Tool
 
 from ..utils.observer import MessageObserver, ProcessType
+from ..utils.tools_common_message import ToolSign
 
 logger = logging.getLogger("list_directory_tool")
 
@@ -26,7 +27,7 @@ class ListDirectoryTool(Tool):
     }
     output_type = "string"
 
-    tool_sign = "f"  # File operation tool identifier
+    tool_sign = ToolSign.FILE_OPERATION.value  # File operation tool identifier
 
     def __init__(self, 
                  init_path: str = Field(description="Initial workspace path", default="/mnt/nexent"),

--- a/sdk/nexent/core/tools/move_item_tool.py
+++ b/sdk/nexent/core/tools/move_item_tool.py
@@ -7,6 +7,7 @@ from pydantic import Field
 from smolagents.tools import Tool
 
 from ..utils.observer import MessageObserver, ProcessType
+from ..utils.tools_common_message import ToolSign
 
 logger = logging.getLogger("move_item_tool")
 
@@ -26,7 +27,7 @@ class MoveItemTool(Tool):
     }
     output_type = "string"
 
-    tool_sign = "f"  # File operation tool identifier
+    tool_sign = ToolSign.FILE_OPERATION.value  # File operation tool identifier
 
     def __init__(self, 
                  init_path: str = Field(description="Initial workspace path", default="/mnt/nexent"),

--- a/sdk/nexent/core/tools/read_file_tool.py
+++ b/sdk/nexent/core/tools/read_file_tool.py
@@ -6,6 +6,7 @@ from pydantic import Field
 from smolagents.tools import Tool
 
 from ..utils.observer import MessageObserver, ProcessType
+from ..utils.tools_common_message import ToolSign
 
 logger = logging.getLogger("read_file_tool")
 
@@ -25,7 +26,7 @@ class ReadFileTool(Tool):
     }
     output_type = "string"
 
-    tool_sign = "f"  # File operation tool identifier
+    tool_sign = ToolSign.FILE_OPERATION.value  # File operation tool identifier
 
     def __init__(self, 
                  init_path: str = Field(description="Initial workspace path", default="/mnt/nexent"),

--- a/sdk/nexent/core/tools/tavily_search_tool.py
+++ b/sdk/nexent/core/tools/tavily_search_tool.py
@@ -22,7 +22,7 @@ class TavilySearchTool(Tool):
 
     inputs = {"query": {"type": "string", "description": "The search query to perform."}}
     output_type = "string"
-    tool_sign = "b"  # Used to distinguish different index sources in summary
+    tool_sign = "d"  # Used to distinguish different index sources in summary
 
     def __init__(self, tavily_api_key:str=Field(description="Tavily API key"),
                  observer: MessageObserver=Field(description="Message observer", default=None, exclude=True),

--- a/sdk/nexent/core/tools/tavily_search_tool.py
+++ b/sdk/nexent/core/tools/tavily_search_tool.py
@@ -8,7 +8,7 @@ from smolagents.tools import Tool
 from pydantic import Field
 
 from ..utils.observer import MessageObserver, ProcessType
-from ..utils.tools_common_message import SearchResultTextMessage
+from ..utils.tools_common_message import SearchResultTextMessage, ToolSign
 
 # Get logger instance
 logger = logging.getLogger("tavily_search_tool")
@@ -22,7 +22,7 @@ class TavilySearchTool(Tool):
 
     inputs = {"query": {"type": "string", "description": "The search query to perform."}}
     output_type = "string"
-    tool_sign = "d"  # Used to distinguish different index sources in summary
+    tool_sign = ToolSign.TAVILY_SEARCH.value  # Used to distinguish different index sources in summary
 
     def __init__(self, tavily_api_key:str=Field(description="Tavily API key"),
                  observer: MessageObserver=Field(description="Message observer", default=None, exclude=True),

--- a/sdk/nexent/core/tools/terminal_tool.py
+++ b/sdk/nexent/core/tools/terminal_tool.py
@@ -9,6 +9,7 @@ from smolagents.tools import Tool
 import paramiko
 
 from ..utils.observer import MessageObserver, ProcessType
+from ..utils.tools_common_message import ToolSign
 
 logger = logging.getLogger("terminal_tool")
 
@@ -28,7 +29,7 @@ class TerminalTool(Tool):
     }
     output_type = "string"
 
-    tool_sign = "t"  # Terminal operation tool identifier
+    tool_sign = ToolSign.TERMINAL_OPERATION.value  # Terminal operation tool identifier
 
     # Class-level session storage
     _sessions: Dict[str, Dict[str, Any]] = {}

--- a/sdk/nexent/core/utils/tools_common_message.py
+++ b/sdk/nexent/core/utils/tools_common_message.py
@@ -9,6 +9,8 @@ class ToolSign(Enum):
     EXA_SEARCH = "b"  # Exa search tool identifier
     LINKUP_SEARCH = "c"       # Linkup search tool identifier
     TAVILY_SEARCH = "d"  # Tavily search tool identifier
+    FILE_OPERATION = "f"      # File operation tool identifier
+    TERMINAL_OPERATION = "t"  # Terminal operation tool identifier
 
 
 # Tool sign mapping for backward compatibility
@@ -17,6 +19,8 @@ TOOL_SIGN_MAPPING = {
     "tavily_search": ToolSign.TAVILY_SEARCH.value,
     "linkup_search": ToolSign.LINKUP_SEARCH.value,
     "exa_search": ToolSign.EXA_SEARCH.value,
+    "file_operation": ToolSign.FILE_OPERATION.value,
+    "terminal_operation": ToolSign.TERMINAL_OPERATION.value,
 }
 
 # Reverse mapping for lookup

--- a/sdk/nexent/core/utils/tools_common_message.py
+++ b/sdk/nexent/core/utils/tools_common_message.py
@@ -1,5 +1,26 @@
 from dataclasses import dataclass
 from typing import Optional, Dict, Any
+from enum import Enum
+
+
+class ToolSign(Enum):
+    """Tool identifier enum for distinguishing different search sources in summaries"""
+    KNOWLEDGE_BASE = "a"      # Knowledge base search tool identifier
+    EXA_SEARCH = "b"  # Exa search tool identifier
+    LINKUP_SEARCH = "c"       # Linkup search tool identifier
+    TAVILY_SEARCH = "d"  # Tavily search tool identifier
+
+
+# Tool sign mapping for backward compatibility
+TOOL_SIGN_MAPPING = {
+    "knowledge_base_search": ToolSign.KNOWLEDGE_BASE.value,
+    "tavily_search": ToolSign.TAVILY_SEARCH.value,
+    "linkup_search": ToolSign.LINKUP_SEARCH.value,
+    "exa_search": ToolSign.EXA_SEARCH.value,
+}
+
+# Reverse mapping for lookup
+REVERSE_TOOL_SIGN_MAPPING = {v: k for k, v in TOOL_SIGN_MAPPING.items()}
 
 
 @dataclass


### PR DESCRIPTION
Frontend citation ground color should coordinate with search tools
#828 

Linkup
<img width="817" height="679" alt="image" src="https://github.com/user-attachments/assets/da5a294e-b87b-4f8b-ae6c-1fb423037275" />

Knowledge base
<img width="748" height="330" alt="image" src="https://github.com/user-attachments/assets/3028a33a-cebd-4492-990f-bb60c0c36ff6" />

Tavily search
<img width="833" height="1045" alt="image" src="https://github.com/user-attachments/assets/a8657d1d-34a3-4838-b10b-161189d3a938" />

EXA_SEARCH
<img width="784" height="520" alt="image" src="https://github.com/user-attachments/assets/6c77da13-b586-4d84-bdce-0a030282114d" />

