### PR TITLE
🐛 Bugfix: the trial environment on the official website cannot stream out the conversation #124

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -23,6 +23,13 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        
+        # 流式响应支持
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_set_header Connection '';
+        proxy_http_version 1.1;
+        chunked_transfer_encoding off;
     }
 }
 
@@ -37,6 +44,13 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        
+        # 流式响应支持
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_set_header Connection '';
+        proxy_http_version 1.1;
+        chunked_transfer_encoding off;
     }
 }
 ```


### PR DESCRIPTION
通过修改nginx转发配置恢复流式输出
<img width="1344" height="965" alt="image" src="https://github.com/user-attachments/assets/feaa16ab-47f2-4634-8cce-3be918b08532" />
