### PR TITLE
✨Improvement tool config test page inconsistency

### DIFF
--- a/frontend/app/[locale]/agents/components/tool/ToolConfigModal.tsx
+++ b/frontend/app/[locale]/agents/components/tool/ToolConfigModal.tsx
@@ -258,7 +258,7 @@ export default function ToolConfigModal({
 
   // Handle tool testing - open test panel
   const handleTestTool = () => {
-    if (!tool) return;
+    if (!tool || !checkRequiredFields()) return;
     setTestPanelVisible(true);
   };
 


### PR DESCRIPTION
#1871 

1. Unify the display mode of tool parameter names
2. Display parameter descriptions via prompt boxes
3. The tool can only be tested after the required configuration parameters are set


https://github.com/user-attachments/assets/75dd10ea-36ca-441a-85c5-3e347a0817cc

