### PR TITLE
🐛 fix When deploying, the mirror sources of db, kong, and auth in mainland China are not configured.

### DIFF
--- a/docker/.env.general
+++ b/docker/.env.general
@@ -7,3 +7,7 @@ POSTGRESQL_IMAGE=postgres:15-alpine
 REDIS_IMAGE=redis:alpine
 MINIO_IMAGE=quay.io/minio/minio:RELEASE.2023-12-20T01-00-02Z
 OPENSSH_SERVER_IMAGE=nexent/nexent-ubuntu-terminal:latest
+
+SUPABASE_KONG=kong:2.8.1
+SUPABASE_GOTRUE=supabase/gotrue:v2.170.0
+SUPABASE_DB=supabase/postgres:15.8.1.060

--- a/docker/.env.mainland
+++ b/docker/.env.mainland
@@ -7,3 +7,7 @@ POSTGRESQL_IMAGE=docker.m.daocloud.io/postgres:15-alpine
 REDIS_IMAGE=docker.m.daocloud.io/redis:alpine
 MINIO_IMAGE=quay.m.daocloud.io/minio/minio:RELEASE.2023-12-20T01-00-02Z
 OPENSSH_SERVER_IMAGE=ccr.ccs.tencentyun.com/nexent-hub/nexent-ubuntu-terminal:latest
+
+SUPABASE_KONG=swr.cn-north-4.myhuaweicloud.com/ddn-k8s/docker.io/kong:2.8.1
+SUPABASE_GOTRUE=swr.cn-north-4.myhuaweicloud.com/ddn-k8s/docker.io/supabase/gotrue:v2.170.0
+SUPABASE_DB=swr.cn-north-4.myhuaweicloud.com/ddn-k8s/docker.io/supabase/postgres:15.8.1.060

--- a/docker/docker-compose-supabase.prod.yml
+++ b/docker/docker-compose-supabase.prod.yml
@@ -1,7 +1,7 @@
 services:
   kong:
     container_name: supabase-kong-mini
-    image: kong:2.8.1
+    image: ${SUPABASE_KONG}
     restart: unless-stopped
     volumes:
       - $ROOT_DIR/volumes/api/kong.yml:/home/kong/temp.yml
@@ -35,7 +35,7 @@ services:
 
   auth:
     container_name: supabase-auth-mini
-    image: supabase/gotrue:v2.170.0
+    image: ${SUPABASE_GOTRUE}
     restart: unless-stopped
     healthcheck:
       test:
@@ -87,7 +87,7 @@ services:
 
   db:
     container_name: supabase-db-mini
-    image: supabase/postgres:15.8.1.060
+    image: ${SUPABASE_DB}
     restart: unless-stopped
     volumes:
       - $ROOT_DIR/volumes/db/realtime.sql:/docker-entrypoint-initdb.d/migrations/99-realtime.sql

--- a/docker/docker-compose-supabase.yml
+++ b/docker/docker-compose-supabase.yml
@@ -1,7 +1,7 @@
 services:
   kong:
     container_name: supabase-kong-mini
-    image: kong:2.8.1
+    image: ${SUPABASE_KONG}
     restart: unless-stopped
     ports:
       - "8000:8000/tcp"
@@ -38,7 +38,7 @@ services:
 
   auth:
     container_name: supabase-auth-mini
-    image: supabase/gotrue:v2.170.0
+    image: ${SUPABASE_GOTRUE}
     restart: unless-stopped
     healthcheck:
       test:
@@ -89,7 +89,7 @@ services:
 
   db:
     container_name: supabase-db-mini
-    image: supabase/postgres:15.8.1.060
+    image: ${SUPABASE_DB}
     restart: unless-stopped
     # 暴露数据库端口，以便直连管理
     ports:


### PR DESCRIPTION
🐛 fix When deploying, the mirror sources of db, kong, and auth in mainland China are not configured.