### PR TITLE
♻️ Improve frontend build time, use dependencies caches #2112

### DIFF
--- a/make/web/Dockerfile
+++ b/make/web/Dockerfile
@@ -8,6 +8,10 @@ COPY frontend /opt/frontend
 # Build Next.js application
 WORKDIR /opt/frontend
 
+# BuildKit must be enabled for --mount=type=cache to work
+# Docker 23.0+ has BuildKit enabled by default
+# For older versions, set environment variable: DOCKER_BUILDKIT=1
+# Or add "features": {"buildkit": true} to ~/.docker/config.json
 # Use BuildKit named caches for npm cache and node_modules
 # - id=npm-cache: persists across builds, keyed by cache id
 # - sharing=locked: allows concurrent access from multiple builds


### PR DESCRIPTION
#2112 使用了缓存之后，nexent/web的镜像大小并没有发生多大的变化：
<img width="516" height="153" alt="image" src="https://github.com/user-attachments/assets/43545ea6-d09c-402e-9672-30b95780131f" />
但打包时间节省了很多：
<img width="739" height="751" alt="image" src="https://github.com/user-attachments/assets/dfd60fa9-da56-42fe-8890-2940543ab1f3" />
