### PR TITLE
✨ The terminal tool supports password login #1052

### DIFF
--- a/backend/database/tool_db.py
+++ b/backend/database/tool_db.py
@@ -164,7 +164,9 @@ def add_tool_field(tool_info):
         # add tool params
         tool_params = tool.params
         for ele in tool_params:
-            ele["default"] = tool_info["params"][ele["name"]]
+            param_name = ele["name"]
+            param_value = tool_info["params"].get(param_name)
+            ele["default"] = param_value
 
         tool_dict = as_dict(tool)
         tool_dict["params"] = tool_params

--- a/backend/database/tool_db.py
+++ b/backend/database/tool_db.py
@@ -165,8 +165,7 @@ def add_tool_field(tool_info):
         tool_params = tool.params
         for ele in tool_params:
             param_name = ele["name"]
-            param_value = tool_info["params"].get(param_name)
-            ele["default"] = param_value
+            ele["default"] = tool_info["params"].get(param_name)
 
         tool_dict = as_dict(tool)
         tool_dict["params"] = tool_params

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -200,10 +200,10 @@ services:
     container_name: nexent-openssh-server
     hostname: nexent-openssh-server
     environment:
-      - DEV_USER=linuxserver.io
+      - DEV_USER=${SSH_USERNAME:-linuxserver.io}
+      - DEV_PASSWORD=${SSH_PASSWORD:-nexent123}
     volumes:
       - ${TERMINAL_MOUNT_DIR:-./workspace}:/opt/terminal
-      - ${ROOT_DIR}/openssh-server/config:/tmp/ssh_keys:ro  # 只读挂载SSH公钥
     networks:
       - nexent
     restart: always

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -214,12 +214,12 @@ services:
     container_name: nexent-openssh-server
     hostname: nexent-openssh-server
     environment:
-      - DEV_USER=linuxserver.io
+      - DEV_USER=${SSH_USERNAME:-linuxserver.io}
+      - DEV_PASSWORD=${SSH_PASSWORD:-nexent123}
     ports:
       - "2222:22"  # SSH port
     volumes:
       - ${TERMINAL_MOUNT_DIR:-./workspace}:/opt/terminal
-      - ${ROOT_DIR}/openssh-server/ssh-keys:/tmp/ssh_keys:ro
     networks:
       - nexent
     restart: always

--- a/docker/generate_env.sh
+++ b/docker/generate_env.sh
@@ -73,6 +73,25 @@ update_env_file() {
       echo "ELASTICSEARCH_API_KEY=$ELASTICSEARCH_API_KEY" >> ../.env
     fi
   fi
+
+  # Update or add SSH credentials (only if they were set)
+  if [ -n "$SSH_USERNAME" ]; then
+    if grep -q "^SSH_USERNAME=" ../.env; then
+      sed -i.bak "s~^SSH_USERNAME=.*~SSH_USERNAME=$SSH_USERNAME~" ../.env
+    else
+      echo "" >> ../.env
+      echo "# SSH Terminal Tool Credentials" >> ../.env
+      echo "SSH_USERNAME=$SSH_USERNAME" >> ../.env
+    fi
+  fi
+
+  if [ -n "$SSH_PASSWORD" ]; then
+    if grep -q "^SSH_PASSWORD=" ../.env; then
+      sed -i.bak "s~^SSH_PASSWORD=.*~SSH_PASSWORD=$SSH_PASSWORD~" ../.env
+    else
+      echo "SSH_PASSWORD=$SSH_PASSWORD" >> ../.env
+    fi
+  fi
   echo "   ✅ Generated keys updated successfully"
 
   # Force update development environment service URLs for localhost access
@@ -217,6 +236,12 @@ show_summary() {
   fi
   if [ -n "$SERVICE_ROLE_KEY" ]; then
     echo "  🔑 SERVICE_ROLE_KEY: $SERVICE_ROLE_KEY"
+  fi
+  if [ -n "$SSH_USERNAME" ]; then
+    echo "  👤 SSH_USERNAME: $SSH_USERNAME"
+  fi
+  if [ -n "$SSH_PASSWORD" ]; then
+    echo "  🔑 SSH_PASSWORD: [HIDDEN]"
   fi
   if [ -z "$ELASTICSEARCH_API_KEY" ]; then
     echo "   ⚠️  Note: To generate ELASTICSEARCH_API_KEY later, please:"

--- a/make/terminal/Dockerfile
+++ b/make/terminal/Dockerfile
@@ -19,16 +19,12 @@ RUN apt-get clean && \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
-# Create development user
-ARG DEV_USER=linuxserver.io
-RUN useradd -m -s /bin/bash $DEV_USER && \
-    usermod -aG sudo $DEV_USER && \
-    echo "$DEV_USER ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+# Using root user - no additional user creation needed
 
-# Configure SSH - disable root login + disable password authentication
+# Configure SSH - enable root login + enable password authentication
 RUN mkdir /var/run/sshd && \
-    sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin no/' /etc/ssh/sshd_config && \
-    sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config
+    sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
+    sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/' /etc/ssh/sshd_config
 
 # Install Miniconda
 ARG TARGETARCH
@@ -36,21 +32,18 @@ RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-$(if [ "$TA
     bash /tmp/miniconda.sh -b -p $CONDA_DIR && \
     rm /tmp/miniconda.sh
 
-# Set conda permissions
-RUN chown -R $DEV_USER:$DEV_USER $CONDA_DIR
+# Conda permissions - root owns everything by default
 
 # Add conda to PATH and initialize
 ENV PATH="$CONDA_DIR/bin:$PATH"
 RUN conda init
 
-# Create .ssh directory
-RUN mkdir -p /home/$DEV_USER/.ssh && \
-    chown $DEV_USER:$DEV_USER /home/$DEV_USER/.ssh && \
-    chmod 700 /home/$DEV_USER/.ssh
+# Create .ssh directory for root
+RUN mkdir -p /root/.ssh && \
+    chmod 700 /root/.ssh
 
 # Create default working directory
-RUN mkdir -p /opt/terminal && \
-    chown $DEV_USER:$DEV_USER /opt/terminal
+RUN mkdir -p /opt/terminal
 
 # Set working directory
 WORKDIR /opt

--- a/sdk/nexent/core/tools/terminal_tool.py
+++ b/sdk/nexent/core/tools/terminal_tool.py
@@ -19,7 +19,7 @@ class TerminalTool(Tool):
     name = "terminal"
     description = "Execute shell commands on a remote terminal via SSH connection. " \
                   "Supports session management to maintain shell state across commands. " \
-                  "Uses private key authentication with root user by default. " \
+                  "Uses password authentication for secure connection. " \
                   "Returns the command output as a string."
 
     inputs = {
@@ -35,29 +35,34 @@ class TerminalTool(Tool):
     _sessions: Dict[str, Dict[str, Any]] = {}
 
     def __init__(self, 
-                 init_path: str = Field(description="Initial workspace path", default="/mnt/nexent"),
+                 init_path: str = Field(description="Initial workspace path", default="~"),
                  observer: MessageObserver = Field(description="Message observer", default=None, exclude=True),
                  ssh_host: str = Field(description="SSH host", default="nexent-openssh-server"),
                  ssh_port: int = Field(description="SSH port", default=22),
-                 ssh_user: str = Field(description="SSH username", default="linuxserver.io"),
-                 private_key_path: str = Field(description="Path to private key file", default="/opt/ssh-keys/openssh_server_key")):
+                 ssh_user: str = Field(description="SSH username"),
+                 password: str = Field(description="SSH password")):
         """Initialize the TerminalTool.
         
         Args:
-            init_path (str): Initial workspace path. Defaults to "/mnt/nexent".
+            init_path (str): Initial workspace path. Defaults to "~".
             observer (MessageObserver, optional): Message observer instance. Defaults to None.
-            ssh_host (str): SSH server host. Defaults to "localhost".
+            ssh_host (str): SSH server host. Defaults to "nexent-openssh-server".
             ssh_port (int): SSH server port. Defaults to 22.
-            ssh_user (str): SSH username. Defaults to "root".
-            private_key_path (str): Path to SSH private key. Defaults to "~/.ssh/id_rsa".
+            ssh_user (str): SSH username. Required parameter.
+            password (str): SSH password for authentication. Required parameter.
         """
         super().__init__()
-        self.init_path = os.path.abspath(init_path)
+        # Handle ~ for home directory
+        if init_path == "~":
+            self.init_path = "~"
+        else:
+            self.init_path = os.path.abspath(init_path)
+        
         self.observer = observer
         self.ssh_host = ssh_host
         self.ssh_port = ssh_port
         self.ssh_user = ssh_user
-        self.private_key_path = os.path.expanduser(private_key_path)
+        self.password = password
         self.running_prompt_zh = "正在执行终端命令..."
         self.running_prompt_en = "Executing terminal command..."
 
@@ -98,18 +103,19 @@ class TerminalTool(Tool):
             client = paramiko.SSHClient()
             client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
             
-            # Load ED25519 private key
-            if os.path.exists(self.private_key_path):
-                private_key = paramiko.Ed25519Key.from_private_key_file(self.private_key_path)
-                client.connect(
-                    hostname=self.ssh_host,
-                    port=self.ssh_port,
-                    username=self.ssh_user,
-                    pkey=private_key,
-                    timeout=10
-                )
-            else:
-                raise FileNotFoundError(f"Private key not found: {self.private_key_path}")
+            # Authentication: password only
+            if not self.password:
+                raise ValueError("SSH password is required for authentication")
+            
+            # Use password authentication
+            client.connect(
+                hostname=self.ssh_host,
+                port=self.ssh_port,
+                username=self.ssh_user,
+                password=self.password,
+                timeout=10
+            )
+            logger.info(f"Connected using password authentication")
             
             # Create interactive shell
             channel = client.invoke_shell()
@@ -118,6 +124,16 @@ class TerminalTool(Tool):
             # Clear initial output
             if channel.recv_ready():
                 channel.recv(4096)
+            
+            # Change to initial working directory
+            if self.init_path:
+                cd_command = f"cd {self.init_path}"
+                channel.send(cd_command + "\n")
+                time.sleep(0.5)
+                # Clear the cd command output
+                if channel.recv_ready():
+                    channel.recv(4096)
+                logger.info(f"Changed to working directory: {self.init_path}")
             
             logger.info(f"SSH session created successfully: {self.ssh_user}@{self.ssh_host}:{self.ssh_port}")
             
@@ -346,17 +362,18 @@ if __name__ == "__main__":
     # Basic configuration - 直接创建实例并设置属性
     tool = TerminalTool.__new__(TerminalTool)
     Tool.__init__(tool)
-    tool.init_path = "/mnt/nexent"
+    tool.init_path = "~"  # Use home directory as default
     tool.observer = None
     tool.ssh_host = "localhost"  # For local testing
     tool.ssh_port = 2222
-    tool.ssh_user = "linuxserver.io"
-    tool.private_key_path = "/Users/shuangruichen/Code/nexent/docker/openssh-server/ssh-keys/openssh_server_key"
+    tool.ssh_user = input("Enter SSH username: ").strip()
+    tool.password = input("Enter SSH password: ").strip()
     tool.running_prompt_zh = "正在执行终端命令..."
     tool.running_prompt_en = "Executing terminal command..."
     
     print("=== Terminal Tool Test ===")
-    print("Make sure openssh-server container is running and SSH keys are configured.")
+    print("Make sure openssh-server container is running and password authentication is configured.")
+    print("You will be prompted to enter SSH username and password.")
     print("Commands to test: 'ls -la', 'pwd', 'whoami', 'echo \"Hello World\"', 'exit'")
     print()
     

--- a/test/sdk/core/tools/test_terminal_tool.py
+++ b/test/sdk/core/tools/test_terminal_tool.py
@@ -1,0 +1,577 @@
+import pytest
+import json
+import time
+from unittest.mock import MagicMock, patch, Mock
+import os
+
+# Create all necessary mocks
+mock_paramiko = MagicMock()
+mock_ssh_client = MagicMock()
+mock_channel = MagicMock()
+mock_transport = MagicMock()
+
+# Configure paramiko mocks
+mock_paramiko.SSHClient = mock_ssh_client
+mock_paramiko.AutoAddPolicy = MagicMock()
+
+# Use module-level mocks
+module_mocks = {
+    'paramiko': mock_paramiko,
+}
+
+# Apply mocks
+with patch.dict('sys.modules', module_mocks):
+    # Import all required modules
+    from sdk.nexent.core.utils.observer import MessageObserver, ProcessType
+    from sdk.nexent.core.utils.tools_common_message import ToolSign
+    # Import target module
+    from sdk.nexent.core.tools.terminal_tool import TerminalTool
+
+
+@pytest.fixture
+def mock_observer():
+    """Create a mock observer for testing"""
+    observer = MagicMock(spec=MessageObserver)
+    observer.lang = "en"
+    return observer
+
+
+@pytest.fixture
+def mock_ssh_session():
+    """Create a mock SSH session with client and channel"""
+    client = MagicMock()
+    channel = MagicMock()
+    transport = MagicMock()
+    
+    # Configure channel behavior
+    channel.closed = False
+    channel.recv_ready.return_value = True
+    channel.recv.return_value = b"test output\n$ "
+    channel.send.return_value = None
+    channel.get_transport.return_value = transport
+    
+    # Configure transport behavior
+    transport.is_active.return_value = True
+    
+    # Configure client behavior
+    client.connect.return_value = None
+    client.invoke_shell.return_value = channel
+    client.close.return_value = None
+    
+    return {
+        "client": client,
+        "channel": channel,
+        "created_time": time.time()
+    }
+
+
+@pytest.fixture
+def terminal_tool(mock_observer):
+    """Create a TerminalTool instance for testing"""
+    with patch('paramiko.SSHClient') as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        
+        tool = TerminalTool(
+            init_path="/test/path",
+            observer=mock_observer,
+            ssh_host="test-host",
+            ssh_port=2222,
+            ssh_user="testuser",
+            password="testpass"
+        )
+        return tool
+
+
+@pytest.fixture
+def terminal_tool_no_observer():
+    """Create a TerminalTool instance without observer for testing"""
+    with patch('paramiko.SSHClient') as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        
+        tool = TerminalTool(
+            init_path="~",
+            observer=None,
+            ssh_host="localhost",
+            ssh_port=22,
+            ssh_user="root",
+            password="password"
+        )
+        return tool
+
+
+class TestTerminalToolInitialization:
+    """Test TerminalTool initialization"""
+    
+    def test_init_with_custom_path(self, mock_observer):
+        """Test initialization with custom path"""
+        with patch('paramiko.SSHClient'):
+            tool = TerminalTool(
+                init_path="/custom/path",
+                observer=mock_observer,
+                ssh_host="test-host",
+                ssh_port=2222,
+                ssh_user="testuser",
+                password="testpass"
+            )
+            
+            expected_path = os.path.abspath("/custom/path")
+            assert tool.init_path == expected_path
+            assert tool.observer == mock_observer
+            assert tool.ssh_host == "test-host"
+            assert tool.ssh_port == 2222
+            assert tool.ssh_user == "testuser"
+            assert tool.password == "testpass"
+    
+    def test_init_with_home_directory(self, mock_observer):
+        """Test initialization with home directory"""
+        with patch('paramiko.SSHClient'):
+            tool = TerminalTool(
+                init_path="~",
+                observer=mock_observer,
+                ssh_host="test-host",
+                ssh_user="testuser",
+                password="testpass"
+            )
+            
+            assert tool.init_path == "~"
+    
+    def test_init_with_absolute_path(self, mock_observer):
+        """Test initialization with absolute path"""
+        with patch('paramiko.SSHClient'):
+            test_path = "/absolute/test/path"
+            tool = TerminalTool(
+                init_path=test_path,
+                observer=mock_observer,
+                ssh_host="test-host",
+                ssh_user="testuser",
+                password="testpass"
+            )
+            
+            assert tool.init_path == os.path.abspath(test_path)
+    
+    def test_init_without_observer(self):
+        """Test initialization without observer"""
+        with patch('paramiko.SSHClient'):
+            tool = TerminalTool(
+                init_path="~",
+                observer=None,
+                ssh_host="test-host",
+                ssh_user="testuser",
+                password="testpass"
+            )
+            
+            assert tool.observer is None
+            assert tool.ssh_host == "test-host"
+            assert tool.ssh_user == "testuser"
+            assert tool.password == "testpass"
+    
+    def test_tool_properties(self, terminal_tool):
+        """Test tool class properties"""
+        assert TerminalTool.name == "terminal"
+        assert "Execute shell commands" in TerminalTool.description
+        assert TerminalTool.tool_sign == ToolSign.TERMINAL_OPERATION.value
+        assert "command" in TerminalTool.inputs
+        assert TerminalTool.output_type == "string"
+
+
+class TestSessionManagement:
+    """Test SSH session management"""
+    
+    def test_create_session_success(self, mock_observer, mock_ssh_session):
+        """Test successful session creation"""
+        with patch('paramiko.SSHClient') as mock_client_class, \
+             patch('time.sleep') as mock_sleep:  # Mock time.sleep to avoid delays
+            mock_client = MagicMock()
+            mock_client_class.return_value = mock_client
+            mock_client.connect.return_value = None
+            
+            # Create a fresh mock channel to avoid conflicts with fixture
+            mock_channel = MagicMock()
+            mock_client.invoke_shell.return_value = mock_channel
+            
+            # Mock channel behavior for initial connection and cd command
+            # First call: initial output available, second call: cd command output available
+            mock_channel.recv_ready.side_effect = [True, True, True]
+            mock_channel.recv.return_value = b"Welcome to SSH\n"
+            mock_channel.send.return_value = None
+            
+            # Create tool instance within the patch context
+            tool = TerminalTool(
+                init_path="/test/path",
+                observer=mock_observer,
+                ssh_host="test-host",
+                ssh_port=2222,
+                ssh_user="testuser",
+                password="testpass"
+            )
+            
+            session = tool._create_session()
+            
+            assert "client" in session
+            assert "channel" in session
+            assert "created_time" in session
+    
+    def test_create_session_no_init_path(self, mock_observer, mock_ssh_session):
+        """Test session creation without init_path (no cd command)"""
+        with patch('paramiko.SSHClient') as mock_client_class, \
+             patch('time.sleep') as mock_sleep:  # Mock time.sleep to avoid delays
+            mock_client = MagicMock()
+            mock_client_class.return_value = mock_client
+            mock_client.connect.return_value = None
+            
+            # Create a fresh mock channel to avoid conflicts with fixture
+            mock_channel = MagicMock()
+            mock_client.invoke_shell.return_value = mock_channel
+            
+            # Mock channel behavior - no initial output
+            mock_channel.recv_ready.return_value = False
+            mock_channel.send.return_value = None
+            
+            # Create tool instance without init_path
+            tool = TerminalTool(
+                init_path=None,  # No init path
+                observer=mock_observer,
+                ssh_host="test-host",
+                ssh_port=2222,
+                ssh_user="testuser",
+                password="testpass"
+            )
+            
+            session = tool._create_session()
+            
+            assert "client" in session
+            assert "channel" in session
+            assert "created_time" in session
+            
+            # Verify that no cd command was sent
+            mock_channel.send.assert_not_called()
+    
+    def test_create_session_no_password(self, mock_observer):
+        """Test session creation without password"""
+        with patch('paramiko.SSHClient'):
+            tool = TerminalTool(
+                init_path="~",
+                observer=mock_observer,
+                ssh_host="test-host",
+                ssh_user="testuser",
+                password=""  # Empty password
+            )
+            
+            with pytest.raises(ValueError, match="SSH password is required"):
+                tool._create_session()
+    
+    def test_get_session_creates_new(self, terminal_tool, mock_ssh_session):
+        """Test getting a new session"""
+        with patch.object(terminal_tool, '_create_session') as mock_create:
+            mock_create.return_value = mock_ssh_session
+            
+            session = terminal_tool._get_session("test_session")
+            
+            assert session == mock_ssh_session
+            mock_create.assert_called_once()
+    
+    def test_get_session_reuses_existing(self, terminal_tool, mock_ssh_session):
+        """Test reusing existing session"""
+        with patch.object(terminal_tool, '_create_session') as mock_create:
+            mock_create.return_value = mock_ssh_session
+            with patch.object(terminal_tool, '_is_session_alive') as mock_alive:
+                mock_alive.return_value = True
+                
+                # First call creates session
+                session1 = terminal_tool._get_session("test_session")
+                # Second call reuses session
+                session2 = terminal_tool._get_session("test_session")
+                
+                assert session1 == session2
+                mock_create.assert_called_once()  # Only called once
+    
+    def test_get_session_recreates_dead_session(self, terminal_tool, mock_ssh_session):
+        """Test recreating dead session"""
+        with patch.object(terminal_tool, '_create_session') as mock_create:
+            mock_create.return_value = mock_ssh_session
+            with patch.object(terminal_tool, '_is_session_alive') as mock_alive:
+                mock_alive.return_value = False
+                with patch.object(terminal_tool, '_cleanup_session') as mock_cleanup:
+                    
+                    session = terminal_tool._get_session("test_session")
+                    
+                    mock_cleanup.assert_called_once()
+                    assert mock_create.call_count == 2  # Called twice (create + recreate)
+    
+    def test_is_session_alive_true(self, terminal_tool, mock_ssh_session):
+        """Test session alive check returns true"""
+        mock_ssh_session["channel"].closed = False
+        mock_ssh_session["channel"].get_transport.return_value.is_active.return_value = True
+        
+        result = terminal_tool._is_session_alive(mock_ssh_session)
+        
+        assert result is True
+    
+    def test_is_session_alive_false_closed_channel(self, terminal_tool, mock_ssh_session):
+        """Test session alive check returns false for closed channel"""
+        mock_ssh_session["channel"].closed = True
+        
+        result = terminal_tool._is_session_alive(mock_ssh_session)
+        
+        assert result is False
+    
+    def test_is_session_alive_false_inactive_transport(self, terminal_tool, mock_ssh_session):
+        """Test session alive check returns false for inactive transport"""
+        mock_ssh_session["channel"].closed = False
+        mock_ssh_session["channel"].get_transport.return_value.is_active.return_value = False
+        
+        result = terminal_tool._is_session_alive(mock_ssh_session)
+        
+        assert result is False
+    
+    def test_is_session_alive_false_no_session(self, terminal_tool):
+        """Test session alive check returns false for no session"""
+        result = terminal_tool._is_session_alive(None)
+        assert result is False
+        
+        result = terminal_tool._is_session_alive({})
+        assert result is False
+    
+    def test_cleanup_session(self, terminal_tool, mock_ssh_session):
+        """Test session cleanup"""
+        terminal_tool._cleanup_session(mock_ssh_session)
+        
+        mock_ssh_session["channel"].close.assert_called_once()
+        mock_ssh_session["client"].close.assert_called_once()
+    
+    def test_cleanup_session_handles_exceptions(self, terminal_tool):
+        """Test session cleanup handles exceptions gracefully"""
+        bad_session = {
+            "channel": MagicMock(),
+            "client": MagicMock()
+        }
+        bad_session["channel"].close.side_effect = Exception("Close failed")
+        
+        # Should not raise exception
+        terminal_tool._cleanup_session(bad_session)
+
+
+class TestOutputCleaning:
+    """Test terminal output cleaning functionality"""
+    
+    def test_clean_output_basic(self, terminal_tool):
+        """Test basic output cleaning"""
+        raw_output = "user@host:~$ ls -la\nfile1.txt\nfile2.txt\nuser@host:~$ "
+        command = "ls -la"
+        
+        result = terminal_tool._clean_output(raw_output, command)
+        
+        assert "file1.txt" in result
+        assert "file2.txt" in result
+        assert "user@host:~$" not in result
+        assert "ls -la" not in result
+    
+    def test_clean_output_with_ansi_escape(self, terminal_tool):
+        """Test output cleaning with ANSI escape sequences"""
+        raw_output = "\x1B[32muser@host:~$\x1B[0m ls -la\n\x1B[34mfile1.txt\x1B[0m\nfile2.txt\n\x1B[32muser@host:~$\x1B[0m "
+        command = "ls -la"
+        
+        result = terminal_tool._clean_output(raw_output, command)
+        
+        assert "file1.txt" in result
+        assert "file2.txt" in result
+        assert "\x1B[" not in result  # No ANSI escape sequences
+    
+    def test_clean_output_empty(self, terminal_tool):
+        """Test cleaning empty output"""
+        result = terminal_tool._clean_output("", "test")
+        assert result == ""
+        
+        result = terminal_tool._clean_output(None, "test")
+        assert result == ""
+    
+    def test_clean_output_removes_prompts(self, terminal_tool):
+        """Test removing various shell prompts"""
+        raw_output = "user@host:~$ ls\nfile1.txt\nuser@host:~$ "
+        command = "ls"
+        
+        result = terminal_tool._clean_output(raw_output, command)
+        
+        assert "file1.txt" in result
+        assert "$" not in result
+        assert "#" not in result
+    
+    def test_clean_output_removes_bracketed_paste(self, terminal_tool):
+        """Test removing bracketed paste mode sequences"""
+        raw_output = "\x1b[?2004huser@host:~$ ls\nfile1.txt\n\x1b[?2004luser@host:~$ "
+        command = "ls"
+        
+        result = terminal_tool._clean_output(raw_output, command)
+        
+        assert "file1.txt" in result
+        assert "\x1b[?2004" not in result
+
+
+class TestCommandExecution:
+    """Test command execution functionality"""
+    
+    def test_execute_command_success(self, terminal_tool, mock_ssh_session):
+        """Test successful command execution"""
+        mock_channel = mock_ssh_session["channel"]
+        mock_channel.recv_ready.return_value = True
+        mock_channel.recv.return_value = b"test output\n$ "
+        
+        with patch.object(terminal_tool, '_clean_output') as mock_clean:
+            mock_clean.return_value = "cleaned output"
+            
+            result = terminal_tool._execute_command(mock_channel, "ls", 30)
+            
+            assert result == "cleaned output"
+            mock_channel.send.assert_called_with("ls\n")
+            mock_clean.assert_called_once()
+    
+    def test_execute_command_timeout(self, terminal_tool, mock_ssh_session):
+        """Test command execution timeout"""
+        mock_channel = mock_ssh_session["channel"]
+        mock_channel.recv_ready.return_value = False  # No output
+        
+        with patch('time.time') as mock_time:
+            mock_time.side_effect = [0, 0, 35]  # Timeout after 35 seconds
+            
+            result = terminal_tool._execute_command(mock_channel, "sleep 60", 30)
+            
+            assert "cleaned output" in result or result == ""
+    
+    def test_execute_command_exception(self, terminal_tool, mock_ssh_session):
+        """Test command execution with exception"""
+        mock_channel = mock_ssh_session["channel"]
+        mock_channel.send.side_effect = Exception("Send failed")
+        
+        result = terminal_tool._execute_command(mock_channel, "ls", 30)
+        
+        assert "Error executing command" in result
+        assert "Send failed" in result
+
+
+class TestForwardMethod:
+    """Test the main forward method"""
+    
+    def test_forward_success(self, terminal_tool, mock_ssh_session):
+        """Test successful forward execution"""
+        with patch.object(terminal_tool, '_get_session') as mock_get_session:
+            mock_get_session.return_value = mock_ssh_session
+            with patch.object(terminal_tool, '_execute_command') as mock_execute:
+                mock_execute.return_value = "command output"
+                
+                result = terminal_tool.forward("ls -la", "test_session", 30)
+                
+                result_data = json.loads(result)
+                assert result_data["command"] == "ls -la"
+                assert result_data["session_name"] == "test_session"
+                assert result_data["output"] == "command output"
+                assert "timestamp" in result_data
+                
+                mock_get_session.assert_called_with("test_session")
+                mock_execute.assert_called_with(mock_ssh_session["channel"], "ls -la", 30)
+    
+    def test_forward_with_observer(self, terminal_tool, mock_ssh_session):
+        """Test forward execution with observer"""
+        with patch.object(terminal_tool, '_get_session') as mock_get_session:
+            mock_get_session.return_value = mock_ssh_session
+            with patch.object(terminal_tool, '_execute_command') as mock_execute:
+                mock_execute.return_value = "command output"
+                
+                terminal_tool.forward("ls -la", "test_session", 30)
+                
+                # Check observer calls
+                assert terminal_tool.observer.add_message.call_count >= 2
+                calls = terminal_tool.observer.add_message.call_args_list
+                
+                # Check for running prompt
+                running_calls = [call for call in calls if "Executing terminal command" in str(call)]
+                assert len(running_calls) > 0
+                
+                # Check for completion message
+                completion_calls = [call for call in calls if "Command executed" in str(call)]
+                assert len(completion_calls) > 0
+    
+    def test_forward_without_observer(self, terminal_tool_no_observer, mock_ssh_session):
+        """Test forward execution without observer"""
+        with patch.object(terminal_tool_no_observer, '_get_session') as mock_get_session:
+            mock_get_session.return_value = mock_ssh_session
+            with patch.object(terminal_tool_no_observer, '_execute_command') as mock_execute:
+                mock_execute.return_value = "command output"
+                
+                result = terminal_tool_no_observer.forward("ls -la", "test_session", 30)
+                
+                result_data = json.loads(result)
+                assert result_data["command"] == "ls -la"
+                assert result_data["output"] == "command output"
+    
+    def test_forward_exception(self, terminal_tool, mock_ssh_session):
+        """Test forward execution with exception"""
+        with patch.object(terminal_tool, '_get_session') as mock_get_session:
+            mock_get_session.side_effect = Exception("Session failed")
+            
+            result = terminal_tool.forward("ls -la", "test_session", 30)
+            
+            result_data = json.loads(result)
+            assert result_data["command"] == "ls -la"
+            assert result_data["session_name"] == "test_session"
+            assert "error" in result_data
+            assert "Session failed" in result_data["error"]
+    
+    def test_forward_default_parameters(self, terminal_tool, mock_ssh_session):
+        """Test forward execution with default parameters"""
+        with patch.object(terminal_tool, '_get_session') as mock_get_session:
+            mock_get_session.return_value = mock_ssh_session
+            with patch.object(terminal_tool, '_execute_command') as mock_execute:
+                mock_execute.return_value = "output"
+                
+                result = terminal_tool.forward("ls")
+                
+                result_data = json.loads(result)
+                assert result_data["session_name"] == "default"
+                mock_execute.assert_called_with(mock_ssh_session["channel"], "ls", 30)
+
+
+class TestIntegration:
+    """Integration tests"""
+    
+    def test_full_workflow(self, terminal_tool, mock_ssh_session):
+        """Test complete workflow from initialization to command execution"""
+        with patch('paramiko.SSHClient') as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value = mock_client
+            mock_client.connect.return_value = None
+            mock_client.invoke_shell.return_value = mock_ssh_session["channel"]
+            
+            # Mock channel behavior for command execution
+            mock_ssh_session["channel"].recv_ready.return_value = True
+            mock_ssh_session["channel"].recv.return_value = b"file1.txt\nfile2.txt\n$ "
+            
+            # Execute command
+            result = terminal_tool.forward("ls", "integration_test", 30)
+            
+            result_data = json.loads(result)
+            assert result_data["command"] == "ls"
+            assert result_data["session_name"] == "integration_test"
+            assert "timestamp" in result_data
+    
+    def test_multiple_commands_same_session(self, terminal_tool, mock_ssh_session):
+        """Test multiple commands using the same session"""
+        with patch.object(terminal_tool, '_get_session') as mock_get_session:
+            mock_get_session.return_value = mock_ssh_session
+            with patch.object(terminal_tool, '_execute_command') as mock_execute:
+                mock_execute.return_value = "output"
+                
+                # Execute multiple commands
+                result1 = terminal_tool.forward("ls", "shared_session", 30)
+                result2 = terminal_tool.forward("pwd", "shared_session", 30)
+                
+                # Should reuse the same session
+                assert mock_get_session.call_count == 2
+                assert mock_execute.call_count == 2
+                
+                # Both should succeed
+                data1 = json.loads(result1)
+                data2 = json.loads(result2)
+                assert data1["session_name"] == "shared_session"
+                assert data2["session_name"] == "shared_session"


### PR DESCRIPTION
✨ The terminal tool supports password login #1052

terminal镜像登录方式改为用户名密码认证，并在deploy脚本中支持用户手动设置（默认用户root）
<img width="702" height="786" alt="image" src="https://github.com/user-attachments/assets/7a0ec336-ba89-403b-85fe-ba53abbcecd5" />

使用本地环境进行terminal操作
<img width="1187" height="706" alt="image" src="https://github.com/user-attachments/assets/09153edf-b568-4e2f-971f-7c5c7c000dc1" />

<img width="1835" height="1019" alt="image" src="https://github.com/user-attachments/assets/0ad1b03b-a72c-4c16-8f78-34f2f929c51c" />

使用远端环境进行terminal操作
<img width="1186" height="1089" alt="image" src="https://github.com/user-attachments/assets/e9a237fd-7bf5-485c-87e3-725d3df13f5d" />

<img width="1875" height="990" alt="image" src="https://github.com/user-attachments/assets/1920d4c6-2f40-4ddd-9a42-4305379d5548" />
