### PR TITLE
🐛Agent name not updated in memory config after rename

### DIFF
--- a/frontend/services/memoryService.ts
+++ b/frontend/services/memoryService.ts
@@ -229,7 +229,7 @@ export async function fetchAgentSharedGroups(): Promise<MemoryGroup[]> {
   })
 
   // 后续需要补全“无记忆”的 Agent 分组
-  const agentList: Array<{ agent_id: string; name?: string }> = (agentsRes as any)?.success ? (agentsRes as any).data : []
+  const agentList: Array<{ agent_id: string; name?: string; display_name?: string }> = (agentsRes as any)?.success ? (agentsRes as any).data : []
 
   const groups: MemoryGroup[] = []
 
@@ -238,7 +238,7 @@ export async function fetchAgentSharedGroups(): Promise<MemoryGroup[]> {
     const agentId = agent.agent_id
     const list = groupMap[agentId] || []
     groups.push({
-      title: i18next.t('memoryService.agentSharedGroupTitle', { agentName: agent.name || agentId }),
+      title: i18next.t('memoryService.agentSharedGroupTitle', { agentName: agent.display_name || agent.name || agentId }),
       key: `agent-${agentId}`,
       items: list,
     })
@@ -283,7 +283,7 @@ export async function fetchUserAgentGroups(): Promise<MemoryGroup[]> {
     groupMap[item.agent_id].push(item)
   })
 
-  const agentList: Array<{ agent_id: string | number; name?: string }> = (agentsRes as any)?.success ? (agentsRes as any).data : []
+  const agentList: Array<{ agent_id: string | number; name?: string; display_name?: string }> = (agentsRes as any)?.success ? (agentsRes as any).data : []
 
   const groups: MemoryGroup[] = []
 
@@ -291,7 +291,7 @@ export async function fetchUserAgentGroups(): Promise<MemoryGroup[]> {
     const agentId = String(agent.agent_id)
     const list = groupMap[agentId] || []
     groups.push({
-      title: i18next.t('memoryService.userAgentGroupTitle', { agentName: agent.name || agentId }),
+      title: i18next.t('memoryService.userAgentGroupTitle', { agentName: agent.display_name || agent.name || agentId }),
       key: `user-agent-${agentId}`,
       items: list,
     })


### PR DESCRIPTION
#876 
#955 中的第五点

memory中展示的agent名称是agent变量名中设置的名称，为避免误解及提升用户体验，将其改为用户设置的agent name



<img width="393" height="301" alt="image" src="https://github.com/user-attachments/assets/ba83a3dc-c998-4d78-bfb6-da912bfd151e" />


zh环境
<img width="752" height="233" alt="image" src="https://github.com/user-attachments/assets/3d445731-4549-4655-9394-cfea8701536e" />



en环境
<img width="760" height="244" alt="image" src="https://github.com/user-attachments/assets/462a9a1b-879b-4001-851b-3c66e1846e98" />



