### PR TITLE
🐛 Bugfix: login window cannot be closed #1476

### DIFF
--- a/frontend/app/[locale]/chat/page.tsx
+++ b/frontend/app/[locale]/chat/page.tsx
@@ -5,12 +5,13 @@ import { useAuth } from "@/hooks/useAuth";
 
 import { useConfig } from "@/hooks/useConfig";
 import { configService } from "@/services/configService";
+import { EVENTS } from "@/const/auth";
 
 import { ChatInterface } from "./internal/chatInterface";
 
 export default function ChatPage() {
   const { appConfig } = useConfig();
-  const { user, isLoading: userLoading, openLoginModal, isSpeedMode } = useAuth();
+  const { user, isLoading: userLoading, isSpeedMode } = useAuth();
 
   useEffect(() => {
     // Load config from backend when entering chat page
@@ -22,11 +23,16 @@ export default function ChatPage() {
   }, [appConfig.appName]);
 
   // Require login on chat page when unauthenticated (full mode only)
+  // Trigger SESSION_EXPIRED event to show "Login Expired" modal instead of directly opening login modal
   useEffect(() => {
     if (!isSpeedMode && !userLoading && !user) {
-      openLoginModal();
+      window.dispatchEvent(
+        new CustomEvent(EVENTS.SESSION_EXPIRED, {
+          detail: { message: "Session expired, please sign in again" },
+        })
+      );
     }
-  }, [isSpeedMode, user, userLoading, openLoginModal]);
+  }, [isSpeedMode, user, userLoading]);
 
   // Avoid rendering and backend calls when unauthenticated (full mode only)
   if (!isSpeedMode && (!user || userLoading)) {

--- a/frontend/app/[locale]/setup/agents/page.tsx
+++ b/frontend/app/[locale]/setup/agents/page.tsx
@@ -14,6 +14,7 @@ import {
   CONNECTION_STATUS,
   ConnectionStatus,
 } from "@/const/modelConfig";
+import { EVENTS } from "@/const/auth";
 import log from "@/lib/logger";
 
 import SetupLayout from "../SetupLayout";
@@ -30,8 +31,7 @@ export default function AgentSetupPage() {
   const {
     user,
     isLoading: userLoading,
-    isSpeedMode,
-    openLoginModal,
+    isSpeedMode
   } = useAuth();
 
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>(
@@ -41,9 +41,14 @@ export default function AgentSetupPage() {
   const [isSaving, setIsSaving] = useState(false);
 
   // Check login status and permission
+  // Trigger SESSION_EXPIRED event to show "Login Expired" modal instead of directly opening login modal
   useEffect(() => {
     if (!isSpeedMode && !userLoading && !user) {
-      openLoginModal();
+      window.dispatchEvent(
+        new CustomEvent(EVENTS.SESSION_EXPIRED, {
+          detail: { message: "Session expired, please sign in again" },
+        })
+      );
       return;
     }
 
@@ -52,7 +57,7 @@ export default function AgentSetupPage() {
       router.push("/setup/knowledges");
       return;
     }
-  }, [isSpeedMode, user, userLoading, router, openLoginModal]);
+  }, [isSpeedMode, user, userLoading, router]);
 
   // Check the connection status when the page is initialized
   useEffect(() => {

--- a/frontend/app/[locale]/setup/knowledges/page.tsx
+++ b/frontend/app/[locale]/setup/knowledges/page.tsx
@@ -16,6 +16,7 @@ import {
   CONNECTION_STATUS,
   ConnectionStatus,
 } from "@/const/modelConfig";
+import { EVENTS } from "@/const/auth";
 import log from "@/lib/logger";
 
 import SetupLayout from "../SetupLayout";
@@ -25,7 +26,7 @@ export default function KnowledgeSetupPage() {
   const { message } = App.useApp();
   const router = useRouter();
   const { t } = useTranslation();
-  const { user, isLoading: userLoading, isSpeedMode, openLoginModal } = useAuth();
+  const { user, isLoading: userLoading, isSpeedMode } = useAuth();
 
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>(
     CONNECTION_STATUS.PROCESSING
@@ -34,12 +35,17 @@ export default function KnowledgeSetupPage() {
   const [isSaving, setIsSaving] = useState(false);
 
   // Check login status and permission
+  // Trigger SESSION_EXPIRED event to show "Login Expired" modal instead of directly opening login modal
   useEffect(() => {
     if (!isSpeedMode && !userLoading && !user) {
-      openLoginModal();
+      window.dispatchEvent(
+        new CustomEvent(EVENTS.SESSION_EXPIRED, {
+          detail: { message: "Session expired, please sign in again" },
+        })
+      );
       return;
     }
-  }, [isSpeedMode, user, userLoading, openLoginModal]);
+  }, [isSpeedMode, user, userLoading]);
 
   // Check the connection status when the page is initialized
   useEffect(() => {

--- a/frontend/app/[locale]/setup/models/page.tsx
+++ b/frontend/app/[locale]/setup/models/page.tsx
@@ -17,6 +17,7 @@ import {
   ConnectionStatus,
   MODEL_STATUS,
 } from "@/const/modelConfig";
+import { EVENTS } from "@/const/auth";
 import log from "@/lib/logger";
 
 import SetupLayout from "../SetupLayout";
@@ -28,7 +29,7 @@ export default function ModelSetupPage() {
   const { message } = App.useApp();
   const router = useRouter();
   const { t } = useTranslation();
-  const { user, isLoading: userLoading, isSpeedMode, openLoginModal } = useAuth();
+  const { user, isLoading: userLoading, isSpeedMode } = useAuth();
 
   const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>(
     CONNECTION_STATUS.PROCESSING
@@ -47,9 +48,14 @@ export default function ModelSetupPage() {
   const modelConfigSectionRef = useRef<ModelConfigSectionRef | null>(null);
 
   // Check login status and permission
+  // Trigger SESSION_EXPIRED event to show "Login Expired" modal instead of directly opening login modal
   useEffect(() => {
     if (!isSpeedMode && !userLoading && !user) {
-      openLoginModal();
+      window.dispatchEvent(
+        new CustomEvent(EVENTS.SESSION_EXPIRED, {
+          detail: { message: "Session expired, please sign in again" },
+        })
+      );
       return;
     }
 
@@ -58,7 +64,7 @@ export default function ModelSetupPage() {
       router.push("/setup/knowledges");
       return;
     }
-  }, [isSpeedMode, user, userLoading, openLoginModal, router]);
+  }, [isSpeedMode, user, userLoading, router]);
 
   // Check the connection status when the page is initialized
   useEffect(() => {

--- a/frontend/components/auth/loginModal.tsx
+++ b/frontend/components/auth/loginModal.tsx
@@ -138,8 +138,10 @@ export function LoginModal() {
     closeLoginModal();
 
     // If login modal was opened due to session expiration,
-    // re-trigger the session expired event
+    // reset modal state and re-trigger the session expired event
     if (isFromSessionExpired) {
+      // Reset modal state so session expired modal can be shown again
+      document.dispatchEvent(new CustomEvent("modalClosed"));
       setTimeout(() => {
         window.dispatchEvent(
           new CustomEvent(EVENTS.SESSION_EXPIRED, {
@@ -163,9 +165,10 @@ export function LoginModal() {
       width={400}
       centered
       forceRender
-      // Prevent modal from being closed by clicking mask or close button when session is expired
+      // Prevent modal from being closed by clicking mask when session is expired
+      // But allow close button to be visible so user can return to session expired prompt
       maskClosable={!isFromSessionExpired}
-      closable={!isFromSessionExpired}
+      closable={true}
     >
       <Form
         id="login-form"

--- a/frontend/hooks/useAuth.ts
+++ b/frontend/hooks/useAuth.ts
@@ -12,7 +12,7 @@ import { configService } from "@/services/configService"
 import { API_ENDPOINTS } from "@/services/api"
 import { User, AuthContextType } from "@/types/auth"
 import { EVENTS, STATUS_CODES } from "@/const/auth"
-import { getSessionFromStorage } from "@/lib/auth"
+import { getSessionFromStorage, removeSessionFromStorage } from "@/lib/auth"
 import log from "@/lib/logger"
 
 // Create auth context
@@ -300,6 +300,16 @@ export function AuthProvider({ children }: { children: (value: AuthContextType) 
     }
   }
 
+  // Clear local session state without calling backend API
+  // Used when session is already expired on the backend
+  const clearLocalSession = () => {
+    removeSessionFromStorage()
+    setUser(null)
+    setShouldCheckSession(false)
+    // Manually trigger storage event
+    window.dispatchEvent(new StorageEvent("storage", { key: "session", newValue: null }))
+  }
+
   const logout = async (options?: { silent?: boolean }) => {
     try {
       setIsLoading(true)
@@ -357,6 +367,7 @@ export function AuthProvider({ children }: { children: (value: AuthContextType) 
     login,
     register,
     logout,
+    clearLocalSession,
     revoke,
   };
 

--- a/frontend/types/auth.ts
+++ b/frontend/types/auth.ts
@@ -53,6 +53,7 @@ export interface AuthContextType {
     inviteCode?: string
   ) => Promise<void>;
   logout: (options?: { silent?: boolean }) => Promise<void>;
+  clearLocalSession: () => void;
   revoke: () => Promise<void>;
 }
 


### PR DESCRIPTION
🐛 Bugfix: login window cannot be closed #1476
首次进入首页无弹窗：
<img width="1328" height="834" alt="image" src="https://github.com/user-attachments/assets/37d8a372-a80a-4d74-a7e2-c86dd06a0614" />

非登录状态尝试访问配置页面，弹出提示框：
<img width="1374" height="787" alt="image" src="https://github.com/user-attachments/assets/a692c7b4-acab-4800-8a1c-4d2c8f2f9872" />

点击重新登录后保留在原页面：
<img width="1332" height="791" alt="image" src="https://github.com/user-attachments/assets/c7e9b48f-609e-4b58-935d-39b08e5007b9" />

点击返回首页后展示首页：
<img width="1354" height="864" alt="image" src="https://github.com/user-attachments/assets/5d72a37f-4200-4a9f-80cb-deba38b65c6b" />

