### PR TITLE
🐛 When a non-root user redeploys, an error is reported and folder permissions cannot be set. #1023

### DIFF
--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -499,14 +499,9 @@ create_dir_with_permission() {
   fi
 
   # Set directory permissions
-  chmod -R "$permission" "$dir_path"
-  if [ $? -ne 0 ]; then
-      echo "   ❌ ERROR Failed to set permissions $permission for directory $dir_path." >&2
-      ERROR_OCCURRED=1
-      return 1
+  if chmod -R "$permission" "$dir_path" 2>/dev/null; then
+      echo "   📁 Directory $dir_path has been created and permissions set to $permission."
   fi
-
-  echo "   📁 Directory $dir_path has been created and permissions set to $permission."
 }
 
 prepare_directory_and_data() {


### PR DESCRIPTION
#1023 🐛 When a non-root user redeploys, an error is reported and folder permissions cannot be set. 
修改原因：非root用户非首次部署时终端提示权限修改报错，会干扰用户定位排查。

before:
<img width="482" height="290" alt="image" src="https://github.com/user-attachments/assets/a8f35370-afa2-4c57-bc1a-defefc7f1ba0" />

after:
<img width="782" height="687" alt="image" src="https://github.com/user-attachments/assets/a69a4877-f75f-4d7d-9b61-d3106d3a38cd" />
