### PR TITLE
🐛 Replace ant design modal deprecated usage

### DIFF
--- a/frontend/app/[locale]/agents/components/agentManage/AgentCallRelationshipModal.tsx
+++ b/frontend/app/[locale]/agents/components/agentManage/AgentCallRelationshipModal.tsx
@@ -406,7 +406,7 @@ export default function AgentCallRelationshipModal({
         onCancel={onClose}
         footer={null}
         width={1800}
-        destroyOnClose
+        destroyOnHidden
         centered
         style={{ top: 20 }}
       >

--- a/frontend/app/[locale]/knowledges/components/document/DocumentChunk.tsx
+++ b/frontend/app/[locale]/knowledges/components/document/DocumentChunk.tsx
@@ -776,7 +776,7 @@ const DocumentChunk: React.FC<DocumentChunkProps> = ({
       </div>
       <Modal
         centered
-        destroyOnClose
+        destroyOnHidden
         open={isChunkModalOpen}
         title={
           chunkModalMode === "create"

--- a/frontend/app/[locale]/models/components/appConfig.tsx
+++ b/frontend/app/[locale]/models/components/appConfig.tsx
@@ -404,7 +404,7 @@ export const AppConfigSection: React.FC = () => {
               {t("common.confirm")}
             </Button>,
           ]}
-          destroyOnClose={true}
+          destroyOnHidden={true}
           width={520}
           centered
         >

--- a/frontend/app/[locale]/models/components/model/ModelAddDialog.tsx
+++ b/frontend/app/[locale]/models/components/model/ModelAddDialog.tsx
@@ -653,7 +653,7 @@ export const ModelAddDialog = ({
       open={isOpen}
       onCancel={onClose}
       footer={null}
-      destroyOnClose
+      destroyOnHidden
     >
       <div className="space-y-4">
         {/* Batch Import Switch */}
@@ -1248,7 +1248,7 @@ export const ModelAddDialog = ({
         onOk={handleSettingsSave}
         cancelText={t("common.cancel")}
         okText={t("common.confirm")}
-        destroyOnClose
+        destroyOnHidden
       >
         <div className="space-y-3">
           <div>

--- a/frontend/app/[locale]/models/components/model/ModelDeleteDialog.tsx
+++ b/frontend/app/[locale]/models/components/model/ModelDeleteDialog.tsx
@@ -865,7 +865,7 @@ export const ModelDeleteDialog = ({
           ),
       ]}
       width={520}
-      destroyOnClose
+      destroyOnHidden
     >
       {!deletingModelType ? (
         <div className="space-y-4">
@@ -1375,7 +1375,7 @@ export const ModelDeleteDialog = ({
         onOk={handleSettingsSave}
         cancelText={t("common.button.cancel")}
         okText={t("common.button.save")}
-        destroyOnClose
+        destroyOnHidden
       >
         <div className="space-y-3">
           <div>
@@ -1409,7 +1409,7 @@ export const ModelDeleteDialog = ({
         cancelText={t("common.button.cancel")}
         okText={t("common.button.save")}
         confirmLoading={savingEmbeddingConfig}
-        destroyOnClose
+        destroyOnHidden
       >
         <div className="space-y-4">
           {/* Chunk Size Range */}

--- a/frontend/app/[locale]/models/components/model/ModelEditDialog.tsx
+++ b/frontend/app/[locale]/models/components/model/ModelEditDialog.tsx
@@ -235,7 +235,7 @@ export const ModelEditDialog = ({
       open={isOpen}
       onCancel={onClose}
       footer={null}
-      destroyOnClose
+      destroyOnHidden
     >
       <div className="space-y-4">
         {/* Model Name */}
@@ -434,7 +434,7 @@ export const ProviderConfigEditDialog = ({
       open={isOpen}
       onCancel={onClose}
       footer={null}
-      destroyOnClose
+      destroyOnHidden
     >
       <div className="space-y-4">
         <div>

--- a/frontend/components/ui/AgentCallRelationshipModal.tsx
+++ b/frontend/components/ui/AgentCallRelationshipModal.tsx
@@ -406,7 +406,7 @@ export default function AgentCallRelationshipModal({
         onCancel={onClose}
         footer={null}
         width={1400}
-        destroyOnClose
+        destroyOnHidden
         centered
         style={{ top: 20 }}
       >


### PR DESCRIPTION
Ant Design upgraded, causing modal destroyOnClose attributes deprecated.