### PR TITLE
🐛 use translate key when embedding model mismatched

### DIFF
--- a/frontend/app/[locale]/setup/knowledgeSetup/config.tsx
+++ b/frontend/app/[locale]/setup/knowledgeSetup/config.tsx
@@ -679,7 +679,10 @@ const getAuthHeaders = () => {
                 knowledgeBaseModel={kbState.activeKnowledgeBase.embeddingModel}
                 embeddingModelInfo={
                   !isKnowledgeBaseSelectable(kbState.activeKnowledgeBase) ?
-                  `当前模型${kbState.currentEmbeddingModel || ''}与知识库模型${kbState.activeKnowledgeBase.embeddingModel}不匹配，无法使用` :
+                  t('document.modelMismatch.withModels', {
+                    currentModel: kbState.currentEmbeddingModel || '',
+                    knowledgeBaseModel: kbState.activeKnowledgeBase.embeddingModel
+                  }) :
                   undefined
                 }
                 containerHeight={SETUP_PAGE_CONTAINER.MAIN_CONTENT_HEIGHT}


### PR DESCRIPTION
#1051
<img width="2503" height="704" alt="image" src="https://github.com/user-attachments/assets/23d8693b-dad9-4fd7-8266-f5d3331e9075" />
