### PR TITLE
fix: replace 14 bare excepts with except Exception

### DIFF
--- a/sdk/nexent/core/agents/core_agent.py
+++ b/sdk/nexent/core/agents/core_agent.py
@@ -399,7 +399,7 @@ You have been provided with these additional arguments, that you can access usin
         try:
             self.observer.add_message(
                 self.name, ProcessType.AGENT_FINISH, str(report))
-        except:
+        except Exception:
             self.observer.add_message(self.name, ProcessType.AGENT_FINISH, "")
 
         answer = Template(self.prompt_templates["managed_agent"]["report"], undefined=StrictUndefined).render({

--- a/sdk/nexent/core/models/stt_model.py
+++ b/sdk/nexent/core/models/stt_model.py
@@ -503,7 +503,7 @@ class STTModel:
                             try:
                                 await ws_client.send_json({"error": f"STT service error: {str(e)}"})
                                 client_connected = False
-                            except:
+                            except Exception:
                                 pass
                         break
 
@@ -515,7 +515,7 @@ class STTModel:
                         try:
                             result_text = result['payload_msg']['result']['text'] if result['payload_msg']['result'][
                                 'text'] else "empty"
-                        except:
+                        except Exception:
                             logger.error(f"Malformed result: {result}")
                         logger.info(f"Received response: {result_text}")
 
@@ -550,7 +550,7 @@ class STTModel:
                             try:
                                 await ws_client.send_json({"error": f"STT service connection closed unexpectedly: {e}"})
                                 client_connected = False
-                            except:
+                            except Exception:
                                 pass
                             break
 
@@ -572,7 +572,7 @@ class STTModel:
             if client_connected:
                 try:
                     await ws_client.send_json({"error": error_msg})
-                except:
+                except Exception:
                     logger.error("Cannot send error message: client disconnected")
 
         except websockets.exceptions.WebSocketException as e:
@@ -581,7 +581,7 @@ class STTModel:
             if client_connected:
                 try:
                     await ws_client.send_json({"error": error_msg})
-                except:
+                except Exception:
                     logger.error("Cannot send error message: client disconnected")
 
         except Exception as e:
@@ -592,7 +592,7 @@ class STTModel:
             if client_connected:
                 try:
                     await ws_client.send_json({"error": error_msg})
-                except:
+                except Exception:
                     logger.error("Cannot send error message: client disconnected")
 
         finally:

--- a/sdk/nexent/core/tools/terminal_tool.py
+++ b/sdk/nexent/core/tools/terminal_tool.py
@@ -173,7 +173,7 @@ class TerminalTool(Tool):
                 return True
                 
             return False
-        except:
+        except Exception:
             return False
 
     def _cleanup_session(self, session: Dict[str, Any]):
@@ -187,7 +187,7 @@ class TerminalTool(Tool):
                 session["channel"].close()
             if session and "client" in session:
                 session["client"].close()
-        except:
+        except Exception:
             pass
 
     def _clean_output(self, raw_output: str, command: str) -> str:

--- a/sdk/nexent/core/utils/favicon_extractor.py
+++ b/sdk/nexent/core/utils/favicon_extractor.py
@@ -32,7 +32,7 @@ def check_favicon_exists(url):
     try:
         response = requests.head(url, timeout=3, allow_redirects=True)
         return response.status_code == 200
-    except:
+    except Exception:
         return False
 
 

--- a/test/backend/services/test_mcp_container_service.py
+++ b/test/backend/services/test_mcp_container_service.py
@@ -514,7 +514,7 @@ class TestLoadImageFromTarFile:
             # Clean up
             try:
                 os.unlink(temp_file_path)
-            except:
+            except Exception:
                 pass
 
     @pytest.mark.asyncio
@@ -540,7 +540,7 @@ class TestLoadImageFromTarFile:
             # Clean up
             try:
                 os.unlink(temp_file_path)
-            except:
+            except Exception:
                 pass
 
     @pytest.mark.asyncio
@@ -560,7 +560,7 @@ class TestLoadImageFromTarFile:
             # Clean up
             try:
                 os.unlink(temp_file_path)
-            except:
+            except Exception:
                 pass
 
     @pytest.mark.asyncio
@@ -581,7 +581,7 @@ class TestLoadImageFromTarFile:
             # Clean up
             try:
                 os.unlink(temp_file_path)
-            except:
+            except Exception:
                 pass
 
 


### PR DESCRIPTION
Replace 14 bare `except:` with `except Exception:` across 5 files. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors.