### PR TITLE
✨ Add clear button in debug page & Add model providers' links

### DIFF
--- a/frontend/app/[locale]/agents/components/agentInfo/DebugConfig.tsx
+++ b/frontend/app/[locale]/agents/components/agentInfo/DebugConfig.tsx
@@ -18,6 +18,7 @@ import log from "@/lib/logger";
 interface AgentDebuggingProps {
   onAskQuestion: (question: string) => void;
   onStop: () => void;
+  onClear: () => void;
   isStreaming: boolean;
   messages: ChatMessageType[];
 }
@@ -33,6 +34,7 @@ interface DebugConfigProps {
 function AgentDebugging({
   onAskQuestion,
   onStop,
+  onClear,
   isStreaming,
   messages,
 }: AgentDebuggingProps) {
@@ -127,6 +129,15 @@ function AgentDebugging({
           onPressEnter={handleSend}
           disabled={isStreaming}
         />
+        {/* Clear history button */}
+        <button
+          onClick={onClear}
+          disabled={isStreaming}
+          className="min-w-[56px] px-4 py-1.5 rounded-md flex items-center justify-center text-sm bg-gray-200 hover:bg-gray-300 text-gray-800 whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed"
+          style={{ border: "none" }}
+        >
+          {t("agent.debug.clear")}
+        </button>
         {isStreaming ? (
           <button
             onClick={onStop}
@@ -224,6 +235,12 @@ export default function DebugConfig({ agentId }: DebugConfigProps) {
       }
       return newMessages;
     });
+  };
+
+  // Clear local history and reset the step counter
+  const handleClearHistory = async () => {
+    setMessages([]);
+    stepIdCounter.current.current = 0;
   };
 
   // Process test question
@@ -347,6 +364,7 @@ export default function DebugConfig({ agentId }: DebugConfigProps) {
         key={agentId} // Re-render when agentId changes to ensure state resets
         onAskQuestion={handleTestQuestion}
         onStop={handleStop}
+        onClear={handleClearHistory}
         isStreaming={isStreaming}
         messages={messages}
       />

--- a/frontend/app/[locale]/models/components/model/ModelAddDialog.tsx
+++ b/frontend/app/[locale]/models/components/model/ModelAddDialog.tsx
@@ -15,7 +15,7 @@ import { configService } from "@/services/configService";
 import { getConnectivityMeta, ConnectivityStatusType } from "@/lib/utils";
 import { modelService } from "@/services/modelService";
 import { ModelType, SingleModelConfig } from "@/types/modelConfig";
-import { MODEL_TYPES } from "@/const/modelConfig";
+import { MODEL_TYPES, PROVIDER_LINKS } from "@/const/modelConfig";
 import { useSiliconModelList } from "@/hooks/model/useSiliconModelList";
 import log from "@/lib/logger";
 import {
@@ -1143,42 +1143,62 @@ export const ModelAddDialog = ({
             <div className="mt-2 ml-6 flex items-center">
               <span>{t("model.dialog.label.currentlySupported")}</span>
               <Tooltip title="ModelEngine">
-                <img
-                  src="/modelengine-logo.png"
-                  alt="ModelEngine"
-                  className="h-4 ml-1.5"
-                />
+                <a
+                  href={PROVIDER_LINKS.modelengine}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <img
+                    src="/modelengine-logo.png"
+                    alt="ModelEngine"
+                    className="h-4 ml-1.5 cursor-pointer"
+                  />
+                </a>
               </Tooltip>
               {form.isBatchImport && (
                 <Tooltip title="SiliconFlow">
-                  <img
-                    src="/siliconflow.png"
-                    alt="SiliconFlow"
-                    className="h-4 ml-1.5"
-                  />
+                  <a
+                    href={PROVIDER_LINKS.siliconflow}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <img
+                      src="/siliconflow.png"
+                      alt="SiliconFlow"
+                      className="h-4 ml-1.5 cursor-pointer"
+                    />
+                  </a>
                 </Tooltip>
               )}
               {form.type === "llm" && !form.isBatchImport && (
                 <>
                   <Tooltip title="OpenAI">
-                    <img
-                      src="/openai.png"
-                      alt="OpenAI"
-                      className="h-4 ml-1.5"
-                    />
+                    <a href={PROVIDER_LINKS.openai} target="_blank" rel="noopener noreferrer">
+                      <img
+                        src="/openai.png"
+                        alt="OpenAI"
+                        className="h-4 ml-1.5 cursor-pointer"
+                      />
+                    </a>
                   </Tooltip>
                   <Tooltip title="Kimi">
-                    <img src="/kimi.png" alt="Kimi" className="h-4 ml-1.5" />
+                    <a href={PROVIDER_LINKS.kimi} target="_blank" rel="noopener noreferrer">
+                      <img src="/kimi.png" alt="Kimi" className="h-4 ml-1.5 cursor-pointer" />
+                    </a>
                   </Tooltip>
                   <Tooltip title="Deepseek">
-                    <img
-                      src="/deepseek.png"
-                      alt="Deepseek"
-                      className="h-4 ml-1.5"
-                    />
+                    <a href={PROVIDER_LINKS.deepseek} target="_blank" rel="noopener noreferrer">
+                      <img
+                        src="/deepseek.png"
+                        alt="Deepseek"
+                        className="h-4 ml-1.5 cursor-pointer"
+                      />
+                    </a>
                   </Tooltip>
                   <Tooltip title="Qwen">
-                    <img src="/qwen.png" alt="Qwen" className="h-4 ml-1.5" />
+                    <a href={PROVIDER_LINKS.qwen} target="_blank" rel="noopener noreferrer">
+                      <img src="/qwen.png" alt="Qwen" className="h-4 ml-1.5 cursor-pointer" />
+                    </a>
                   </Tooltip>
                   <span className="ml-1.5">...</span>
                 </>
@@ -1186,20 +1206,28 @@ export const ModelAddDialog = ({
               {form.type === "embedding" && !form.isBatchImport && (
                 <>
                   <Tooltip title="OpenAI">
-                    <img
-                      src="/openai.png"
-                      alt="OpenAI"
-                      className="h-4 ml-1.5"
-                    />
+                    <a href={PROVIDER_LINKS.openai} target="_blank" rel="noopener noreferrer">
+                      <img
+                        src="/openai.png"
+                        alt="OpenAI"
+                        className="h-4 ml-1.5 cursor-pointer"
+                      />
+                    </a>
                   </Tooltip>
                   <Tooltip title="Qwen">
-                    <img src="/qwen.png" alt="Qwen" className="h-4 ml-1.5" />
+                    <a href={PROVIDER_LINKS.qwen} target="_blank" rel="noopener noreferrer">
+                      <img src="/qwen.png" alt="Qwen" className="h-4 ml-1.5 cursor-pointer" />
+                    </a>
                   </Tooltip>
                   <Tooltip title="Jina">
-                    <img src="/jina.png" alt="Jina" className="h-4 ml-1.5" />
+                    <a href={PROVIDER_LINKS.jina} target="_blank" rel="noopener noreferrer">
+                      <img src="/jina.png" alt="Jina" className="h-4 ml-1.5 cursor-pointer" />
+                    </a>
                   </Tooltip>
                   <Tooltip title="Baai">
-                    <img src="/baai.png" alt="Baai" className="h-4 ml-1.5" />
+                    <a href={PROVIDER_LINKS.baai} target="_blank" rel="noopener noreferrer">
+                      <img src="/baai.png" alt="Baai" className="h-4 ml-1.5 cursor-pointer" />
+                    </a>
                   </Tooltip>
                   <span className="ml-1.5">...</span>
                 </>
@@ -1207,14 +1235,18 @@ export const ModelAddDialog = ({
               {form.type === "vlm" && !form.isBatchImport && (
                 <>
                   <Tooltip title="Qwen">
-                    <img src="/qwen.png" alt="Qwen" className="h-4 ml-1.5" />
+                    <a href={PROVIDER_LINKS.qwen} target="_blank" rel="noopener noreferrer">
+                      <img src="/qwen.png" alt="Qwen" className="h-4 ml-1.5 cursor-pointer" />
+                    </a>
                   </Tooltip>
                   <Tooltip title="Deepseek">
-                    <img
-                      src="/deepseek.png"
-                      alt="Deepseek"
-                      className="h-4 ml-1.5"
-                    />
+                    <a href={PROVIDER_LINKS.deepseek} target="_blank" rel="noopener noreferrer">
+                      <img
+                        src="/deepseek.png"
+                        alt="Deepseek"
+                        className="h-4 ml-1.5 cursor-pointer"
+                      />
+                    </a>
                   </Tooltip>
                   <span className="ml-1.5">...</span>
                 </>

--- a/frontend/const/modelConfig.ts
+++ b/frontend/const/modelConfig.ts
@@ -73,6 +73,18 @@ export const PROVIDER_ICON_MAP: Record<ModelProviderKey, string> = {
 export const OFFICIAL_PROVIDER_ICON = "/modelengine-logo.png";
 export const DEFAULT_PROVIDER_ICON = "/default-icon.png";
 
+// Provider official website links
+export const PROVIDER_LINKS: Record<string, string> = {
+  modelengine: "https://modelengine-ai.net/",
+  siliconflow: "https://siliconflow.ai/",
+  openai: "https://platform.openai.com/",
+  kimi: "https://platform.moonshot.ai/",
+  deepseek: "https://platform.deepseek.com/",
+  qwen: "https://bailian.console.aliyun.com/",
+  jina: "https://jina.ai/",
+  baai: "https://www.baai.ac.cn/"
+};
+
 // User role constants
 export const USER_ROLES = {
   USER: "user",

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -312,6 +312,7 @@
   "agent.error.modelUnavailable": "LLM {{modelName}} is unavailable, please modify",
   "agent.debug.placeholder": "Enter test question...",
   "agent.debug.stop": "Stop",
+  "agent.debug.clear": "Clear",
   "agent.debug.send": "Send",
   "agent.debug.userStop": "User manually stopped debugging",
   "agent.debug.cancelError": "Error while canceling request",

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -313,6 +313,7 @@
   "agent.error.modelUnavailable": "大语言模型{{modelName}}不可用，请修改",
   "agent.debug.placeholder": "输入测试问题...",
   "agent.debug.stop": "停止",
+  "agent.debug.clear": "清空",
   "agent.debug.send": "发送",
   "agent.debug.userStop": "用户手动停止调试",
   "agent.debug.cancelError": "取消请求时出错",


### PR DESCRIPTION
1. 在调试页面增加清空按钮，一键清空历史对话内容；对话过程中此按钮不可点击 #2248 


https://github.com/user-attachments/assets/30eb3ca2-6d40-450a-9fd6-921fa533eb18



2. 在添加模型弹窗中的供应商icon上增加跳转链接，点击即可跳转至供应商官网 #1545 

https://github.com/user-attachments/assets/0eebf5c7-951e-42ea-83fc-7201ee3d0ecf

