### PR TITLE
♻️ Delete Radix UI Dependency: Tooltip

### DIFF
--- a/frontend/app/[locale]/agents/components/agent/SubAgentPool.tsx
+++ b/frontend/app/[locale]/agents/components/agent/SubAgentPool.tsx
@@ -16,12 +16,7 @@ import {
 } from "lucide-react";
 
 import { ScrollArea } from "@/components/ui/scrollArea";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { Tooltip, TooltipProvider } from "@/components/ui/tooltip";
 import { Agent, SubAgentPoolProps } from "@/types/agentConfig";
 
 import AgentCallRelationshipModal from "@/components/ui/AgentCallRelationshipModal";
@@ -176,14 +171,19 @@ export default function SubAgentPool({
             <div className="mb-4">
               <Row gutter={12}>
                 <Col xs={24} sm={12}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <div
-                        className={`rounded-md p-2 flex items-center cursor-pointer transition-all duration-200 min-h-[70px] ${
-                          isCreatingNewAgent
-                            ? "bg-blue-100 border border-blue-200 shadow-sm" // Highlight in creation mode
-                            : "bg-white hover:bg-blue-50 hover:shadow-sm"
-                        }`}
+                  <Tooltip
+                    title={
+                      isCreatingNewAgent
+                        ? t("subAgentPool.tooltip.exitCreateMode")
+                        : t("subAgentPool.tooltip.createNewAgent")
+                    }
+                  >
+                    <div
+                      className={`rounded-md p-2 flex items-center cursor-pointer transition-all duration-200 min-h-[70px] ${
+                        isCreatingNewAgent
+                          ? "bg-blue-100 border border-blue-200 shadow-sm" // Highlight in creation mode
+                          : "bg-white hover:bg-blue-50 hover:shadow-sm"
+                      }`}
                       onClick={() => {
                         if (isCreatingNewAgent) {
                           // If currently in creation mode, click to exit creation mode
@@ -230,26 +230,25 @@ export default function SubAgentPool({
                               : t("subAgentPool.description.createAgent")}
                           </div>
                         </div>
-                        </div>
                       </div>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      {isCreatingNewAgent
-                        ? t("subAgentPool.tooltip.exitCreateMode")
-                        : t("subAgentPool.tooltip.createNewAgent")}
-                    </TooltipContent>
+                    </div>
                   </Tooltip>
                 </Col>
 
                 <Col xs={24} sm={12}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <div
-                        className={`rounded-md p-2 flex items-center transition-all duration-200 min-h-[70px] ${
-                          isImporting
-                            ? "bg-gray-100 cursor-not-allowed" // Importing: disabled state
-                            : "bg-white cursor-pointer hover:bg-green-50 hover:shadow-sm" // Normal state: clickable
-                        }`}
+                  <Tooltip
+                    title={
+                      isImporting
+                        ? t("subAgentPool.description.importing")
+                        : t("subAgentPool.description.importAgent")
+                    }
+                  >
+                    <div
+                      className={`rounded-md p-2 flex items-center transition-all duration-200 min-h-[70px] ${
+                        isImporting
+                          ? "bg-gray-100 cursor-not-allowed" // Importing: disabled state
+                          : "bg-white cursor-pointer hover:bg-green-50 hover:shadow-sm" // Normal state: clickable
+                      }`}
                       onClick={isImporting ? undefined : onImportAgent}
                     >
                       <div
@@ -280,14 +279,8 @@ export default function SubAgentPool({
                               : t("subAgentPool.description.importAgent")}
                           </div>
                         </div>
-                        </div>
                       </div>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      {isImporting
-                        ? t("subAgentPool.description.importing")
-                        : t("subAgentPool.description.importAgent")}
-                    </TooltipContent>
+                    </div>
                   </Tooltip>
                 </Col>
               </Row>
@@ -371,84 +364,64 @@ export default function SubAgentPool({
                         <div className="flex items-center gap-1 ml-2 flex-shrink-0">
                           {/* Copy agent button */}
                           {onCopyAgent && (
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Button
-                                  type="text"
-                                  size="small"
-                                  icon={<Copy className="w-4 h-4" />}
-                                  onClick={(e) => {
-                                    e.preventDefault();
-                                    e.stopPropagation();
-                                    onCopyAgent(agent);
-                                  }}
-                                  className="agent-action-button agent-action-button-blue"
-                                />
-                              </TooltipTrigger>
-                              <TooltipContent>
-                                {t("agent.contextMenu.copy")}
-                              </TooltipContent>
-                            </Tooltip>
-                          )}
-                          {/* View call relationship button */}
-                          <Tooltip>
-                            <TooltipTrigger asChild>
+                            <Tooltip title={t("agent.contextMenu.copy")}>
                               <Button
                                 type="text"
                                 size="small"
-                                icon={<Network className="w-4 h-4" />}
+                                icon={<Copy className="w-4 h-4" />}
                                 onClick={(e) => {
                                   e.preventDefault();
                                   e.stopPropagation();
-                                  handleViewCallRelationship(agent);
+                                  onCopyAgent(agent);
                                 }}
                                 className="agent-action-button agent-action-button-blue"
                               />
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              {t("agent.action.viewCallRelationship")}
-                            </TooltipContent>
+                            </Tooltip>
+                          )}
+                          {/* View call relationship button */}
+                          <Tooltip title={t("agent.action.viewCallRelationship")}>
+                            <Button
+                              type="text"
+                              size="small"
+                              icon={<Network className="w-4 h-4" />}
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                handleViewCallRelationship(agent);
+                              }}
+                              className="agent-action-button agent-action-button-blue"
+                            />
                           </Tooltip>
                           {/* Export button */}
                           {onExportAgent && (
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Button
-                                  type="text"
-                                  size="small"
-                                  icon={<FileOutput className="w-4 h-4" />}
-                                  onClick={(e) => {
-                                    e.preventDefault();
-                                    e.stopPropagation();
-                                    onExportAgent(agent);
-                                  }}
-                                  className="agent-action-button agent-action-button-green"
-                                />
-                              </TooltipTrigger>
-                              <TooltipContent>
-                                {t("agent.contextMenu.export")}
-                              </TooltipContent>
+                            <Tooltip title={t("agent.contextMenu.export")}>
+                              <Button
+                                type="text"
+                                size="small"
+                                icon={<FileOutput className="w-4 h-4" />}
+                                onClick={(e) => {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                  onExportAgent(agent);
+                                }}
+                                className="agent-action-button agent-action-button-green"
+                              />
                             </Tooltip>
                           )}
                           {/* Delete button */}
                           {onDeleteAgent && (
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Button
-                                  type="text"
-                                  size="small"
-                                  icon={<Trash2 className="w-4 h-4" />}
-                                  onClick={(e) => {
-                                    e.preventDefault();
-                                    e.stopPropagation();
-                                    onDeleteAgent(agent);
-                                  }}
-                                  className="agent-action-button agent-action-button-red"
-                                />
-                              </TooltipTrigger>
-                              <TooltipContent>
-                                {t("agent.contextMenu.delete")}
-                              </TooltipContent>
+                            <Tooltip title={t("agent.contextMenu.delete")}>
+                              <Button
+                                type="text"
+                                size="small"
+                                icon={<Trash2 className="w-4 h-4" />}
+                                onClick={(e) => {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                  onDeleteAgent(agent);
+                                }}
+                                className="agent-action-button agent-action-button-red"
+                              />
                             </Tooltip>
                           )}
                         </div>

--- a/frontend/app/[locale]/chat/components/chatInput.tsx
+++ b/frontend/app/[locale]/chat/components/chatInput.tsx
@@ -16,12 +16,7 @@ import {
 
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { Tooltip } from "@/components/ui/tooltip";
 import { Textarea } from "@/components/ui/textarea";
 import { conversationService } from "@/services/conversationService";
 import { useConfig } from "@/hooks/useConfig";
@@ -251,35 +246,35 @@ const getFileIcon = (file: File) => {
   if (chatConfig.fileIcons.pdf.includes(extension)) {
     return <FilePdfFilled size={iconSize} color="#e74c3c" />;
   }
-  
+
   if (chatConfig.fileIcons.word.includes(extension)) {
     return <FileWordFilled size={iconSize} color="#3498db" />;
   }
-  
+
   if (chatConfig.fileIcons.text.includes(extension)) {
     return <FileTextFilled size={iconSize} color="#7f8c8d" />;
   }
-  
+
   if (chatConfig.fileIcons.markdown.includes(extension)) {
     return <FileMarkdownFilled size={iconSize} color="#34495e" />;
   }
-  
+
   if (chatConfig.fileIcons.excel.includes(extension)) {
     return <FileExcelFilled size={iconSize} color="#27ae60" />;
   }
-  
+
   if (chatConfig.fileIcons.powerpoint.includes(extension)) {
     return <FilePptFilled size={iconSize} color="#e67e22" />;
   }
-  
+
   if (chatConfig.fileIcons.html.includes(extension)) {
     return <Html5Filled size={iconSize} color="#e67e22" />;
   }
-  
+
   if (chatConfig.fileIcons.code.includes(extension)) {
     return <CodeFilled size={iconSize} color="#f39c12" />;
   }
-  
+
   if (chatConfig.fileIcons.json.includes(extension)) {
     return <CodeFilled size={iconSize} color="#f1c40f" />;
   }
@@ -1031,73 +1026,64 @@ export function ChatInput({
 
         <div className="absolute right-3 top-[40%] -translate-y-1/2 flex items-center space-x-1">
           {/* Voice to text button */}
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-10 w-10 text-slate-700 flex items-center justify-center rounded-full border border-slate-300 hover:bg-slate-200 transition-colors"
-                  onClick={toggleRecording}
-                  disabled={recordingStatus === "connecting" || isStreaming}
-                >
-                  {isRecording ? (
-                    <MicOff className="h-5 w-5" />
-                  ) : (
-                    <Mic className="h-5 w-5" />
-                  )}
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                {isRecording
-                  ? t("chatInput.stopRecording")
-                  : t("chatInput.startRecording")}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip
+            title={
+              isRecording
+                ? t("chatInput.stopRecording")
+                : t("chatInput.startRecording")
+            }
+          >
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-10 w-10 text-slate-700 flex items-center justify-center rounded-full border border-slate-300 hover:bg-slate-200 transition-colors"
+              onClick={toggleRecording}
+              disabled={recordingStatus === "connecting" || isStreaming}
+            >
+              {isRecording ? (
+                <MicOff className="h-5 w-5" />
+              ) : (
+                <Mic className="h-5 w-5" />
+              )}
+            </Button>
+          </Tooltip>
 
           {/* Upload file button */}
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-10 w-10 text-slate-700 flex items-center justify-center rounded-full border border-slate-300 hover:bg-slate-200 transition-colors"
-                  onClick={() =>
-                    document.getElementById("file-upload-regular")?.click()
-                  }
-                >
-                  <Paperclip className="h-5 w-5" />
-                  <Input
-                    type="file"
-                    id="file-upload-regular"
-                    className="hidden"
-                    onChange={handleFileUpload}
-                    accept={`image/*,${Object.values(chatConfig.fileIcons).flat().map(ext => `.${ext}`).join(',')}`}
-                    multiple
-                  />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>{t("chatInput.uploadFiles")}</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip title={t("chatInput.uploadFiles")}>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-10 w-10 text-slate-700 flex items-center justify-center rounded-full border border-slate-300 hover:bg-slate-200 transition-colors"
+              onClick={() =>
+                document.getElementById("file-upload-regular")?.click()
+              }
+            >
+              <Paperclip className="h-5 w-5" />
+              <Input
+                type="file"
+                id="file-upload-regular"
+                className="hidden"
+                onChange={handleFileUpload}
+                accept={`image/*,${Object.values(chatConfig.fileIcons).flat().map(ext => `.${ext}`).join(',')}`}
+                multiple
+              />
+            </Button>
+          </Tooltip>
 
           {isStreaming ? (
-            <TooltipProvider>
-              <Tooltip open={showStopTooltip} onOpenChange={setShowStopTooltip}>
-                <TooltipTrigger asChild>
-                  <Button
-                    onClick={onStop}
-                    size="icon"
-                    className="h-10 w-10 bg-red-500 hover:bg-red-600 text-white rounded-full"
-                  >
-                    <Square className="h-5 w-5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>{t("chatInput.stopGenerating")}</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+            <Tooltip
+              title={t("chatInput.stopGenerating")}
+              open={showStopTooltip}
+              onOpenChange={setShowStopTooltip}
+            >
+              <Button
+                onClick={onStop}
+                size="icon"
+                className="h-10 w-10 bg-red-500 hover:bg-red-600 text-white rounded-full"
+              >
+                <Square className="h-5 w-5" />
+              </Button>
+            </Tooltip>
           ) : (
             <Button
               onClick={handleSend}

--- a/frontend/app/[locale]/chat/components/chatLeftSidebar.tsx
+++ b/frontend/app/[locale]/chat/components/chatLeftSidebar.tsx
@@ -19,12 +19,7 @@ import {
 } from "@/components/ui/dropdownMenu";
 import { Input } from "@/components/ui/input";
 import { App } from "antd";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { Tooltip, TooltipProvider } from "@/components/ui/tooltip";
 import { StaticScrollArea } from "@/components/ui/scrollArea";
 import { USER_ROLES } from "@/const/modelConfig";
 import { useTranslation } from "react-i18next";
@@ -233,29 +228,28 @@ export function ChatSidebar({
               // Display mode
               <>
                 <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        className="flex-1 justify-start text-left hover:bg-transparent min-w-0 max-w-[250px]"
-                        onClick={() => onDialogClick(dialog)}
-                      >
-                        <ConversationStatusIndicator
-                          isStreaming={streamingConversations.has(
-                            dialog.conversation_id
-                          )}
-                          isCompleted={completedConversations.has(
-                            dialog.conversation_id
-                          )}
-                        />
-                        <span className="truncate block text-base font-normal text-gray-800 tracking-wide font-sans">
-                          {dialog.conversation_title}
-                        </span>
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="right" className="max-w-xs">
-                      <p className="break-words">{dialog.conversation_title}</p>
-                    </TooltipContent>
+                  <Tooltip
+                    title={<p className="break-words">{dialog.conversation_title}</p>}
+                    placement="right"
+                    overlayStyle={{ maxWidth: "300px" }}
+                  >
+                    <Button
+                      variant="ghost"
+                      className="flex-1 justify-start text-left hover:bg-transparent min-w-0 max-w-[250px]"
+                      onClick={() => onDialogClick(dialog)}
+                    >
+                      <ConversationStatusIndicator
+                        isStreaming={streamingConversations.has(
+                          dialog.conversation_id
+                        )}
+                        isCompleted={completedConversations.has(
+                          dialog.conversation_id
+                        )}
+                      />
+                      <span className="truncate block text-base font-normal text-gray-800 tracking-wide font-sans">
+                        {dialog.conversation_title}
+                      </span>
+                    </Button>
                   </Tooltip>
                 </TooltipProvider>
 
@@ -313,20 +307,15 @@ export function ChatSidebar({
         {/* Expand/Collapse button */}
         <div className="py-3 flex justify-center">
           <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-10 w-10 rounded-full hover:bg-slate-100"
-                  onClick={onToggleSidebar}
-                >
-                  <ChevronRight className="h-6 w-6" strokeWidth={2.5} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="right">
-                {t("chatLeftSidebar.expandSidebar")}
-              </TooltipContent>
+            <Tooltip title={t("chatLeftSidebar.expandSidebar")} placement="right">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-10 w-10 rounded-full hover:bg-slate-100"
+                onClick={onToggleSidebar}
+              >
+                <ChevronRight className="h-6 w-6" strokeWidth={2.5} />
+              </Button>
             </Tooltip>
           </TooltipProvider>
         </div>
@@ -334,20 +323,15 @@ export function ChatSidebar({
         {/* New conversation button */}
         <div className="py-3 flex justify-center">
           <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-10 w-10 rounded-full hover:bg-slate-100"
-                  onClick={onNewConversation}
-                >
-                  <Plus className="h-6 w-6" strokeWidth={2.5} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="right">
-                {t("chatLeftSidebar.newConversation")}
-              </TooltipContent>
+            <Tooltip title={t("chatLeftSidebar.newConversation")} placement="right">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-10 w-10 rounded-full hover:bg-slate-100"
+                onClick={onNewConversation}
+              >
+                <Plus className="h-6 w-6" strokeWidth={2.5} />
+              </Button>
             </Tooltip>
           </TooltipProvider>
         </div>
@@ -383,7 +367,7 @@ export function ChatSidebar({
                 </Button>
                 <TooltipProvider>
                   <Tooltip>
-                    <TooltipTrigger asChild>
+                    <Tooltip title={t("chatLeftSidebar.collapseSidebar")}>
                       <Button
                         variant="ghost"
                         size="icon"
@@ -392,10 +376,7 @@ export function ChatSidebar({
                       >
                         <ChevronLeft className="h-5 w-5" />
                       </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>{t("chatLeftSidebar.collapseSidebar")}</p>
-                    </TooltipContent>
+                    </Tooltip>
                   </Tooltip>
                 </TooltipProvider>
               </div>

--- a/frontend/app/[locale]/chat/internal/chatInterface.tsx
+++ b/frontend/app/[locale]/chat/internal/chatInterface.tsx
@@ -30,12 +30,7 @@ import {
   createMessageAttachments,
   cleanupAttachmentUrls,
 } from "@/app/chat/internal/chatPreprocess";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { Tooltip, TooltipProvider } from "@/components/ui/tooltip";
 
 import { ConversationListItem, ApiConversationDetail } from "@/types/chat";
 import { ChatMessageType } from "@/types/chat";
@@ -70,7 +65,7 @@ export function ChatInterface() {
   const [isSwitchedConversation, setIsSwitchedConversation] = useState(false); // Add conversation switching tracking state
   const [isLoading, setIsLoading] = useState(false);
   const { t } = useTranslation("common");
-  
+
   // Use conversation management hook
   const conversationManagement = useConversationManagement();
   const [openDropdownId, setOpenDropdownId] = useState<string | null>(null);
@@ -746,7 +741,7 @@ export function ChatInterface() {
     setInput("");
     setIsLoading(false);
     setIsSwitchedConversation(false);
-    
+
     // Use conversation management hook
     conversationManagement.handleNewConversation();
     setIsLoadingHistoricalConversation(false); // Ensure not loading historical conversation
@@ -1476,17 +1471,12 @@ export function ChatInterface() {
         </div>
       </div>
       <TooltipProvider>
-        <Tooltip open={false}>
-          <TooltipTrigger asChild>
-            <div className="fixed inset-0 pointer-events-none" />
-          </TooltipTrigger>
-          <TooltipContent
-            side="top"
-            align="center"
-            className="absolute bottom-24 left-1/2 transform -translate-x-1/2"
-          >
-            {t("chatInterface.stopGenerating")}
-          </TooltipContent>
+        <Tooltip
+          title={t("chatInterface.stopGenerating")}
+          open={false}
+          placement="top"
+        >
+          <div className="fixed inset-0 pointer-events-none" />
         </Tooltip>
       </TooltipProvider>
     </>

--- a/frontend/app/[locale]/chat/streaming/chatStreamFinalMessage.tsx
+++ b/frontend/app/[locale]/chat/streaming/chatStreamFinalMessage.tsx
@@ -1,23 +1,18 @@
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { 
-  Copy, 
-  Volume2, 
-  ChevronRight, 
-  Square, 
-  Loader2, 
-  ThumbsDown, 
+import {
+  Copy,
+  Volume2,
+  ChevronRight,
+  Square,
+  Loader2,
+  ThumbsDown,
   ThumbsUp,
 } from "lucide-react";
 
 import { MarkdownRenderer } from "@/components/ui/markdownRenderer";
 import { Button } from "@/components/ui/button";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { Tooltip, TooltipProvider } from "@/components/ui/tooltip";
 import { ChatMessageType } from "@/types/chat";
 import { chatConfig, Opinion } from "@/const/chatConfig";
 import { conversationService } from "@/services/conversationService";
@@ -327,105 +322,91 @@ export function ChatStreamFinalMessage({
                   <div className="flex items-center space-x-2 mt-1 justify-end">
                     <TooltipProvider>
                       {/* Copy button */}
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="outline"
-                            size="icon"
-                            className={`h-8 w-8 rounded-full bg-white hover:bg-gray-100 transition-all duration-200 shadow-sm ${
-                              copied
-                                ? "bg-green-100 text-green-600 border-green-200"
-                                : ""
-                            }`}
-                            onClick={handleCopyContent}
-                            disabled={copied}
-                          >
-                            <Copy className="h-4 w-4" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p>
-                            {copied
-                              ? t("chatStreamMessage.copied")
-                              : t("chatStreamMessage.copyContent")}
-                          </p>
-                        </TooltipContent>
+                      <Tooltip
+                        title={
+                          copied
+                            ? t("chatStreamMessage.copied")
+                            : t("chatStreamMessage.copyContent")
+                        }
+                      >
+                        <Button
+                          variant="outline"
+                          size="icon"
+                          className={`h-8 w-8 rounded-full bg-white hover:bg-gray-100 transition-all duration-200 shadow-sm ${
+                            copied
+                              ? "bg-green-100 text-green-600 border-green-200"
+                              : ""
+                          }`}
+                          onClick={handleCopyContent}
+                          disabled={copied}
+                        >
+                          <Copy className="h-4 w-4" />
+                        </Button>
                       </Tooltip>
 
                       {/* Thumbs up button */}
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant={
-                              localOpinion === chatConfig.opinion.POSITIVE ? "secondary" : "outline"
-                            }
-                            size="icon"
-                            className={`h-8 w-8 rounded-full ${
-                              localOpinion === chatConfig.opinion.POSITIVE
-                                ? "bg-green-100 text-green-600 border-green-200"
-                                : "bg-white hover:bg-gray-100"
-                            } transition-all duration-200 shadow-sm`}
-                            onClick={handleThumbsUp}
-                          >
-                            <ThumbsUp className="h-4 w-4" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p>
-                            {localOpinion === chatConfig.opinion.POSITIVE
-                              ? t("chatStreamMessage.cancelLike")
-                              : t("chatStreamMessage.like")}
-                          </p>
-                        </TooltipContent>
+                      <Tooltip
+                        title={
+                          localOpinion === chatConfig.opinion.POSITIVE
+                            ? t("chatStreamMessage.cancelLike")
+                            : t("chatStreamMessage.like")
+                        }
+                      >
+                        <Button
+                          variant={
+                            localOpinion === chatConfig.opinion.POSITIVE ? "secondary" : "outline"
+                          }
+                          size="icon"
+                          className={`h-8 w-8 rounded-full ${
+                            localOpinion === chatConfig.opinion.POSITIVE
+                              ? "bg-green-100 text-green-600 border-green-200"
+                              : "bg-white hover:bg-gray-100"
+                          } transition-all duration-200 shadow-sm`}
+                          onClick={handleThumbsUp}
+                        >
+                          <ThumbsUp className="h-4 w-4" />
+                        </Button>
                       </Tooltip>
 
                       {/* Thumbs down button */}
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant={
-                              localOpinion === chatConfig.opinion.NEGATIVE ? "secondary" : "outline"
-                            }
-                            size="icon"
-                            className={`h-8 w-8 rounded-full ${
-                              localOpinion === chatConfig.opinion.NEGATIVE
-                                ? "bg-red-100 text-red-600 border-red-200"
-                                : "bg-white hover:bg-gray-100"
-                            } transition-all duration-200 shadow-sm`}
-                            onClick={handleThumbsDown}
-                          >
-                            <ThumbsDown className="h-4 w-4" />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p>
-                            {localOpinion === chatConfig.opinion.NEGATIVE
-                              ? t("chatStreamMessage.cancelDislike")
-                              : t("chatStreamMessage.dislike")}
-                          </p>
-                        </TooltipContent>
+                      <Tooltip
+                        title={
+                          localOpinion === chatConfig.opinion.NEGATIVE
+                            ? t("chatStreamMessage.cancelDislike")
+                            : t("chatStreamMessage.dislike")
+                        }
+                      >
+                        <Button
+                          variant={
+                            localOpinion === chatConfig.opinion.NEGATIVE ? "secondary" : "outline"
+                          }
+                          size="icon"
+                          className={`h-8 w-8 rounded-full ${
+                            localOpinion === chatConfig.opinion.NEGATIVE
+                              ? "bg-red-100 text-red-600 border-red-200"
+                              : "bg-white hover:bg-gray-100"
+                          } transition-all duration-200 shadow-sm`}
+                          onClick={handleThumbsDown}
+                        >
+                          <ThumbsDown className="h-4 w-4" />
+                        </Button>
                       </Tooltip>
 
                       {/* Voice playback button */}
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant="outline"
-                            size="icon"
-                            className={`h-8 w-8 rounded-full ${ttsButtonContent.className} transition-all duration-200 shadow-sm`}
-                            onClick={handleTTSPlay}
-                            disabled={
-                              ttsStatus === "generating" ||
-                              (message.finalAnswer === undefined &&
-                                message.content === undefined)
-                            }
-                          >
-                            {ttsButtonContent.icon}
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p>{ttsButtonContent.tooltip}</p>
-                        </TooltipContent>
+                      <Tooltip title={ttsButtonContent.tooltip}>
+                        <Button
+                          variant="outline"
+                          size="icon"
+                          className={`h-8 w-8 rounded-full ${ttsButtonContent.className} transition-all duration-200 shadow-sm`}
+                          onClick={handleTTSPlay}
+                          disabled={
+                            ttsStatus === "generating" ||
+                            (message.finalAnswer === undefined &&
+                              message.content === undefined)
+                          }
+                        >
+                          {ttsButtonContent.icon}
+                        </Button>
                       </Tooltip>
                     </TooltipProvider>
                   </div>

--- a/frontend/app/[locale]/knowledges/components/document/DocumentChunk.tsx
+++ b/frontend/app/[locale]/knowledges/components/document/DocumentChunk.tsx
@@ -34,12 +34,7 @@ import knowledgeBaseService from "@/services/knowledgeBaseService";
 import { Document } from "@/types/knowledgeBase";
 import log from "@/lib/logger";
 import { formatScoreAsPercentage, getScoreColor } from "@/lib/utils";
-import {
-  Tooltip as UITooltip,
-  TooltipTrigger,
-  TooltipContent,
-  TooltipProvider,
-} from "@/components/ui/tooltip";
+import { Tooltip, TooltipProvider } from "@/components/ui/tooltip";
 
 interface Chunk {
   id: string;
@@ -454,7 +449,7 @@ const DocumentChunk: React.FC<DocumentChunkProps> = ({
     }
 
     forceCloseTooltips();
-    
+
     confirm({
       title: t("document.chunk.confirm.deleteTitle"),
       content: t("document.chunk.confirm.deleteContent"),
@@ -603,51 +598,36 @@ const DocumentChunk: React.FC<DocumentChunkProps> = ({
                         </div>
                         <div className="flex items-center gap-1">
                           {!isReadOnlyMode && (
-                            <UITooltip>
-                              <TooltipTrigger asChild>
-                                <Button
-                                  type="text"
-                                  icon={<SquarePen size={16} />}
-                                  onClick={() => openEditChunkModal(chunk)}
-                                  size="small"
-                                  className="self-center"
-                                />
-                              </TooltipTrigger>
-                              <TooltipContent className="font-normal">
-                                {t("document.chunk.tooltip.edit")}
-                              </TooltipContent>
-                            </UITooltip>
-                          )}
-                          <UITooltip>
-                            <TooltipTrigger asChild>
+                            <Tooltip title={t("document.chunk.tooltip.edit")}>
                               <Button
                                 type="text"
-                                icon={<Download size={16} />}
-                                onClick={() => handleDownloadChunk(chunk)}
+                                icon={<SquarePen size={16} />}
+                                onClick={() => openEditChunkModal(chunk)}
                                 size="small"
                                 className="self-center"
                               />
-                            </TooltipTrigger>
-                            <TooltipContent className="font-normal">
-                              {t("document.chunk.tooltip.download")}
-                            </TooltipContent>
-                          </UITooltip>
+                            </Tooltip>
+                          )}
+                          <Tooltip title={t("document.chunk.tooltip.download")}>
+                            <Button
+                              type="text"
+                              icon={<Download size={16} />}
+                              onClick={() => handleDownloadChunk(chunk)}
+                              size="small"
+                              className="self-center"
+                            />
+                          </Tooltip>
                           {!isReadOnlyMode && (
-                            <UITooltip>
-                              <TooltipTrigger asChild>
-                                <Button
-                                  type="text"
-                                  danger
-                                  icon={<Trash2 size={16} />}
-                                  onClick={() => handleDeleteChunk(chunk)}
-                                  size="small"
-                                  className="self-center"
-                                />
-                              </TooltipTrigger>
-                              <TooltipContent className="font-normal">
-                                {t("document.chunk.tooltip.delete")}
-                              </TooltipContent>
-                            </UITooltip>
+                            <Tooltip title={t("document.chunk.tooltip.delete")}>
+                              <Button
+                                type="text"
+                                danger
+                                icon={<Trash2 size={16} />}
+                                onClick={() => handleDeleteChunk(chunk)}
+                                size="small"
+                                className="self-center"
+                              />
+                            </Tooltip>
                           )}
                         </div>
                       </div>
@@ -749,18 +729,13 @@ const DocumentChunk: React.FC<DocumentChunkProps> = ({
             />
           </div>
           {!isReadOnlyMode && (
-            <UITooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="text"
-                  icon={<FilePlus2 size={16} />}
-                  onClick={openCreateChunkModal}
-                ></Button>
-              </TooltipTrigger>
-              <TooltipContent className="font-normal">
-                {t("document.chunk.tooltip.create")}
-              </TooltipContent>
-            </UITooltip>
+            <Tooltip title={t("document.chunk.tooltip.create")}>
+              <Button
+                type="text"
+                icon={<FilePlus2 size={16} />}
+                onClick={openCreateChunkModal}
+              ></Button>
+            </Tooltip>
           )}
         </div>
 

--- a/frontend/components/ui/copyButton.tsx
+++ b/frontend/components/ui/copyButton.tsx
@@ -5,12 +5,7 @@ import { Copy } from "lucide-react";
 import { copyToClipboard } from "@/lib/clipboard";
 import log from "@/lib/logger";
 import { Button } from "@/components/ui/button";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { Tooltip, TooltipProvider } from "@/components/ui/tooltip";
 
 
 interface CopyButtonProps {
@@ -112,23 +107,18 @@ export const CopyButton: React.FC<CopyButtonProps> = ({
 
   return (
     <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="outline"
-            size="icon"
-            className={`${variantStyles.button} ${sizeStyles} ${className}`}
-            onClick={handleCopy}
-            disabled={disabled || copied}
-            style={variantStyles.style}
-            title={copied ? finalTooltipText.copied : finalTooltipText.copy}
-          >
-            <Copy className={variantStyles.icon} />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>
-          <p>{copied ? finalTooltipText.copied : finalTooltipText.copy}</p>
-        </TooltipContent>
+      <Tooltip title={<p>{copied ? finalTooltipText.copied : finalTooltipText.copy}</p>}>
+        <Button
+          variant="outline"
+          size="icon"
+          className={`${variantStyles.button} ${sizeStyles} ${className}`}
+          onClick={handleCopy}
+          disabled={disabled || copied}
+          style={variantStyles.style}
+          title={copied ? finalTooltipText.copied : finalTooltipText.copy}
+        >
+          <Copy className={variantStyles.icon} />
+        </Button>
       </Tooltip>
     </TooltipProvider>
   );

--- a/frontend/components/ui/tooltip.tsx
+++ b/frontend/components/ui/tooltip.tsx
@@ -1,30 +1,56 @@
 "use client";
 
 import * as React from "react";
-import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+import { Tooltip as AntdTooltip, ConfigProvider } from "antd";
+import type { TooltipProps as AntdTooltipProps } from "antd";
 
 import { cn } from "@/lib/utils";
 
-const TooltipProvider = TooltipPrimitive.Provider;
+export const TooltipProvider: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  return (
+    <ConfigProvider
+      theme={{
+        components: {
+          Tooltip: {
+            zIndexPopup: 1050,
+          },
+        },
+      }}
+    >
+      {children}
+    </ConfigProvider>
+  );
+};
 
-const Tooltip = TooltipPrimitive.Root;
+// Tooltip component - wrapper around antd Tooltip with default smooth transition and no arrow
+export const Tooltip: React.FC<AntdTooltipProps> = ({
+  children,
+  arrow = false,
+  mouseEnterDelay = 0.1,
+  mouseLeaveDelay = 0.1,
+  className,
+  ...props
+}) => {
+  // Merge provided classNames with our default root class to replace deprecated overlayClassName
+  const mergedClassNames = {
+    ...(props.classNames || {}),
+    root: cn("ant-tooltip-no-arrow", (props.classNames as any)?.root),
+  };
+  return (
+    <AntdTooltip
+      arrow={arrow}
+      mouseEnterDelay={mouseEnterDelay}
+      mouseLeaveDelay={mouseLeaveDelay}
+      classNames={mergedClassNames}
+      className={className}
+      {...props}
+    >
+      {children}
+    </AntdTooltip>
+  );
+};
 
-const TooltipTrigger = TooltipPrimitive.Trigger;
-
-const TooltipContent = React.forwardRef<
-  React.ElementRef<typeof TooltipPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    className={cn(
-      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className
-    )}
-    {...props}
-  />
-));
-TooltipContent.displayName = TooltipPrimitive.Content.displayName;
-
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };
+// Re-export for convenience
+export { Tooltip as default };


### PR DESCRIPTION
期望效果如下：
<img width="659" height="122" alt="image" src="https://github.com/user-attachments/assets/2d957cbd-9917-4222-8131-558d0568ed7d" />


但当前前端还存在部分组件使用title属性，导致弹框样式依然不统一：
<img width="255" height="162" alt="image" src="https://github.com/user-attachments/assets/7cd99504-5b45-4f89-82bd-1e3e5ca7f220" />

建议纳入前端统一重构需求中，单独审视。
