### PR TITLE
♻️ MCP services support authorization #2086

### DIFF
--- a/backend/agents/create_agent_info.py
+++ b/backend/agents/create_agent_info.py
@@ -372,12 +372,37 @@ async def create_agent_run_info(
     remote_mcp_list.append({
         "remote_mcp_server_name": "nexent",
         "remote_mcp_server": default_mcp_url,
-        "status": True
+        "status": True,
+        "authorization_token": None
     })
     remote_mcp_dict = {record["remote_mcp_server_name"]: record for record in remote_mcp_list if record["status"]}
 
-    # Filter MCP servers and tools
-    mcp_host = filter_mcp_servers_and_tools(agent_config, remote_mcp_dict)
+    # Filter MCP servers and tools, and build mcp_host with authorization
+    used_mcp_urls = filter_mcp_servers_and_tools(agent_config, remote_mcp_dict)
+
+    # Build mcp_host list with authorization tokens
+    mcp_host = []
+    for url in used_mcp_urls:
+        # Find the MCP record for this URL
+        mcp_record = None
+        for record in remote_mcp_list:
+            if record.get("remote_mcp_server") == url and record.get("status"):
+                mcp_record = record
+                break
+
+        if mcp_record:
+            mcp_config = {
+                "url": url,
+                "transport": "sse" if url.endswith("/sse") else "streamable-http"
+            }
+            # Add authorization if present
+            auth_token = mcp_record.get("authorization_token")
+            if auth_token:
+                mcp_config["authorization"] = auth_token
+            mcp_host.append(mcp_config)
+        else:
+            # Fallback to string format if record not found
+            mcp_host.append(url)
 
     agent_run_info = AgentRunInfo(
         query=final_query,

--- a/backend/apps/remote_mcp_app.py
+++ b/backend/apps/remote_mcp_app.py
@@ -17,6 +17,7 @@ from services.remote_mcp_service import (
     upload_and_start_mcp_image,
     update_remote_mcp_server_list,
     attach_mcp_container_permissions,
+    get_mcp_record_by_id,
 )
 from database.remote_mcp_db import check_mcp_name_exists
 from services.tool_configuration_service import get_tool_from_remote_mcp_server
@@ -30,11 +31,18 @@ logger = logging.getLogger("remote_mcp_app")
 @router.post("/tools")
 async def get_tools_from_remote_mcp(
     service_name: str,
-    mcp_url: str
+    mcp_url: str,
+    authorization: Optional[str] = Header(None),
+    http_request: Request = None
 ):
     """ Used to list tool information from the remote MCP server """
     try:
-        tools_info = await get_tool_from_remote_mcp_server(mcp_server_name=service_name, remote_mcp_server=mcp_url)
+        user_id, tenant_id, _ = get_current_user_info(authorization, http_request)
+        tools_info = await get_tool_from_remote_mcp_server(
+            mcp_server_name=service_name,
+            remote_mcp_server=mcp_url,
+            tenant_id=tenant_id
+        )
         return JSONResponse(
             status_code=HTTPStatus.OK,
             content={
@@ -54,6 +62,8 @@ async def get_tools_from_remote_mcp(
 async def add_remote_proxies(
     mcp_url: str,
     service_name: str,
+    authorization_token: Optional[str] = Query(
+        None, description="Authorization token for MCP server authentication (e.g., Bearer token)"),
     tenant_id: Optional[str] = Query(
         None, description="Tenant ID for filtering (uses auth if not provided)"),
     authorization: Optional[str] = Header(None),
@@ -68,7 +78,8 @@ async def add_remote_proxies(
                                          user_id=user_id,
                                          remote_mcp_server=mcp_url,
                                          remote_mcp_server_name=service_name,
-                                         container_id=None)
+                                         container_id=None,
+                                         authorization_token=authorization_token)
         return JSONResponse(
             status_code=HTTPStatus.OK,
             content={"message": "Successfully added remote MCP proxy",
@@ -181,6 +192,50 @@ async def get_remote_proxies(
         logger.error(f"Failed to get remote MCP proxy: {e}")
         raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
                             detail="Failed to get remote MCP proxy")
+
+
+@router.get("/record/{mcp_id}")
+async def get_mcp_record(
+    mcp_id: int,
+    tenant_id: Optional[str] = Query(
+        None, description="Tenant ID for filtering (uses auth if not provided)"),
+    authorization: Optional[str] = Header(None),
+    http_request: Request = None
+):
+    """ Get single MCP record by ID """
+    try:
+        user_id, auth_tenant_id, _ = get_current_user_info(authorization, http_request)
+        # Use explicit tenant_id if provided, otherwise fall back to auth tenant_id
+        effective_tenant_id = tenant_id or auth_tenant_id
+
+        mcp_record = await get_mcp_record_by_id(
+            mcp_id=mcp_id,
+            tenant_id=effective_tenant_id
+        )
+
+        if not mcp_record:
+            raise HTTPException(
+                status_code=HTTPStatus.NOT_FOUND,
+                detail="MCP record not found"
+            )
+
+        return JSONResponse(
+            status_code=HTTPStatus.OK,
+            content={
+                "mcp_name": mcp_record.get("mcp_name"),
+                "mcp_server": mcp_record.get("mcp_server"),
+                "authorization_token": mcp_record.get("authorization_token"),
+                "status": "success"
+            }
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to get MCP record: {e}")
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail="Failed to get MCP record"
+        )
 
 
 @router.get("/healthcheck")

--- a/backend/consts/model.py
+++ b/backend/consts/model.py
@@ -491,6 +491,8 @@ class MCPUpdateRequest(BaseModel):
     current_mcp_url: str = Field(..., description="Current MCP server URL")
     new_service_name: str = Field(..., description="New MCP service name")
     new_mcp_url: str = Field(..., description="New MCP server URL")
+    new_authorization_token: Optional[str] = Field(
+        None, description="New authorization token for MCP server authentication (e.g., Bearer token)")
 
 
 # Tenant Management Data Models

--- a/backend/database/db_models.py
+++ b/backend/database/db_models.py
@@ -322,6 +322,11 @@ class McpRecord(TableBase):
         String(200),
         doc="Docker container ID for MCP service, None for non-containerized MCP",
     )
+    authorization_token = Column(
+        String(500),
+        doc="Authorization token for MCP server authentication (e.g., Bearer token)",
+        default=None,
+    )
 
 
 class UserTenant(TableBase):

--- a/backend/database/remote_mcp_db.py
+++ b/backend/database/remote_mcp_db.py
@@ -114,6 +114,26 @@ def get_mcp_server_by_name_and_tenant(mcp_name: str, tenant_id: str) -> str:
         return mcp_record.mcp_server if mcp_record else ""
 
 
+def get_mcp_authorization_token_by_name_and_url(mcp_name: str, mcp_server: str, tenant_id: str) -> str | None:
+    """
+    Get MCP authorization token by name, URL and tenant ID
+
+    :param mcp_name: MCP name
+    :param mcp_server: MCP server URL
+    :param tenant_id: Tenant ID
+    :return: Authorization token, None if not found
+    """
+    with get_db_session() as session:
+        mcp_record = session.query(McpRecord).filter(
+            McpRecord.mcp_name == mcp_name,
+            McpRecord.mcp_server == mcp_server,
+            McpRecord.tenant_id == tenant_id,
+            McpRecord.delete_flag != 'Y'
+        ).first()
+
+        return mcp_record.authorization_token if mcp_record else None
+
+
 def update_mcp_record_by_name_and_url(
     update_data,
     tenant_id: str,
@@ -136,6 +156,10 @@ def update_mcp_record_by_name_and_url(
 
     if status is not None:
         update_fields["status"] = status
+
+    # Update authorization_token if provided
+    if hasattr(update_data, 'new_authorization_token') and update_data.new_authorization_token is not None:
+        update_fields["authorization_token"] = update_data.new_authorization_token
 
     with get_db_session() as session:
         session.query(McpRecord).filter(
@@ -161,3 +185,21 @@ def check_mcp_name_exists(mcp_name: str, tenant_id: str) -> bool:
             McpRecord.delete_flag != 'Y'
         ).first()
         return mcp_record is not None
+
+
+def get_mcp_record_by_id_and_tenant(mcp_id: int, tenant_id: str) -> Dict[str, Any] | None:
+    """
+    Get MCP record by ID and tenant ID
+
+    :param mcp_id: MCP record ID
+    :param tenant_id: Tenant ID
+    :return: MCP record as dictionary, or None if not found
+    """
+    with get_db_session() as session:
+        mcp_record = session.query(McpRecord).filter(
+            McpRecord.mcp_id == mcp_id,
+            McpRecord.tenant_id == tenant_id,
+            McpRecord.delete_flag != 'Y'
+        ).first()
+
+        return as_dict(mcp_record) if mcp_record else None

--- a/backend/database/remote_mcp_db.py
+++ b/backend/database/remote_mcp_db.py
@@ -158,7 +158,7 @@ def update_mcp_record_by_name_and_url(
         update_fields["status"] = status
 
     # Update authorization_token if provided
-    if hasattr(update_data, 'new_authorization_token') and update_data.new_authorization_token is not None:
+    if hasattr(update_data, 'new_authorization_token'):
         update_fields["authorization_token"] = update_data.new_authorization_token
 
     with get_db_session() as session:

--- a/backend/services/mcp_container_service.py
+++ b/backend/services/mcp_container_service.py
@@ -97,7 +97,7 @@ class MCPContainerManager:
             service_name: Name of the MCP service
             tenant_id: Tenant ID for isolation
             user_id: User ID for isolation
-            env_vars: Optional environment variables
+            env_vars: Optional environment variables (may contain authorization_token)
 
         Returns:
             Dictionary with container_id, mcp_url, host_port, and status
@@ -149,7 +149,7 @@ class MCPContainerManager:
             service_name: Name of the MCP service
             tenant_id: Tenant ID for isolation
             user_id: User ID for isolation
-            env_vars: Optional environment variables
+            env_vars: Optional environment variables (may contain authorization_token)
             host_port: Optional host port to bind
             full_command: Optional command to run in container
 

--- a/backend/services/remote_mcp_service.py
+++ b/backend/services/remote_mcp_service.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 
 from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport, SSETransport
 
 from consts.const import CAN_EDIT_ALL_USER_ROLES, PERMISSION_EDIT, PERMISSION_READ
 from consts.exceptions import MCPConnectionError, MCPNameIllegal
@@ -14,6 +15,8 @@ from database.remote_mcp_db import (
     check_mcp_name_exists,
     update_mcp_status_by_name_and_url,
     update_mcp_record_by_name_and_url,
+    get_mcp_authorization_token_by_name_and_url,
+    get_mcp_record_by_id_and_tenant,
 )
 from database.user_tenant_db import get_user_tenant_by_user_id
 from services.mcp_container_service import MCPContainerManager
@@ -21,9 +24,30 @@ from services.mcp_container_service import MCPContainerManager
 logger = logging.getLogger("remote_mcp_service")
 
 
-async def mcp_server_health(remote_mcp_server: str) -> bool:
+async def mcp_server_health(remote_mcp_server: str, authorization_token: str | None = None) -> bool:
     try:
-        client = Client(remote_mcp_server)
+        # Select transport based on URL ending
+        url_stripped = remote_mcp_server.strip()
+        headers = {"Authorization": authorization_token} if authorization_token else {}
+
+        if url_stripped.endswith("/sse"):
+            transport = SSETransport(
+                url=url_stripped,
+                headers=headers
+            )
+        elif url_stripped.endswith("/mcp"):
+            transport = StreamableHttpTransport(
+                url=url_stripped,
+                headers=headers
+            )
+        else:
+            # Default to StreamableHttpTransport for unrecognized formats
+            transport = StreamableHttpTransport(
+                url=url_stripped,
+                headers=headers
+            )
+
+        client = Client(transport=transport)
         async with client:
             connected = client.is_connected()
             return connected
@@ -40,6 +64,7 @@ async def add_remote_mcp_server_list(
     remote_mcp_server: str,
     remote_mcp_server_name: str,
     container_id: str | None = None,
+    authorization_token: str | None = None,
 ):
 
     # check if MCP name already exists
@@ -49,7 +74,7 @@ async def add_remote_mcp_server_list(
         raise MCPNameIllegal("MCP name already exists")
 
     # check if the address is available
-    if not await mcp_server_health(remote_mcp_server=remote_mcp_server):
+    if not await mcp_server_health(remote_mcp_server=remote_mcp_server, authorization_token=authorization_token):
         raise MCPConnectionError("MCP connection failed")
 
     # update the PG database record
@@ -58,6 +83,7 @@ async def add_remote_mcp_server_list(
         "mcp_server": remote_mcp_server,
         "status": True,
         "container_id": container_id,
+        "authorization_token": authorization_token,
     }
     create_mcp_record(mcp_data=insert_mcp_data,
                       tenant_id=tenant_id, user_id=user_id)
@@ -104,9 +130,21 @@ async def update_remote_mcp_server_list(
                 f"New MCP name already exists, tenant_id: {tenant_id}, new_mcp_server_name: {update_data.new_service_name}")
             raise MCPNameIllegal("New MCP name already exists")
 
+    # Get authorization token: use new one if provided, otherwise get existing from database
+    authorization_token = update_data.new_authorization_token
+    if authorization_token is None:
+        authorization_token = get_mcp_authorization_token_by_name_and_url(
+            mcp_name=update_data.current_service_name,
+            mcp_server=update_data.current_mcp_url,
+            tenant_id=tenant_id
+        )
+
     # Check if the new server URL is accessible
     try:
-        status = await mcp_server_health(remote_mcp_server=update_data.new_mcp_url)
+        status = await mcp_server_health(
+            remote_mcp_server=update_data.new_mcp_url,
+            authorization_token=authorization_token
+        )
     except BaseException:
         status = False
 
@@ -146,6 +184,7 @@ async def get_remote_mcp_server_list(tenant_id: str, user_id: str | None = None)
             "remote_mcp_server": record["mcp_server"],
             "status": record["status"],
             "permission": permission,
+            "mcp_id": record.get("mcp_id")
         })
     return mcp_records_list
 
@@ -202,9 +241,19 @@ def attach_mcp_container_permissions(
 
 
 async def check_mcp_health_and_update_db(mcp_url, service_name, tenant_id, user_id):
+    # Get authorization token from database
+    authorization_token = get_mcp_authorization_token_by_name_and_url(
+        mcp_name=service_name,
+        mcp_server=mcp_url,
+        tenant_id=tenant_id
+    )
+
     # check the health of the MCP server
     try:
-        status = await mcp_server_health(remote_mcp_server=mcp_url)
+        status = await mcp_server_health(
+            remote_mcp_server=mcp_url,
+            authorization_token=authorization_token
+        )
     except BaseException:
         status = False
     # update the status of the MCP server in the database
@@ -230,6 +279,28 @@ async def delete_mcp_by_container_id(tenant_id: str, user_id: str, container_id:
         tenant_id=tenant_id,
         user_id=user_id,
     )
+
+
+async def get_mcp_record_by_id(mcp_id: int, tenant_id: str) -> dict | None:
+    """
+    Get MCP record by ID
+
+    Args:
+        mcp_id: MCP record ID
+        tenant_id: Tenant ID
+
+    Returns:
+        Dictionary containing mcp_name, mcp_server, and authorization_token, or None if not found
+    """
+    mcp_record = get_mcp_record_by_id_and_tenant(mcp_id=mcp_id, tenant_id=tenant_id)
+    if not mcp_record:
+        return None
+
+    return {
+        "mcp_name": mcp_record.get("mcp_name"),
+        "mcp_server": mcp_record.get("mcp_server"),
+        "authorization_token": mcp_record.get("authorization_token"),
+    }
 
 
 async def upload_and_start_mcp_image(
@@ -320,6 +391,11 @@ async def upload_and_start_mcp_image(
             logger.warning(
                 f"Failed to clean up temporary file {temp_file_path}: {e}")
 
+    # Extract authorization_token from env_vars for database registration
+    authorization_token = None
+    if parsed_env_vars:
+        authorization_token = parsed_env_vars.get("authorization_token")
+
     # Register to remote MCP server list
     await add_remote_mcp_server_list(
         tenant_id=tenant_id,
@@ -327,6 +403,7 @@ async def upload_and_start_mcp_image(
         remote_mcp_server=container_info["mcp_url"],
         remote_mcp_server_name=final_service_name,
         container_id=container_info["container_id"],
+        authorization_token=authorization_token,
     )
 
     return {

--- a/backend/services/remote_mcp_service.py
+++ b/backend/services/remote_mcp_service.py
@@ -130,14 +130,8 @@ async def update_remote_mcp_server_list(
                 f"New MCP name already exists, tenant_id: {tenant_id}, new_mcp_server_name: {update_data.new_service_name}")
             raise MCPNameIllegal("New MCP name already exists")
 
-    # Get authorization token: use new one if provided, otherwise get existing from database
+    # User authorization token
     authorization_token = update_data.new_authorization_token
-    if authorization_token is None:
-        authorization_token = get_mcp_authorization_token_by_name_and_url(
-            mcp_name=update_data.current_service_name,
-            mcp_server=update_data.current_mcp_url,
-            tenant_id=tenant_id
-        )
 
     # Check if the new server URL is accessible
     try:

--- a/backend/services/tool_configuration_service.py
+++ b/backend/services/tool_configuration_service.py
@@ -7,13 +7,18 @@ from urllib.parse import urljoin
 
 from pydantic_core import PydanticUndefined
 from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport, SSETransport
 import jsonref
 from mcpadapt.smolagents_adapter import _sanitize_function_name
 
 from consts.const import LOCAL_MCP_SERVER, DATA_PROCESS_SERVICE
 from consts.exceptions import MCPConnectionError, ToolExecutionException, NotFoundException
 from consts.model import ToolInstanceInfoRequest, ToolInfo, ToolSourceEnum, ToolValidateRequest
-from database.remote_mcp_db import get_mcp_records_by_tenant, get_mcp_server_by_name_and_tenant
+from database.remote_mcp_db import (
+    get_mcp_records_by_tenant,
+    get_mcp_server_by_name_and_tenant,
+    get_mcp_authorization_token_by_name_and_url,
+)
 from database.tool_db import (
     create_or_update_tool_by_tool_info,
     query_all_tools,
@@ -28,6 +33,29 @@ from database.client import minio_client
 from services.image_service import get_vlm_model
 
 logger = logging.getLogger("tool_configuration_service")
+
+
+def _create_mcp_transport(url: str, authorization_token: Optional[str] = None):
+    """
+    Create appropriate MCP transport based on URL ending.
+
+    Args:
+        url: MCP server URL
+        authorization_token: Optional authorization token
+
+    Returns:
+        Transport instance (SSETransport or StreamableHttpTransport)
+    """
+    url_stripped = url.strip()
+    headers = {"Authorization": authorization_token} if authorization_token else {}
+
+    if url_stripped.endswith("/sse"):
+        return SSETransport(url=url, headers=headers)
+    elif url_stripped.endswith("/mcp"):
+        return StreamableHttpTransport(url=url, headers=headers)
+    else:
+        # Default to StreamableHttpTransport for unrecognized formats
+        return StreamableHttpTransport(url=url, headers=headers)
 
 
 def python_type_to_json_schema(annotation: Any) -> str:
@@ -209,14 +237,20 @@ async def get_all_mcp_tools(tenant_id: str) -> List[ToolInfo]:
         # only update connected server
         if record["status"]:
             try:
-                tools_info.extend(await get_tool_from_remote_mcp_server(mcp_server_name=record["mcp_name"],
-                                                                        remote_mcp_server=record["mcp_server"]))
+                tools_info.extend(await get_tool_from_remote_mcp_server(
+                    mcp_server_name=record["mcp_name"],
+                    remote_mcp_server=record["mcp_server"],
+                    tenant_id=tenant_id
+                ))
             except Exception as e:
                 logger.error(f"mcp connection error: {str(e)}")
 
     default_mcp_url = urljoin(LOCAL_MCP_SERVER, "sse")
-    tools_info.extend(await get_tool_from_remote_mcp_server(mcp_server_name="nexent",
-                                                            remote_mcp_server=default_mcp_url))
+    tools_info.extend(await get_tool_from_remote_mcp_server(
+        mcp_server_name="nexent",
+        remote_mcp_server=default_mcp_url,
+        tenant_id=None
+    ))
     return tools_info
 
 
@@ -274,12 +308,34 @@ def update_tool_info_impl(tool_info: ToolInstanceInfoRequest, tenant_id: str, us
     }
 
 
-async def get_tool_from_remote_mcp_server(mcp_server_name: str, remote_mcp_server: str):
-    """get the tool information from the remote MCP server, avoid blocking the event loop"""
+async def get_tool_from_remote_mcp_server(
+    mcp_server_name: str,
+    remote_mcp_server: str,
+    tenant_id: Optional[str] = None,
+    authorization_token: Optional[str] = None
+):
+    """
+    Get the tool information from the remote MCP server, avoid blocking the event loop
+
+    Args:
+        mcp_server_name: Name of the MCP server
+        remote_mcp_server: URL of the MCP server
+        tenant_id: Optional tenant ID for database lookup of authorization_token
+        authorization_token: Optional authorization token for authentication (if not provided and tenant_id is given, will be fetched from database)
+    """
+    # Get authorization token from database if not provided
+    if authorization_token is None and tenant_id:
+        authorization_token = get_mcp_authorization_token_by_name_and_url(
+            mcp_name=mcp_server_name,
+            mcp_server=remote_mcp_server,
+            tenant_id=tenant_id
+        )
+
     tools_info = []
 
     try:
-        client = Client(remote_mcp_server, timeout=10)
+        transport = _create_mcp_transport(remote_mcp_server, authorization_token)
+        client = Client(transport=transport, timeout=10)
         async with client:
             # List available operations
             tools = await client.list_tools()
@@ -407,7 +463,8 @@ def load_last_tool_config_impl(tool_id: int, tenant_id: str, user_id: str):
 async def _call_mcp_tool(
     mcp_url: str,
     tool_name: str,
-    inputs: Optional[Dict[str, Any]]
+    inputs: Optional[Dict[str, Any]],
+    authorization_token: Optional[str] = None
 ) -> Dict[str, Any]:
     """
     Common method to call MCP tool with connection handling.
@@ -416,6 +473,7 @@ async def _call_mcp_tool(
         mcp_url: MCP server URL
         tool_name: Name of the tool to call
         inputs: Parameters to pass to the tool
+        authorization_token: Optional authorization token for authentication
 
     Returns:
         Dict containing tool execution result
@@ -423,7 +481,8 @@ async def _call_mcp_tool(
     Raises:
         MCPConnectionError: If MCP connection fails
     """
-    client = Client(mcp_url)
+    transport = _create_mcp_transport(mcp_url, authorization_token)
+    client = Client(transport=transport)
     async with client:
         # Check if connected
         if not client.is_connected():
@@ -486,7 +545,16 @@ async def _validate_mcp_tool_remote(
     if not actual_mcp_url:
         raise NotFoundException(f"MCP server not found for name: {usage}")
 
-    return await _call_mcp_tool(actual_mcp_url, tool_name, inputs)
+    # Get authorization token from database
+    authorization_token = None
+    if tenant_id:
+        authorization_token = get_mcp_authorization_token_by_name_and_url(
+            mcp_name=usage,
+            mcp_server=actual_mcp_url,
+            tenant_id=tenant_id
+        )
+
+    return await _call_mcp_tool(actual_mcp_url, tool_name, inputs, authorization_token)
 
 
 def _get_tool_class_by_name(tool_name: str) -> Optional[type]:

--- a/backend/services/tool_configuration_service.py
+++ b/backend/services/tool_configuration_service.py
@@ -50,12 +50,12 @@ def _create_mcp_transport(url: str, authorization_token: Optional[str] = None):
     headers = {"Authorization": authorization_token} if authorization_token else {}
 
     if url_stripped.endswith("/sse"):
-        return SSETransport(url=url, headers=headers)
+        return SSETransport(url=url_stripped, headers=headers)
     elif url_stripped.endswith("/mcp"):
-        return StreamableHttpTransport(url=url, headers=headers)
+        return StreamableHttpTransport(url=url_stripped, headers=headers)
     else:
         # Default to StreamableHttpTransport for unrecognized formats
-        return StreamableHttpTransport(url=url, headers=headers)
+        return StreamableHttpTransport(url=url_stripped, headers=headers)
 
 
 def python_type_to_json_schema(annotation: Any) -> str:

--- a/docker/init.sql
+++ b/docker/init.sql
@@ -487,6 +487,7 @@ CREATE TABLE IF NOT EXISTS nexent.mcp_record_t (
     mcp_server VARCHAR(500),
     status BOOLEAN DEFAULT NULL,
     container_id VARCHAR(200) DEFAULT NULL,
+    authorization_token VARCHAR(500) DEFAULT NULL,
     create_time TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     update_time TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     created_by VARCHAR(100),
@@ -505,6 +506,7 @@ COMMENT ON COLUMN nexent.mcp_record_t.mcp_name IS 'MCP name';
 COMMENT ON COLUMN nexent.mcp_record_t.mcp_server IS 'MCP server address';
 COMMENT ON COLUMN nexent.mcp_record_t.status IS 'MCP server connection status, true=connected, false=disconnected, null=unknown';
 COMMENT ON COLUMN nexent.mcp_record_t.container_id IS 'Docker container ID for MCP service, NULL for non-containerized MCP';
+COMMENT ON COLUMN nexent.mcp_record_t.authorization_token IS 'Authorization token for MCP server authentication (e.g., Bearer token)';
 COMMENT ON COLUMN nexent.mcp_record_t.create_time IS 'Creation time, audit field';
 COMMENT ON COLUMN nexent.mcp_record_t.update_time IS 'Update time, audit field';
 COMMENT ON COLUMN nexent.mcp_record_t.created_by IS 'Creator ID, audit field';

--- a/docker/sql/v1.8.1_0301_add_authorization_token_to_mcp_record_t.sql
+++ b/docker/sql/v1.8.1_0301_add_authorization_token_to_mcp_record_t.sql
@@ -1,0 +1,10 @@
+-- Migration: Add authorization_token column to mcp_record_t table
+-- Date: 2025-03-01
+-- Description: Add authorization_token field to support MCP server authentication
+
+-- Add authorization_token column to mcp_record_t table
+ALTER TABLE nexent.mcp_record_t
+ADD COLUMN IF NOT EXISTS authorization_token VARCHAR(500) DEFAULT NULL;
+
+-- Add comment to the column
+COMMENT ON COLUMN nexent.mcp_record_t.authorization_token IS 'Authorization token for MCP server authentication (e.g., Bearer token)';

--- a/frontend/app/[locale]/agents/components/agentConfig/McpConfigModal.tsx
+++ b/frontend/app/[locale]/agents/components/agentConfig/McpConfigModal.tsx
@@ -67,12 +67,14 @@ export default function McpConfigModal({
     handleUploadImage,
     handleDeleteContainer,
     handleViewLogs,
+    handleGetMcpRecord,
   } = useMcpConfig({ enabled: visible });
 
   // Local UI state
   const [addingServer, setAddingServer] = useState(false);
   const [newServerName, setNewServerName] = useState("");
   const [newServerUrl, setNewServerUrl] = useState("");
+  const [newServerAuthorizationToken, setNewServerAuthorizationToken] = useState("");
 
   const [toolsModalVisible, setToolsModalVisible] = useState(false);
   const [currentServerTools, setCurrentServerTools] = useState<any[]>([]);
@@ -82,6 +84,7 @@ export default function McpConfigModal({
   const [editServerModalVisible, setEditServerModalVisible] = useState(false);
   const [editingServer, setEditingServer] = useState<any>(null);
   const [updatingServer, setUpdatingServer] = useState(false);
+  const [loadingMcpRecord, setLoadingMcpRecord] = useState(false);
 
   const [addingContainer, setAddingContainer] = useState(false);
   const [containerConfigJson, setContainerConfigJson] = useState("");
@@ -98,6 +101,7 @@ export default function McpConfigModal({
   const [uploadFileList, setUploadFileList] = useState<UploadFile[]>([]);
   const [uploadPort, setUploadPort] = useState<number | undefined>(undefined);
   const [uploadServiceName, setUploadServiceName] = useState("");
+  const [uploadAuthorizationToken, setUploadAuthorizationToken] = useState("");
 
   const actionsLocked = updatingTools || addingContainer || uploadingImage;
   const noMcpEditPermissionTitle = t("mcpConfig.permission.noEdit");
@@ -158,10 +162,15 @@ export default function McpConfigModal({
     }
 
     setAddingServer(true);
-    const result = await handleAddServer(newServerUrl.trim(), serverName);
+    const result = await handleAddServer(
+      newServerUrl.trim(),
+      serverName,
+      newServerAuthorizationToken.trim() || null
+    );
     if (result.success) {
       setNewServerName("");
       setNewServerUrl("");
+      setNewServerAuthorizationToken("");
       message.success(result.messageKey ? t(result.messageKey) : t("mcpService.message.addServerSuccess"));
     } else {
       message.error(result.messageKey ? t(result.messageKey) : (result.message || t("mcpConfig.message.addServerFailed")));
@@ -244,12 +253,29 @@ export default function McpConfigModal({
     }
   };
 
-  const onEditServer = (server: any) => {
+  const onEditServer = async (server: any) => {
     setEditingServer(server);
     setEditServerModalVisible(true);
+    setLoadingMcpRecord(true);
+
+    // If mcp_id is available, fetch the latest record data including authorization_token
+    if (server.mcp_id) {
+      const result = await handleGetMcpRecord(server.mcp_id);
+      if (result.success && result.data) {
+        setEditingServer({
+          ...server,
+          service_name: result.data.mcp_name,
+          mcp_url: result.data.mcp_server,
+          authorization_token: result.data.authorization_token,
+        });
+      } else {
+        message.error(result.messageKey ? t(result.messageKey) : (result.message || t("mcpConfig.message.getMcpRecordFailed")));
+      }
+    }
+    setLoadingMcpRecord(false);
   };
 
-  const onSaveEditedServer = async (name: string, url: string) => {
+  const onSaveEditedServer = async (name: string, url: string, authorizationToken?: string | null) => {
     if (!editingServer) return;
     if (!name.trim() || !url.trim()) {
       message.error(t("mcpConfig.message.nameAndUrlRequired"));
@@ -272,7 +298,8 @@ export default function McpConfigModal({
       editingServer.service_name,
       editingServer.mcp_url,
       name.trim(),
-      url.trim()
+      url.trim(),
+      authorizationToken
     );
     if (result.success) {
       setEditServerModalVisible(false);
@@ -343,13 +370,19 @@ export default function McpConfigModal({
     }
 
     setUploadingImage(true);
-    const result = await handleUploadImage(file, uploadPort, uploadServiceName.trim() || undefined);
+    const result = await handleUploadImage(
+      file,
+      uploadPort,
+      uploadServiceName.trim() || undefined,
+      uploadAuthorizationToken.trim() || undefined
+    );
     if (!result.success) {
       message.error(result.messageKey ? t(result.messageKey) : (result.message || t("mcpConfig.message.uploadImageFailed")));
     } else {
       setUploadFileList([]);
       setUploadPort(undefined);
       setUploadServiceName("");
+      setUploadAuthorizationToken("");
       message.success(result.messageKey ? t(result.messageKey) : t("mcpService.message.uploadImageSuccess"));
     }
     setUploadingImage(false);
@@ -638,49 +671,66 @@ export default function McpConfigModal({
                 children: (
                   <Card size="small" style={{ marginTop: 8 }}>
                     <Space orientation="vertical" style={{ width: "100%" }}>
-                      <div
-                        style={{
-                          display: "flex",
-                          gap: 8,
-                          alignItems: "center",
-                        }}
-                      >
-                        <Input
-                          placeholder={t("mcpConfig.addServer.namePlaceholder")}
-                          value={newServerName}
-                          onChange={(e) => setNewServerName(e.target.value)}
-                          style={{ flex: 1 }}
-                          maxLength={20}
-                          disabled={actionsLocked || addingServer}
-                        />
-                        <Input
-                          placeholder={t("mcpConfig.addServer.urlPlaceholder")}
-                          value={newServerUrl}
-                          onChange={(e) => setNewServerUrl(e.target.value)}
-                          style={{ flex: 2 }}
-                          disabled={actionsLocked || addingServer}
-                        />
-                        <Button
-                          type="primary"
-                          onClick={onAddServer}
-                          loading={addingServer || updatingTools}
-                          icon={
-                            addingServer || updatingTools ? (
-                              <LoaderCircle
-                                className="animate-spin"
-                                style={{ width: 16, height: 16 }}
-                              />
-                            ) : (
-                              <Plus style={{ width: 16, height: 16 }} />
-                            )
-                          }
-                          disabled={actionsLocked}
+                      <Space direction="vertical" style={{ width: "100%" }} size="small">
+                        <div
+                          style={{
+                            display: "flex",
+                            gap: 8,
+                            alignItems: "center",
+                          }}
                         >
-                          {updatingTools
-                            ? t("mcpConfig.addServer.button.updating")
-                            : t("mcpConfig.addServer.button.add")}
-                        </Button>
-                      </div>
+                          <Input
+                            placeholder={t("mcpConfig.addServer.namePlaceholder")}
+                            value={newServerName}
+                            onChange={(e) => setNewServerName(e.target.value)}
+                            style={{ flex: 0.8 }}
+                            maxLength={20}
+                            disabled={actionsLocked || addingServer}
+                          />
+                          <Input
+                            placeholder={t("mcpConfig.addServer.urlPlaceholder")}
+                            value={newServerUrl}
+                            onChange={(e) => setNewServerUrl(e.target.value)}
+                            style={{ flex: 3 }}
+                            disabled={actionsLocked || addingServer}
+                          />
+                        </div>
+                        <div
+                          style={{
+                            display: "flex",
+                            gap: 8,
+                            alignItems: "center",
+                          }}
+                        >
+                          <Input.Password
+                            placeholder={t("mcpConfig.editServer.authorizationTokenPlaceholder")}
+                            value={newServerAuthorizationToken}
+                            onChange={(e) => setNewServerAuthorizationToken(e.target.value)}
+                            disabled={actionsLocked || addingServer}
+                            style={{ flex: 1 }}
+                          />
+                          <Button
+                            type="primary"
+                            onClick={onAddServer}
+                            loading={addingServer || updatingTools}
+                            icon={
+                              addingServer || updatingTools ? (
+                                <LoaderCircle
+                                  className="animate-spin"
+                                  style={{ width: 16, height: 16 }}
+                                />
+                              ) : (
+                                <Plus style={{ width: 16, height: 16 }} />
+                              )
+                            }
+                            disabled={actionsLocked}
+                          >
+                            {updatingTools
+                              ? t("mcpConfig.addServer.button.updating")
+                              : t("mcpConfig.addServer.button.add")}
+                          </Button>
+                        </div>
+                      </Space>
                     </Space>
                   </Card>
                 ),
@@ -864,6 +914,23 @@ export default function McpConfigModal({
                                 style={{ flex: 1 }}
                                 disabled={actionsLocked}
                               />
+                            </div>
+                            <div
+                              style={{
+                                display: "flex",
+                                gap: 8,
+                                alignItems: "center",
+                              }}
+                            >
+                              <Input.Password
+                                placeholder={t("mcpConfig.editServer.authorizationTokenPlaceholder")}
+                                value={uploadAuthorizationToken}
+                                onChange={(e) =>
+                                  setUploadAuthorizationToken(e.target.value)
+                                }
+                                disabled={actionsLocked}
+                                style={{ flex: 1 }}
+                              />
                               <Button
                                 type="primary"
                                 onClick={onUploadImage}
@@ -964,11 +1031,15 @@ export default function McpConfigModal({
       {/* Edit server modal */}
       <McpEditServerModal
         open={editServerModalVisible}
-        onCancel={() => setEditServerModalVisible(false)}
+        onCancel={() => {
+          setEditServerModalVisible(false);
+          setEditingServer(null);
+        }}
         onSave={onSaveEditedServer}
         initialName={editingServer?.service_name || ""}
         initialUrl={editingServer?.mcp_url || ""}
-        loading={updatingServer}
+        initialAuthorizationToken={editingServer?.authorization_token || null}
+        loading={updatingServer || loadingMcpRecord}
       />
 
       {/* Container logs modal */}

--- a/frontend/app/[locale]/tenant-resources/components/resources/McpList.tsx
+++ b/frontend/app/[locale]/tenant-resources/components/resources/McpList.tsx
@@ -66,6 +66,7 @@ export default function McpList({ tenantId }: { tenantId: string | null }) {
     handleUploadImage,
     handleDeleteContainer,
     handleViewLogs,
+    handleGetMcpRecord,
   } = useMcpConfig({ enabled: true, tenantId });
 
   // Add Modal State
@@ -73,6 +74,7 @@ export default function McpList({ tenantId }: { tenantId: string | null }) {
   const [addingServer, setAddingServer] = useState(false);
   const [newServerName, setNewServerName] = useState("");
   const [newServerUrl, setNewServerUrl] = useState("");
+  const [newServerAuthorizationToken, setNewServerAuthorizationToken] = useState("");
 
   // Tools Modal State
   const [toolsModalVisible, setToolsModalVisible] = useState(false);
@@ -84,6 +86,7 @@ export default function McpList({ tenantId }: { tenantId: string | null }) {
   const [editServerModalVisible, setEditServerModalVisible] = useState(false);
   const [editingServer, setEditingServer] = useState<McpServer | null>(null);
   const [updatingServer, setUpdatingServer] = useState(false);
+  const [loadingMcpRecord, setLoadingMcpRecord] = useState(false);
 
   // Container Add/Logs State
   const [addingContainer, setAddingContainer] = useState(false);
@@ -99,6 +102,7 @@ export default function McpList({ tenantId }: { tenantId: string | null }) {
   const [uploadFileList, setUploadFileList] = useState<UploadFile[]>([]);
   const [uploadPort, setUploadPort] = useState<number | undefined>(undefined);
   const [uploadServiceName, setUploadServiceName] = useState("");
+  const [uploadAuthorizationToken, setUploadAuthorizationToken] = useState("");
 
   const actionsLocked = updatingTools || addingContainer || uploadingImage;
 
@@ -125,10 +129,15 @@ export default function McpList({ tenantId }: { tenantId: string | null }) {
     }
 
     setAddingServer(true);
-    const result = await handleAddServer(newServerUrl.trim(), serverName);
+    const result = await handleAddServer(
+      newServerUrl.trim(),
+      serverName,
+      newServerAuthorizationToken.trim() || null
+    );
     if (result.success) {
       setNewServerName("");
       setNewServerUrl("");
+      setNewServerAuthorizationToken("");
       setAddModalVisible(false);
       message.success(result.messageKey ? t(result.messageKey) : t("mcpService.message.addServerSuccess"));
     } else {
@@ -199,12 +208,29 @@ export default function McpList({ tenantId }: { tenantId: string | null }) {
   };
 
   // Handlers (Edit Server)
-  const onEditServer = (server: McpServer) => {
+  const onEditServer = async (server: McpServer) => {
     setEditingServer(server);
     setEditServerModalVisible(true);
+    setLoadingMcpRecord(true);
+
+    // If mcp_id is available, fetch the latest record data including authorization_token
+    if (server.mcp_id) {
+      const result = await handleGetMcpRecord(server.mcp_id);
+      if (result.success && result.data) {
+        setEditingServer({
+          ...server,
+          service_name: result.data.mcp_name,
+          mcp_url: result.data.mcp_server,
+          authorization_token: result.data.authorization_token,
+        });
+      } else {
+        message.error(result.messageKey ? t(result.messageKey) : (result.message || t("mcpConfig.message.getMcpRecordFailed")));
+      }
+    }
+    setLoadingMcpRecord(false);
   };
 
-  const onSaveEditedServer = async (name: string, url: string) => {
+  const onSaveEditedServer = async (name: string, url: string, authorizationToken?: string | null) => {
     if (!editingServer) return;
     if (!name.trim() || !url.trim()) {
       message.error(t("mcpConfig.message.nameAndUrlRequired"));
@@ -225,7 +251,8 @@ export default function McpList({ tenantId }: { tenantId: string | null }) {
       editingServer.service_name,
       editingServer.mcp_url,
       name.trim(),
-      url.trim()
+      url.trim(),
+      authorizationToken
     );
     if (result.success) {
       setEditServerModalVisible(false);
@@ -292,11 +319,17 @@ export default function McpList({ tenantId }: { tenantId: string | null }) {
     }
 
     setUploadingImage(true);
-    const result = await handleUploadImage(file, uploadPort, uploadServiceName.trim() || undefined);
+    const result = await handleUploadImage(
+      file,
+      uploadPort,
+      uploadServiceName.trim() || undefined,
+      uploadAuthorizationToken.trim() || undefined
+    );
     if (result.success) {
       setUploadFileList([]);
       setUploadPort(undefined);
       setUploadServiceName("");
+      setUploadAuthorizationToken("");
       setAddModalVisible(false);
       message.success(result.messageKey ? t(result.messageKey) : t("mcpService.message.uploadImageSuccess"));
     } else {
@@ -580,32 +613,45 @@ export default function McpList({ tenantId }: { tenantId: string | null }) {
               ),
               children: (
                 <Card size="small" className="mt-2">
-                  <div className="flex items-center gap-2 w-full">
-                    <Input
-                      placeholder={t("mcpConfig.addServer.namePlaceholder")}
-                      value={newServerName}
-                      onChange={(e) => setNewServerName(e.target.value)}
-                      maxLength={20}
-                      disabled={actionsLocked || addingServer}
-                      style={{ flex: 1 }}
-                    />
-                    <Input
-                      placeholder={t("mcpConfig.addServer.urlPlaceholder")}
-                      value={newServerUrl}
-                      onChange={(e) => setNewServerUrl(e.target.value)}
-                      disabled={actionsLocked || addingServer}
-                      style={{ flex: 2 }}
-                    />
-                    <Button
-                      type="primary"
-                      onClick={onAddServer}
-                      loading={addingServer || updatingTools}
-                      disabled={actionsLocked}
-                      icon={addingServer || updatingTools ? <LoaderCircle className="animate-spin size-4" /> : <Plus className="size-4" />}
-                    >
-                      {t("mcpConfig.addServer.button.add")}
-                    </Button>
-                  </div>
+                  <Space direction="vertical" className="w-full" size="small">
+                    <div className="flex items-center gap-2 w-full">
+                      <Input
+                        placeholder={t("mcpConfig.addServer.namePlaceholder")}
+                        value={newServerName}
+                        onChange={(e) => setNewServerName(e.target.value)}
+                        maxLength={20}
+                        disabled={actionsLocked || addingServer}
+                        style={{ flex: 0.8 }}
+                      />
+                      <Input
+                        placeholder={t("mcpConfig.addServer.urlPlaceholder")}
+                        value={newServerUrl}
+                        onChange={(e) => setNewServerUrl(e.target.value)}
+                        disabled={actionsLocked || addingServer}
+                        style={{ flex: 3 }}
+                      />
+                    </div>
+                    <div className="flex items-center gap-2 w-full">
+                      <Input.Password
+                        placeholder={t("mcpConfig.editServer.authorizationTokenPlaceholder")}
+                        value={newServerAuthorizationToken}
+                        onChange={(e) => setNewServerAuthorizationToken(e.target.value)}
+                        disabled={actionsLocked || addingServer}
+                        className="flex-1"
+                      />
+                      <Button
+                        type="primary"
+                        onClick={onAddServer}
+                        loading={addingServer || updatingTools}
+                        disabled={actionsLocked}
+                        icon={addingServer || updatingTools ? <LoaderCircle className="animate-spin size-4" /> : <Plus className="size-4" />}
+                      >
+                        {updatingTools
+                          ? t("mcpConfig.addServer.button.updating")
+                          : t("mcpConfig.addServer.button.add")}
+                      </Button>
+                    </div>
+                  </Space>
                 </Card>
               ),
             },
@@ -702,6 +748,15 @@ export default function McpList({ tenantId }: { tenantId: string | null }) {
                         className="flex-1"
                         disabled={actionsLocked}
                       />
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Input.Password
+                        placeholder={t("mcpConfig.editServer.authorizationTokenPlaceholder")}
+                        value={uploadAuthorizationToken}
+                        onChange={(e) => setUploadAuthorizationToken(e.target.value)}
+                        className="flex-1"
+                        disabled={actionsLocked}
+                      />
                       <Button
                         type="primary"
                         onClick={onUploadImage}
@@ -709,7 +764,9 @@ export default function McpList({ tenantId }: { tenantId: string | null }) {
                         disabled={actionsLocked}
                         icon={uploadingImage || updatingTools ? <LoaderCircle className="animate-spin size-4" /> : <Plus className="size-4" />}
                       >
-                         {t("mcpConfig.addContainer.button.add")}
+                        {updatingTools
+                          ? t("mcpConfig.addContainer.button.updating")
+                          : t("mcpConfig.addContainer.button.add")}
                       </Button>
                     </div>
                   </Space>
@@ -732,11 +789,15 @@ export default function McpList({ tenantId }: { tenantId: string | null }) {
       {/* Edit Server Modal */}
       <McpEditServerModal
         open={editServerModalVisible}
-        onCancel={() => setEditServerModalVisible(false)}
+        onCancel={() => {
+          setEditServerModalVisible(false);
+          setEditingServer(null);
+        }}
         onSave={onSaveEditedServer}
         initialName={editingServer?.service_name || ""}
         initialUrl={editingServer?.mcp_url || ""}
-        loading={updatingServer}
+        initialAuthorizationToken={editingServer?.authorization_token || null}
+        loading={updatingServer || loadingMcpRecord}
       />
 
       {/* Logs Modal */}

--- a/frontend/components/mcp/McpEditServerModal.tsx
+++ b/frontend/components/mcp/McpEditServerModal.tsx
@@ -7,9 +7,10 @@ const { Text } = Typography;
 interface McpEditServerModalProps {
   open: boolean;
   onCancel: () => void;
-  onSave: (name: string, url: string) => Promise<void>;
+  onSave: (name: string, url: string, authorizationToken?: string | null) => Promise<void>;
   initialName: string;
   initialUrl: string;
+  initialAuthorizationToken?: string | null;
   loading: boolean;
 }
 
@@ -19,21 +20,24 @@ export default function McpEditServerModal({
   onSave,
   initialName,
   initialUrl,
+  initialAuthorizationToken,
   loading,
 }: McpEditServerModalProps) {
   const { t } = useTranslation("common");
   const [name, setName] = useState(initialName);
   const [url, setUrl] = useState(initialUrl);
+  const [authorizationToken, setAuthorizationToken] = useState(initialAuthorizationToken || "");
 
   useEffect(() => {
     if (open) {
       setName(initialName);
       setUrl(initialUrl);
+      setAuthorizationToken(initialAuthorizationToken || "");
     }
-  }, [open, initialName, initialUrl]);
+  }, [open, initialName, initialUrl, initialAuthorizationToken]);
 
   const handleSave = () => {
-    onSave(name, url);
+    onSave(name, url, authorizationToken || null);
   };
 
   return (
@@ -54,6 +58,15 @@ export default function McpEditServerModal({
         <div>
           <Text strong>{t("mcpConfig.editServer.mcpUrl")}</Text>
           <Input value={url} onChange={(e) => setUrl(e.target.value)} className="mt-2" />
+        </div>
+        <div>
+          <Text strong>{t("mcpConfig.editServer.authorizationToken")}</Text>
+          <Input.Password
+            value={authorizationToken}
+            onChange={(e) => setAuthorizationToken(e.target.value)}
+            placeholder={t("mcpConfig.editServer.authorizationTokenPlaceholder")}
+            className="mt-2"
+          />
         </div>
       </Space>
     </Modal>

--- a/frontend/hooks/useMcpConfig.ts
+++ b/frontend/hooks/useMcpConfig.ts
@@ -13,6 +13,7 @@ import {
   uploadMcpImage,
   getMcpContainerLogs,
   deleteMcpContainer,
+  getMcpRecord,
 } from "@/services/mcpService";
 import { McpServer, McpContainer } from "@/types/agentConfig";
 import log from "@/lib/logger";
@@ -116,9 +117,9 @@ export function useMcpConfig(options: UseMcpConfigOptions = {}) {
   }, [refetchMcpContainers]);
 
   // Add MCP server
-  const handleAddServer = useCallback(async (url: string, name: string) => {
+  const handleAddServer = useCallback(async (url: string, name: string, authorizationToken?: string | null) => {
     try {
-      const result = await addMcpServer(url, name, options.tenantId);
+      const result = await addMcpServer(url, name, authorizationToken, options.tenantId);
       if (result.success) {
         invalidateMcpServers();
         await refreshToolsAndAgents();
@@ -196,10 +197,11 @@ export function useMcpConfig(options: UseMcpConfigOptions = {}) {
     oldName: string,
     oldUrl: string,
     newName: string,
-    newUrl: string
+    newUrl: string,
+    newAuthorizationToken?: string | null
   ) => {
     try {
-      const result = await updateMcpServer(oldName, oldUrl, newName, newUrl, options.tenantId);
+      const result = await updateMcpServer(oldName, oldUrl, newName, newUrl, newAuthorizationToken, options.tenantId);
       if (result.success) {
         // Best-effort optimistic status update for UI responsiveness
         queryClient.setQueryData([...MCP_SERVERS_QUERY_KEY, options.tenantId], (prev: any) => {
@@ -265,10 +267,17 @@ export function useMcpConfig(options: UseMcpConfigOptions = {}) {
   const handleUploadImage = useCallback(async (
     file: File,
     port: number,
-    serviceName?: string
+    serviceName?: string,
+    authorizationToken?: string
   ) => {
     try {
-      const result = await uploadMcpImage(file, port, serviceName, undefined, options.tenantId);
+      // Build env_vars JSON string with authorization_token if provided
+      let envVars: string | undefined = undefined;
+      if (authorizationToken) {
+        envVars = JSON.stringify({ authorization_token: authorizationToken });
+      }
+
+      const result = await uploadMcpImage(file, port, serviceName, envVars, options.tenantId);
       if (result.success) {
         invalidateMcpContainers();
         invalidateMcpServers();
@@ -317,6 +326,21 @@ export function useMcpConfig(options: UseMcpConfigOptions = {}) {
     }
   }, [options.tenantId]);
 
+  // Get MCP record by ID
+  const handleGetMcpRecord = useCallback(async (mcpId: number) => {
+    try {
+      const result = await getMcpRecord(mcpId, options.tenantId);
+      if (result.success) {
+        return { success: true, data: result.data };
+      } else {
+        return { success: false, data: null, message: result.message, messageKey: "mcpConfig.message.getMcpRecordFailed" };
+      }
+    } catch (error) {
+      log.error("Failed to get MCP record:", error);
+      return { success: false, data: null, message: "Failed to get MCP record", messageKey: "mcpConfig.message.getMcpRecordFailed" };
+    }
+  }, [options.tenantId]);
+
   return {
     // State
     serverList,
@@ -341,5 +365,6 @@ export function useMcpConfig(options: UseMcpConfigOptions = {}) {
     handleUploadImage,
     handleDeleteContainer,
     handleViewLogs,
+    handleGetMcpRecord,
   };
 }

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -1008,6 +1008,8 @@
   "mcpConfig.editServer.serviceNamePlaceholder": "Enter service name",
   "mcpConfig.editServer.mcpUrl": "MCP URL",
   "mcpConfig.editServer.mcpUrlPlaceholder": "Enter MCP server URL",
+  "mcpConfig.editServer.authorizationToken": "Authorization Token",
+  "mcpConfig.editServer.authorizationTokenPlaceholder": "Server Bearer Token (Optional)",
   "mcpConfig.containerList.title": "Running Containerized MCP Services",
   "mcpConfig.containerList.column.name": "Name",
   "mcpConfig.containerList.column.containerId": "Container ID",

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -1010,6 +1010,8 @@
   "mcpConfig.editServer.serviceNamePlaceholder": "请输入服务名称",
   "mcpConfig.editServer.mcpUrl": "MCP URL",
   "mcpConfig.editServer.mcpUrlPlaceholder": "请输入MCP服务器URL",
+  "mcpConfig.editServer.authorizationToken": "Authorization Token",
+  "mcpConfig.editServer.authorizationTokenPlaceholder": "服务器Bearer Token（可选）",
   "mcpConfig.containerList.title": "已启动的容器化MCP服务",
   "mcpConfig.containerList.column.name": "名称",
   "mcpConfig.containerList.column.containerId": "容器ID",

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -212,6 +212,7 @@ export const API_ENDPOINTS = {
       `${API_BASE_URL}/mcp/container/${containerId}/logs`,
     deleteContainer: (containerId: string) =>
       `${API_BASE_URL}/mcp/container/${containerId}`,
+    record: (mcpId: number) => `${API_BASE_URL}/mcp/record/${mcpId}`,
   },
   memory: {
     // ---------------- Memory configuration ----------------

--- a/frontend/services/mcpService.ts
+++ b/frontend/services/mcpService.ts
@@ -26,7 +26,7 @@ const getAuthHeaders = () => {
  */
 export const getMcpServerList = async (tenantId?: string | null) => {
   try {
-    const url = tenantId 
+    const url = tenantId
       ? `${API_ENDPOINTS.mcp.list}?tenant_id=${encodeURIComponent(tenantId)}`
       : API_ENDPOINTS.mcp.list;
     const response = await fetch(url, {
@@ -44,6 +44,7 @@ export const getMcpServerList = async (tenantId?: string | null) => {
           mcp_url: server.remote_mcp_server,
           status: server.status || false,
           permission: server.permission,
+          mcp_id: server.mcp_id,
         };
       });
 
@@ -87,12 +88,15 @@ export const getMcpServerList = async (tenantId?: string | null) => {
 /**
  * Add MCP server
  */
-export const addMcpServer = async (mcpUrl: string, serviceName: string, tenantId?: string | null) => {
+export const addMcpServer = async (mcpUrl: string, serviceName: string, authorizationToken?: string | null, tenantId?: string | null) => {
   try {
     const params = new URLSearchParams({
       mcp_url: mcpUrl,
       service_name: serviceName,
     });
+    if (authorizationToken) {
+      params.append('authorization_token', authorizationToken);
+    }
     if (tenantId) {
       params.append('tenant_id', tenantId);
     }
@@ -148,21 +152,26 @@ export const updateMcpServer = async (
   currentMcpUrl: string,
   newServiceName: string,
   newMcpUrl: string,
+  newAuthorizationToken?: string | null,
   tenantId?: string | null
 ) => {
   try {
-    const url = tenantId 
+    const url = tenantId
       ? `${API_ENDPOINTS.mcp.update}?tenant_id=${encodeURIComponent(tenantId)}`
       : API_ENDPOINTS.mcp.update;
+    const body: any = {
+      current_service_name: currentServiceName,
+      current_mcp_url: currentMcpUrl,
+      new_service_name: newServiceName,
+      new_mcp_url: newMcpUrl,
+    };
+    if (newAuthorizationToken !== undefined) {
+      body.new_authorization_token = newAuthorizationToken;
+    }
     const response = await fetch(url, {
       method: "PUT",
       headers: getAuthHeaders(),
-      body: JSON.stringify({
-        current_service_name: currentServiceName,
-        current_mcp_url: currentMcpUrl,
-        new_service_name: newServiceName,
-        new_mcp_url: newMcpUrl,
-      }),
+      body: JSON.stringify(body),
     });
 
     const data = await response.json();
@@ -411,7 +420,7 @@ export const checkMcpServerHealth = async (mcpUrl: string, serviceName: string, 
  */
 export const addMcpFromConfig = async (mcpConfig: { mcpServers: Record<string, { command: string; args?: string[]; env?: Record<string, string>; port?: number; image?: string }> }, tenantId?: string | null) => {
   try {
-    const url = tenantId 
+    const url = tenantId
       ? `${API_ENDPOINTS.mcp.addFromConfig}?tenant_id=${encodeURIComponent(tenantId)}`
       : API_ENDPOINTS.mcp.addFromConfig;
     const response = await fetch(url, {
@@ -458,7 +467,7 @@ export const addMcpFromConfig = async (mcpConfig: { mcpServers: Record<string, {
  */
 export const getMcpContainers = async (tenantId?: string | null) => {
   try {
-    const url = tenantId 
+    const url = tenantId
       ? `${API_ENDPOINTS.mcp.containers}?tenant_id=${encodeURIComponent(tenantId)}`
       : API_ENDPOINTS.mcp.containers;
     const response = await fetch(url, {
@@ -618,7 +627,7 @@ export const uploadMcpImage = async (file: File, port: number, serviceName?: str
  */
 export const deleteMcpContainer = async (containerId: string, tenantId?: string | null) => {
   try {
-    const url = tenantId 
+    const url = tenantId
       ? `${API_ENDPOINTS.mcp.deleteContainer(containerId)}?tenant_id=${encodeURIComponent(tenantId)}`
       : API_ENDPOINTS.mcp.deleteContainer(containerId);
     const response = await fetch(url, {
@@ -651,6 +660,55 @@ export const deleteMcpContainer = async (containerId: string, tenantId?: string 
     }
   } catch (error) {
     log.error(t('mcpService.debug.deleteContainerFailed'), error);
+    return {
+      success: false,
+      data: null,
+      message: t('mcpService.message.networkError')
+    };
+  }
+};
+
+/**
+ * Get single MCP record by ID
+ */
+export const getMcpRecord = async (mcpId: number, tenantId?: string | null) => {
+  try {
+    const url = tenantId
+      ? `${API_ENDPOINTS.mcp.record(mcpId)}?tenant_id=${encodeURIComponent(tenantId)}`
+      : API_ENDPOINTS.mcp.record(mcpId);
+    const response = await fetch(url, {
+      headers: getAuthHeaders(),
+    });
+
+    const data = await response.json();
+
+    if (response.ok && data.status === 'success') {
+      return {
+        success: true,
+        data: {
+          mcp_name: data.mcp_name,
+          mcp_server: data.mcp_server,
+          authorization_token: data.authorization_token,
+        },
+        message: ''
+      };
+    } else {
+      let errorMessage = data.detail || data.message || t('mcpService.message.getMcpRecordFailed');
+
+      if (response.status === 404) {
+        errorMessage = t('mcpService.message.mcpRecordNotFound');
+      } else if (response.status === 500) {
+        errorMessage = t('mcpService.message.getMcpRecordFailed');
+      }
+
+      return {
+        success: false,
+        data: null,
+        message: errorMessage
+      };
+    }
+  } catch (error) {
+    log.error(t('mcpService.debug.getMcpRecordFailed'), error);
     return {
       success: false,
       data: null,

--- a/frontend/types/agentConfig.ts
+++ b/frontend/types/agentConfig.ts
@@ -336,6 +336,8 @@ export interface McpServer {
   status: boolean;
   remote_mcp_server_name?: string;
   remote_mcp_server?: string;
+  authorization_token?: string | null;
+  mcp_id?: number;
   /**
    * Per-item permission returned by /mcp/list.
    * EDIT: editable, READ_ONLY: read-only.

--- a/sdk/nexent/container/docker_client.py
+++ b/sdk/nexent/container/docker_client.py
@@ -11,6 +11,7 @@ from typing import Dict, List, Optional, Any
 import docker
 from docker.errors import APIError, DockerException, NotFound
 from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport, SSETransport
 
 from .container_client_base import ContainerClient, ContainerConfig
 from .docker_config import DockerContainerConfig
@@ -270,6 +271,11 @@ class DockerContainerClient(ContainerClient):
                     logger.error(f"Failed to find free port: {e}")
                     raise
 
+        # Extract authorization_token from env_vars if present (for health check)
+        authorization_token = None
+        if env_vars:
+            authorization_token = env_vars.get("authorization_token")
+
         # Prepare environment variables
         container_env = {
             "PORT": str(host_port),
@@ -326,7 +332,7 @@ class DockerContainerClient(ContainerClient):
             host = self._get_service_host(container_name)
             service_url = f"http://{host}:{host_port}/mcp"
             try:
-                await self._wait_for_service_ready(service_url, max_retries=30)
+                await self._wait_for_service_ready(service_url, max_retries=30, authorization_token=authorization_token)
             except ContainerConnectionError:
                 # If health check fails, log but don't fail immediately
                 logger.warning(
@@ -359,7 +365,7 @@ class DockerContainerClient(ContainerClient):
             raise ContainerError(f"Container startup failed: {e}")
 
     async def _wait_for_service_ready(
-        self, url: str, max_retries: int = 30, retry_delay: int = 5
+        self, url: str, max_retries: int = 30, retry_delay: int = 5, authorization_token: Optional[str] = None
     ):
         """
         Wait for service to be ready by checking connection
@@ -368,13 +374,35 @@ class DockerContainerClient(ContainerClient):
             url: Service URL
             max_retries: Maximum number of retry attempts
             retry_delay: Delay between retries in seconds
+            authorization_token: Optional authorization token for MCP server
 
         Raises:
             ContainerConnectionError: If service is not ready after max retries
         """
         for i in range(max_retries):
             try:
-                client = Client(url)
+                # Select transport based on URL ending and set headers
+                url_stripped = url.strip()
+                headers = {"Authorization": authorization_token} if authorization_token else {}
+
+                if url_stripped.endswith("/sse"):
+                    transport = SSETransport(
+                        url=url,
+                        headers=headers
+                    )
+                elif url_stripped.endswith("/mcp"):
+                    transport = StreamableHttpTransport(
+                        url=url,
+                        headers=headers
+                    )
+                else:
+                    # Default to StreamableHttpTransport for unrecognized formats
+                    transport = StreamableHttpTransport(
+                        url=url,
+                        headers=headers
+                    )
+
+                client = Client(transport=transport)
                 async with client:
                     if client.is_connected():
                         logger.info(f"Service ready at {url}")

--- a/sdk/nexent/container/docker_client.py
+++ b/sdk/nexent/container/docker_client.py
@@ -387,18 +387,18 @@ class DockerContainerClient(ContainerClient):
 
                 if url_stripped.endswith("/sse"):
                     transport = SSETransport(
-                        url=url,
+                        url=url_stripped,
                         headers=headers
                     )
                 elif url_stripped.endswith("/mcp"):
                     transport = StreamableHttpTransport(
-                        url=url,
+                        url=url_stripped,
                         headers=headers
                     )
                 else:
                     # Default to StreamableHttpTransport for unrecognized formats
                     transport = StreamableHttpTransport(
-                        url=url,
+                        url=url_stripped,
                         headers=headers
                     )
 

--- a/sdk/nexent/core/agents/agent_model.py
+++ b/sdk/nexent/core/agents/agent_model.py
@@ -55,9 +55,11 @@ class AgentRunInfo(BaseModel):
     observer: MessageObserver = Field(description="Return data")
     agent_config: AgentConfig = Field(description="Detailed Agent configuration")
     mcp_host: Optional[List[Union[str, Dict[str, Any]]]] = Field(
-        description="MCP server address(es). Can be a string (URL) or dict with 'url' and 'transport' keys. "
+        description="MCP server address(es). Can be a string (URL) or dict with 'url', 'transport', "
+        "and optionally 'authorization' or 'headers' keys. "
         "Transport can be 'sse' or 'streamable-http'. If string, transport is auto-detected based on URL ending: "
-        "URLs ending with '/sse' use 'sse' transport, URLs ending with '/mcp' use 'streamable-http' transport.",
+        "URLs ending with '/sse' use 'sse' transport, URLs ending with '/mcp' use 'streamable-http' transport. "
+        "Authorization can be provided as 'authorization' (e.g., 'Bearer token') or as 'headers' dict.",
         default=None
     )
     history: Optional[List[AgentHistory]] = Field(description="Historical conversation information", default=None)

--- a/sdk/nexent/core/agents/run_agent.py
+++ b/sdk/nexent/core/agents/run_agent.py
@@ -17,21 +17,21 @@ monitoring_manager = get_monitoring_manager()
 def _detect_transport(url: str) -> str:
     """
     Auto-detect MCP transport type based on URL format.
-    
+
     Args:
         url: MCP server URL
-        
+
     Returns:
         Transport type: 'sse' or 'streamable-http'
     """
     url_stripped = url.strip()
-    
+
     # Check URL ending to determine transport type
     if url_stripped.endswith("/sse"):
         return "sse"
     elif url_stripped.endswith("/mcp"):
         return "streamable-http"
-    
+
     # Default to streamable-http for unrecognized formats
     return "streamable-http"
 
@@ -39,12 +39,13 @@ def _detect_transport(url: str) -> str:
 def _normalize_mcp_config(mcp_host_item: Union[str, Dict[str, Any]]) -> Dict[str, Any]:
     """
     Normalize MCP host configuration to a dictionary format.
-    
+
     Args:
-        mcp_host_item: Either a string URL or a dict with 'url' and optional 'transport'
-        
+        mcp_host_item: Either a string URL or a dict with 'url', optional 'transport',
+                       and optional 'headers' or 'authorization'
+
     Returns:
-        Dictionary with 'url' and 'transport' keys
+        Dictionary with 'url', 'transport', and optionally 'headers' keys
     """
     if isinstance(mcp_host_item, str):
         url = mcp_host_item
@@ -59,7 +60,23 @@ def _normalize_mcp_config(mcp_host_item: Union[str, Dict[str, Any]]) -> Dict[str
             transport = _detect_transport(url)
         if transport not in ("sse", "streamable-http"):
             raise ValueError(f"Invalid transport type: {transport}. Must be 'sse' or 'streamable-http'")
-        return {"url": url, "transport": transport}
+
+        result = {"url": url, "transport": transport}
+
+        # Support authorization parameter - convert to headers format
+        if "authorization" in mcp_host_item and "headers" in mcp_host_item:
+            # Both provided: merge headers with authorization
+            headers = mcp_host_item["headers"].copy() if isinstance(mcp_host_item["headers"], dict) else {}
+            headers["Authorization"] = mcp_host_item["authorization"]
+            result["headers"] = headers
+        elif "authorization" in mcp_host_item:
+            # Only authorization provided: create headers dict
+            result["headers"] = {"Authorization": mcp_host_item["authorization"]}
+        elif "headers" in mcp_host_item:
+            # Only headers provided: use as is
+            result["headers"] = mcp_host_item["headers"]
+
+        return result
     else:
         raise ValueError(f"Invalid MCP host item type: {type(mcp_host_item)}. Must be str or dict")
 

--- a/test/backend/agents/test_create_agent_info.py
+++ b/test/backend/agents/test_create_agent_info.py
@@ -1622,7 +1622,8 @@ class TestCreateAgentRunInfo:
 
     @pytest.mark.asyncio
     async def test_create_agent_run_info_success(self):
-        """Test case for successfully creating agent run info"""
+        """Test case for successfully creating agent run info with dict format mcp_host"""
+        mock_agent_run_info.reset_mock()
         with patch('backend.agents.create_agent_info.join_minio_file_description_to_query') as mock_join_query, \
                 patch('backend.agents.create_agent_info.create_model_config_list') as mock_create_models, \
                 patch('backend.agents.create_agent_info.get_remote_mcp_server_list', new_callable=AsyncMock) as mock_get_mcp, \
@@ -1638,7 +1639,8 @@ class TestCreateAgentRunInfo:
                 {
                     "remote_mcp_server_name": "test_server",
                     "remote_mcp_server": "http://test.server",
-                    "status": True
+                    "status": True,
+                    "authorization_token": None
                 }
             ]
             mock_create_agent.return_value = "agent_config"
@@ -1656,13 +1658,17 @@ class TestCreateAgentRunInfo:
                 language="zh"
             )
 
-            # Verify that AgentRunInfo was called correctly
-            mock_agent_run_info.assert_called_once_with(
+            # Verify that AgentRunInfo was called correctly with dict format mcp_host
+            assert mock_agent_run_info.call_count == 1
+            mock_agent_run_info.assert_called_with(
                 query="processed_query",
                 model_config_list=["model_config"],
                 observer=mock_message_observer.return_value,
                 agent_config="agent_config",
-                mcp_host=["http://test.server"],
+                mcp_host=[{
+                    "url": "http://test.server",
+                    "transport": "streamable-http"
+                }],
                 history=[],
                 stop_event="stop_event"
             )
@@ -1684,14 +1690,268 @@ class TestCreateAgentRunInfo:
                 "test_server": {
                     "remote_mcp_server_name": "test_server",
                     "remote_mcp_server": "http://test.server",
-                    "status": True
+                    "status": True,
+                    "authorization_token": None
                 },
                 "nexent": {
                     "remote_mcp_server_name": "nexent",
                     "remote_mcp_server": "http://nexent.mcp/sse",
-                    "status": True
+                    "status": True,
+                    "authorization_token": None
                 }
             })
+
+    @pytest.mark.asyncio
+    async def test_create_agent_run_info_with_authorization_token(self):
+        """Test case for mcp_host with authorization token"""
+        mock_agent_run_info.reset_mock()
+        with patch('backend.agents.create_agent_info.join_minio_file_description_to_query') as mock_join_query, \
+                patch('backend.agents.create_agent_info.create_model_config_list') as mock_create_models, \
+                patch('backend.agents.create_agent_info.get_remote_mcp_server_list', new_callable=AsyncMock) as mock_get_mcp, \
+                patch('backend.agents.create_agent_info.create_agent_config') as mock_create_agent, \
+                patch('backend.agents.create_agent_info.filter_mcp_servers_and_tools') as mock_filter, \
+                patch('backend.agents.create_agent_info.urljoin') as mock_urljoin, \
+                patch('backend.agents.create_agent_info.threading') as mock_threading:
+
+            mock_join_query.return_value = "processed_query"
+            mock_create_models.return_value = ["model_config"]
+            mock_get_mcp.return_value = [
+                {
+                    "remote_mcp_server_name": "test_server",
+                    "remote_mcp_server": "http://test.server",
+                    "status": True,
+                    "authorization_token": "bearer_token_123"
+                }
+            ]
+            mock_create_agent.return_value = "agent_config"
+            mock_urljoin.return_value = "http://nexent.mcp/sse"
+            mock_filter.return_value = ["http://test.server"]
+            mock_threading.Event.return_value = "stop_event"
+
+            await create_agent_run_info(
+                agent_id="agent_1",
+                minio_files=[],
+                query="test query",
+                history=[],
+                user_id="user_1",
+                tenant_id="tenant_1",
+                language="zh"
+            )
+
+            # Verify mcp_host includes authorization token
+            assert mock_agent_run_info.call_count == 1
+            call_args = mock_agent_run_info.call_args
+            mcp_host = call_args[1]["mcp_host"]
+            assert len(mcp_host) == 1
+            assert mcp_host[0] == {
+                "url": "http://test.server",
+                "transport": "streamable-http",
+                "authorization": "bearer_token_123"
+            }
+
+    @pytest.mark.asyncio
+    async def test_create_agent_run_info_with_sse_transport(self):
+        """Test case for mcp_host with SSE transport (URL ends with /sse)"""
+        mock_agent_run_info.reset_mock()
+        with patch('backend.agents.create_agent_info.join_minio_file_description_to_query') as mock_join_query, \
+                patch('backend.agents.create_agent_info.create_model_config_list') as mock_create_models, \
+                patch('backend.agents.create_agent_info.get_remote_mcp_server_list', new_callable=AsyncMock) as mock_get_mcp, \
+                patch('backend.agents.create_agent_info.create_agent_config') as mock_create_agent, \
+                patch('backend.agents.create_agent_info.filter_mcp_servers_and_tools') as mock_filter, \
+                patch('backend.agents.create_agent_info.urljoin') as mock_urljoin, \
+                patch('backend.agents.create_agent_info.threading') as mock_threading:
+
+            mock_join_query.return_value = "processed_query"
+            mock_create_models.return_value = ["model_config"]
+            mock_get_mcp.return_value = [
+                {
+                    "remote_mcp_server_name": "sse_server",
+                    "remote_mcp_server": "http://sse.server/sse",
+                    "status": True,
+                    "authorization_token": None
+                }
+            ]
+            mock_create_agent.return_value = "agent_config"
+            mock_urljoin.return_value = "http://nexent.mcp/sse"
+            mock_filter.return_value = ["http://sse.server/sse"]
+            mock_threading.Event.return_value = "stop_event"
+
+            await create_agent_run_info(
+                agent_id="agent_1",
+                minio_files=[],
+                query="test query",
+                history=[],
+                user_id="user_1",
+                tenant_id="tenant_1",
+                language="zh"
+            )
+
+            # Verify mcp_host uses SSE transport
+            assert mock_agent_run_info.call_count == 1
+            call_args = mock_agent_run_info.call_args
+            mcp_host = call_args[1]["mcp_host"]
+            assert len(mcp_host) == 1
+            assert mcp_host[0] == {
+                "url": "http://sse.server/sse",
+                "transport": "sse"
+            }
+
+    @pytest.mark.asyncio
+    async def test_create_agent_run_info_fallback_to_string_format(self):
+        """Test case for fallback to string format when MCP record not found"""
+        mock_agent_run_info.reset_mock()
+        with patch('backend.agents.create_agent_info.join_minio_file_description_to_query') as mock_join_query, \
+                patch('backend.agents.create_agent_info.create_model_config_list') as mock_create_models, \
+                patch('backend.agents.create_agent_info.get_remote_mcp_server_list', new_callable=AsyncMock) as mock_get_mcp, \
+                patch('backend.agents.create_agent_info.create_agent_config') as mock_create_agent, \
+                patch('backend.agents.create_agent_info.filter_mcp_servers_and_tools') as mock_filter, \
+                patch('backend.agents.create_agent_info.urljoin') as mock_urljoin, \
+                patch('backend.agents.create_agent_info.threading') as mock_threading:
+
+            mock_join_query.return_value = "processed_query"
+            mock_create_models.return_value = ["model_config"]
+            # Return empty list so the URL from filter won't be found in remote_mcp_list
+            mock_get_mcp.return_value = []
+            mock_create_agent.return_value = "agent_config"
+            mock_urljoin.return_value = "http://nexent.mcp/sse"
+            # Filter returns a URL that doesn't exist in remote_mcp_list
+            mock_filter.return_value = ["http://unknown.server"]
+            mock_threading.Event.return_value = "stop_event"
+
+            await create_agent_run_info(
+                agent_id="agent_1",
+                minio_files=[],
+                query="test query",
+                history=[],
+                user_id="user_1",
+                tenant_id="tenant_1",
+                language="zh"
+            )
+
+            # Verify mcp_host falls back to string format
+            assert mock_agent_run_info.call_count == 1
+            call_args = mock_agent_run_info.call_args
+            mcp_host = call_args[1]["mcp_host"]
+            assert len(mcp_host) == 1
+            assert mcp_host[0] == "http://unknown.server"
+
+    @pytest.mark.asyncio
+    async def test_create_agent_run_info_mixed_scenarios(self):
+        """Test case for mixed scenarios: multiple servers with different configurations"""
+        mock_agent_run_info.reset_mock()
+        with patch('backend.agents.create_agent_info.join_minio_file_description_to_query') as mock_join_query, \
+                patch('backend.agents.create_agent_info.create_model_config_list') as mock_create_models, \
+                patch('backend.agents.create_agent_info.get_remote_mcp_server_list', new_callable=AsyncMock) as mock_get_mcp, \
+                patch('backend.agents.create_agent_info.create_agent_config') as mock_create_agent, \
+                patch('backend.agents.create_agent_info.filter_mcp_servers_and_tools') as mock_filter, \
+                patch('backend.agents.create_agent_info.urljoin') as mock_urljoin, \
+                patch('backend.agents.create_agent_info.threading') as mock_threading:
+
+            mock_join_query.return_value = "processed_query"
+            mock_create_models.return_value = ["model_config"]
+            mock_get_mcp.return_value = [
+                {
+                    "remote_mcp_server_name": "server1",
+                    "remote_mcp_server": "http://server1.com",
+                    "status": True,
+                    "authorization_token": "token1"
+                },
+                {
+                    "remote_mcp_server_name": "server2",
+                    "remote_mcp_server": "http://server2.com/sse",
+                    "status": True,
+                    "authorization_token": None
+                },
+                {
+                    "remote_mcp_server_name": "server3",
+                    "remote_mcp_server": "http://server3.com",
+                    "status": True,
+                    "authorization_token": "token3"
+                }
+            ]
+            mock_create_agent.return_value = "agent_config"
+            mock_urljoin.return_value = "http://nexent.mcp/sse"
+            # Filter returns URLs: one with token, one SSE without token, one unknown
+            mock_filter.return_value = [
+                "http://server1.com",
+                "http://server2.com/sse",
+                "http://unknown.server"
+            ]
+            mock_threading.Event.return_value = "stop_event"
+
+            await create_agent_run_info(
+                agent_id="agent_1",
+                minio_files=[],
+                query="test query",
+                history=[],
+                user_id="user_1",
+                tenant_id="tenant_1",
+                language="zh"
+            )
+
+            # Verify mcp_host contains mixed formats
+            assert mock_agent_run_info.call_count == 1
+            call_args = mock_agent_run_info.call_args
+            mcp_host = call_args[1]["mcp_host"]
+            assert len(mcp_host) == 3
+            # First: dict with authorization and streamable-http
+            assert mcp_host[0] == {
+                "url": "http://server1.com",
+                "transport": "streamable-http",
+                "authorization": "token1"
+            }
+            # Second: dict with SSE transport, no authorization
+            assert mcp_host[1] == {
+                "url": "http://server2.com/sse",
+                "transport": "sse"
+            }
+            # Third: string format (fallback for unknown server)
+            assert mcp_host[2] == "http://unknown.server"
+
+    @pytest.mark.asyncio
+    async def test_create_agent_run_info_with_status_false(self):
+        """Test case for MCP record with status=False (should not be matched)"""
+        mock_agent_run_info.reset_mock()
+        with patch('backend.agents.create_agent_info.join_minio_file_description_to_query') as mock_join_query, \
+                patch('backend.agents.create_agent_info.create_model_config_list') as mock_create_models, \
+                patch('backend.agents.create_agent_info.get_remote_mcp_server_list', new_callable=AsyncMock) as mock_get_mcp, \
+                patch('backend.agents.create_agent_info.create_agent_config') as mock_create_agent, \
+                patch('backend.agents.create_agent_info.filter_mcp_servers_and_tools') as mock_filter, \
+                patch('backend.agents.create_agent_info.urljoin') as mock_urljoin, \
+                patch('backend.agents.create_agent_info.threading') as mock_threading:
+
+            mock_join_query.return_value = "processed_query"
+            mock_create_models.return_value = ["model_config"]
+            mock_get_mcp.return_value = [
+                {
+                    "remote_mcp_server_name": "disabled_server",
+                    "remote_mcp_server": "http://disabled.server",
+                    "status": False,  # Status is False
+                    "authorization_token": "token"
+                }
+            ]
+            mock_create_agent.return_value = "agent_config"
+            mock_urljoin.return_value = "http://nexent.mcp/sse"
+            # Filter returns URL that exists but has status=False
+            mock_filter.return_value = ["http://disabled.server"]
+            mock_threading.Event.return_value = "stop_event"
+
+            await create_agent_run_info(
+                agent_id="agent_1",
+                minio_files=[],
+                query="test query",
+                history=[],
+                user_id="user_1",
+                tenant_id="tenant_1",
+                language="zh"
+            )
+
+            # Verify mcp_host falls back to string format because status=False
+            assert mock_agent_run_info.call_count == 1
+            call_args = mock_agent_run_info.call_args
+            mcp_host = call_args[1]["mcp_host"]
+            assert len(mcp_host) == 1
+            assert mcp_host[0] == "http://disabled.server"
 
     @pytest.mark.asyncio
     async def test_create_agent_run_info_forwards_allow_memory_false(self):

--- a/test/backend/app/test_remote_mcp_app.py
+++ b/test/backend/app/test_remote_mcp_app.py
@@ -75,9 +75,11 @@ class MockToolInfo:
 class TestGetToolsFromRemoteMCP:
     """Test endpoint for getting tools from remote MCP server"""
 
+    @patch('apps.remote_mcp_app.get_current_user_info')
     @patch('apps.remote_mcp_app.get_tool_from_remote_mcp_server')
-    def test_get_tools_success(self, mock_get_tools):
+    def test_get_tools_success(self, mock_get_tools, mock_get_user_info):
         """Test successful retrieval of tool information"""
+        mock_get_user_info.return_value = ("user123", "tenant456", "en")
         # Mock tool information
         mock_tools = [
             MockToolInfo("tool1", "Tool 1 description"),
@@ -88,7 +90,8 @@ class TestGetToolsFromRemoteMCP:
         response = client.post(
             "/mcp/tools",
             params={"service_name": "test_service",
-                    "mcp_url": "http://test.com"}
+                    "mcp_url": "http://test.com"},
+            headers={"Authorization": "Bearer test_token"}
         )
 
         assert response.status_code == HTTPStatus.OK
@@ -97,36 +100,44 @@ class TestGetToolsFromRemoteMCP:
         assert len(data["tools"]) == 2
         assert data["status"] == "success"
 
+        mock_get_user_info.assert_called_once()
         mock_get_tools.assert_called_once_with(
             mcp_server_name="test_service",
-            remote_mcp_server="http://test.com"
+            remote_mcp_server="http://test.com",
+            tenant_id="tenant456"
         )
 
+    @patch('apps.remote_mcp_app.get_current_user_info')
     @patch('apps.remote_mcp_app.get_tool_from_remote_mcp_server')
-    def test_get_tools_connection_error(self, mock_get_tools):
+    def test_get_tools_connection_error(self, mock_get_tools, mock_get_user_info):
         """Test MCP connection error when retrieving tool information"""
+        mock_get_user_info.return_value = ("user123", "tenant456", "en")
         mock_get_tools.side_effect = MCPConnectionError(
             "MCP connection failed")
 
         response = client.post(
             "/mcp/tools",
             params={"service_name": "test_service",
-                    "mcp_url": "http://unreachable.com"}
+                    "mcp_url": "http://unreachable.com"},
+            headers={"Authorization": "Bearer test_token"}
         )
 
         assert response.status_code == HTTPStatus.SERVICE_UNAVAILABLE
         data = response.json()
         assert "MCP connection failed" in data["detail"]
 
+    @patch('apps.remote_mcp_app.get_current_user_info')
     @patch('apps.remote_mcp_app.get_tool_from_remote_mcp_server')
-    def test_get_tools_general_failure(self, mock_get_tools):
+    def test_get_tools_general_failure(self, mock_get_tools, mock_get_user_info):
         """Test general failure to retrieve tool information"""
+        mock_get_user_info.return_value = ("user123", "tenant456", "en")
         mock_get_tools.side_effect = Exception("Unexpected error")
 
         response = client.post(
             "/mcp/tools",
             params={"service_name": "test_service",
-                    "mcp_url": "http://test.com"}
+                    "mcp_url": "http://test.com"},
+            headers={"Authorization": "Bearer test_token"}
         )
 
         assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
@@ -163,6 +174,7 @@ class TestAddRemoteProxies:
             remote_mcp_server="http://test.com",
             remote_mcp_server_name="test_service",
             container_id=None,
+            authorization_token=None,
         )
 
     @patch('apps.remote_mcp_app.get_current_user_info')
@@ -193,6 +205,7 @@ class TestAddRemoteProxies:
             remote_mcp_server="http://test.com",
             remote_mcp_server_name="test_service",
             container_id=None,
+            authorization_token=None,
         )
 
     @patch('apps.remote_mcp_app.get_current_user_info')
@@ -231,6 +244,37 @@ class TestAddRemoteProxies:
         assert response.status_code == HTTPStatus.SERVICE_UNAVAILABLE
         data = response.json()
         assert "MCP connection failed" in data["detail"]
+
+    @patch('apps.remote_mcp_app.get_current_user_info')
+    @patch('apps.remote_mcp_app.add_remote_mcp_server_list')
+    def test_add_remote_proxy_with_authorization_token(self, mock_add_server, mock_get_user_info):
+        """Test adding remote MCP proxy with authorization token"""
+        mock_get_user_info.return_value = ("user123", "tenant456", "en")
+        mock_add_server.return_value = None
+
+        response = client.post(
+            "/mcp/add",
+            params={
+                "mcp_url": "http://test.com",
+                "service_name": "test_service",
+                "authorization_token": "Bearer token123"
+            },
+            headers={"Authorization": "Bearer test_token"}
+        )
+
+        assert response.status_code == HTTPStatus.OK
+        data = response.json()
+        assert data["status"] == "success"
+
+        # Verify that authorization_token is passed to service
+        mock_add_server.assert_called_once_with(
+            tenant_id="tenant456",
+            user_id="user123",
+            remote_mcp_server="http://test.com",
+            remote_mcp_server_name="test_service",
+            container_id=None,
+            authorization_token="Bearer token123",
+        )
 
     @patch('apps.remote_mcp_app.get_current_user_info')
     @patch('apps.remote_mcp_app.add_remote_mcp_server_list')
@@ -402,6 +446,126 @@ class TestGetRemoteProxies:
         assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
         data = response.json()
         assert "Failed to get remote MCP proxy" in data["detail"]
+
+
+class TestGetMCPRecord:
+    """Test endpoint for getting single MCP record by ID"""
+
+    @patch('apps.remote_mcp_app.get_current_user_info')
+    @patch('apps.remote_mcp_app.get_mcp_record_by_id')
+    def test_get_mcp_record_success(self, mock_get_record, mock_get_user_info):
+        """Test successful retrieval of MCP record"""
+        mock_get_user_info.return_value = ("user123", "tenant456", "en")
+        mock_record = {
+            "mcp_name": "test-service",
+            "mcp_server": "http://test.com/mcp",
+            "authorization_token": "token123"
+        }
+        mock_get_record.return_value = mock_record
+
+        response = client.get(
+            "/mcp/record/1",
+            headers={"Authorization": "Bearer test_token"}
+        )
+
+        assert response.status_code == HTTPStatus.OK
+        data = response.json()
+        assert data["status"] == "success"
+        assert data["mcp_name"] == "test-service"
+        assert data["mcp_server"] == "http://test.com/mcp"
+        assert data["authorization_token"] == "token123"
+
+        mock_get_user_info.assert_called_once()
+        mock_get_record.assert_called_once_with(
+            mcp_id=1,
+            tenant_id="tenant456"
+        )
+
+    @patch('apps.remote_mcp_app.get_current_user_info')
+    @patch('apps.remote_mcp_app.get_mcp_record_by_id')
+    def test_get_mcp_record_with_tenant_id_param(self, mock_get_record, mock_get_user_info):
+        """Test getting MCP record with explicit tenant_id parameter"""
+        mock_get_user_info.return_value = ("user123", "tenant456", "en")
+        mock_record = {
+            "mcp_name": "test-service",
+            "mcp_server": "http://test.com/mcp",
+            "authorization_token": "token123"
+        }
+        mock_get_record.return_value = mock_record
+
+        response = client.get(
+            "/mcp/record/1",
+            params={"tenant_id": "explicit_tenant789"},
+            headers={"Authorization": "Bearer test_token"}
+        )
+
+        assert response.status_code == HTTPStatus.OK
+        # Verify that explicit tenant_id is used
+        mock_get_record.assert_called_once_with(
+            mcp_id=1,
+            tenant_id="explicit_tenant789"
+        )
+
+    @patch('apps.remote_mcp_app.get_current_user_info')
+    @patch('apps.remote_mcp_app.get_mcp_record_by_id')
+    def test_get_mcp_record_not_found(self, mock_get_record, mock_get_user_info):
+        """Test getting MCP record when record does not exist"""
+        mock_get_user_info.return_value = ("user123", "tenant456", "en")
+        mock_get_record.return_value = None  # Record not found
+
+        response = client.get(
+            "/mcp/record/999",
+            headers={"Authorization": "Bearer test_token"}
+        )
+
+        assert response.status_code == HTTPStatus.NOT_FOUND
+        data = response.json()
+        assert "MCP record not found" in data["detail"]
+
+        mock_get_record.assert_called_once_with(
+            mcp_id=999,
+            tenant_id="tenant456"
+        )
+
+    @patch('apps.remote_mcp_app.get_current_user_info')
+    @patch('apps.remote_mcp_app.get_mcp_record_by_id')
+    def test_get_mcp_record_with_none_values(self, mock_get_record, mock_get_user_info):
+        """Test getting MCP record when some fields are None"""
+        mock_get_user_info.return_value = ("user123", "tenant456", "en")
+        mock_record = {
+            "mcp_name": "test-service",
+            "mcp_server": "http://test.com/mcp",
+            "authorization_token": None  # Token can be None
+        }
+        mock_get_record.return_value = mock_record
+
+        response = client.get(
+            "/mcp/record/1",
+            headers={"Authorization": "Bearer test_token"}
+        )
+
+        assert response.status_code == HTTPStatus.OK
+        data = response.json()
+        assert data["status"] == "success"
+        assert data["mcp_name"] == "test-service"
+        assert data["mcp_server"] == "http://test.com/mcp"
+        assert data["authorization_token"] is None
+
+    @patch('apps.remote_mcp_app.get_current_user_info')
+    @patch('apps.remote_mcp_app.get_mcp_record_by_id')
+    def test_get_mcp_record_exception(self, mock_get_record, mock_get_user_info):
+        """Test getting MCP record when exception occurs"""
+        mock_get_user_info.return_value = ("user123", "tenant456", "en")
+        mock_get_record.side_effect = Exception("Database error")
+
+        response = client.get(
+            "/mcp/record/1",
+            headers={"Authorization": "Bearer test_token"}
+        )
+
+        assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        data = response.json()
+        assert "Failed to get MCP record" in data["detail"]
 
 
 class TestCheckMCPHealth:

--- a/test/backend/database/test_remote_mcp_db.py
+++ b/test/backend/database/test_remote_mcp_db.py
@@ -485,7 +485,8 @@ def test_update_mcp_record_by_name_and_url_success(monkeypatch, mock_session):
         "mcp_name": "new_name",
         "mcp_server": "http://new.url",
         "updated_by": "user1",
-        "status": True
+        "status": True,
+        "authorization_token": None
     })
 
 
@@ -521,7 +522,8 @@ def test_update_mcp_record_by_name_and_url_without_status(monkeypatch, mock_sess
     mock_update.assert_called_once_with({
         "mcp_name": "new_name",
         "mcp_server": "http://new.url",
-        "updated_by": "user1"
+        "updated_by": "user1",
+        "authorization_token": None
     })
 
 
@@ -724,7 +726,7 @@ def test_update_mcp_record_by_name_and_url_with_authorization_token(monkeypatch,
 
 
 def test_update_mcp_record_by_name_and_url_without_authorization_token(monkeypatch, mock_session):
-    """Test update of MCP record without authorization token (should not include it in update)"""
+    """Test update of MCP record without authorization token (None will be included in update)"""
     session, query = mock_session
     mock_update = MagicMock()
     mock_filter = MagicMock()
@@ -753,17 +755,18 @@ def test_update_mcp_record_by_name_and_url_without_authorization_token(monkeypat
         status=True
     )
 
-    # Verify the update was called without authorization_token
+    # Verify the update was called with authorization_token as None
     mock_update.assert_called_once_with({
         "mcp_name": "new_name",
         "mcp_server": "http://new.url",
         "updated_by": "user1",
-        "status": True
+        "status": True,
+        "authorization_token": None
     })
 
 
 def test_update_mcp_record_by_name_and_url_with_none_authorization_token(monkeypatch, mock_session):
-    """Test update of MCP record with None authorization token (should not include it in update)"""
+    """Test update of MCP record with None authorization token (None will be included in update)"""
     session, query = mock_session
     mock_update = MagicMock()
     mock_filter = MagicMock()
@@ -791,11 +794,12 @@ def test_update_mcp_record_by_name_and_url_with_none_authorization_token(monkeyp
         user_id="user1"
     )
 
-    # Verify the update was called without authorization_token (None should not be included)
+    # Verify the update was called with authorization_token as None
     mock_update.assert_called_once_with({
         "mcp_name": "new_name",
         "mcp_server": "http://new.url",
-        "updated_by": "user1"
+        "updated_by": "user1",
+        "authorization_token": None
     })
 
 

--- a/test/backend/database/test_remote_mcp_db.py
+++ b/test/backend/database/test_remote_mcp_db.py
@@ -73,11 +73,14 @@ from backend.database.remote_mcp_db import (
     update_mcp_record_by_name_and_url,
     get_mcp_records_by_tenant,
     get_mcp_server_by_name_and_tenant,
+    get_mcp_authorization_token_by_name_and_url,
+    get_mcp_record_by_id_and_tenant,
     check_mcp_name_exists,
 )
 
 class MockMcpRecord:
     def __init__(self):
+        self.mcp_id = 1
         self.mcp_name = "test_mcp"
         self.mcp_server = "http://test.server.com"
         self.tenant_id = "tenant1"
@@ -85,8 +88,10 @@ class MockMcpRecord:
         self.status = True
         self.delete_flag = "N"
         self.container_id = "container-1"
+        self.authorization_token = "test_token_123"
         self.create_time = "2024-01-01 00:00:00"
         self.__dict__ = {
+            "mcp_id": 1,
             "mcp_name": "test_mcp",
             "mcp_server": "http://test.server.com",
             "tenant_id": "tenant1",
@@ -94,6 +99,7 @@ class MockMcpRecord:
             "status": True,
             "delete_flag": "N",
             "container_id": "container-1",
+            "authorization_token": "test_token_123",
             "create_time": "2024-01-01 00:00:00"
         }
 
@@ -437,11 +443,12 @@ def test_check_mcp_name_exists_database_error(monkeypatch, mock_session):
 
 
 class MockMCPUpdateRequest:
-    def __init__(self, current_service_name, current_mcp_url, new_service_name, new_mcp_url):
+    def __init__(self, current_service_name, current_mcp_url, new_service_name, new_mcp_url, new_authorization_token=None):
         self.current_service_name = current_service_name
         self.current_mcp_url = current_mcp_url
         self.new_service_name = new_service_name
         self.new_mcp_url = new_mcp_url
+        self.new_authorization_token = new_authorization_token
 
 
 def test_update_mcp_record_by_name_and_url_success(monkeypatch, mock_session):
@@ -609,3 +616,293 @@ def test_mcp_record_lifecycle(monkeypatch, mock_session):
 
     # 6. Delete MCP record by container_id - should not raise exception
     delete_mcp_record_by_container_id("container-1", "tenant1", "user1")
+
+
+def test_get_mcp_authorization_token_by_name_and_url_success(monkeypatch, mock_session):
+    """Test successful retrieval of MCP authorization token by name and URL"""
+    session, query = mock_session
+    mock_mcp = MockMcpRecord()
+    mock_mcp.authorization_token = "bearer_token_123"
+
+    mock_first = MagicMock()
+    mock_first.return_value = mock_mcp
+    mock_filter = MagicMock()
+    mock_filter.first = mock_first
+    query.filter.return_value = mock_filter
+
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__.return_value = session
+    mock_ctx.__exit__.return_value = None
+    monkeypatch.setattr(
+        "backend.database.remote_mcp_db.get_db_session", lambda: mock_ctx)
+
+    result = get_mcp_authorization_token_by_name_and_url(
+        "test_mcp", "http://test.server.com", "tenant1")
+
+    assert result == "bearer_token_123"
+
+
+def test_get_mcp_authorization_token_by_name_and_url_not_found(monkeypatch, mock_session):
+    """Test retrieval of MCP authorization token when record does not exist"""
+    session, query = mock_session
+
+    mock_first = MagicMock()
+    mock_first.return_value = None
+    mock_filter = MagicMock()
+    mock_filter.first = mock_first
+    query.filter.return_value = mock_filter
+
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__.return_value = session
+    mock_ctx.__exit__.return_value = None
+    monkeypatch.setattr(
+        "backend.database.remote_mcp_db.get_db_session", lambda: mock_ctx)
+
+    result = get_mcp_authorization_token_by_name_and_url(
+        "nonexistent_mcp", "http://test.server.com", "tenant1")
+
+    assert result is None
+
+
+def test_get_mcp_authorization_token_by_name_and_url_database_error(monkeypatch, mock_session):
+    """Test database error when retrieving MCP authorization token - exception should propagate"""
+    from sqlalchemy.exc import SQLAlchemyError
+
+    session, query = mock_session
+    query.filter.side_effect = SQLAlchemyError("Database error")
+
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__.return_value = session
+    mock_ctx.__exit__.return_value = None
+    monkeypatch.setattr(
+        "backend.database.remote_mcp_db.get_db_session", lambda: mock_ctx)
+
+    # Should raise SQLAlchemyError
+    with pytest.raises(SQLAlchemyError):
+        get_mcp_authorization_token_by_name_and_url(
+            "test_mcp", "http://test.server.com", "tenant1")
+
+
+def test_update_mcp_record_by_name_and_url_with_authorization_token(monkeypatch, mock_session):
+    """Test update of MCP record with authorization token"""
+    session, query = mock_session
+    mock_update = MagicMock()
+    mock_filter = MagicMock()
+    mock_filter.update = mock_update
+    query.filter.return_value = mock_filter
+
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__.return_value = session
+    mock_ctx.__exit__.return_value = None
+    monkeypatch.setattr(
+        "backend.database.remote_mcp_db.get_db_session", lambda: mock_ctx)
+
+    update_data = MockMCPUpdateRequest(
+        current_service_name="old_name",
+        current_mcp_url="http://old.url",
+        new_service_name="new_name",
+        new_mcp_url="http://new.url",
+        new_authorization_token="new_token_456"
+    )
+
+    # Should not raise any exception
+    update_mcp_record_by_name_and_url(
+        update_data=update_data,
+        tenant_id="tenant1",
+        user_id="user1",
+        status=True
+    )
+
+    # Verify the update was called with authorization_token
+    mock_update.assert_called_once_with({
+        "mcp_name": "new_name",
+        "mcp_server": "http://new.url",
+        "updated_by": "user1",
+        "status": True,
+        "authorization_token": "new_token_456"
+    })
+
+
+def test_update_mcp_record_by_name_and_url_without_authorization_token(monkeypatch, mock_session):
+    """Test update of MCP record without authorization token (should not include it in update)"""
+    session, query = mock_session
+    mock_update = MagicMock()
+    mock_filter = MagicMock()
+    mock_filter.update = mock_update
+    query.filter.return_value = mock_filter
+
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__.return_value = session
+    mock_ctx.__exit__.return_value = None
+    monkeypatch.setattr(
+        "backend.database.remote_mcp_db.get_db_session", lambda: mock_ctx)
+
+    update_data = MockMCPUpdateRequest(
+        current_service_name="old_name",
+        current_mcp_url="http://old.url",
+        new_service_name="new_name",
+        new_mcp_url="http://new.url"
+        # new_authorization_token is None by default
+    )
+
+    # Should not raise any exception
+    update_mcp_record_by_name_and_url(
+        update_data=update_data,
+        tenant_id="tenant1",
+        user_id="user1",
+        status=True
+    )
+
+    # Verify the update was called without authorization_token
+    mock_update.assert_called_once_with({
+        "mcp_name": "new_name",
+        "mcp_server": "http://new.url",
+        "updated_by": "user1",
+        "status": True
+    })
+
+
+def test_update_mcp_record_by_name_and_url_with_none_authorization_token(monkeypatch, mock_session):
+    """Test update of MCP record with None authorization token (should not include it in update)"""
+    session, query = mock_session
+    mock_update = MagicMock()
+    mock_filter = MagicMock()
+    mock_filter.update = mock_update
+    query.filter.return_value = mock_filter
+
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__.return_value = session
+    mock_ctx.__exit__.return_value = None
+    monkeypatch.setattr(
+        "backend.database.remote_mcp_db.get_db_session", lambda: mock_ctx)
+
+    update_data = MockMCPUpdateRequest(
+        current_service_name="old_name",
+        current_mcp_url="http://old.url",
+        new_service_name="new_name",
+        new_mcp_url="http://new.url",
+        new_authorization_token=None  # Explicitly None
+    )
+
+    # Should not raise any exception
+    update_mcp_record_by_name_and_url(
+        update_data=update_data,
+        tenant_id="tenant1",
+        user_id="user1"
+    )
+
+    # Verify the update was called without authorization_token (None should not be included)
+    mock_update.assert_called_once_with({
+        "mcp_name": "new_name",
+        "mcp_server": "http://new.url",
+        "updated_by": "user1"
+    })
+
+
+def test_update_mcp_record_by_name_and_url_without_authorization_token_attribute(monkeypatch, mock_session):
+    """Test update of MCP record when object does not have new_authorization_token attribute"""
+    session, query = mock_session
+    mock_update = MagicMock()
+    mock_filter = MagicMock()
+    mock_filter.update = mock_update
+    query.filter.return_value = mock_filter
+
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__.return_value = session
+    mock_ctx.__exit__.return_value = None
+    monkeypatch.setattr(
+        "backend.database.remote_mcp_db.get_db_session", lambda: mock_ctx)
+
+    # Create an object without new_authorization_token attribute
+    class UpdateDataWithoutToken:
+        def __init__(self):
+            self.current_service_name = "old_name"
+            self.current_mcp_url = "http://old.url"
+            self.new_service_name = "new_name"
+            self.new_mcp_url = "http://new.url"
+            # No new_authorization_token attribute
+
+    update_data = UpdateDataWithoutToken()
+
+    # Should not raise any exception
+    update_mcp_record_by_name_and_url(
+        update_data=update_data,
+        tenant_id="tenant1",
+        user_id="user1",
+        status=False
+    )
+
+    # Verify the update was called without authorization_token
+    mock_update.assert_called_once_with({
+        "mcp_name": "new_name",
+        "mcp_server": "http://new.url",
+        "updated_by": "user1",
+        "status": False
+    })
+
+
+def test_get_mcp_record_by_id_and_tenant_success(monkeypatch, mock_session):
+    """Test successful retrieval of MCP record by ID and tenant"""
+    session, query = mock_session
+    mock_mcp = MockMcpRecord()
+    mock_mcp.mcp_id = 123
+
+    mock_first = MagicMock()
+    mock_first.return_value = mock_mcp
+    mock_filter = MagicMock()
+    mock_filter.first = mock_first
+    query.filter.return_value = mock_filter
+
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__.return_value = session
+    mock_ctx.__exit__.return_value = None
+    monkeypatch.setattr(
+        "backend.database.remote_mcp_db.get_db_session", lambda: mock_ctx)
+    monkeypatch.setattr(
+        "backend.database.remote_mcp_db.as_dict", lambda obj: obj.__dict__)
+
+    result = get_mcp_record_by_id_and_tenant(123, "tenant1")
+
+    assert result is not None
+    assert result["mcp_id"] == 123
+    assert result["mcp_name"] == "test_mcp"
+    assert result["mcp_server"] == "http://test.server.com"
+
+
+def test_get_mcp_record_by_id_and_tenant_not_found(monkeypatch, mock_session):
+    """Test retrieval of MCP record by ID and tenant when record does not exist"""
+    session, query = mock_session
+
+    mock_first = MagicMock()
+    mock_first.return_value = None
+    mock_filter = MagicMock()
+    mock_filter.first = mock_first
+    query.filter.return_value = mock_filter
+
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__.return_value = session
+    mock_ctx.__exit__.return_value = None
+    monkeypatch.setattr(
+        "backend.database.remote_mcp_db.get_db_session", lambda: mock_ctx)
+
+    result = get_mcp_record_by_id_and_tenant(999, "tenant1")
+
+    assert result is None
+
+
+def test_get_mcp_record_by_id_and_tenant_database_error(monkeypatch, mock_session):
+    """Test database error when retrieving MCP record by ID - exception should propagate"""
+    from sqlalchemy.exc import SQLAlchemyError
+
+    session, query = mock_session
+    query.filter.side_effect = SQLAlchemyError("Database error")
+
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__.return_value = session
+    mock_ctx.__exit__.return_value = None
+    monkeypatch.setattr(
+        "backend.database.remote_mcp_db.get_db_session", lambda: mock_ctx)
+
+    # Should raise SQLAlchemyError
+    with pytest.raises(SQLAlchemyError):
+        get_mcp_record_by_id_and_tenant(123, "tenant1")

--- a/test/backend/services/test_remote_mcp_service.py
+++ b/test/backend/services/test_remote_mcp_service.py
@@ -35,6 +35,7 @@ from backend.services.remote_mcp_service import (
     get_remote_mcp_server_list,
     check_mcp_health_and_update_db,
     delete_mcp_by_container_id,
+    get_mcp_record_by_id,
     upload_and_start_mcp_image,
     attach_mcp_container_permissions,
 )
@@ -100,6 +101,130 @@ class TestMcpServerHealth(unittest.IsolatedAsyncioTestCase):
         result = await mcp_server_health('http://test-server:8080')
         self.assertTrue(result)
 
+    @patch('backend.services.remote_mcp_service.Client')
+    async def test_health_with_authorization_token(self, mock_client_cls):
+        """Test health check with authorization token"""
+        from fastmcp.client.transports import StreamableHttpTransport
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.is_connected = MagicMock(return_value=True)
+        mock_client_cls.return_value = mock_client
+
+        result = await mcp_server_health('http://test-server', authorization_token='Bearer token123')
+        self.assertTrue(result)
+
+        # Verify Client was called with transport containing headers
+        mock_client_cls.assert_called_once()
+        call_args = mock_client_cls.call_args
+        transport = call_args[1]['transport']
+        self.assertIsInstance(transport, StreamableHttpTransport)
+        self.assertEqual(transport.headers, {"Authorization": "Bearer token123"})
+
+    @patch('backend.services.remote_mcp_service.Client')
+    async def test_health_without_authorization_token(self, mock_client_cls):
+        """Test health check without authorization token"""
+        from fastmcp.client.transports import StreamableHttpTransport
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.is_connected = MagicMock(return_value=True)
+        mock_client_cls.return_value = mock_client
+
+        result = await mcp_server_health('http://test-server', authorization_token=None)
+        self.assertTrue(result)
+
+        # Verify Client was called with transport containing empty headers
+        mock_client_cls.assert_called_once()
+        call_args = mock_client_cls.call_args
+        transport = call_args[1]['transport']
+        self.assertIsInstance(transport, StreamableHttpTransport)
+        self.assertEqual(transport.headers, {})
+
+    @patch('backend.services.remote_mcp_service.Client')
+    async def test_health_with_sse_url(self, mock_client_cls):
+        """Test health check with /sse URL ending - should use SSETransport"""
+        from fastmcp.client.transports import SSETransport
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.is_connected = MagicMock(return_value=True)
+        mock_client_cls.return_value = mock_client
+
+        result = await mcp_server_health('http://test-server/sse', authorization_token='token123')
+        self.assertTrue(result)
+
+        # Verify SSETransport was used
+        mock_client_cls.assert_called_once()
+        call_args = mock_client_cls.call_args
+        transport = call_args[1]['transport']
+        self.assertIsInstance(transport, SSETransport)
+        self.assertEqual(transport.url, 'http://test-server/sse')
+        self.assertEqual(transport.headers, {"Authorization": "token123"})
+
+    @patch('backend.services.remote_mcp_service.Client')
+    async def test_health_with_mcp_url(self, mock_client_cls):
+        """Test health check with /mcp URL ending - should use StreamableHttpTransport"""
+        from fastmcp.client.transports import StreamableHttpTransport
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.is_connected = MagicMock(return_value=True)
+        mock_client_cls.return_value = mock_client
+
+        result = await mcp_server_health('http://test-server/mcp', authorization_token='token123')
+        self.assertTrue(result)
+
+        # Verify StreamableHttpTransport was used
+        mock_client_cls.assert_called_once()
+        call_args = mock_client_cls.call_args
+        transport = call_args[1]['transport']
+        self.assertIsInstance(transport, StreamableHttpTransport)
+        self.assertEqual(transport.url, 'http://test-server/mcp')
+        self.assertEqual(transport.headers, {"Authorization": "token123"})
+
+    @patch('backend.services.remote_mcp_service.Client')
+    async def test_health_with_unknown_url_format(self, mock_client_cls):
+        """Test health check with unknown URL format - should default to StreamableHttpTransport"""
+        from fastmcp.client.transports import StreamableHttpTransport
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.is_connected = MagicMock(return_value=True)
+        mock_client_cls.return_value = mock_client
+
+        result = await mcp_server_health('http://test-server/api', authorization_token='token123')
+        self.assertTrue(result)
+
+        # Verify StreamableHttpTransport was used as default
+        mock_client_cls.assert_called_once()
+        call_args = mock_client_cls.call_args
+        transport = call_args[1]['transport']
+        self.assertIsInstance(transport, StreamableHttpTransport)
+        self.assertEqual(transport.url, 'http://test-server/api')
+        self.assertEqual(transport.headers, {"Authorization": "token123"})
+
+    @patch('backend.services.remote_mcp_service.Client')
+    async def test_health_with_url_whitespace(self, mock_client_cls):
+        """Test health check with URL containing whitespace - should be stripped"""
+        from fastmcp.client.transports import StreamableHttpTransport
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.is_connected = MagicMock(return_value=True)
+        mock_client_cls.return_value = mock_client
+
+        result = await mcp_server_health('  http://test-server/mcp  ', authorization_token='token123')
+        self.assertTrue(result)
+
+        # Verify URL was stripped and StreamableHttpTransport was used
+        mock_client_cls.assert_called_once()
+        call_args = mock_client_cls.call_args
+        transport = call_args[1]['transport']
+        self.assertIsInstance(transport, StreamableHttpTransport)
+        # URL should be stripped before being passed to transport
+        self.assertEqual(transport.url, 'http://test-server/mcp')
+
 
 class TestAddRemoteMcpServerList(unittest.IsolatedAsyncioTestCase):
     """Test add_remote_mcp_server_list"""
@@ -118,8 +243,36 @@ class TestAddRemoteMcpServerList(unittest.IsolatedAsyncioTestCase):
         # Verify calls
         mock_check_name.assert_called_once_with(
             mcp_name='name', tenant_id='tid')
-        mock_health.assert_called_once_with(remote_mcp_server='http://srv')
+        mock_health.assert_called_once_with(remote_mcp_server='http://srv', authorization_token=None)
         mock_create.assert_called_once()
+
+    @patch('backend.services.remote_mcp_service.create_mcp_record')
+    @patch('backend.services.remote_mcp_service.mcp_server_health')
+    @patch('backend.services.remote_mcp_service.check_mcp_name_exists')
+    async def test_add_success_with_authorization_token(self, mock_check_name, mock_health, mock_create):
+        """Test successful MCP server addition with authorization token"""
+        mock_check_name.return_value = False  # Name doesn't exist
+        mock_health.return_value = True  # Health check passes
+
+        # Should execute successfully without exception
+        await add_remote_mcp_server_list(
+            'tid', 'uid', 'http://srv', 'name',
+            container_id='container-123',
+            authorization_token='Bearer token123'
+        )
+
+        # Verify calls
+        mock_check_name.assert_called_once_with(
+            mcp_name='name', tenant_id='tid')
+        mock_health.assert_called_once_with(
+            remote_mcp_server='http://srv',
+            authorization_token='Bearer token123'
+        )
+        mock_create.assert_called_once()
+        # Verify authorization_token was passed to create_mcp_record
+        create_call_kwargs = mock_create.call_args[1]
+        self.assertEqual(create_call_kwargs['mcp_data']['authorization_token'], 'Bearer token123')
+        self.assertEqual(create_call_kwargs['mcp_data']['container_id'], 'container-123')
 
     @patch('backend.services.remote_mcp_service.check_mcp_name_exists')
     async def test_add_name_exists(self, mock_check_name):
@@ -134,6 +287,16 @@ class TestAddRemoteMcpServerList(unittest.IsolatedAsyncioTestCase):
     @patch('backend.services.remote_mcp_service.check_mcp_name_exists')
     async def test_add_health_fail(self, mock_check_name, mock_health):
         """Test health check failure"""
+        mock_check_name.return_value = False
+        mock_health.return_value = False  # Health check returns False
+
+        with self.assertRaises(MCPConnectionError):
+            await add_remote_mcp_server_list('tid', 'uid', 'http://srv', 'name')
+
+    @patch('backend.services.remote_mcp_service.mcp_server_health')
+    @patch('backend.services.remote_mcp_service.check_mcp_name_exists')
+    async def test_add_health_fail_with_exception(self, mock_check_name, mock_health):
+        """Test health check failure with exception"""
         mock_check_name.return_value = False
         mock_health.side_effect = MCPConnectionError("MCP connection failed")
 
@@ -326,14 +489,24 @@ class TestCheckMcpHealthAndUpdateDb(unittest.IsolatedAsyncioTestCase):
 
     @patch('backend.services.remote_mcp_service.update_mcp_status_by_name_and_url')
     @patch('backend.services.remote_mcp_service.mcp_server_health')
-    async def test_check_health_success(self, mock_health, mock_update):
+    @patch('backend.services.remote_mcp_service.get_mcp_authorization_token_by_name_and_url')
+    async def test_check_health_success(self, mock_get_token, mock_health, mock_update):
         """Test successful health check and update"""
+        mock_get_token.return_value = 'Bearer token123'
         mock_health.return_value = True
 
         # Should execute successfully without exception
         await check_mcp_health_and_update_db('http://srv', 'name', 'tid', 'uid')
 
-        mock_health.assert_called_once_with(remote_mcp_server='http://srv')
+        mock_get_token.assert_called_once_with(
+            mcp_name='name',
+            mcp_server='http://srv',
+            tenant_id='tid'
+        )
+        mock_health.assert_called_once_with(
+            remote_mcp_server='http://srv',
+            authorization_token='Bearer token123'
+        )
         mock_update.assert_called_once_with(
             mcp_name='name',
             mcp_server='http://srv',
@@ -344,8 +517,25 @@ class TestCheckMcpHealthAndUpdateDb(unittest.IsolatedAsyncioTestCase):
 
     @patch('backend.services.remote_mcp_service.update_mcp_status_by_name_and_url')
     @patch('backend.services.remote_mcp_service.mcp_server_health')
-    async def test_check_health_false(self, mock_health, mock_update):
+    @patch('backend.services.remote_mcp_service.get_mcp_authorization_token_by_name_and_url')
+    async def test_check_health_with_none_token(self, mock_get_token, mock_health, mock_update):
+        """Test health check with None authorization token"""
+        mock_get_token.return_value = None
+        mock_health.return_value = True
+
+        await check_mcp_health_and_update_db('http://srv', 'name', 'tid', 'uid')
+
+        mock_health.assert_called_once_with(
+            remote_mcp_server='http://srv',
+            authorization_token=None
+        )
+
+    @patch('backend.services.remote_mcp_service.update_mcp_status_by_name_and_url')
+    @patch('backend.services.remote_mcp_service.mcp_server_health')
+    @patch('backend.services.remote_mcp_service.get_mcp_authorization_token_by_name_and_url')
+    async def test_check_health_false(self, mock_get_token, mock_health, mock_update):
         """Test health check failure - should raise MCPConnectionError when status is False"""
+        mock_get_token.return_value = 'Bearer token123'
         mock_health.return_value = False
 
         with self.assertRaises(MCPConnectionError) as context:
@@ -362,10 +552,12 @@ class TestCheckMcpHealthAndUpdateDb(unittest.IsolatedAsyncioTestCase):
 
     @patch('backend.services.remote_mcp_service.update_mcp_status_by_name_and_url')
     @patch('backend.services.remote_mcp_service.mcp_server_health')
-    async def test_update_db_fail(self, mock_health, mock_update):
+    @patch('backend.services.remote_mcp_service.get_mcp_authorization_token_by_name_and_url')
+    async def test_update_db_fail(self, mock_get_token, mock_health, mock_update):
         """Test database update failure - exception should propagate from database layer"""
         from sqlalchemy.exc import SQLAlchemyError
 
+        mock_get_token.return_value = 'Bearer token123'
         mock_health.return_value = True
         mock_update.side_effect = SQLAlchemyError("Database error")
 
@@ -374,8 +566,10 @@ class TestCheckMcpHealthAndUpdateDb(unittest.IsolatedAsyncioTestCase):
 
     @patch('backend.services.remote_mcp_service.update_mcp_status_by_name_and_url')
     @patch('backend.services.remote_mcp_service.mcp_server_health')
-    async def test_health_check_exception(self, mock_health, mock_update):
+    @patch('backend.services.remote_mcp_service.get_mcp_authorization_token_by_name_and_url')
+    async def test_health_check_exception(self, mock_get_token, mock_health, mock_update):
         """Test health check exception - should catch exception, set status to False, and raise MCPConnectionError"""
+        mock_get_token.return_value = 'Bearer token123'
         mock_health.side_effect = MCPConnectionError("Connection failed")
 
         # Should catch the exception from mcp_server_health, set status to False, and then raise MCPConnectionError
@@ -383,7 +577,10 @@ class TestCheckMcpHealthAndUpdateDb(unittest.IsolatedAsyncioTestCase):
             await check_mcp_health_and_update_db('http://srv', 'name', 'tid', 'uid')
 
         self.assertEqual(str(context.exception), "MCP connection failed")
-        mock_health.assert_called_once_with(remote_mcp_server='http://srv')
+        mock_health.assert_called_once_with(
+            remote_mcp_server='http://srv',
+            authorization_token='Bearer token123'
+        )
         mock_update.assert_called_once_with(
             mcp_name='name',
             mcp_server='http://srv',
@@ -524,6 +721,94 @@ class TestUploadAndStartMcpImage(unittest.IsolatedAsyncioTestCase):
 
         # Verify MCP server was registered
         mock_add_server.assert_called_once()
+
+    @patch('backend.services.remote_mcp_service.add_remote_mcp_server_list')
+    @patch('backend.services.remote_mcp_service.MCPContainerManager')
+    @patch('backend.services.remote_mcp_service.check_mcp_name_exists')
+    @patch('tempfile.NamedTemporaryFile')
+    async def test_upload_success_with_authorization_token_in_env_vars(self, mock_temp_file, mock_check_name, mock_container_manager_class, mock_add_server):
+        """Test successful upload with authorization_token in env_vars"""
+        # Mock tempfile
+        mock_temp_file_obj = MagicMock()
+        mock_temp_file_obj.__enter__.return_value = mock_temp_file_obj
+        mock_temp_file_obj.__exit__.return_value = None
+        mock_temp_file_obj.name = "/tmp/test.tar"
+        mock_temp_file.return_value = mock_temp_file_obj
+
+        # Mock container manager
+        mock_container_manager = MagicMock()
+        mock_container_manager_class.return_value = mock_container_manager
+        mock_container_manager.start_mcp_container_from_tar = AsyncMock(return_value={
+            "container_id": "container-123",
+            "mcp_url": "http://localhost:5020/mcp",
+            "host_port": "5020",
+            "status": "started",
+            "container_name": "test-service-user1234"
+        })
+
+        mock_check_name.return_value = False
+        mock_add_server.return_value = None
+
+        result = await upload_and_start_mcp_image(
+            tenant_id="tenant123",
+            user_id="user456",
+            file_content=b"fake tar content",
+            filename="test.tar",
+            port=5020,
+            service_name="test-service",
+            env_vars='{"NODE_ENV": "production", "authorization_token": "Bearer token123"}'
+        )
+
+        self.assertEqual(result["status"], "success")
+
+        # Verify authorization_token was extracted from env_vars and passed to add_remote_mcp_server_list
+        mock_add_server.assert_called_once()
+        call_kwargs = mock_add_server.call_args[1]
+        self.assertEqual(call_kwargs["authorization_token"], "Bearer token123")
+
+    @patch('backend.services.remote_mcp_service.add_remote_mcp_server_list')
+    @patch('backend.services.remote_mcp_service.MCPContainerManager')
+    @patch('backend.services.remote_mcp_service.check_mcp_name_exists')
+    @patch('tempfile.NamedTemporaryFile')
+    async def test_upload_success_without_authorization_token_in_env_vars(self, mock_temp_file, mock_check_name, mock_container_manager_class, mock_add_server):
+        """Test successful upload without authorization_token in env_vars"""
+        # Mock tempfile
+        mock_temp_file_obj = MagicMock()
+        mock_temp_file_obj.__enter__.return_value = mock_temp_file_obj
+        mock_temp_file_obj.__exit__.return_value = None
+        mock_temp_file_obj.name = "/tmp/test.tar"
+        mock_temp_file.return_value = mock_temp_file_obj
+
+        # Mock container manager
+        mock_container_manager = MagicMock()
+        mock_container_manager_class.return_value = mock_container_manager
+        mock_container_manager.start_mcp_container_from_tar = AsyncMock(return_value={
+            "container_id": "container-123",
+            "mcp_url": "http://localhost:5020/mcp",
+            "host_port": "5020",
+            "status": "started",
+            "container_name": "test-service-user1234"
+        })
+
+        mock_check_name.return_value = False
+        mock_add_server.return_value = None
+
+        result = await upload_and_start_mcp_image(
+            tenant_id="tenant123",
+            user_id="user456",
+            file_content=b"fake tar content",
+            filename="test.tar",
+            port=5020,
+            service_name="test-service",
+            env_vars='{"NODE_ENV": "production"}'  # No authorization_token
+        )
+
+        self.assertEqual(result["status"], "success")
+
+        # Verify authorization_token is None when not in env_vars
+        mock_add_server.assert_called_once()
+        call_kwargs = mock_add_server.call_args[1]
+        self.assertIsNone(call_kwargs["authorization_token"])
 
     @patch('backend.services.remote_mcp_service.check_mcp_name_exists')
     async def test_upload_invalid_file_type(self, mock_check_name):
@@ -754,11 +1039,12 @@ class TestUploadAndStartMcpImage(unittest.IsolatedAsyncioTestCase):
 class MockMCPUpdateRequest:
     """Mock MCPUpdateRequest for testing"""
 
-    def __init__(self, current_service_name, current_mcp_url, new_service_name, new_mcp_url):
+    def __init__(self, current_service_name, current_mcp_url, new_service_name, new_mcp_url, new_authorization_token=None):
         self.current_service_name = current_service_name
         self.current_mcp_url = current_mcp_url
         self.new_service_name = new_service_name
         self.new_mcp_url = new_mcp_url
+        self.new_authorization_token = new_authorization_token
 
 
 class TestUpdateRemoteMcpServerList(unittest.IsolatedAsyncioTestCase):
@@ -766,12 +1052,14 @@ class TestUpdateRemoteMcpServerList(unittest.IsolatedAsyncioTestCase):
 
     @patch('backend.services.remote_mcp_service.update_mcp_record_by_name_and_url')
     @patch('backend.services.remote_mcp_service.mcp_server_health')
+    @patch('backend.services.remote_mcp_service.get_mcp_authorization_token_by_name_and_url')
     @patch('backend.services.remote_mcp_service.check_mcp_name_exists')
-    async def test_update_success(self, mock_check_name, mock_health, mock_update_record):
+    async def test_update_success(self, mock_check_name, mock_get_token, mock_health, mock_update_record):
         """Test successful MCP server update"""
         # Current name exists, new name is different and doesn't exist, health check passes
         # current exists, new doesn't
         mock_check_name.side_effect = [True, False]
+        mock_get_token.return_value = 'Bearer existing_token'
         mock_health.return_value = True
 
         update_data = MockMCPUpdateRequest(
@@ -787,7 +1075,15 @@ class TestUpdateRemoteMcpServerList(unittest.IsolatedAsyncioTestCase):
         # Verify calls
         mock_check_name.assert_any_call(mcp_name='old_name', tenant_id='tid')
         mock_check_name.assert_any_call(mcp_name='new_name', tenant_id='tid')
-        mock_health.assert_called_once_with(remote_mcp_server='http://new.url')
+        mock_get_token.assert_called_once_with(
+            mcp_name='old_name',
+            mcp_server='http://old.url',
+            tenant_id='tid'
+        )
+        mock_health.assert_called_once_with(
+            remote_mcp_server='http://new.url',
+            authorization_token='Bearer existing_token'
+        )
         mock_update_record.assert_called_once_with(
             update_data=update_data,
             tenant_id='tid',
@@ -798,10 +1094,37 @@ class TestUpdateRemoteMcpServerList(unittest.IsolatedAsyncioTestCase):
     @patch('backend.services.remote_mcp_service.update_mcp_record_by_name_and_url')
     @patch('backend.services.remote_mcp_service.mcp_server_health')
     @patch('backend.services.remote_mcp_service.check_mcp_name_exists')
-    async def test_update_success_same_name(self, mock_check_name, mock_health, mock_update_record):
+    async def test_update_success_with_new_authorization_token(self, mock_check_name, mock_health, mock_update_record):
+        """Test successful MCP server update with new authorization token"""
+        mock_check_name.side_effect = [True, False]
+        mock_health.return_value = True
+
+        update_data = MockMCPUpdateRequest(
+            current_service_name="old_name",
+            current_mcp_url="http://old.url",
+            new_service_name="new_name",
+            new_mcp_url="http://new.url",
+            new_authorization_token='Bearer new_token123'
+        )
+
+        # Should execute successfully without exception
+        await update_remote_mcp_server_list(update_data, 'tid', 'uid')
+
+        # Verify that new authorization token was used (not fetched from DB)
+        mock_health.assert_called_once_with(
+            remote_mcp_server='http://new.url',
+            authorization_token='Bearer new_token123'
+        )
+
+    @patch('backend.services.remote_mcp_service.update_mcp_record_by_name_and_url')
+    @patch('backend.services.remote_mcp_service.mcp_server_health')
+    @patch('backend.services.remote_mcp_service.get_mcp_authorization_token_by_name_and_url')
+    @patch('backend.services.remote_mcp_service.check_mcp_name_exists')
+    async def test_update_success_same_name(self, mock_check_name, mock_get_token, mock_health, mock_update_record):
         """Test successful MCP server update with same name (only URL change)"""
         # Current name exists, new name is same so no additional check, health check passes
         mock_check_name.return_value = True  # current exists
+        mock_get_token.return_value = 'Bearer existing_token'
         mock_health.return_value = True
 
         update_data = MockMCPUpdateRequest(
@@ -818,7 +1141,15 @@ class TestUpdateRemoteMcpServerList(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(mock_check_name.call_count, 1)
         mock_check_name.assert_called_with(
             mcp_name='same_name', tenant_id='tid')
-        mock_health.assert_called_once_with(remote_mcp_server='http://new.url')
+        mock_get_token.assert_called_once_with(
+            mcp_name='same_name',
+            mcp_server='http://old.url',
+            tenant_id='tid'
+        )
+        mock_health.assert_called_once_with(
+            remote_mcp_server='http://new.url',
+            authorization_token='Bearer existing_token'
+        )
         mock_update_record.assert_called_once_with(
             update_data=update_data,
             tenant_id='tid',
@@ -866,11 +1197,13 @@ class TestUpdateRemoteMcpServerList(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(str(context.exception), "New MCP name already exists")
 
     @patch('backend.services.remote_mcp_service.mcp_server_health')
+    @patch('backend.services.remote_mcp_service.get_mcp_authorization_token_by_name_and_url')
     @patch('backend.services.remote_mcp_service.check_mcp_name_exists')
-    async def test_update_health_check_fail(self, mock_check_name, mock_health):
+    async def test_update_health_check_fail(self, mock_check_name, mock_get_token, mock_health):
         """Test update when health check fails"""
         mock_check_name.side_effect = [
             True, False]  # current exists, new doesn't
+        mock_get_token.return_value = 'Bearer existing_token'
         mock_health.return_value = False  # health check fails
 
         update_data = MockMCPUpdateRequest(
@@ -885,13 +1218,19 @@ class TestUpdateRemoteMcpServerList(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(str(context.exception),
                          "New MCP server connection failed")
+        mock_health.assert_called_once_with(
+            remote_mcp_server='http://unreachable.url',
+            authorization_token='Bearer existing_token'
+        )
 
     @patch('backend.services.remote_mcp_service.mcp_server_health')
+    @patch('backend.services.remote_mcp_service.get_mcp_authorization_token_by_name_and_url')
     @patch('backend.services.remote_mcp_service.check_mcp_name_exists')
-    async def test_update_health_check_exception(self, mock_check_name, mock_health):
+    async def test_update_health_check_exception(self, mock_check_name, mock_get_token, mock_health):
         """Test update when health check raises exception"""
         mock_check_name.side_effect = [
             True, False]  # current exists, new doesn't
+        mock_get_token.return_value = 'Bearer existing_token'
         mock_health.side_effect = MCPConnectionError("Connection failed")
 
         update_data = MockMCPUpdateRequest(
@@ -906,16 +1245,22 @@ class TestUpdateRemoteMcpServerList(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(str(context.exception),
                          "New MCP server connection failed")
+        mock_health.assert_called_once_with(
+            remote_mcp_server='http://failing.url',
+            authorization_token='Bearer existing_token'
+        )
 
     @patch('backend.services.remote_mcp_service.update_mcp_record_by_name_and_url')
     @patch('backend.services.remote_mcp_service.mcp_server_health')
+    @patch('backend.services.remote_mcp_service.get_mcp_authorization_token_by_name_and_url')
     @patch('backend.services.remote_mcp_service.check_mcp_name_exists')
-    async def test_update_db_error(self, mock_check_name, mock_health, mock_update_record):
+    async def test_update_db_error(self, mock_check_name, mock_get_token, mock_health, mock_update_record):
         """Test update when database operation fails"""
         from sqlalchemy.exc import SQLAlchemyError
 
         # current exists, new doesn't
         mock_check_name.side_effect = [True, False]
+        mock_get_token.return_value = 'Bearer existing_token'
         mock_health.return_value = True
         mock_update_record.side_effect = SQLAlchemyError("Database error")
 
@@ -1349,6 +1694,127 @@ class TestAttachMcpContainerPermissions(unittest.TestCase):
         self.assertEqual(result[0]["status"], "running")
         self.assertEqual(result[0]["port"], 8080)
         self.assertEqual(result[0]["permission"], "READ_ONLY")
+
+
+class TestGetMcpRecordById(unittest.IsolatedAsyncioTestCase):
+    """Test get_mcp_record_by_id function"""
+
+    @patch('backend.services.remote_mcp_service.get_mcp_record_by_id_and_tenant')
+    async def test_get_mcp_record_success(self, mock_get_record):
+        """Test successful retrieval of MCP record"""
+        mock_get_record.return_value = {
+            "mcp_name": "test-service",
+            "mcp_server": "http://test.com/mcp",
+            "authorization_token": "Bearer token123",
+            "status": True,
+            "mcp_id": 1
+        }
+
+        result = await get_mcp_record_by_id(mcp_id=1, tenant_id="tenant123")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["mcp_name"], "test-service")
+        self.assertEqual(result["mcp_server"], "http://test.com/mcp")
+        self.assertEqual(result["authorization_token"], "Bearer token123")
+
+        mock_get_record.assert_called_once_with(mcp_id=1, tenant_id="tenant123")
+
+    @patch('backend.services.remote_mcp_service.get_mcp_record_by_id_and_tenant')
+    async def test_get_mcp_record_not_found(self, mock_get_record):
+        """Test when MCP record does not exist"""
+        mock_get_record.return_value = None
+
+        result = await get_mcp_record_by_id(mcp_id=999, tenant_id="tenant123")
+
+        self.assertIsNone(result)
+        mock_get_record.assert_called_once_with(mcp_id=999, tenant_id="tenant123")
+
+    @patch('backend.services.remote_mcp_service.get_mcp_record_by_id_and_tenant')
+    async def test_get_mcp_record_with_none_authorization_token(self, mock_get_record):
+        """Test MCP record with None authorization token"""
+        mock_get_record.return_value = {
+            "mcp_name": "test-service",
+            "mcp_server": "http://test.com/mcp",
+            "authorization_token": None,
+            "status": True,
+            "mcp_id": 1
+        }
+
+        result = await get_mcp_record_by_id(mcp_id=1, tenant_id="tenant123")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["mcp_name"], "test-service")
+        self.assertEqual(result["mcp_server"], "http://test.com/mcp")
+        self.assertIsNone(result["authorization_token"])
+
+    @patch('backend.services.remote_mcp_service.get_mcp_record_by_id_and_tenant')
+    async def test_get_mcp_record_with_missing_fields(self, mock_get_record):
+        """Test MCP record with missing optional fields"""
+        mock_get_record.return_value = {
+            "mcp_name": "test-service",
+            "mcp_server": "http://test.com/mcp",
+            # authorization_token missing
+            "status": True,
+            "mcp_id": 1
+        }
+
+        result = await get_mcp_record_by_id(mcp_id=1, tenant_id="tenant123")
+
+        self.assertIsNotNone(result)
+        self.assertEqual(result["mcp_name"], "test-service")
+        self.assertEqual(result["mcp_server"], "http://test.com/mcp")
+        self.assertIsNone(result["authorization_token"])  # Should be None when missing
+
+    @patch('backend.services.remote_mcp_service.get_mcp_record_by_id_and_tenant')
+    async def test_get_mcp_record_with_empty_dict(self, mock_get_record):
+        """Test when database returns empty dict (should not happen but handle gracefully)"""
+        mock_get_record.return_value = {}
+
+        result = await get_mcp_record_by_id(mcp_id=1, tenant_id="tenant123")
+
+        # Empty dict is falsy, so should return None
+        self.assertIsNone(result)
+
+    @patch('backend.services.remote_mcp_service.get_mcp_record_by_id_and_tenant')
+    async def test_get_mcp_record_different_tenant(self, mock_get_record):
+        """Test getting MCP record with different tenant ID"""
+        mock_get_record.return_value = {
+            "mcp_name": "test-service",
+            "mcp_server": "http://test.com/mcp",
+            "authorization_token": "token123",
+            "status": True,
+            "mcp_id": 1
+        }
+
+        result = await get_mcp_record_by_id(mcp_id=1, tenant_id="different_tenant")
+
+        self.assertIsNotNone(result)
+        mock_get_record.assert_called_once_with(mcp_id=1, tenant_id="different_tenant")
+
+    @patch('backend.services.remote_mcp_service.get_mcp_record_by_id_and_tenant')
+    async def test_get_mcp_record_returns_only_required_fields(self, mock_get_record):
+        """Test that function returns only mcp_name, mcp_server, and authorization_token"""
+        mock_get_record.return_value = {
+            "mcp_name": "test-service",
+            "mcp_server": "http://test.com/mcp",
+            "authorization_token": "token123",
+            "status": True,
+            "mcp_id": 1,
+            "container_id": "container-123",
+            "created_by": "user123",
+            "other_field": "should_not_be_included"
+        }
+
+        result = await get_mcp_record_by_id(mcp_id=1, tenant_id="tenant123")
+
+        self.assertIsNotNone(result)
+        # Should only contain the three required fields
+        self.assertEqual(set(result.keys()), {"mcp_name", "mcp_server", "authorization_token"})
+        self.assertNotIn("status", result)
+        self.assertNotIn("mcp_id", result)
+        self.assertNotIn("container_id", result)
+        self.assertNotIn("created_by", result)
+        self.assertNotIn("other_field", result)
 
 
 if __name__ == '__main__':

--- a/test/backend/services/test_remote_mcp_service.py
+++ b/test/backend/services/test_remote_mcp_service.py
@@ -1052,14 +1052,12 @@ class TestUpdateRemoteMcpServerList(unittest.IsolatedAsyncioTestCase):
 
     @patch('backend.services.remote_mcp_service.update_mcp_record_by_name_and_url')
     @patch('backend.services.remote_mcp_service.mcp_server_health')
-    @patch('backend.services.remote_mcp_service.get_mcp_authorization_token_by_name_and_url')
     @patch('backend.services.remote_mcp_service.check_mcp_name_exists')
-    async def test_update_success(self, mock_check_name, mock_get_token, mock_health, mock_update_record):
+    async def test_update_success(self, mock_check_name, mock_health, mock_update_record):
         """Test successful MCP server update"""
         # Current name exists, new name is different and doesn't exist, health check passes
         # current exists, new doesn't
         mock_check_name.side_effect = [True, False]
-        mock_get_token.return_value = 'Bearer existing_token'
         mock_health.return_value = True
 
         update_data = MockMCPUpdateRequest(
@@ -1075,14 +1073,9 @@ class TestUpdateRemoteMcpServerList(unittest.IsolatedAsyncioTestCase):
         # Verify calls
         mock_check_name.assert_any_call(mcp_name='old_name', tenant_id='tid')
         mock_check_name.assert_any_call(mcp_name='new_name', tenant_id='tid')
-        mock_get_token.assert_called_once_with(
-            mcp_name='old_name',
-            mcp_server='http://old.url',
-            tenant_id='tid'
-        )
         mock_health.assert_called_once_with(
             remote_mcp_server='http://new.url',
-            authorization_token='Bearer existing_token'
+            authorization_token=None
         )
         mock_update_record.assert_called_once_with(
             update_data=update_data,
@@ -1118,13 +1111,11 @@ class TestUpdateRemoteMcpServerList(unittest.IsolatedAsyncioTestCase):
 
     @patch('backend.services.remote_mcp_service.update_mcp_record_by_name_and_url')
     @patch('backend.services.remote_mcp_service.mcp_server_health')
-    @patch('backend.services.remote_mcp_service.get_mcp_authorization_token_by_name_and_url')
     @patch('backend.services.remote_mcp_service.check_mcp_name_exists')
-    async def test_update_success_same_name(self, mock_check_name, mock_get_token, mock_health, mock_update_record):
+    async def test_update_success_same_name(self, mock_check_name, mock_health, mock_update_record):
         """Test successful MCP server update with same name (only URL change)"""
         # Current name exists, new name is same so no additional check, health check passes
         mock_check_name.return_value = True  # current exists
-        mock_get_token.return_value = 'Bearer existing_token'
         mock_health.return_value = True
 
         update_data = MockMCPUpdateRequest(
@@ -1141,14 +1132,9 @@ class TestUpdateRemoteMcpServerList(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(mock_check_name.call_count, 1)
         mock_check_name.assert_called_with(
             mcp_name='same_name', tenant_id='tid')
-        mock_get_token.assert_called_once_with(
-            mcp_name='same_name',
-            mcp_server='http://old.url',
-            tenant_id='tid'
-        )
         mock_health.assert_called_once_with(
             remote_mcp_server='http://new.url',
-            authorization_token='Bearer existing_token'
+            authorization_token=None
         )
         mock_update_record.assert_called_once_with(
             update_data=update_data,
@@ -1197,13 +1183,11 @@ class TestUpdateRemoteMcpServerList(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(str(context.exception), "New MCP name already exists")
 
     @patch('backend.services.remote_mcp_service.mcp_server_health')
-    @patch('backend.services.remote_mcp_service.get_mcp_authorization_token_by_name_and_url')
     @patch('backend.services.remote_mcp_service.check_mcp_name_exists')
-    async def test_update_health_check_fail(self, mock_check_name, mock_get_token, mock_health):
+    async def test_update_health_check_fail(self, mock_check_name, mock_health):
         """Test update when health check fails"""
         mock_check_name.side_effect = [
             True, False]  # current exists, new doesn't
-        mock_get_token.return_value = 'Bearer existing_token'
         mock_health.return_value = False  # health check fails
 
         update_data = MockMCPUpdateRequest(
@@ -1220,17 +1204,15 @@ class TestUpdateRemoteMcpServerList(unittest.IsolatedAsyncioTestCase):
                          "New MCP server connection failed")
         mock_health.assert_called_once_with(
             remote_mcp_server='http://unreachable.url',
-            authorization_token='Bearer existing_token'
+            authorization_token=None
         )
 
     @patch('backend.services.remote_mcp_service.mcp_server_health')
-    @patch('backend.services.remote_mcp_service.get_mcp_authorization_token_by_name_and_url')
     @patch('backend.services.remote_mcp_service.check_mcp_name_exists')
-    async def test_update_health_check_exception(self, mock_check_name, mock_get_token, mock_health):
+    async def test_update_health_check_exception(self, mock_check_name, mock_health):
         """Test update when health check raises exception"""
         mock_check_name.side_effect = [
             True, False]  # current exists, new doesn't
-        mock_get_token.return_value = 'Bearer existing_token'
         mock_health.side_effect = MCPConnectionError("Connection failed")
 
         update_data = MockMCPUpdateRequest(
@@ -1247,20 +1229,18 @@ class TestUpdateRemoteMcpServerList(unittest.IsolatedAsyncioTestCase):
                          "New MCP server connection failed")
         mock_health.assert_called_once_with(
             remote_mcp_server='http://failing.url',
-            authorization_token='Bearer existing_token'
+            authorization_token=None
         )
 
     @patch('backend.services.remote_mcp_service.update_mcp_record_by_name_and_url')
     @patch('backend.services.remote_mcp_service.mcp_server_health')
-    @patch('backend.services.remote_mcp_service.get_mcp_authorization_token_by_name_and_url')
     @patch('backend.services.remote_mcp_service.check_mcp_name_exists')
-    async def test_update_db_error(self, mock_check_name, mock_get_token, mock_health, mock_update_record):
+    async def test_update_db_error(self, mock_check_name, mock_health, mock_update_record):
         """Test update when database operation fails"""
         from sqlalchemy.exc import SQLAlchemyError
 
         # current exists, new doesn't
         mock_check_name.side_effect = [True, False]
-        mock_get_token.return_value = 'Bearer existing_token'
         mock_health.return_value = True
         mock_update_record.side_effect = SQLAlchemyError("Database error")
 

--- a/test/backend/services/test_tool_configuration_service.py
+++ b/test/backend/services/test_tool_configuration_service.py
@@ -663,7 +663,7 @@ class TestUpdateToolInfoImpl:
                 self.agent_id = 1
                 self.tool_id = 1
                 # Explicitly do not set version_no
-        
+
         mock_request = MockToolInfoWithoutVersion()
         mock_tool_instance = {"id": 1, "name": "test_tool"}
         mock_create_update.return_value = mock_tool_instance
@@ -915,12 +915,12 @@ class TestCreateMcpTransport:
     def test_create_mcp_transport_sse_with_token(self, mock_sse_transport):
         """Test creating SSETransport for URL ending with /sse and with authorization token"""
         from backend.services.tool_configuration_service import _create_mcp_transport
-        
+
         mock_transport = Mock()
         mock_sse_transport.return_value = mock_transport
-        
+
         result = _create_mcp_transport("http://test-server.com/sse", "Bearer token123")
-        
+
         assert result == mock_transport
         mock_sse_transport.assert_called_once_with(
             url="http://test-server.com/sse",
@@ -931,12 +931,12 @@ class TestCreateMcpTransport:
     def test_create_mcp_transport_sse_without_token(self, mock_sse_transport):
         """Test creating SSETransport for URL ending with /sse and without authorization token"""
         from backend.services.tool_configuration_service import _create_mcp_transport
-        
+
         mock_transport = Mock()
         mock_sse_transport.return_value = mock_transport
-        
+
         result = _create_mcp_transport("http://test-server.com/sse", None)
-        
+
         assert result == mock_transport
         mock_sse_transport.assert_called_once_with(
             url="http://test-server.com/sse",
@@ -947,12 +947,12 @@ class TestCreateMcpTransport:
     def test_create_mcp_transport_mcp_with_token(self, mock_http_transport):
         """Test creating StreamableHttpTransport for URL ending with /mcp and with authorization token"""
         from backend.services.tool_configuration_service import _create_mcp_transport
-        
+
         mock_transport = Mock()
         mock_http_transport.return_value = mock_transport
-        
+
         result = _create_mcp_transport("http://test-server.com/mcp", "Bearer token456")
-        
+
         assert result == mock_transport
         mock_http_transport.assert_called_once_with(
             url="http://test-server.com/mcp",
@@ -963,12 +963,12 @@ class TestCreateMcpTransport:
     def test_create_mcp_transport_mcp_without_token(self, mock_http_transport):
         """Test creating StreamableHttpTransport for URL ending with /mcp and without authorization token"""
         from backend.services.tool_configuration_service import _create_mcp_transport
-        
+
         mock_transport = Mock()
         mock_http_transport.return_value = mock_transport
-        
+
         result = _create_mcp_transport("http://test-server.com/mcp", None)
-        
+
         assert result == mock_transport
         mock_http_transport.assert_called_once_with(
             url="http://test-server.com/mcp",
@@ -979,12 +979,12 @@ class TestCreateMcpTransport:
     def test_create_mcp_transport_default_with_token(self, mock_http_transport):
         """Test creating default StreamableHttpTransport for unrecognized URL format with authorization token"""
         from backend.services.tool_configuration_service import _create_mcp_transport
-        
+
         mock_transport = Mock()
         mock_http_transport.return_value = mock_transport
-        
+
         result = _create_mcp_transport("http://test-server.com/api", "Bearer token789")
-        
+
         assert result == mock_transport
         mock_http_transport.assert_called_once_with(
             url="http://test-server.com/api",
@@ -995,12 +995,12 @@ class TestCreateMcpTransport:
     def test_create_mcp_transport_default_without_token(self, mock_http_transport):
         """Test creating default StreamableHttpTransport for unrecognized URL format without authorization token"""
         from backend.services.tool_configuration_service import _create_mcp_transport
-        
+
         mock_transport = Mock()
         mock_http_transport.return_value = mock_transport
-        
+
         result = _create_mcp_transport("http://test-server.com/api", None)
-        
+
         assert result == mock_transport
         mock_http_transport.assert_called_once_with(
             url="http://test-server.com/api",
@@ -1011,16 +1011,16 @@ class TestCreateMcpTransport:
     def test_create_mcp_transport_sse_with_whitespace(self, mock_sse_transport):
         """Test creating SSETransport for URL with whitespace ending with /sse"""
         from backend.services.tool_configuration_service import _create_mcp_transport
-        
+
         mock_transport = Mock()
         mock_sse_transport.return_value = mock_transport
-        
+
         result = _create_mcp_transport("  http://test-server.com/sse  ", "token")
-        
+
         assert result == mock_transport
         # Verify URL is stripped before checking ending
         mock_sse_transport.assert_called_once_with(
-            url="  http://test-server.com/sse  ",
+            url="http://test-server.com/sse",
             headers={"Authorization": "token"}
         )
 
@@ -1037,7 +1037,7 @@ class TestGetToolFromRemoteMcpServer:
         # Mock transport
         mock_transport = Mock()
         mock_create_transport.return_value = mock_transport
-        
+
         # Mock client
         mock_client = AsyncMock()
         mock_client.__aenter__.return_value = mock_client
@@ -1095,11 +1095,11 @@ class TestGetToolFromRemoteMcpServer:
         """Test getting tools from remote MCP server with authorization token from database"""
         # Mock authorization token from database
         mock_get_token.return_value = "Bearer token_from_db"
-        
+
         # Mock transport
         mock_transport = Mock()
         mock_create_transport.return_value = mock_transport
-        
+
         # Mock client
         mock_client = AsyncMock()
         mock_client.__aenter__.return_value = mock_client
@@ -1128,14 +1128,14 @@ class TestGetToolFromRemoteMcpServer:
         # Verify results
         assert len(result) == 1
         assert result[0].name == "test_tool"
-        
+
         # Verify authorization token was fetched from database
         mock_get_token.assert_called_once_with(
             mcp_name="test_server",
             mcp_server="http://test-server.com",
             tenant_id="tenant1"
         )
-        
+
         # Verify transport was created with token
         mock_create_transport.assert_called_once_with("http://test-server.com", "Bearer token_from_db")
 
@@ -1148,7 +1148,7 @@ class TestGetToolFromRemoteMcpServer:
         # Mock transport
         mock_transport = Mock()
         mock_create_transport.return_value = mock_transport
-        
+
         # Mock client
         mock_client = AsyncMock()
         mock_client.__aenter__.return_value = mock_client
@@ -1177,7 +1177,7 @@ class TestGetToolFromRemoteMcpServer:
         # Verify results
         assert len(result) == 1
         assert result[0].name == "test_tool"
-        
+
         # Verify transport was created with provided token (not fetched from DB)
         mock_create_transport.assert_called_once_with("http://test-server.com", "Bearer provided_token")
 
@@ -1188,7 +1188,7 @@ class TestGetToolFromRemoteMcpServer:
         # Mock transport
         mock_transport = Mock()
         mock_create_transport.return_value = mock_transport
-        
+
         mock_client = AsyncMock()
         mock_client.__aenter__.return_value = mock_client
         mock_client_cls.return_value = mock_client
@@ -1207,14 +1207,14 @@ class TestGetToolFromRemoteMcpServer:
         # Mock transport
         mock_transport = Mock()
         mock_create_transport.return_value = mock_transport
-        
+
         mock_client_cls.side_effect = Exception("Connection failed")
 
         from backend.services.tool_configuration_service import get_tool_from_remote_mcp_server
 
         with pytest.raises(MCPConnectionError):
             await get_tool_from_remote_mcp_server("test_server", "http://test-server.com")
-        
+
         # Verify transport was created before connection error
         mock_create_transport.assert_called_once_with("http://test-server.com", None)
 
@@ -1227,7 +1227,7 @@ class TestGetToolFromRemoteMcpServer:
         # Mock transport
         mock_transport = Mock()
         mock_create_transport.return_value = mock_transport
-        
+
         mock_client = AsyncMock()
         mock_client.__aenter__.return_value = mock_client
         mock_client_cls.return_value = mock_client
@@ -1659,7 +1659,7 @@ class TestLoadLastToolConfigImpl:
         # Mock transport
         mock_transport = Mock()
         mock_create_transport.return_value = mock_transport
-        
+
         # Mock client
         mock_client = AsyncMock()
         mock_client.__aenter__.return_value = mock_client
@@ -1692,7 +1692,7 @@ class TestLoadLastToolConfigImpl:
         # Mock transport
         mock_transport = Mock()
         mock_create_transport.return_value = mock_transport
-        
+
         # Mock client
         mock_client = AsyncMock()
         mock_client.__aenter__.return_value = mock_client
@@ -1727,7 +1727,7 @@ class TestLoadLastToolConfigImpl:
         # Mock transport
         mock_transport = Mock()
         mock_create_transport.return_value = mock_transport
-        
+
         # Mock client with proper async context manager setup
         mock_client = AsyncMock()
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
@@ -2230,7 +2230,7 @@ class TestValidateLocalToolKnowledgeBaseSearch:
         mock_sig = Mock()
         mock_index_names_param = Mock()
         mock_index_names_param.default = ["default_index"]
-        
+
         mock_sig.parameters = {
             'self': Mock(),
             'index_names': mock_index_names_param,

--- a/test/backend/services/test_tool_configuration_service.py
+++ b/test/backend/services/test_tool_configuration_service.py
@@ -908,14 +908,136 @@ class TestGetAllMcpTools:
         assert mock_get_tools.call_count == 1  # Only call default server once
 
 
+class TestCreateMcpTransport:
+    """Test _create_mcp_transport function"""
+
+    @patch('backend.services.tool_configuration_service.SSETransport')
+    def test_create_mcp_transport_sse_with_token(self, mock_sse_transport):
+        """Test creating SSETransport for URL ending with /sse and with authorization token"""
+        from backend.services.tool_configuration_service import _create_mcp_transport
+        
+        mock_transport = Mock()
+        mock_sse_transport.return_value = mock_transport
+        
+        result = _create_mcp_transport("http://test-server.com/sse", "Bearer token123")
+        
+        assert result == mock_transport
+        mock_sse_transport.assert_called_once_with(
+            url="http://test-server.com/sse",
+            headers={"Authorization": "Bearer token123"}
+        )
+
+    @patch('backend.services.tool_configuration_service.SSETransport')
+    def test_create_mcp_transport_sse_without_token(self, mock_sse_transport):
+        """Test creating SSETransport for URL ending with /sse and without authorization token"""
+        from backend.services.tool_configuration_service import _create_mcp_transport
+        
+        mock_transport = Mock()
+        mock_sse_transport.return_value = mock_transport
+        
+        result = _create_mcp_transport("http://test-server.com/sse", None)
+        
+        assert result == mock_transport
+        mock_sse_transport.assert_called_once_with(
+            url="http://test-server.com/sse",
+            headers={}
+        )
+
+    @patch('backend.services.tool_configuration_service.StreamableHttpTransport')
+    def test_create_mcp_transport_mcp_with_token(self, mock_http_transport):
+        """Test creating StreamableHttpTransport for URL ending with /mcp and with authorization token"""
+        from backend.services.tool_configuration_service import _create_mcp_transport
+        
+        mock_transport = Mock()
+        mock_http_transport.return_value = mock_transport
+        
+        result = _create_mcp_transport("http://test-server.com/mcp", "Bearer token456")
+        
+        assert result == mock_transport
+        mock_http_transport.assert_called_once_with(
+            url="http://test-server.com/mcp",
+            headers={"Authorization": "Bearer token456"}
+        )
+
+    @patch('backend.services.tool_configuration_service.StreamableHttpTransport')
+    def test_create_mcp_transport_mcp_without_token(self, mock_http_transport):
+        """Test creating StreamableHttpTransport for URL ending with /mcp and without authorization token"""
+        from backend.services.tool_configuration_service import _create_mcp_transport
+        
+        mock_transport = Mock()
+        mock_http_transport.return_value = mock_transport
+        
+        result = _create_mcp_transport("http://test-server.com/mcp", None)
+        
+        assert result == mock_transport
+        mock_http_transport.assert_called_once_with(
+            url="http://test-server.com/mcp",
+            headers={}
+        )
+
+    @patch('backend.services.tool_configuration_service.StreamableHttpTransport')
+    def test_create_mcp_transport_default_with_token(self, mock_http_transport):
+        """Test creating default StreamableHttpTransport for unrecognized URL format with authorization token"""
+        from backend.services.tool_configuration_service import _create_mcp_transport
+        
+        mock_transport = Mock()
+        mock_http_transport.return_value = mock_transport
+        
+        result = _create_mcp_transport("http://test-server.com/api", "Bearer token789")
+        
+        assert result == mock_transport
+        mock_http_transport.assert_called_once_with(
+            url="http://test-server.com/api",
+            headers={"Authorization": "Bearer token789"}
+        )
+
+    @patch('backend.services.tool_configuration_service.StreamableHttpTransport')
+    def test_create_mcp_transport_default_without_token(self, mock_http_transport):
+        """Test creating default StreamableHttpTransport for unrecognized URL format without authorization token"""
+        from backend.services.tool_configuration_service import _create_mcp_transport
+        
+        mock_transport = Mock()
+        mock_http_transport.return_value = mock_transport
+        
+        result = _create_mcp_transport("http://test-server.com/api", None)
+        
+        assert result == mock_transport
+        mock_http_transport.assert_called_once_with(
+            url="http://test-server.com/api",
+            headers={}
+        )
+
+    @patch('backend.services.tool_configuration_service.SSETransport')
+    def test_create_mcp_transport_sse_with_whitespace(self, mock_sse_transport):
+        """Test creating SSETransport for URL with whitespace ending with /sse"""
+        from backend.services.tool_configuration_service import _create_mcp_transport
+        
+        mock_transport = Mock()
+        mock_sse_transport.return_value = mock_transport
+        
+        result = _create_mcp_transport("  http://test-server.com/sse  ", "token")
+        
+        assert result == mock_transport
+        # Verify URL is stripped before checking ending
+        mock_sse_transport.assert_called_once_with(
+            url="  http://test-server.com/sse  ",
+            headers={"Authorization": "token"}
+        )
+
+
 class TestGetToolFromRemoteMcpServer:
     """Test get_tool_from_remote_mcp_server function"""
 
     @patch('backend.services.tool_configuration_service.Client')
     @patch('backend.services.tool_configuration_service.jsonref.replace_refs')
     @patch('backend.services.tool_configuration_service._sanitize_function_name')
-    async def test_get_tool_from_remote_mcp_server_success(self, mock_sanitize, mock_replace_refs, mock_client_cls):
+    @patch('backend.services.tool_configuration_service._create_mcp_transport')
+    async def test_get_tool_from_remote_mcp_server_success(self, mock_create_transport, mock_sanitize, mock_replace_refs, mock_client_cls):
         """Test successfully getting tools from remote MCP server"""
+        # Mock transport
+        mock_transport = Mock()
+        mock_create_transport.return_value = mock_transport
+        
         # Mock client
         mock_client = AsyncMock()
         mock_client.__aenter__.return_value = mock_client
@@ -960,13 +1082,113 @@ class TestGetToolFromRemoteMcpServer:
         assert result[1].description == "Test tool 2 description"
 
         # Verify calls
-        mock_client_cls.assert_called_once_with(
-            "http://test-server.com", timeout=10)
+        mock_create_transport.assert_called_once_with("http://test-server.com", None)
+        mock_client_cls.assert_called_once_with(transport=mock_transport, timeout=10)
         assert mock_client.list_tools.call_count == 1
 
     @patch('backend.services.tool_configuration_service.Client')
-    async def test_get_tool_from_remote_mcp_server_empty_tools(self, mock_client_cls):
+    @patch('backend.services.tool_configuration_service.jsonref.replace_refs')
+    @patch('backend.services.tool_configuration_service._sanitize_function_name')
+    @patch('backend.services.tool_configuration_service._create_mcp_transport')
+    @patch('backend.services.tool_configuration_service.get_mcp_authorization_token_by_name_and_url')
+    async def test_get_tool_from_remote_mcp_server_with_token_from_db(self, mock_get_token, mock_create_transport, mock_sanitize, mock_replace_refs, mock_client_cls):
+        """Test getting tools from remote MCP server with authorization token from database"""
+        # Mock authorization token from database
+        mock_get_token.return_value = "Bearer token_from_db"
+        
+        # Mock transport
+        mock_transport = Mock()
+        mock_create_transport.return_value = mock_transport
+        
+        # Mock client
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client_cls.return_value = mock_client
+
+        # Mock tool list
+        mock_tool = Mock()
+        mock_tool.name = "test_tool"
+        mock_tool.description = "Test tool description"
+        mock_tool.inputSchema = {"properties": {"param1": {"type": "string"}}}
+
+        mock_client.list_tools.return_value = [mock_tool]
+
+        # Mock JSON schema processing
+        mock_replace_refs.return_value = {"properties": {"param1": {"type": "string", "description": "see tool description"}}}
+
+        # Mock name sanitization
+        mock_sanitize.return_value = "test_tool"
+
+        from backend.services.tool_configuration_service import get_tool_from_remote_mcp_server
+
+        result = await get_tool_from_remote_mcp_server(
+            "test_server", "http://test-server.com", tenant_id="tenant1"
+        )
+
+        # Verify results
+        assert len(result) == 1
+        assert result[0].name == "test_tool"
+        
+        # Verify authorization token was fetched from database
+        mock_get_token.assert_called_once_with(
+            mcp_name="test_server",
+            mcp_server="http://test-server.com",
+            tenant_id="tenant1"
+        )
+        
+        # Verify transport was created with token
+        mock_create_transport.assert_called_once_with("http://test-server.com", "Bearer token_from_db")
+
+    @patch('backend.services.tool_configuration_service.Client')
+    @patch('backend.services.tool_configuration_service.jsonref.replace_refs')
+    @patch('backend.services.tool_configuration_service._sanitize_function_name')
+    @patch('backend.services.tool_configuration_service._create_mcp_transport')
+    async def test_get_tool_from_remote_mcp_server_with_provided_token(self, mock_create_transport, mock_sanitize, mock_replace_refs, mock_client_cls):
+        """Test getting tools from remote MCP server with directly provided authorization token"""
+        # Mock transport
+        mock_transport = Mock()
+        mock_create_transport.return_value = mock_transport
+        
+        # Mock client
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client_cls.return_value = mock_client
+
+        # Mock tool list
+        mock_tool = Mock()
+        mock_tool.name = "test_tool"
+        mock_tool.description = "Test tool description"
+        mock_tool.inputSchema = {"properties": {"param1": {"type": "string"}}}
+
+        mock_client.list_tools.return_value = [mock_tool]
+
+        # Mock JSON schema processing
+        mock_replace_refs.return_value = {"properties": {"param1": {"type": "string", "description": "see tool description"}}}
+
+        # Mock name sanitization
+        mock_sanitize.return_value = "test_tool"
+
+        from backend.services.tool_configuration_service import get_tool_from_remote_mcp_server
+
+        result = await get_tool_from_remote_mcp_server(
+            "test_server", "http://test-server.com", tenant_id="tenant1", authorization_token="Bearer provided_token"
+        )
+
+        # Verify results
+        assert len(result) == 1
+        assert result[0].name == "test_tool"
+        
+        # Verify transport was created with provided token (not fetched from DB)
+        mock_create_transport.assert_called_once_with("http://test-server.com", "Bearer provided_token")
+
+    @patch('backend.services.tool_configuration_service.Client')
+    @patch('backend.services.tool_configuration_service._create_mcp_transport')
+    async def test_get_tool_from_remote_mcp_server_empty_tools(self, mock_create_transport, mock_client_cls):
         """Test remote server with no tools"""
+        # Mock transport
+        mock_transport = Mock()
+        mock_create_transport.return_value = mock_transport
+        
         mock_client = AsyncMock()
         mock_client.__aenter__.return_value = mock_client
         mock_client_cls.return_value = mock_client
@@ -979,20 +1201,33 @@ class TestGetToolFromRemoteMcpServer:
         assert result == []
 
     @patch('backend.services.tool_configuration_service.Client')
-    async def test_get_tool_from_remote_mcp_server_connection_error(self, mock_client_cls):
+    @patch('backend.services.tool_configuration_service._create_mcp_transport')
+    async def test_get_tool_from_remote_mcp_server_connection_error(self, mock_create_transport, mock_client_cls):
         """Test connection error scenario"""
+        # Mock transport
+        mock_transport = Mock()
+        mock_create_transport.return_value = mock_transport
+        
         mock_client_cls.side_effect = Exception("Connection failed")
 
         from backend.services.tool_configuration_service import get_tool_from_remote_mcp_server
 
         with pytest.raises(MCPConnectionError):
             await get_tool_from_remote_mcp_server("test_server", "http://test-server.com")
+        
+        # Verify transport was created before connection error
+        mock_create_transport.assert_called_once_with("http://test-server.com", None)
 
     @patch('backend.services.tool_configuration_service.Client')
     @patch('backend.services.tool_configuration_service.jsonref.replace_refs')
     @patch('backend.services.tool_configuration_service._sanitize_function_name')
-    async def test_get_tool_from_remote_mcp_server_missing_properties(self, mock_sanitize, mock_replace_refs, mock_client_cls):
+    @patch('backend.services.tool_configuration_service._create_mcp_transport')
+    async def test_get_tool_from_remote_mcp_server_missing_properties(self, mock_create_transport, mock_sanitize, mock_replace_refs, mock_client_cls):
         """Test tools missing required properties"""
+        # Mock transport
+        mock_transport = Mock()
+        mock_create_transport.return_value = mock_transport
+        
         mock_client = AsyncMock()
         mock_client.__aenter__.return_value = mock_client
         mock_client_cls.return_value = mock_client
@@ -1418,8 +1653,13 @@ class TestLoadLastToolConfigImpl:
             123, "tenant1", "user1")
 
     @patch('backend.services.tool_configuration_service.Client')
-    async def test_call_mcp_tool_success(self, mock_client_cls):
+    @patch('backend.services.tool_configuration_service._create_mcp_transport')
+    async def test_call_mcp_tool_success(self, mock_create_transport, mock_client_cls):
         """Test successful MCP tool call"""
+        # Mock transport
+        mock_transport = Mock()
+        mock_create_transport.return_value = mock_transport
+        
         # Mock client
         mock_client = AsyncMock()
         mock_client.__aenter__.return_value = mock_client
@@ -1440,13 +1680,54 @@ class TestLoadLastToolConfigImpl:
         result = await _call_mcp_tool("http://test-server.com", "test_tool", {"param": "value"})
 
         assert result == "test result"
-        mock_client_cls.assert_called_once_with("http://test-server.com")
+        mock_create_transport.assert_called_once_with("http://test-server.com", None)
+        mock_client_cls.assert_called_once_with(transport=mock_transport)
         mock_client.call_tool.assert_called_once_with(
             name="test_tool", arguments={"param": "value"})
 
     @patch('backend.services.tool_configuration_service.Client')
-    async def test_call_mcp_tool_connection_failed(self, mock_client_cls):
+    @patch('backend.services.tool_configuration_service._create_mcp_transport')
+    async def test_call_mcp_tool_with_authorization_token(self, mock_create_transport, mock_client_cls):
+        """Test MCP tool call with authorization token"""
+        # Mock transport
+        mock_transport = Mock()
+        mock_create_transport.return_value = mock_transport
+        
+        # Mock client
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = None
+        mock_client.is_connected.return_value = True
+
+        # Mock tool result structure
+        mock_content_item = Mock()
+        mock_content_item.text = "test result with token"
+        mock_result = Mock()
+        mock_result.content = [mock_content_item]
+        mock_client.call_tool.return_value = mock_result
+
+        mock_client_cls.return_value = mock_client
+
+        from backend.services.tool_configuration_service import _call_mcp_tool
+
+        result = await _call_mcp_tool(
+            "http://test-server.com", "test_tool", {"param": "value"}, authorization_token="Bearer token123"
+        )
+
+        assert result == "test result with token"
+        mock_create_transport.assert_called_once_with("http://test-server.com", "Bearer token123")
+        mock_client_cls.assert_called_once_with(transport=mock_transport)
+        mock_client.call_tool.assert_called_once_with(
+            name="test_tool", arguments={"param": "value"})
+
+    @patch('backend.services.tool_configuration_service.Client')
+    @patch('backend.services.tool_configuration_service._create_mcp_transport')
+    async def test_call_mcp_tool_connection_failed(self, mock_create_transport, mock_client_cls):
         """Test MCP tool call when connection fails"""
+        # Mock transport
+        mock_transport = Mock()
+        mock_create_transport.return_value = mock_transport
+        
         # Mock client with proper async context manager setup
         mock_client = AsyncMock()
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
@@ -1461,7 +1742,8 @@ class TestLoadLastToolConfigImpl:
             await _call_mcp_tool("http://test-server.com", "test_tool", {"param": "value"})
 
         # Verify client was created and connection was checked
-        mock_client_cls.assert_called_once_with("http://test-server.com")
+        mock_create_transport.assert_called_once_with("http://test-server.com", None)
+        mock_client_cls.assert_called_once_with(transport=mock_transport)
         mock_client.is_connected.assert_called_once()
 
     @patch('backend.services.tool_configuration_service.urljoin')
@@ -1480,11 +1762,13 @@ class TestLoadLastToolConfigImpl:
         mock_call_tool.assert_called_once_with(
             "http://nexent-server.com/sse", "test_tool", {"param": "value"})
 
+    @patch('backend.services.tool_configuration_service.get_mcp_authorization_token_by_name_and_url')
     @patch('backend.services.tool_configuration_service.get_mcp_server_by_name_and_tenant')
     @patch('backend.services.tool_configuration_service._call_mcp_tool')
-    async def test_validate_mcp_tool_remote_success(self, mock_call_tool, mock_get_server):
-        """Test successful remote MCP tool validation"""
+    async def test_validate_mcp_tool_remote_success(self, mock_call_tool, mock_get_server, mock_get_token):
+        """Test successful remote MCP tool validation with authorization token from database"""
         mock_get_server.return_value = "http://remote-server.com"
+        mock_get_token.return_value = "Bearer token_from_db"
         mock_call_tool.return_value = "validation result"
 
         from backend.services.tool_configuration_service import _validate_mcp_tool_remote
@@ -1493,8 +1777,31 @@ class TestLoadLastToolConfigImpl:
 
         assert result == "validation result"
         mock_get_server.assert_called_once_with("test_server", "tenant1")
+        mock_get_token.assert_called_once_with(
+            mcp_name="test_server",
+            mcp_server="http://remote-server.com",
+            tenant_id="tenant1"
+        )
+        # _call_mcp_tool is called with authorization_token as positional argument
         mock_call_tool.assert_called_once_with(
-            "http://remote-server.com", "test_tool", {"param": "value"})
+            "http://remote-server.com", "test_tool", {"param": "value"}, "Bearer token_from_db")
+
+    @patch('backend.services.tool_configuration_service.get_mcp_server_by_name_and_tenant')
+    @patch('backend.services.tool_configuration_service._call_mcp_tool')
+    async def test_validate_mcp_tool_remote_without_tenant_id(self, mock_call_tool, mock_get_server):
+        """Test remote MCP tool validation when tenant_id is None (no token fetched)"""
+        mock_get_server.return_value = "http://remote-server.com"
+        mock_call_tool.return_value = "validation result"
+
+        from backend.services.tool_configuration_service import _validate_mcp_tool_remote
+
+        result = await _validate_mcp_tool_remote("test_tool", {"param": "value"}, "test_server", None)
+
+        assert result == "validation result"
+        mock_get_server.assert_called_once_with("test_server", None)
+        # Verify _call_mcp_tool was called with authorization_token as positional argument (None)
+        mock_call_tool.assert_called_once_with(
+            "http://remote-server.com", "test_tool", {"param": "value"}, None)
 
     @patch('backend.services.tool_configuration_service.get_mcp_server_by_name_and_tenant')
     async def test_validate_mcp_tool_remote_server_not_found(self, mock_get_server):

--- a/test/sdk/core/agents/test_run_agent.py
+++ b/test/sdk/core/agents/test_run_agent.py
@@ -351,6 +351,11 @@ def test_detect_transport():
     assert run_agent._detect_transport("http://server") == "streamable-http"
     assert run_agent._detect_transport("https://api.example.com") == "streamable-http"
     assert run_agent._detect_transport("http://server/other") == "streamable-http"
+    
+    # Test URLs with whitespace (should be stripped)
+    assert run_agent._detect_transport("  http://server/sse  ") == "sse"
+    assert run_agent._detect_transport("\thttp://server/mcp\n") == "streamable-http"
+    assert run_agent._detect_transport("  http://server  ") == "streamable-http"
 
 
 def test_normalize_mcp_config():
@@ -366,6 +371,10 @@ def test_normalize_mcp_config():
     result = run_agent._normalize_mcp_config("http://server")
     assert result == {"url": "http://server", "transport": "streamable-http"}
     
+    # Test string format with whitespace (should be preserved in url, but transport detection strips)
+    result = run_agent._normalize_mcp_config("  http://server/sse  ")
+    assert result == {"url": "  http://server/sse  ", "transport": "sse"}
+    
     # Test dict format with explicit transport
     result = run_agent._normalize_mcp_config({"url": "http://server/mcp", "transport": "sse"})
     assert result == {"url": "http://server/mcp", "transport": "sse"}
@@ -376,6 +385,85 @@ def test_normalize_mcp_config():
     
     result = run_agent._normalize_mcp_config({"url": "http://server/mcp"})
     assert result == {"url": "http://server/mcp", "transport": "streamable-http"}
+    
+    # Test dict format with empty string transport (should auto-detect)
+    result = run_agent._normalize_mcp_config({"url": "http://server/sse", "transport": ""})
+    assert result == {"url": "http://server/sse", "transport": "sse"}
+    
+    # Test dict format with None transport (should auto-detect)
+    result = run_agent._normalize_mcp_config({"url": "http://server/mcp", "transport": None})
+    assert result == {"url": "http://server/mcp", "transport": "streamable-http"}
+    
+    # Test dict format with only authorization
+    result = run_agent._normalize_mcp_config({
+        "url": "http://server/mcp",
+        "authorization": "Bearer token123"
+    })
+    assert result == {
+        "url": "http://server/mcp",
+        "transport": "streamable-http",
+        "headers": {"Authorization": "Bearer token123"}
+    }
+    
+    # Test dict format with only headers
+    result = run_agent._normalize_mcp_config({
+        "url": "http://server/sse",
+        "headers": {"Custom-Header": "value"}
+    })
+    assert result == {
+        "url": "http://server/sse",
+        "transport": "sse",
+        "headers": {"Custom-Header": "value"}
+    }
+    
+    # Test dict format with both authorization and headers (authorization should override/merge)
+    result = run_agent._normalize_mcp_config({
+        "url": "http://server/mcp",
+        "authorization": "Bearer token456",
+        "headers": {"Custom-Header": "value", "Other-Header": "other"}
+    })
+    assert result == {
+        "url": "http://server/mcp",
+        "transport": "streamable-http",
+        "headers": {
+            "Custom-Header": "value",
+            "Other-Header": "other",
+            "Authorization": "Bearer token456"
+        }
+    }
+    
+    # Test dict format with headers that is not a dict (should be handled gracefully)
+    result = run_agent._normalize_mcp_config({
+        "url": "http://server/mcp",
+        "authorization": "Bearer token789",
+        "headers": "not-a-dict"  # Not a dict, will be replaced with empty dict
+    })
+    # When headers is not a dict, it will be replaced with empty dict and then Authorization added
+    assert result == {
+        "url": "http://server/mcp",
+        "transport": "streamable-http",
+        "headers": {"Authorization": "Bearer token789"}
+    }
+    
+    # Test dict format with headers as list (not a dict)
+    result = run_agent._normalize_mcp_config({
+        "url": "http://server/mcp",
+        "authorization": "Bearer token999",
+        "headers": ["item1", "item2"]  # Not a dict, will be replaced with empty dict
+    })
+    assert result == {
+        "url": "http://server/mcp",
+        "transport": "streamable-http",
+        "headers": {"Authorization": "Bearer token999"}
+    }
+    
+    # Test dict format with empty url string
+    with pytest.raises(ValueError, match="must contain 'url' key"):
+        run_agent._normalize_mcp_config({"url": ""})
+    
+    # Test dict format with None url
+    with pytest.raises(ValueError, match="must contain 'url' key"):
+        run_agent._normalize_mcp_config({"url": None})
     
     # Test invalid dict (missing url)
     with pytest.raises(ValueError, match="must contain 'url' key"):
@@ -391,6 +479,12 @@ def test_normalize_mcp_config():
     # Test invalid type
     with pytest.raises(ValueError, match="Invalid MCP host item type"):
         run_agent._normalize_mcp_config(123)
+    
+    with pytest.raises(ValueError, match="Invalid MCP host item type"):
+        run_agent._normalize_mcp_config([])
+    
+    with pytest.raises(ValueError, match="Invalid MCP host item type"):
+        run_agent._normalize_mcp_config(None)
 
 
 def test_agent_run_thread_handles_internal_exception(basic_agent_run_info, mock_memory_context, monkeypatch):


### PR DESCRIPTION
♻️ MCP services support authorization #2086
[Specification Details]
1. Add an `authorization_token` field to the `mcp_record` database. This field can be filled in when adding a server. Test connectivity and use tools to query the token from the database and add it to the headers.
2. Add a single MCP query interface to retrieve the token during editing.
3. Modify database initialization scripts and test cases.
[Test Result]
![6511d452-4bd0-49e3-bf70-f3566ac44505](https://github.com/user-attachments/assets/47df3afe-f9e8-4ef9-bde2-57f48815dc36)
![67840043-7fe8-4c95-a9fa-45d7d8688053](https://github.com/user-attachments/assets/096257db-76a3-44df-b68a-1696b6ee2e00)
![e641cc5a-21b1-4857-8393-ccad22dc0dc6](https://github.com/user-attachments/assets/ab7b915d-80da-493b-8fab-96e4e7bf8548)
![fa33ff89-bda6-449c-98bf-f026bd26c46f](https://github.com/user-attachments/assets/1e47a7b2-54b1-4a23-8811-483dd1e58bc3)
![2fc2917f-d775-4d9e-9564-e0333cb1cc26](https://github.com/user-attachments/assets/e91d8a0e-cf90-4d70-85e1-328a5f4f7483)
![6d487996-d91d-495b-a4c7-1fc7ca8d5c3d](https://github.com/user-attachments/assets/192f2ff3-af9f-437f-a32d-95f7373f3577)
![5282aae0-d8c2-47ec-8517-42ef54760044](https://github.com/user-attachments/assets/402a685f-59a3-4a81-84ae-2fed1fba0ad0)
![ec75dae5-f5f7-453e-b53b-0b2ef906c138](https://github.com/user-attachments/assets/0d82821a-ac08-4418-8615-a09acb3e771f)
![48eb1b87-665e-425f-b1bb-921433ed868e](https://github.com/user-attachments/assets/578f0244-9891-42a0-8830-c2ebbc160460)
![56ebb4bf-48eb-4dd6-92d5-d637f7337b4d](https://github.com/user-attachments/assets/c01bb306-a6d3-46a0-acc8-f474667822d2)
