### PR TITLE
🐛 Production mode deployment, unable to access Docker. #2368

### DIFF
--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -76,6 +76,7 @@ services:
     volumes:
       - ${NEXENT_USER_DIR:-$HOME/nexent}:/mnt/nexent
       - ${ROOT_DIR}/openssh-server/ssh-keys:/opt/ssh-keys:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro # Docker socket for MCP container management
     environment:
       <<: [*minio-vars, *es-vars]
       skip_proxy: "true"


### PR DESCRIPTION
🐛 Production mode deployment, unable to access Docker. #2368
[Specification Details]
1. Add a Docker access endpoint to docker-compose.prod.yml.
[Test Result]
<img width="1224" height="783" alt="image" src="https://github.com/user-attachments/assets/c39bb9e5-4d5a-459b-bc65-04279dc16d42" />
