### PR TITLE
🐛 Fixed an issue where batch modification of the maximum token count was not synchronized in a single model setting. #1575

### DIFF
--- a/frontend/app/[locale]/setup/models/components/model/ModelDeleteDialog.tsx
+++ b/frontend/app/[locale]/setup/models/components/model/ModelDeleteDialog.tsx
@@ -460,6 +460,14 @@ export const ModelDeleteDialog = ({
         // Show success message since no exception was thrown
         message.success(t("model.dialog.success.updateSuccess"));
 
+        // Synchronize providerModels state with the updated maxTokens
+        setProviderModels((prev) =>
+          prev.map((model) => ({
+            ...model,
+            max_tokens: maxTokens || model.max_tokens || 4096,
+          }))
+        );
+
         // Optionally use currentModelPayloads for subsequent API calls if needed
       } catch (e) {
         message.error(t("model.dialog.error.noModelsFetched"));


### PR DESCRIPTION
🐛 Fixed an issue where batch modification of the maximum token count was not synchronized in a single model setting. #1575
[Specific implementation] After batch modifying max_token, simultaneously refresh the max_token in the configuration of each individual model on the front end asynchronously.
[Test results]
![4627e921-da82-4a43-a42a-7879ed7d3091](https://github.com/user-attachments/assets/1c102bae-8e1c-4fc3-b2eb-f98823dbff14)
![4dbe0989-6120-4fd5-9afc-87811d4b8376](https://github.com/user-attachments/assets/071870ec-c25c-4514-a634-12f919f43068)
