### PR TITLE
🐛 Keep the likes and dislikes after switching conversations #806

### DIFF
--- a/frontend/app/[locale]/chat/internal/chatInterface.tsx
+++ b/frontend/app/[locale]/chat/internal/chatInterface.tsx
@@ -1262,6 +1262,20 @@ export function ChatInterface() {
       await conversationService.updateOpinion({ message_id: messageId, opinion });
       setSessionMessages((prev) => {
         const newMessages = { ...prev };
+        // Update the opinion_flag for the specific message in all conversations
+        Object.keys(newMessages).forEach(conversationId => {
+          const messages = newMessages[parseInt(conversationId)];
+          if (messages) {
+            const messageIndex = messages.findIndex(msg => msg.message_id === messageId);
+            if (messageIndex !== -1) {
+              newMessages[parseInt(conversationId)] = [...messages];
+              newMessages[parseInt(conversationId)][messageIndex] = {
+                ...newMessages[parseInt(conversationId)][messageIndex],
+                opinion_flag: opinion || undefined
+              };
+            }
+          }
+        });
         return newMessages;
       });
     } catch (error) {


### PR DESCRIPTION
问题背景：
原来的代码在用户点击点赞/点踩后，虽然会调用 API 更新数据库，但本地状态没有正确更新，导致切换对话再切回来时，UI 显示的是旧的状态。
修复逻辑：
当用户点击点赞/点踩后，本地状态没有正确更新，导致切换对话再切回来时，UI 显示的是旧的状态。现在当用户点击点赞/点踩时，不仅会更新数据库，还会正确更新本地状态中的 opinion_flag 字段。
验证截图：
点击两个踩后切换对话再切回当前对话，点踩效果显示正常
<img width="1252" height="911" alt="image" src="https://github.com/user-attachments/assets/31c47d01-5c8a-4052-84f5-c41f5f12537a" />
