### PR TITLE
🐛 Bugfix: Agent import does not import max steps of agent run #1582

### DIFF
--- a/backend/database/agent_db.py
+++ b/backend/database/agent_db.py
@@ -76,14 +76,15 @@ def create_agent(agent_info, tenant_id: str, user_id: str):
     :param user_id:
     :return: Created agent object
     """
-    agent_info.update({
+    info_with_metadata = dict(agent_info)
+    info_with_metadata.setdefault("max_steps", 5)
+    info_with_metadata.update({
         "tenant_id": tenant_id,
         "created_by": user_id,
         "updated_by": user_id,
-        "max_steps": 5
     })
     with get_db_session() as session:
-        new_agent = AgentInfo(**filter_property(agent_info, AgentInfo))
+        new_agent = AgentInfo(**filter_property(info_with_metadata, AgentInfo))
         new_agent.delete_flag = 'N'
         session.add(new_agent)
         session.flush()


### PR DESCRIPTION
创建Agent时直接使用了默认值，无法更新max_steps字段
<img width="1734" height="965" alt="image" src="https://github.com/user-attachments/assets/fb7a3a16-678b-43d1-acf4-539de5def73f" />
