### PR TITLE
🐛 Fix unexpected line break on markdown display of final answer #1475

### DIFF
--- a/frontend/styles/react-markdown.css
+++ b/frontend/styles/react-markdown.css
@@ -131,10 +131,16 @@
   color: var(--color-nord0);
 }
 
+/* Remove first br from paragraphs inside list items */
+.markdown-li > br:first-child {
+  display: none;
+}
+
 /* Remove extra spacing from paragraphs inside list items */
 .markdown-ol li > p,
 .markdown-ul li > p,
 .markdown-li > p {
+  display: inline;
   margin-top: 0 !important;
   margin-bottom: 0 !important;
 }


### PR DESCRIPTION
🐛 Fix unexpected line break on markdown display of final answer #1475
[Specific implementation] Adjust the CSS style file for markdown, and remove the first br in markdown-li and make p display inline.
[Test results]
![e3e4036f-0a82-4ba9-a016-a5050ddcfa7d](https://github.com/user-attachments/assets/65ec1e3e-f764-4319-952c-446bce9d764a)