### PR TITLE
🔨 Rewrite voice APPID/TOKEN when deploying in service

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -89,6 +89,10 @@ jobs:
         run: |
           cd $HOME/nexent/docker
           cp .env.example .env
+          
+          sed -i "s/APPID=.*/APPID=${{ secrets.VOICE_APPID }}/" .env
+          sed -i "s/TOKEN=.*/TOKEN=${{ secrets.VOICE_TOKEN }}/" .env
+          
           if [ "$DEPLOYMENT_MODE" = "production" ]; then
             ./deploy.sh --mode 3 --is-mainland N --enable-terminal N --version 2 --root-dir "$HOME/nexent-production-data"
           else


### PR DESCRIPTION
#1135
体验环境上由于APPID和TOKEN未正确配置导致语音服务不可用，在部署流水线执行时添加对应配置信息