### PR TITLE
🐛 Agent should not have user group info in speed version #2443

### DIFF
--- a/frontend/app/[locale]/agents/components/agentInfo/AgentGenerateDetail.tsx
+++ b/frontend/app/[locale]/agents/components/agentInfo/AgentGenerateDetail.tsx
@@ -39,6 +39,7 @@ import { useModelList } from "@/hooks/model/useModelList";
 import { useTenantList } from "@/hooks/tenant/useTenantList";
 import { useGroupList } from "@/hooks/group/useGroupList";
 import { USER_ROLES } from "@/const/auth";
+import { Can } from "@/components/permission/Can";
 import ExpandEditModal from "./ExpandEditModal";
 
 const { TextArea } = Input;
@@ -611,31 +612,33 @@ export default function AgentGenerateDetail({
                   />
                 </Form.Item>
 
-                <Form.Item
-                  name="group_ids"
-                  label={t("agent.userGroup")}
-                  className="mb-3"
-                >
-                  <Select
-                    mode="multiple"
-                    placeholder={t("agent.userGroup")}
-                    options={groupSelectOptions}
-                    allowClear
-                    onChange={(value) => {
-                      const nextGroupIds = normalizeNumberArray(value || []);
-                      const currentGroupIds = normalizeNumberArray(
-                        editedAgent.group_ids || []
-                      );
-                      if (
-                        JSON.stringify(nextGroupIds) ===
-                        JSON.stringify(currentGroupIds)
-                      ) {
-                        return;
-                      }
-                      onUpdateProfile({ group_ids: nextGroupIds });
-                    }}
-                  />
-                </Form.Item>
+                <Can permission="group:read">
+                  <Form.Item
+                    name="group_ids"
+                    label={t("agent.userGroup")}
+                    className="mb-3"
+                  >
+                    <Select
+                      mode="multiple"
+                      placeholder={t("agent.userGroup")}
+                      options={groupSelectOptions}
+                      allowClear
+                      onChange={(value) => {
+                        const nextGroupIds = normalizeNumberArray(value || []);
+                        const currentGroupIds = normalizeNumberArray(
+                          editedAgent.group_ids || []
+                        );
+                        if (
+                          JSON.stringify(nextGroupIds) ===
+                          JSON.stringify(currentGroupIds)
+                        ) {
+                          return;
+                        }
+                        onUpdateProfile({ group_ids: nextGroupIds });
+                      }}
+                    />
+                  </Form.Item>
+                </Can>
 
                 <Form.Item
                   name="agentAuthor"


### PR DESCRIPTION
🐛 Agent should not have user group info in speed version #2443
[Specification Details]
1. User group parameters use the CAN component for permission checks.
[Test Result]
 full:
![4c9c830f-c7fd-4418-a91b-43efc0830425](https://github.com/user-attachments/assets/c491ec82-e206-4999-b58d-597903dcc643)
speed:
![cdf84eaf-7501-4c70-a13c-359f3e4b5c4b](https://github.com/user-attachments/assets/462cfd61-5bb9-45d8-8326-482997dfab18)

