### PR TITLE
🐛 The knowledge base page failed to load correctly on its first visit  because the indices API was not called. #2427

### DIFF
--- a/frontend/app/[locale]/knowledges/page.tsx
+++ b/frontend/app/[locale]/knowledges/page.tsx
@@ -8,6 +8,7 @@ import { configService } from "@/services/configService";
 import { configStore } from "@/lib/config";
 import { USER_ROLES } from "@/const/auth";
 import log from "@/lib/logger";
+import knowledgeBaseService from "@/services/knowledgeBaseService";
 
 import DataConfig from "./KnowledgeBaseConfiguration";
 
@@ -36,6 +37,15 @@ export default function KnowledgesContent() {
       })
     );
 
+    // Load knowledge base list from API
+    const loadKnowledgeBaseList = async () => {
+      try {
+        await knowledgeBaseService.getKnowledgeBases(true);
+      } catch (error) {
+        log.error("Failed to load knowledge base list:", error);
+      }
+    };
+
     // Load config for normal user
     const loadConfigForNormalUser = async () => {
       if (!isSpeedMode && user && user.role !== USER_ROLES.ADMIN) {
@@ -48,8 +58,9 @@ export default function KnowledgesContent() {
       }
     };
 
+    loadKnowledgeBaseList();
     loadConfigForNormalUser();
-  }, []);
+  }, [isSpeedMode, user]);
 
   return (
     <>


### PR DESCRIPTION
🐛 The knowledge base page failed to load correctly on its first visit  because the indices API was not called. #2427 
[Specification Details]
1. Add the logic for accessing the page and calling the API in page.tsx.
[Test Result]
<img width="747" height="337" alt="image" src="https://github.com/user-attachments/assets/c59993cc-9dcf-4273-92cc-b463a2a62e52" />
