### PR TITLE
🐛 optimize content in step output

### DIFF
--- a/sdk/nexent/core/agents/core_agent.py
+++ b/sdk/nexent/core/agents/core_agent.py
@@ -196,7 +196,8 @@ class CoreAgent(CodeAgent):
             raise AgentExecutionError(error_msg, self.logger)
 
         truncated_output = truncate_content(str(output))
-        observation += "Last output from code snippet:\n" + truncated_output
+        if output is not None:
+            observation += "Last output from code snippet:\n" + truncated_output
         memory_step.observations = observation
 
         execution_outputs_console += [


### PR DESCRIPTION
调用工具后，仅展示工具输出，去除冗余字符串干扰
<img width="1022" height="398" alt="image" src="https://github.com/user-attachments/assets/f93f669d-78b1-4231-a19c-17db01e99927" />

![img_v3_02qe_872170bd-2392-42cb-bc55-bd9012f576eg](https://github.com/user-attachments/assets/16014662-abe7-4cc3-a4e0-dd56a7992a3b)