### PR TITLE
🐛 The index display box has a black border. #2513

### DIFF
--- a/frontend/components/ui/markdownRenderer.tsx
+++ b/frontend/components/ui/markdownRenderer.tsx
@@ -551,7 +551,9 @@ const HoverableText = ({
   return (
     <TooltipProvider>
       <Tooltip
-        styles={{ root: { padding: 0, background: "transparent", boxShadow: "none" } }}
+        styles={{
+          container: { padding: 0, background: "transparent", boxShadow: "none" },
+        }}
         title={
           <div
             className="z-[9999] bg-white px-3 py-2 text-sm border border-gray-200 rounded-md shadow-md max-w-xl overflow-hidden"


### PR DESCRIPTION
🐛 The index display box has a black border. #2513
[Specification Details]
1. Modify front-end style.
[Test Result]
![img_v3_02ur_5fa14b96-d16e-425b-9af2-993bc145d81g](https://github.com/user-attachments/assets/002f14db-98a0-4035-aa77-322e3365544d)
