### PR TITLE
Fixed the default filling of email account and password when adding models

### DIFF
--- a/frontend/app/[locale]/setup/models/components/model/ModelAddDialog.tsx
+++ b/frontend/app/[locale]/setup/models/components/model/ModelAddDialog.tsx
@@ -487,6 +487,7 @@ export const ModelAddDialog = ({ isOpen, onClose, onSuccess }: ModelAddDialogPro
             placeholder={t('model.dialog.placeholder.apiKey')}
             value={form.apiKey}
             onChange={(e) => handleFormChange("apiKey", e.target.value)}
+            autoComplete="new-password"
           />
         </div>
 

--- a/frontend/app/[locale]/setup/models/components/model/ModelEditDialog.tsx
+++ b/frontend/app/[locale]/setup/models/components/model/ModelEditDialog.tsx
@@ -214,6 +214,7 @@ export const ModelEditDialog = ({ isOpen, model, onClose, onSuccess }: ModelEdit
           <Input.Password
             value={form.apiKey}
             onChange={(e) => handleFormChange('apiKey', e.target.value)}
+            autoComplete="new-password"
           />
         </div>
 


### PR DESCRIPTION
Fixed the default filling of email account and password when adding models #1385
<img width="947" height="841" alt="image" src="https://github.com/user-attachments/assets/def686fd-1997-4e17-beb0-7701c2673fca" />
