### PR TITLE
Disable generate prompt textbox while generating

### DIFF
--- a/frontend/app/[locale]/agents/components/PromptManager.tsx
+++ b/frontend/app/[locale]/agents/components/PromptManager.tsx
@@ -615,7 +615,7 @@ export default function PromptManager({
                   overflowY: "auto",
                 }}
                 autoSize={false}
-                disabled={!isEditingMode}
+                disabled={!isEditingMode || isGeneratingAgent}
               />
             </div>
             


### PR DESCRIPTION
Disable the prompt textbox from entering while the LLM is generating agent prompt
<img width="617" height="425" alt="image" src="https://github.com/user-attachments/assets/4a7fc5f1-a976-4052-8bc6-f82a6c01ca52" />
