### PR TITLE
♻️ Support starting MCP services using uvx #2241

### DIFF
--- a/make/mcp/Dockerfile
+++ b/make/mcp/Dockerfile
@@ -22,6 +22,9 @@ RUN if [ "$APT_MIRROR" = "tsinghua" ]; then \
 # Optional pip mirror for Python packages
 RUN if [ -n "$MIRROR" ]; then pip config set global.index-url "$MIRROR"; fi
 
+# Install uv (fast Python package installer)
+RUN pip install --no-cache-dir uv
+
 ARG MCP_PROXY_VERSION
 
 WORKDIR /opt


### PR DESCRIPTION
♻️ Support starting MCP services using uvx #2241
[Specification Details]
1. Install UV dependencies during image build.
[Test Result]
![c6810fe4-6875-4d88-bb10-fd3b39b226bf](https://github.com/user-attachments/assets/a7eccf35-574a-4bf5-bec5-1c8ce59dd888)
![aa480d2b-3fc8-4a48-b5c7-cd00d893ee90](https://github.com/user-attachments/assets/3169dffe-7971-422b-83ad-3ab7182ab23a)
![ac59d51c-de0b-40aa-b8a1-60e89712cb05](https://github.com/user-attachments/assets/41dbc118-ad78-443a-a924-19e807ce40c5)

