### PR TITLE
🐛 fix when generating agent descriptions, the specified model cannot be selected

### DIFF
--- a/frontend/app/[locale]/agents/components/agentInfo/AgentGenerateDetail.tsx
+++ b/frontend/app/[locale]/agents/components/agentInfo/AgentGenerateDetail.tsx
@@ -293,6 +293,12 @@ export default function AgentGenerateDetail({
     const selectedModel = availableLlmModels.find(
       (m) => m.name === modelName || m.displayName === modelName
     );
+    // Update local state so the Select component reflects the change
+    setBusinessInfo((prev) => ({
+      ...prev,
+      businessLogicModelName: modelName,
+      businessLogicModelId: selectedModel?.id || 0,
+    }));
     onUpdateBusinessInfo({
       business_description: businessInfo.businessDescription || "",
       business_logic_model_id: selectedModel?.id || 0,


### PR DESCRIPTION
https://github.com/ModelEngine-Group/nexent/issues/2504

可以选择 非快速配置的模型
<img width="1411" height="1586" alt="image" src="https://github.com/user-attachments/assets/6510b3b8-76b6-483c-aeec-c31b8fb7eeb5" />
