### PR TITLE
🐛 mismatch the pattern of ````\n{{content}}\n```

### DIFF
--- a/sdk/nexent/core/agents/core_agent.py
+++ b/sdk/nexent/core/agents/core_agent.py
@@ -1,6 +1,8 @@
 import re
+import ast
 import time
 import threading
+from textwrap import dedent
 from typing import Any, Optional, List, Dict
 from collections.abc import Generator
 
@@ -12,7 +14,7 @@ from smolagents.local_python_executor import fix_final_answer_code
 from smolagents.memory import ActionStep, PlanningStep, FinalAnswerStep, ToolCall, TaskStep, SystemPromptStep
 from smolagents.models import ChatMessage
 from smolagents.monitoring import LogLevel
-from smolagents.utils import AgentExecutionError, AgentGenerationError, AgentParsingError, parse_code_blobs, \
+from smolagents.utils import AgentExecutionError, AgentGenerationError, AgentParsingError, \
     truncate_content
 
 from ..utils.observer import MessageObserver, ProcessType
@@ -22,6 +24,62 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import PIL.Image
 
+
+def parse_code_blobs(text: str) -> str:
+    """Extract code blocs from the LLM's output.
+
+    If a valid code block is passed, it returns it directly.
+
+    Args:
+        text (`str`): LLM's output text to parse.
+
+    Returns:
+        `str`: Extracted code block.
+
+    Raises:
+        ValueError: If no valid code block is found in the text.
+    """
+    pattern = r"```(?:py|python)\s*\n(.*?)\n```"
+    matches = re.findall(pattern, text, re.DOTALL)
+    if matches:
+        return "\n\n".join(match.strip() for match in matches)
+    # Maybe the LLM outputted a code blob directly
+    try:
+        ast.parse(text)
+        return text
+    except SyntaxError:
+        pass
+
+    if "final" in text and "answer" in text:
+        raise ValueError(
+            dedent(
+                f"""
+                Your code snippet is invalid, because the regex pattern {pattern} was not found in it.
+                Here is your code snippet:
+                {text}
+                It seems like you're trying to return the final answer, you can do it as follows:
+                Code:
+                ```py
+                final_answer("YOUR FINAL ANSWER HERE")
+                ```<end_code>
+                """
+            ).strip()
+        )
+    raise ValueError(
+        dedent(
+            f"""
+            Your code snippet is invalid, because the regex pattern {pattern} was not found in it.
+            Here is your code snippet:
+            {text}
+            Make sure to include code with the correct pattern, for instance:
+            Thoughts: Your thoughts
+            Code:
+            ```py
+            # Your python code here
+            ```<end_code>
+            """
+        ).strip()
+    )
 
 def convert_code_format(text):
     """


### PR DESCRIPTION
#1088
Updated the regex pattern to require explicit Python language identifiers in Markdown code blocks.

Changes:

Removed the last sign ? from (?:py|python)?

Language identifier (py or python) is now mandatory

Before: Matched code blocks with Python identifiers OR no language specified
After: Only matches code blocks explicitly marked as py or python

Matches:

````python\ncontent\n```

````py\ncontent\n```

No longer matches:

````\n{{content}}\n``` (no language identifier)

````javascript\ncontent\n``` (other languages)

<img width="1085" height="736" alt="image" src="https://github.com/user-attachments/assets/cbc8eef6-d1d5-4fbc-a8f9-8263307df1cb" />
