### PR TITLE
🐛 In the MCP configuration, connectivity is verified, and after a tool is deleted or added (or its status changes), the tool list and agent list are refreshed synchronously. #1345

### DIFF
--- a/frontend/app/[locale]/setup/agents/config.tsx
+++ b/frontend/app/[locale]/setup/agents/config.tsx
@@ -408,18 +408,25 @@ export default function AgentConfig() {
   };
 
   // Refresh tool list
-  const handleToolsRefresh = async () => {
+  const handleToolsRefresh = async (showSuccessMessage = true) => {
     try {
       const result = await fetchTools();
       if (result.success) {
         setTools(result.data);
-        message.success(t("agentConfig.tools.refreshSuccess"));
+        // Only show success message if explicitly requested (e.g., manual refresh)
+        // Don't show message when auto-refreshing after MCP tool add/delete
+        if (showSuccessMessage) {
+          message.success(t("agentConfig.tools.refreshSuccess"));
+        }
+        return result.data; // Return the updated tools list
       } else {
         message.error(t("agentConfig.tools.refreshFailed"));
+        return null;
       }
     } catch (error) {
       log.error(t("agentConfig.tools.refreshFailedDebug"), error);
       message.error(t("agentConfig.tools.refreshFailed"));
+      return null;
     }
   };
 

--- a/frontend/types/agentConfig.ts
+++ b/frontend/types/agentConfig.ts
@@ -111,7 +111,7 @@ export interface AgentSetupOrchestratorProps {
   enabledAgentIds: number[];
   setEnabledAgentIds: (ids: number[]) => void;
   onEditingStateChange?: (isEditing: boolean, agent: any) => void;
-  onToolsRefresh: () => void;
+  onToolsRefresh: (showSuccessMessage?: boolean) => void | Promise<any>;
   dutyContent: string;
   setDutyContent: (value: string) => void;
   constraintContent: string;
@@ -158,7 +158,7 @@ export interface ToolPoolProps {
   loadingTools?: boolean;
   mainAgentId?: string | null;
   localIsGenerating?: boolean;
-  onToolsRefresh?: () => void;
+  onToolsRefresh?: (showSuccessMessage?: boolean) => void | Promise<any>;
   isEditingMode?: boolean;
   isGeneratingAgent?: boolean;
   isEmbeddingConfigured?: boolean;


### PR DESCRIPTION
🐛 In the MCP configuration, connectivity is verified, and after a tool is deleted or added (or its status changes), the tool list and agent list are refreshed synchronously. #1345
[Specific implementation]
When the MCP server state changes, the state of the agent and tool list is refreshed asynchronously.
[Test results]
Delete MCP server：
![52c5aa3d-87ee-4da3-9357-dc5f9a20f433](https://github.com/user-attachments/assets/e980f243-3a82-4c9f-8818-2cceea4b6a6d)
![c2483b26-dedd-4c3a-b5ab-aa75b3c769d1](https://github.com/user-attachments/assets/5fa85ac2-55f0-42f9-859c-0b94300397cf)

Add again：
![863d782b-ba8b-4858-af06-7f7d04be445e](https://github.com/user-attachments/assets/88e98c8f-dcce-4a54-9933-acbd8a731b1d)
![536ca456-2f97-4444-9a8d-2fdcf8b034ab](https://github.com/user-attachments/assets/0f95d935-bc30-48e4-a1d1-72547fb4b33b)

Link timeout:
![ced3529e-9857-47a0-bbde-423a251391d2](https://github.com/user-attachments/assets/28067738-746a-420b-a294-e4166adf9a35)

