### PR TITLE
🎨 Reduce the gap between the port and input box when starting the MCP  container, and widen the input box to display the full hint.

### DIFF
--- a/frontend/app/[locale]/agents/components/McpConfigModal.tsx
+++ b/frontend/app/[locale]/agents/components/McpConfigModal.tsx
@@ -714,8 +714,8 @@ export default function McpConfigModal({
                   style={{ fontFamily: "monospace", fontSize: 12 }}
                 />
               </div>
-              <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-                <Text style={{ minWidth: 80 }}>{t("mcpConfig.addContainer.port")}:</Text>
+              <div style={{ display: "flex", alignItems: "center" }}>
+                <Text style={{ marginRight: 8 }}>{t("mcpConfig.addContainer.port")}:</Text>
                 <Input
                   placeholder={t("mcpConfig.addContainer.portPlaceholder")}
                   value={containerPort || ""}
@@ -731,7 +731,7 @@ export default function McpConfigModal({
                     }
                     // If invalid input, keep the previous valid value
                   }}
-                  style={{ width: 150 }}
+                  style={{ width: 200 }}
                   disabled={actionsLocked}
                 />
                 <div style={{ flex: 1 }} />

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -910,7 +910,7 @@
   "mcpConfig.addContainer.configHint": "Please enter MCP server configuration JSON (format: {\"mcpServers\": {\"server-name\": {...}}})",
   "mcpConfig.addContainer.configPlaceholder": "Please enter MCP server configuration JSON",
   "mcpConfig.addContainer.port": "Port",
-  "mcpConfig.addContainer.portPlaceholder": "Please enter port number (1-65535)",
+  "mcpConfig.addContainer.portPlaceholder": "Please enter port number",
   "mcpConfig.addContainer.button.add": "Add",
   "mcpConfig.addContainer.button.updating": "Adding...",
   "mcpConfig.containerList.title": "Running Containerized MCP Services",

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -910,7 +910,7 @@
   "mcpConfig.addContainer.configHint": "请输入MCP服务器配置JSON（格式：{\"mcpServers\": {\"server-name\": {...}}}）",
   "mcpConfig.addContainer.configPlaceholder": "请输入MCP服务器配置JSON",
   "mcpConfig.addContainer.port": "端口",
-  "mcpConfig.addContainer.portPlaceholder": "请输入端口号 (1-65535)",
+  "mcpConfig.addContainer.portPlaceholder": "请输入端口号",
   "mcpConfig.addContainer.button.add": "添加",
   "mcpConfig.addContainer.button.updating": "添加中...",
   "mcpConfig.containerList.title": "已启动的容器化MCP服务",


### PR DESCRIPTION
🎨 Reduce the gap between the port and input box when starting the MCP  container, and widen the input box to display the full hint.
[Result]
<img width="968" height="286" alt="image" src="https://github.com/user-attachments/assets/99032d45-2b92-46ea-96bc-9c28e8f442ac" />
