### PR TITLE
🐛 The creation time of documents in knowledge base is not correct #896

### DIFF
--- a/backend/services/elasticsearch_service.py
+++ b/backend/services/elasticsearch_service.py
@@ -544,7 +544,7 @@ class ElasticSearchService:
                 try:
                     utc_create_timestamp = datetime.strptime(utc_create_time_str, '%Y-%m-%dT%H:%M:%S').replace(
                         tzinfo=timezone.utc).timestamp()
-                except Exception as e:
+                except (ValueError, TypeError):
                     utc_create_timestamp = time.time()
 
                 file_data = {

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -32,8 +32,6 @@ services:
       cluster.routing.allocation.disk.watermark.low: "5gb"
       cluster.routing.allocation.disk.watermark.high: "3gb"
       cluster.routing.allocation.disk.watermark.flood_stage: "2gb"
-      # Timezone setting
-      TZ: "Asia/Shanghai"
     volumes:
       - ${ROOT_DIR}/elasticsearch:/usr/share/elasticsearch/data
     networks:
@@ -57,7 +55,6 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${NEXENT_POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
-      TZ: "Asia/Shanghai"
     volumes:
       - ${ROOT_DIR}/postgresql/data:/var/lib/postgresql/data
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
@@ -173,7 +170,6 @@ services:
       <<: [*minio-vars, *proxy-vars]
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
-      TZ: "Asia/Shanghai"
     volumes:
       - ${ROOT_DIR}/minio/data:/data
     networks:
@@ -202,7 +198,6 @@ services:
     container_name: nexent-openssh-server
     hostname: nexent-openssh-server
     environment:
-      - TZ=Asia/Shanghai
       - DEV_USER=linuxserver.io
     volumes:
       - ${TERMINAL_MOUNT_DIR:-./workspace}:/opt/terminal

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -32,8 +32,6 @@ services:
       cluster.routing.allocation.disk.watermark.low: "5gb"
       cluster.routing.allocation.disk.watermark.high: "3gb"
       cluster.routing.allocation.disk.watermark.flood_stage: "2gb"
-      # Timezone setting
-      TZ: "Asia/Shanghai"
     volumes:
       - ${ROOT_DIR}/elasticsearch:/usr/share/elasticsearch/data
     ports:
@@ -60,7 +58,6 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${NEXENT_POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
-      TZ: "Asia/Shanghai"
     volumes:
       - ${ROOT_DIR}/postgresql/data:/var/lib/postgresql/data
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
@@ -188,7 +185,6 @@ services:
       <<: [*minio-vars, *proxy-vars]
       MINIO_ROOT_USER: ${MINIO_ROOT_USER}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
-      TZ: "Asia/Shanghai"
     volumes:
       - ${ROOT_DIR}/minio/data:/data
     networks:
@@ -217,7 +213,6 @@ services:
     container_name: nexent-openssh-server
     hostname: nexent-openssh-server
     environment:
-      - TZ=Asia/Shanghai
       - DEV_USER=linuxserver.io
     ports:
       - "2222:22"  # SSH port

--- a/frontend/app/[locale]/setup/knowledgeBaseSetup/document/DocumentListLayout.tsx
+++ b/frontend/app/[locale]/setup/knowledgeBaseSetup/document/DocumentListLayout.tsx
@@ -3,7 +3,7 @@ import { Document } from '@/types/knowledgeBase'
 import DocumentStatus from './DocumentStatus'
 import { InfoCircleFilled } from '@ant-design/icons'
 import UploadArea from '../components/UploadArea'
-import { formatFileSize, formatDateTime, sortByStatusAndDate } from '@/lib/utils'
+import { formatFileSize, sortByStatusAndDate } from '@/lib/utils'
 import { Input, Button } from 'antd'
 import { useKnowledgeBaseContext } from '../knowledgeBase/KnowledgeBaseContext'
 import { useDocumentContext } from './DocumentContext'
@@ -394,7 +394,7 @@ const DocumentListContainer = forwardRef<DocumentListRef, DocumentListProps>(({
                         {formatFileSize(doc.size)}
                       </td>
                       <td className={`${LAYOUT.CELL_PADDING} ${LAYOUT.TEXT_SIZE} text-gray-600`}>
-                        {formatDateTime(doc.create_time)}
+                        {new Date(doc.create_time).toLocaleString()}
                       </td>
                       <td className={LAYOUT.CELL_PADDING}>
                         <button

--- a/frontend/app/[locale]/setup/knowledgeBaseSetup/knowledgeBase/KnowledgeBaseList.tsx
+++ b/frontend/app/[locale]/setup/knowledgeBaseSetup/knowledgeBase/KnowledgeBaseList.tsx
@@ -71,7 +71,7 @@ const KnowledgeBaseList: React.FC<KnowledgeBaseListProps> = ({
   const { t } = useTranslation();
 
   // 格式化日期函数，只保留日期部分
-  const formatDate = (dateString: string) => {
+  const formatDate = (dateString: number) => {
     try {
       const date = new Date(dateString);
       return date.toISOString().split('T')[0]; // 只返回YYYY-MM-DD部分

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -54,23 +54,6 @@ export function formatFileSize(bytes: number): string {
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
 }
 
-// Format date time
-export function formatDateTime(dateString: string): string {
-  try {
-    const date = new Date(dateString);
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-    const hours = String(date.getHours()).padStart(2, '0');
-    const minutes = String(date.getMinutes()).padStart(2, '0');
-    const seconds = String(date.getSeconds()).padStart(2, '0');
-    
-    return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
-  } catch (e) {
-    return dateString;
-  }
-}
-
 // Format date
 export function formatDate(dateString: string): string {
   try {

--- a/sdk/nexent/vector_database/elasticsearch_core.py
+++ b/sdk/nexent/vector_database/elasticsearch_core.py
@@ -477,8 +477,8 @@ class ElasticSearchCore:
 
     def _preprocess_documents(self, documents: List[Dict[str, Any]], content_field: str) -> List[Dict[str, Any]]:
         """Ensure all documents have the required fields and set default values"""
-        current_time = time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime())
-        current_date = time.strftime('%Y-%m-%d', time.localtime())
+        current_time = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime())
+        current_date = time.strftime('%Y-%m-%d', time.gmtime())
 
         processed_docs = []
         for doc in documents:
@@ -491,11 +491,6 @@ class ElasticSearchCore:
 
             if not doc_copy.get("date"):
                 doc_copy["date"] = current_date
-
-            # Convert create_time to ISO string if it's a number
-            if isinstance(doc_copy.get("create_time"), (int, float)):
-                import datetime
-                doc_copy["create_time"] = datetime.datetime.fromtimestamp(doc_copy["create_time"]).isoformat()
 
             # Ensure file_size is present (default to 0 if not provided)
             if not doc_copy.get("file_size"):
@@ -862,8 +857,8 @@ class ElasticSearchCore:
                         "process_source": process_source,
                         "embedding_model": embedding_model,
                         "embedding_dim": embedding_dim or 1024,
-                        "creation_date": format_timestamp(creation_date),
-                        "update_date": format_timestamp(update_time)
+                        "creation_date": creation_date,
+                        "update_date": update_time
                     },
                     "search_performance": {
                         "total_search_count": index_stats["search"]["query_total"],

--- a/test/sdk/vector_database/test_elasticsearch_core.py
+++ b/test/sdk/vector_database/test_elasticsearch_core.py
@@ -1,0 +1,289 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import time
+from typing import List, Dict, Any
+
+# Import the class under test
+from sdk.nexent.vector_database.elasticsearch_core import ElasticSearchCore
+
+
+# ----------------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------------
+
+@pytest.fixture
+def elasticsearch_core_instance():
+    """Create an ElasticSearchCore instance for testing."""
+    return ElasticSearchCore(
+        host="http://localhost:9200",
+        api_key="test_api_key",
+        verify_certs=False,
+        ssl_show_warn=False
+    )
+
+
+@pytest.fixture
+def sample_documents():
+    """Sample documents for testing."""
+    return [
+        {
+            "content": "This is test content 1",
+            "title": "Test Document 1",
+            "filename": "test1.pdf",
+            "path_or_url": "/path/to/test1.pdf"
+        },
+        {
+            "content": "This is test content 2",
+            "title": "Test Document 2",
+            "filename": "test2.pdf",
+            "path_or_url": "/path/to/test2.pdf",
+            "file_size": 1024,
+            "create_time": "2025-01-15T10:30:00",
+            "date": "2025-01-15",
+            "process_source": "CustomProcessor",
+            "id": "existing_id_123"
+        }
+    ]
+
+
+# ----------------------------------------------------------------------------
+# Tests for _preprocess_documents method
+# ----------------------------------------------------------------------------
+
+def test_preprocess_documents_with_complete_document(elasticsearch_core_instance, sample_documents):
+    """Test preprocessing a document that already has all required fields."""
+    # Use the second document which has all fields
+    complete_doc = [sample_documents[1]]
+    content_field = "content"
+    
+    result = elasticsearch_core_instance._preprocess_documents(complete_doc, content_field)
+    
+    assert len(result) == 1
+    doc = result[0]
+    
+    # Should preserve existing values
+    assert doc["content"] == "This is test content 2"
+    assert doc["title"] == "Test Document 2"
+    assert doc["filename"] == "test2.pdf"
+    assert doc["path_or_url"] == "/path/to/test2.pdf"
+    assert doc["file_size"] == 1024
+    assert doc["create_time"] == "2025-01-15T10:30:00"
+    assert doc["date"] == "2025-01-15"
+    assert doc["process_source"] == "CustomProcessor"
+    assert doc["id"] == "existing_id_123"
+
+
+def test_preprocess_documents_with_incomplete_document(elasticsearch_core_instance, sample_documents):
+    """Test preprocessing a document missing required fields."""
+    # Use the first document which is missing several fields
+    incomplete_doc = [sample_documents[0]]
+    content_field = "content"
+    
+    with patch('time.strftime') as mock_strftime, \
+         patch('time.time') as mock_time, \
+         patch('time.gmtime') as mock_gmtime:
+        
+        # Mock time functions
+        mock_strftime.side_effect = lambda fmt, t: "2025-01-15T10:30:00" if "T" in fmt else "2025-01-15"
+        mock_time.return_value = 1642234567
+        mock_gmtime.return_value = None
+        
+        result = elasticsearch_core_instance._preprocess_documents(incomplete_doc, content_field)
+    
+    assert len(result) == 1
+    doc = result[0]
+    
+    # Should preserve existing values
+    assert doc["content"] == "This is test content 1"
+    assert doc["title"] == "Test Document 1"
+    assert doc["filename"] == "test1.pdf"
+    assert doc["path_or_url"] == "/path/to/test1.pdf"
+    
+    # Should add missing fields with default values
+    assert doc["create_time"] == "2025-01-15T10:30:00"
+    assert doc["date"] == "2025-01-15"
+    assert doc["file_size"] == 0
+    assert doc["process_source"] == "Unstructured"
+    
+    # Should generate an ID
+    assert "id" in doc
+    assert doc["id"].startswith("1642234567_")
+    assert len(doc["id"]) <= 20
+
+
+def test_preprocess_documents_with_multiple_documents(elasticsearch_core_instance, sample_documents):
+    """Test preprocessing multiple documents."""
+    content_field = "content"
+    
+    with patch('time.strftime') as mock_strftime, \
+         patch('time.time') as mock_time, \
+         patch('time.gmtime') as mock_gmtime:
+        
+        # Mock time functions
+        mock_strftime.side_effect = lambda fmt, t: "2025-01-15T10:30:00" if "T" in fmt else "2025-01-15"
+        mock_time.return_value = 1642234567
+        mock_gmtime.return_value = None
+        
+        result = elasticsearch_core_instance._preprocess_documents(sample_documents, content_field)
+    
+    assert len(result) == 2
+    
+    # First document should have defaults added
+    doc1 = result[0]
+    assert doc1["create_time"] == "2025-01-15T10:30:00"
+    assert doc1["date"] == "2025-01-15"
+    assert doc1["file_size"] == 0
+    assert doc1["process_source"] == "Unstructured"
+    assert "id" in doc1
+    
+    # Second document should preserve existing values
+    doc2 = result[1]
+    assert doc2["create_time"] == "2025-01-15T10:30:00"
+    assert doc2["date"] == "2025-01-15"
+    assert doc2["file_size"] == 1024
+    assert doc2["process_source"] == "CustomProcessor"
+    assert doc2["id"] == "existing_id_123"
+
+
+def test_preprocess_documents_preserves_original_data(elasticsearch_core_instance):
+    """Test that original documents are not modified."""
+    original_docs = [
+        {
+            "content": "Original content",
+            "title": "Original title"
+        }
+    ]
+    content_field = "content"
+    
+    with patch('time.strftime') as mock_strftime, \
+         patch('time.time') as mock_time, \
+         patch('time.gmtime') as mock_gmtime:
+        
+        mock_strftime.side_effect = lambda fmt, t: "2025-01-15T10:30:00" if "T" in fmt else "2025-01-15"
+        mock_time.return_value = 1642234567
+        mock_gmtime.return_value = None
+        
+        result = elasticsearch_core_instance._preprocess_documents(original_docs, content_field)
+    
+    # Original document should remain unchanged
+    assert original_docs[0] == {"content": "Original content", "title": "Original title"}
+    
+    # Result should be a new document with added fields
+    assert result[0]["content"] == "Original content"
+    assert result[0]["title"] == "Original title"
+    assert "create_time" in result[0]
+    assert "date" in result[0]
+    assert "file_size" in result[0]
+    assert "process_source" in result[0]
+    assert "id" in result[0]
+
+
+def test_preprocess_documents_with_empty_list(elasticsearch_core_instance):
+    """Test preprocessing an empty list of documents."""
+    content_field = "content"
+    
+    result = elasticsearch_core_instance._preprocess_documents([], content_field)
+    
+    assert result == []
+
+
+def test_preprocess_documents_id_generation(elasticsearch_core_instance):
+    """Test that ID generation works correctly with different content."""
+    docs = [
+        {"content": "Content 1"},
+        {"content": "Content 2"},
+        {"content": "Content 1"}  # Same content as first
+    ]
+    content_field = "content"
+    
+    with patch('time.strftime') as mock_strftime, \
+         patch('time.time') as mock_time, \
+         patch('time.gmtime') as mock_gmtime:
+        
+        mock_strftime.side_effect = lambda fmt, t: "2025-01-15T10:30:00" if "T" in fmt else "2025-01-15"
+        mock_time.return_value = 1642234567
+        mock_gmtime.return_value = None
+        
+        result = elasticsearch_core_instance._preprocess_documents(docs, content_field)
+    
+    assert len(result) == 3
+    
+    # All documents should have IDs
+    assert "id" in result[0]
+    assert "id" in result[1]
+    assert "id" in result[2]
+    
+    # IDs should be different for different content
+    assert result[0]["id"] != result[1]["id"]
+    
+    # Same content should generate same hash part (but might be different due to time)
+    id1_parts = result[0]["id"].split("_")
+    id3_parts = result[2]["id"].split("_")
+    assert len(id1_parts) == 2
+    assert len(id3_parts) == 2
+    assert id1_parts[1] == id3_parts[1]  # Hash part should be same
+
+
+def test_preprocess_documents_with_none_values(elasticsearch_core_instance):
+    """Test preprocessing documents with None values."""
+    docs = [
+        {
+            "content": "Test content",
+            "file_size": None,
+            "create_time": None,
+            "date": None,
+            "process_source": None
+        }
+    ]
+    content_field = "content"
+    
+    with patch('time.strftime') as mock_strftime, \
+         patch('time.time') as mock_time, \
+         patch('time.gmtime') as mock_gmtime:
+        
+        mock_strftime.side_effect = lambda fmt, t: "2025-01-15T10:30:00" if "T" in fmt else "2025-01-15"
+        mock_time.return_value = 1642234567
+        mock_gmtime.return_value = None
+        
+        result = elasticsearch_core_instance._preprocess_documents(docs, content_field)
+    
+    doc = result[0]
+    
+    # None values should be replaced with defaults
+    assert doc["file_size"] == 0
+    assert doc["create_time"] == "2025-01-15T10:30:00"
+    assert doc["date"] == "2025-01-15"
+    assert doc["process_source"] == "Unstructured"
+    assert "id" in doc
+
+
+def test_preprocess_documents_with_zero_values(elasticsearch_core_instance):
+    """Test that zero values are preserved and not replaced."""
+    docs = [
+        {
+            "content": "Test content",
+            "file_size": 0,
+            "create_time": "2025-01-15T10:30:00",
+            "date": "2025-01-15",
+            "process_source": "CustomProcessor"
+        }
+    ]
+    content_field = "content"
+    
+    with patch('time.strftime') as mock_strftime, \
+         patch('time.time') as mock_time, \
+         patch('time.gmtime') as mock_gmtime:
+        
+        mock_strftime.side_effect = lambda fmt, t: "2025-01-15T10:30:00" if "T" in fmt else "2025-01-15"
+        mock_time.return_value = 1642234567
+        mock_gmtime.return_value = None
+        
+        result = elasticsearch_core_instance._preprocess_documents(docs, content_field)
+    
+    doc = result[0]
+    
+    # Zero values should be preserved
+    assert doc["file_size"] == 0
+    assert doc["create_time"] == "2025-01-15T10:30:00"
+    assert doc["date"] == "2025-01-15"
+    assert doc["process_source"] == "CustomProcessor"


### PR DESCRIPTION
#896 🐛 The creation time of documents in knowledge base is not correct.
一、修改方法：
1、PG数据库、es库存储时都默认存储UTC时区时间；
2、返回给前端时统一返回无时区时间戳，前端统一使用new Date(number)方法根据当前所在时区，将时间戳转换为对应时间展示。

二、验证结果：
知识库页面：
<img width="2186" height="1009" alt="image" src="https://github.com/user-attachments/assets/dc435c5a-25f1-4dcf-b638-20154f8b1766" />

<img width="1190" height="313" alt="image" src="https://github.com/user-attachments/assets/7f43e150-e66a-4331-bc22-0dcb0a5e28fc" />

问答页面：
<img width="1576" height="885" alt="image" src="https://github.com/user-attachments/assets/80f4403c-cfc4-4208-a94d-112b5d00e578" />


