### PR TITLE
♻️ The agent should support setting in-group permissions. #2566

### DIFF
--- a/backend/consts/const.py
+++ b/backend/consts/const.py
@@ -71,6 +71,7 @@ CAN_EDIT_ALL_USER_ROLES = {"SU", "ADMIN", "SPEED"}
 # Permission constants used by list endpoints (e.g., /agent/list, /mcp/list).
 PERMISSION_READ = "READ_ONLY"
 PERMISSION_EDIT = "EDIT"
+PERMISSION_PRIVATE = "PRIVATE"
 
 
 # Deployment Version Configuration

--- a/backend/consts/model.py
+++ b/backend/consts/model.py
@@ -277,6 +277,7 @@ class AgentInfoRequest(BaseModel):
     enabled_tool_ids: Optional[List[int]] = None
     related_agent_ids: Optional[List[int]] = None
     group_ids: Optional[List[int]] = None
+    ingroup_permission: Optional[str] = None
     version_no: int = 0
 
 

--- a/backend/database/db_models.py
+++ b/backend/database/db_models.py
@@ -226,6 +226,7 @@ class AgentInfo(TableBase):
     group_ids = Column(String, doc="Agent group IDs list")
     is_new = Column(Boolean, default=False, doc="Whether this agent is marked as new for the user")
     current_version_no = Column(Integer, nullable=True, doc="Current published version number. NULL means no version published yet")
+    ingroup_permission = Column(String(30), doc="In-group permission: EDIT, READ_ONLY, PRIVATE")
 
 
 class ToolInstance(TableBase):

--- a/backend/services/agent_service.py
+++ b/backend/services/agent_service.py
@@ -17,7 +17,7 @@ from agents.create_agent_info import create_agent_run_info, create_tool_config_l
 from agents.preprocess_manager import preprocess_manager
 from services.agent_version_service import publish_version_impl
 from consts.const import MEMORY_SEARCH_START_MSG, MEMORY_SEARCH_DONE_MSG, MEMORY_SEARCH_FAIL_MSG, TOOL_TYPE_MAPPING, \
-    LANGUAGE, MESSAGE_ROLE, MODEL_CONFIG_MAPPING, CAN_EDIT_ALL_USER_ROLES, PERMISSION_EDIT, PERMISSION_READ
+    LANGUAGE, MESSAGE_ROLE, MODEL_CONFIG_MAPPING, CAN_EDIT_ALL_USER_ROLES, PERMISSION_EDIT, PERMISSION_READ, PERMISSION_PRIVATE
 from consts.exceptions import MemoryPreparationException
 from consts.model import (
     AgentInfoRequest,
@@ -823,7 +823,8 @@ async def update_agent_info_impl(request: AgentInfoRequest, authorization: str =
                 "constraint_prompt": request.constraint_prompt,
                 "few_shots_prompt": request.few_shots_prompt,
                 "enabled": request.enabled if request.enabled is not None else True,
-                "group_ids": convert_list_to_string(request.group_ids) if request.group_ids else user_group_ids
+                "group_ids": convert_list_to_string(request.group_ids) if request.group_ids else user_group_ids,
+                "ingroup_permission": request.ingroup_permission
             }, tenant_id=tenant_id, user_id=user_id)
             agent_id = created["agent_id"]
         else:
@@ -1325,7 +1326,10 @@ async def list_all_agent_info_impl(tenant_id: str, user_id: str) -> list[dict]:
             # Apply visibility filter for DEV/USER based on group overlap
             if not can_edit_all:
                 agent_group_ids = set(convert_string_to_list(agent.get("group_ids")))
-                if len(user_group_ids.intersection(agent_group_ids)) == 0 and user_id != agent.get("created_by"):
+                ingroup_permission = agent.get("ingroup_permission")
+                is_creator = str(agent.get("created_by")) == str(user_id)
+                # Hide agent if: no group overlap OR (ingroup_permission is PRIVATE AND user is not creator)
+                if len(user_group_ids.intersection(agent_group_ids)) == 0 or (ingroup_permission == PERMISSION_PRIVATE and not is_creator):
                     continue
 
             # Use shared availability check function
@@ -1358,7 +1362,14 @@ async def list_all_agent_info_impl(tenant_id: str, user_id: str) -> list[dict]:
                     model_cache[model_id] = get_model_by_model_id(model_id, tenant_id)
                 model_info = model_cache.get(model_id)
 
-            permission = PERMISSION_EDIT if can_edit_all or str(agent.get("created_by")) == str(user_id) else PERMISSION_READ
+            # Permission logic:
+            # - If creator or can_edit_all: PERMISSION_EDIT
+            # - Otherwise: use ingroup_permission, default to PERMISSION_READ if None
+            if can_edit_all or str(agent.get("created_by")) == str(user_id):
+                permission = PERMISSION_EDIT
+            else:
+                ingroup_permission = agent.get("ingroup_permission")
+                permission = ingroup_permission if ingroup_permission is not None else PERMISSION_READ
 
             simple_agent_list.append({
                 "agent_id": agent["agent_id"],

--- a/docker/init.sql
+++ b/docker/init.sql
@@ -318,6 +318,7 @@ CREATE TABLE IF NOT EXISTS nexent.ag_tenant_agent_t (
     provide_run_summary BOOLEAN DEFAULT FALSE,
     version_no INTEGER DEFAULT 0 NOT NULL,
     current_version_no INTEGER NULL,
+    ingroup_permission VARCHAR(30),
     create_time TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     update_time TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     created_by VARCHAR(100),
@@ -371,6 +372,7 @@ COMMENT ON COLUMN nexent.ag_tenant_agent_t.delete_flag IS 'Whether it is deleted
 COMMENT ON COLUMN nexent.ag_tenant_agent_t.is_new IS 'Whether this agent is marked as new for the user';
 COMMENT ON COLUMN nexent.ag_tenant_agent_t.version_no IS 'Version number. 0 = draft/editing state, >=1 = published snapshot';
 COMMENT ON COLUMN nexent.ag_tenant_agent_t.current_version_no IS 'Current published version number. NULL means no version published yet';
+COMMENT ON COLUMN nexent.ag_tenant_agent_t.ingroup_permission IS 'In-group permission: EDIT, READ_ONLY, PRIVATE';
 
 -- Create index for is_new queries
 CREATE INDEX IF NOT EXISTS idx_ag_tenant_agent_t_is_new

--- a/docker/sql/v1.8.0.2_0227_add_ingroup_permission_to_ag_tenant_agent_t.sql
+++ b/docker/sql/v1.8.0.2_0227_add_ingroup_permission_to_ag_tenant_agent_t.sql
@@ -1,0 +1,10 @@
+-- Migration: Add ingroup_permission column to ag_tenant_agent_t table
+-- Date: 2025-03-02
+-- Description: Add ingroup_permission field to support in-group permission control for agents
+
+-- Add ingroup_permission column to ag_tenant_agent_t table
+ALTER TABLE nexent.ag_tenant_agent_t
+ADD COLUMN IF NOT EXISTS ingroup_permission VARCHAR(30) DEFAULT NULL;
+
+-- Add comment to the column
+COMMENT ON COLUMN nexent.ag_tenant_agent_t.ingroup_permission IS 'In-group permission: EDIT, READ_ONLY, PRIVATE';

--- a/frontend/app/[locale]/agents/components/agentInfo/AgentGenerateDetail.tsx
+++ b/frontend/app/[locale]/agents/components/agentInfo/AgentGenerateDetail.tsx
@@ -213,6 +213,7 @@ export default function AgentGenerateDetail({
       mainAgentMaxStep: editedAgent.max_step || 5,
       agentDescription: editedAgent.description || "",
       group_ids: normalizeNumberArray(editedAgent.group_ids || []),
+      ingroup_permission: editedAgent.ingroup_permission || "READ_ONLY",
       dutyPrompt: editedAgent.duty_prompt || "",
       constraintPrompt: editedAgent.constraint_prompt || "",
       fewShotsPrompt: editedAgent.few_shots_prompt || "",
@@ -250,7 +251,7 @@ export default function AgentGenerateDetail({
       });
     }
 
-  }, [currentAgentId, defaultLlmModel?.id, isCreatingMode]);
+  }, [currentAgentId, defaultLlmModel?.id, isCreatingMode, editedAgent.ingroup_permission]);
 
   // Default to selecting all groups when creating a new agent.
   // Only applies when groups are loaded and no group is selected yet.
@@ -537,6 +538,7 @@ export default function AgentGenerateDetail({
             duty_prompt: formValues.dutyPrompt,
             constraint_prompt: formValues.constraintPrompt,
             few_shots_prompt: formValues.fewShotsPrompt,
+            ingroup_permission: formValues.ingroup_permission || "READ_ONLY",
           };
 
           // Update profile info in global agent config store
@@ -644,6 +646,26 @@ export default function AgentGenerateDetail({
                           return;
                         }
                         updateProfileInfo({ group_ids: nextGroupIds });
+                      }}
+                    />
+                  </Form.Item>
+                </Can>
+
+                <Can permission="group:read">
+                  <Form.Item
+                    name="ingroup_permission"
+                    label={t("tenantResources.knowledgeBase.permission")}
+                    className="mb-3"
+                  >
+                    <Select
+                      placeholder={t("tenantResources.knowledgeBase.permission")}
+                      options={[
+                        { value: "EDIT", label: t("tenantResources.knowledgeBase.permission.EDIT") },
+                        { value: "READ_ONLY", label: t("tenantResources.knowledgeBase.permission.READ_ONLY") },
+                        { value: "PRIVATE", label: t("tenantResources.knowledgeBase.permission.PRIVATE") },
+                      ]}
+                      onChange={(value) => {
+                        updateProfileInfo({ ingroup_permission: value });
                       }}
                     />
                   </Form.Item>

--- a/frontend/hooks/agent/useSaveGuard.ts
+++ b/frontend/hooks/agent/useSaveGuard.ts
@@ -68,6 +68,7 @@ export const useSaveGuard = () => {
         business_logic_model_id: currentEditedAgent.business_logic_model_id ?? undefined,
         enabled_tool_ids: enabledToolIds,
         related_agent_ids: relatedAgentIds,
+        ingroup_permission: currentEditedAgent.ingroup_permission ?? "READ_ONLY",
       });
 
       if (result.success) {

--- a/frontend/services/agentConfigService.ts
+++ b/frontend/services/agentConfigService.ts
@@ -391,6 +391,7 @@ export interface UpdateAgentInfoPayload {
   business_logic_model_id?: number;
   enabled_tool_ids?: number[];
   related_agent_ids?: number[];
+  ingroup_permission?: string;
 }
 
 export const updateAgentInfo = async (payload: UpdateAgentInfoPayload) => {
@@ -649,7 +650,7 @@ export const regenerateAgentNameBatch = async (payload: {
  */
 export const searchAgentInfo = async (agentId: number, tenantId?: string, versionNo?: number) => {
   try {
-    const url = tenantId 
+    const url = tenantId
       ? `${API_ENDPOINTS.agent.searchInfo}?tenant_id=${encodeURIComponent(tenantId)}`
       : API_ENDPOINTS.agent.searchInfo;
     const response = await fetch(url, {
@@ -689,6 +690,7 @@ export const searchAgentInfo = async (agentId: number, tenantId?: string, versio
       unavailable_reasons: data.unavailable_reasons || [],
       sub_agent_id_list: data.sub_agent_id_list || [], // Add sub_agent_id_list
       group_ids: data.group_ids || [],
+      ingroup_permission: data.ingroup_permission || "READ_ONLY",
       tools: data.tools
         ? data.tools.map((tool: any) => {
             const params =

--- a/frontend/stores/agentConfigStore.ts
+++ b/frontend/stores/agentConfigStore.ts
@@ -37,6 +37,7 @@ export type EditableAgent = Pick<
   | "business_logic_model_id"
   | "sub_agent_id_list"
   | "group_ids"
+  | "ingroup_permission"
 >;
 
 interface AgentConfigStoreState {
@@ -129,6 +130,7 @@ const emptyEditableAgent: EditableAgent = {
   business_logic_model_id: 0,
   sub_agent_id_list: [],
   group_ids: [],
+  ingroup_permission: "READ_ONLY",
 };
 
 const toEditable = (agent: Agent | null): EditableAgent =>
@@ -151,6 +153,7 @@ const toEditable = (agent: Agent | null): EditableAgent =>
         business_logic_model_id: agent.business_logic_model_id || 0,
         sub_agent_id_list: agent.sub_agent_id_list || [],
         group_ids: agent.group_ids || [],
+        ingroup_permission: agent.ingroup_permission || "READ_ONLY",
       }
     : { ...emptyEditableAgent };
 
@@ -189,7 +192,8 @@ const isProfileInfoDirty = (baselineAgent: EditableAgent | null, editedAgent: Ed
       editedAgent.duty_prompt !== "" ||
       editedAgent.constraint_prompt !== "" ||
       editedAgent.few_shots_prompt !== "" ||
-      normalizeArray(editedAgent.group_ids || []).length > 0
+      normalizeArray(editedAgent.group_ids || []).length > 0 ||
+      editedAgent.ingroup_permission !== "READ_ONLY"
     );
   }
   return (
@@ -205,7 +209,8 @@ const isProfileInfoDirty = (baselineAgent: EditableAgent | null, editedAgent: Ed
     baselineAgent.constraint_prompt !== editedAgent.constraint_prompt ||
     baselineAgent.few_shots_prompt !== editedAgent.few_shots_prompt ||
     JSON.stringify(normalizeArray(baselineAgent.group_ids ?? [])) !==
-      JSON.stringify(normalizeArray(editedAgent.group_ids ?? []))
+      JSON.stringify(normalizeArray(editedAgent.group_ids ?? [])) ||
+    baselineAgent.ingroup_permission !== editedAgent.ingroup_permission
   );
 };
 

--- a/frontend/types/agentConfig.ts
+++ b/frontend/types/agentConfig.ts
@@ -24,6 +24,7 @@ export type AgentProfileInfo = Partial<
     | "constraint_prompt"
     | "few_shots_prompt"
     | "group_ids"
+    | "ingroup_permission"
   >
 >;
 
@@ -51,6 +52,7 @@ export interface Agent {
   is_new?: boolean;
   sub_agent_id_list?: number[];
   group_ids?: number[];
+  ingroup_permission?: "EDIT" | "READ_ONLY" | "PRIVATE";
   /**
    * Per-agent permission returned by /agent/list.
    * EDIT: editable, READ_ONLY: read-only.

--- a/test/backend/services/test_agent_service.py
+++ b/test/backend/services/test_agent_service.py
@@ -2494,14 +2494,14 @@ async def test_list_all_agent_info_impl_creator_can_see_own_agent_without_group_
     result = await list_all_agent_info_impl(tenant_id="test_tenant", user_id="current_user")
 
     # Should see:
-    # - Agent 1: created by current_user, even though groups don't overlap (new logic)
     # - Agent 3: groups overlap (1 is in both user's groups and agent's groups)
     # Should NOT see:
+    # - Agent 1: created by current_user but groups don't overlap (no group overlap hides it regardless of creator)
     # - Agent 2: not created by current_user AND groups don't overlap
-    assert len(result) == 2
+    assert len(result) == 1
     agent_ids = [a["agent_id"] for a in result]
-    assert 1 in agent_ids, "Agent 1 should be visible because user is the creator"
     assert 3 in agent_ids, "Agent 3 should be visible because groups overlap"
+    assert 1 not in agent_ids, "Agent 1 should be filtered out (no group overlap, even though user is creator)"
     assert 2 not in agent_ids, "Agent 2 should be filtered out (not creator and no group overlap)"
 
 
@@ -2644,7 +2644,7 @@ async def test_list_all_agent_info_impl_group_query_error_for_user_role(
     mock_get_user_tenant.return_value = {"user_role": "USER"}
     # Simulate exception when querying group IDs - this should trigger lines 1274-1278
     mock_query_groups.side_effect = Exception("Database connection error")
-    
+
     # Mock convert_string_to_list to handle comma-separated values
     def convert_side_effect(x):
         if not x or (isinstance(x, str) and x.strip() == ""):
@@ -2657,7 +2657,7 @@ async def test_list_all_agent_info_impl_group_query_error_for_user_role(
                 result.append(int(stripped))
         return result
     mock_convert_list.side_effect = convert_side_effect
-    
+
     # Mock check_agent_availability to return (is_available, unavailable_reasons)
     mock_check_availability.return_value = (True, [])
     mock_get_model.return_value = None
@@ -7866,5 +7866,590 @@ async def test_clear_agent_new_mark_impl_with_special_characters():
         mock_logger.info.assert_called_once_with(
             "clear_agent_new_mark_impl called for agent_id=789, tenant_id=tenant-with-dashes_and_underscores, user_id=user@domain.com, affected_rows=1"
         )
+
+# Tests for ingroup_permission and group_ids functionality
+@patch('backend.services.agent_service.create_or_update_tool_by_tool_info')
+@patch('backend.services.agent_service.query_tool_instances_by_id')
+@patch('backend.services.agent_service.query_all_tools')
+@patch('backend.services.agent_service.create_agent')
+@patch('backend.services.agent_service.get_current_user_info')
+@patch('backend.services.agent_service.convert_list_to_string')
+@patch('backend.services.agent_service._get_user_group_ids')
+@pytest.mark.asyncio
+async def test_update_agent_info_impl_create_agent_with_ingroup_permission(
+    mock_get_user_group_ids,
+    mock_convert_list_to_string,
+    mock_get_current_user_info,
+    mock_create_agent,
+    mock_query_all_tools,
+    mock_query_tool_instances_by_id,
+    mock_create_or_update_tool
+):
+    """Test creating agent with ingroup_permission set."""
+    from consts.const import PERMISSION_READ, PERMISSION_EDIT, PERMISSION_PRIVATE
+
+    mock_get_current_user_info.return_value = ("test_user", "test_tenant", "en")
+    mock_get_user_group_ids.return_value = "1,2,3"
+    mock_convert_list_to_string.return_value = "1,2"
+    mock_create_agent.return_value = {"agent_id": 123}
+
+    request = MagicMock()
+    request.agent_id = None
+    request.name = "Test Agent"
+    request.display_name = "Test Display"
+    request.description = "Test description"
+    request.business_description = None
+    request.author = None
+    request.model_id = None
+    request.model_name = None
+    request.business_logic_model_id = None
+    request.business_logic_model_name = None
+    request.max_steps = None
+    request.provide_run_summary = None
+    request.duty_prompt = None
+    request.constraint_prompt = None
+    request.few_shots_prompt = None
+    request.enabled = True
+    request.enabled_tool_ids = None
+    request.related_agent_ids = None
+    request.group_ids = [1, 2]
+    request.ingroup_permission = PERMISSION_READ
+
+    result = await update_agent_info_impl(request, authorization="Bearer token")
+
+    assert result["agent_id"] == 123
+    call_args = mock_create_agent.call_args[1]["agent_info"]
+    assert call_args["ingroup_permission"] == PERMISSION_READ
+    assert call_args["group_ids"] == "1,2"
+
+
+@patch('backend.services.agent_service.create_or_update_tool_by_tool_info')
+@patch('backend.services.agent_service.query_tool_instances_by_id')
+@patch('backend.services.agent_service.query_all_tools')
+@patch('backend.services.agent_service.create_agent')
+@patch('backend.services.agent_service.get_current_user_info')
+@patch('backend.services.agent_service._get_user_group_ids')
+@pytest.mark.asyncio
+async def test_update_agent_info_impl_create_agent_with_ingroup_permission_none(
+    mock_get_user_group_ids,
+    mock_get_current_user_info,
+    mock_create_agent,
+    mock_query_all_tools,
+    mock_query_tool_instances_by_id,
+    mock_create_or_update_tool
+):
+    """Test creating agent with ingroup_permission None."""
+    mock_get_current_user_info.return_value = ("test_user", "test_tenant", "en")
+    mock_get_user_group_ids.return_value = "1,2,3"
+    mock_create_agent.return_value = {"agent_id": 456}
+
+    request = MagicMock()
+    request.agent_id = None
+    request.name = "Test Agent"
+    request.display_name = "Test Display"
+    request.description = "Test description"
+    request.business_description = None
+    request.author = None
+    request.model_id = None
+    request.model_name = None
+    request.business_logic_model_id = None
+    request.business_logic_model_name = None
+    request.max_steps = None
+    request.provide_run_summary = None
+    request.duty_prompt = None
+    request.constraint_prompt = None
+    request.few_shots_prompt = None
+    request.enabled = True
+    request.enabled_tool_ids = None
+    request.related_agent_ids = None
+    request.group_ids = None
+    request.ingroup_permission = None
+
+    result = await update_agent_info_impl(request, authorization="Bearer token")
+
+    assert result["agent_id"] == 456
+    call_args = mock_create_agent.call_args[1]["agent_info"]
+    assert call_args["ingroup_permission"] is None
+    assert call_args["group_ids"] == "1,2,3"  # Should use user's groups
+
+
+@pytest.mark.asyncio
+@patch("backend.services.agent_service.get_model_by_model_id")
+@patch("backend.services.agent_service.check_agent_availability")
+@patch("backend.services.agent_service.convert_string_to_list")
+@patch("backend.services.agent_service.get_user_tenant_by_user_id")
+@patch("backend.services.agent_service.query_group_ids_by_user")
+@patch("backend.services.agent_service.query_all_agent_info_by_tenant_id")
+async def test_list_all_agent_info_impl_creator_with_private_permission_no_group_overlap(
+    mock_query_agents,
+    mock_query_groups,
+    mock_get_user_tenant,
+    mock_convert_list,
+    mock_check_availability,
+    mock_get_model,
+):
+    """Test that creators cannot see their own agents if no group overlap, even with PRIVATE permission."""
+    from consts.const import PERMISSION_PRIVATE
+
+    mock_agents = [
+        {
+            "agent_id": 1,
+            "name": "Agent 1",
+            "display_name": "Display Agent 1",
+            "description": "Agent with PRIVATE permission, created by current_user, but no group overlap",
+            "enabled": True,
+            "group_ids": "5,6",  # No overlap with user's groups [1, 2]
+            "ingroup_permission": PERMISSION_PRIVATE,
+            "created_by": "current_user",
+            "create_time": 1,
+        },
+    ]
+
+    mock_query_agents.return_value = mock_agents
+    mock_get_user_tenant.return_value = {"user_role": "USER"}
+    mock_query_groups.return_value = [1, 2]
+
+    def convert_side_effect(x):
+        if not x or (isinstance(x, str) and x.strip() == ""):
+            return []
+        parts = str(x).split(",")
+        result = []
+        for part in parts:
+            stripped = part.strip()
+            if stripped and stripped.isdigit():
+                result.append(int(stripped))
+        return result
+    mock_convert_list.side_effect = convert_side_effect
+
+    mock_check_availability.return_value = (True, [])
+    mock_get_model.return_value = None
+
+    result = await list_all_agent_info_impl(tenant_id="test_tenant", user_id="current_user")
+
+    # Creator cannot see their own agent if no group overlap (no group overlap hides it regardless of creator)
+    assert len(result) == 0
+
+
+@pytest.mark.asyncio
+@patch("backend.services.agent_service.get_model_by_model_id")
+@patch("backend.services.agent_service.check_agent_availability")
+@patch("backend.services.agent_service.convert_string_to_list")
+@patch("backend.services.agent_service.get_user_tenant_by_user_id")
+@patch("backend.services.agent_service.query_group_ids_by_user")
+@patch("backend.services.agent_service.query_all_agent_info_by_tenant_id")
+async def test_list_all_agent_info_impl_creator_with_private_permission_with_group_overlap(
+    mock_query_agents,
+    mock_query_groups,
+    mock_get_user_tenant,
+    mock_convert_list,
+    mock_check_availability,
+    mock_get_model,
+):
+    """Test that creators can see their own agents with PRIVATE permission if there is group overlap."""
+    from consts.const import PERMISSION_PRIVATE
+
+    mock_agents = [
+        {
+            "agent_id": 1,
+            "name": "Agent 1",
+            "display_name": "Display Agent 1",
+            "description": "Agent with PRIVATE permission, created by current_user, with group overlap",
+            "enabled": True,
+            "group_ids": "1,6",  # Overlaps with user's group 1
+            "ingroup_permission": PERMISSION_PRIVATE,
+            "created_by": "current_user",
+            "create_time": 1,
+        },
+    ]
+
+    mock_query_agents.return_value = mock_agents
+    mock_get_user_tenant.return_value = {"user_role": "USER"}
+    mock_query_groups.return_value = [1, 2]
+
+    def convert_side_effect(x):
+        if not x or (isinstance(x, str) and x.strip() == ""):
+            return []
+        parts = str(x).split(",")
+        result = []
+        for part in parts:
+            stripped = part.strip()
+            if stripped and stripped.isdigit():
+                result.append(int(stripped))
+        return result
+    mock_convert_list.side_effect = convert_side_effect
+
+    mock_check_availability.return_value = (True, [])
+    mock_get_model.return_value = None
+
+    result = await list_all_agent_info_impl(tenant_id="test_tenant", user_id="current_user")
+
+    # Creator can see their own agent with PRIVATE permission if there is group overlap
+    assert len(result) == 1
+    assert result[0]["agent_id"] == 1
+
+
+@pytest.mark.asyncio
+@patch("backend.services.agent_service.get_model_by_model_id")
+@patch("backend.services.agent_service.check_agent_availability")
+@patch("backend.services.agent_service.convert_string_to_list")
+@patch("backend.services.agent_service.get_user_tenant_by_user_id")
+@patch("backend.services.agent_service.query_group_ids_by_user")
+@patch("backend.services.agent_service.query_all_agent_info_by_tenant_id")
+async def test_list_all_agent_info_impl_non_creator_with_private_permission_hidden(
+    mock_query_agents,
+    mock_query_groups,
+    mock_get_user_tenant,
+    mock_convert_list,
+    mock_check_availability,
+    mock_get_model,
+):
+    """Test that non-creators cannot see agents with PRIVATE permission even with group overlap."""
+    from consts.const import PERMISSION_PRIVATE
+
+    mock_agents = [
+        {
+            "agent_id": 1,
+            "name": "Agent 1",
+            "display_name": "Display Agent 1",
+            "description": "Agent with PRIVATE permission, not created by current_user",
+            "enabled": True,
+            "group_ids": "1,2",  # Overlaps with user's groups [1, 2]
+            "ingroup_permission": PERMISSION_PRIVATE,
+            "created_by": "other_user",
+            "create_time": 1,
+        },
+    ]
+
+    mock_query_agents.return_value = mock_agents
+    mock_get_user_tenant.return_value = {"user_role": "USER"}
+    mock_query_groups.return_value = [1, 2]
+
+    def convert_side_effect(x):
+        if not x or (isinstance(x, str) and x.strip() == ""):
+            return []
+        parts = str(x).split(",")
+        result = []
+        for part in parts:
+            stripped = part.strip()
+            if stripped and stripped.isdigit():
+                result.append(int(stripped))
+        return result
+    mock_convert_list.side_effect = convert_side_effect
+
+    mock_check_availability.return_value = (True, [])
+    mock_get_model.return_value = None
+
+    result = await list_all_agent_info_impl(tenant_id="test_tenant", user_id="current_user")
+
+    # Non-creator should NOT see agent with PRIVATE permission even with group overlap
+    assert len(result) == 0
+
+
+@pytest.mark.asyncio
+@patch("backend.services.agent_service.get_model_by_model_id")
+@patch("backend.services.agent_service.check_agent_availability")
+@patch("backend.services.agent_service.convert_string_to_list")
+@patch("backend.services.agent_service.get_user_tenant_by_user_id")
+@patch("backend.services.agent_service.query_group_ids_by_user")
+@patch("backend.services.agent_service.query_all_agent_info_by_tenant_id")
+async def test_list_all_agent_info_impl_permission_assignment_creator_gets_edit(
+    mock_query_agents,
+    mock_query_groups,
+    mock_get_user_tenant,
+    mock_convert_list,
+    mock_check_availability,
+    mock_get_model,
+):
+    """Test that creators get PERMISSION_EDIT regardless of ingroup_permission."""
+    from consts.const import PERMISSION_READ, PERMISSION_EDIT
+
+    mock_agents = [
+        {
+            "agent_id": 1,
+            "name": "Agent 1",
+            "display_name": "Display Agent 1",
+            "description": "Agent created by current_user",
+            "enabled": True,
+            "group_ids": "1,2",
+            "ingroup_permission": PERMISSION_READ,  # Even with READ permission
+            "created_by": "current_user",
+            "create_time": 1,
+        },
+    ]
+
+    mock_query_agents.return_value = mock_agents
+    mock_get_user_tenant.return_value = {"user_role": "USER"}
+    mock_query_groups.return_value = [1, 2]
+
+    def convert_side_effect(x):
+        if not x or (isinstance(x, str) and x.strip() == ""):
+            return []
+        parts = str(x).split(",")
+        result = []
+        for part in parts:
+            stripped = part.strip()
+            if stripped and stripped.isdigit():
+                result.append(int(stripped))
+        return result
+    mock_convert_list.side_effect = convert_side_effect
+
+    mock_check_availability.return_value = (True, [])
+    mock_get_model.return_value = None
+
+    result = await list_all_agent_info_impl(tenant_id="test_tenant", user_id="current_user")
+
+    assert len(result) == 1
+    assert result[0]["permission"] == PERMISSION_EDIT  # Creator gets EDIT
+
+
+@pytest.mark.asyncio
+@patch("backend.services.agent_service.get_model_by_model_id")
+@patch("backend.services.agent_service.check_agent_availability")
+@patch("backend.services.agent_service.convert_string_to_list")
+@patch("backend.services.agent_service.get_user_tenant_by_user_id")
+@patch("backend.services.agent_service.query_group_ids_by_user")
+@patch("backend.services.agent_service.query_all_agent_info_by_tenant_id")
+async def test_list_all_agent_info_impl_permission_assignment_non_creator_uses_ingroup_permission(
+    mock_query_agents,
+    mock_query_groups,
+    mock_get_user_tenant,
+    mock_convert_list,
+    mock_check_availability,
+    mock_get_model,
+):
+    """Test that non-creators use ingroup_permission when set."""
+    from consts.const import PERMISSION_READ, PERMISSION_EDIT
+
+    mock_agents = [
+        {
+            "agent_id": 1,
+            "name": "Agent 1",
+            "display_name": "Display Agent 1",
+            "description": "Agent not created by current_user",
+            "enabled": True,
+            "group_ids": "1,2",
+            "ingroup_permission": PERMISSION_EDIT,  # Set to EDIT
+            "created_by": "other_user",
+            "create_time": 1,
+        },
+        {
+            "agent_id": 2,
+            "name": "Agent 2",
+            "display_name": "Display Agent 2",
+            "description": "Agent with READ permission",
+            "enabled": True,
+            "group_ids": "1,2",
+            "ingroup_permission": PERMISSION_READ,  # Set to READ
+            "created_by": "other_user",
+            "create_time": 2,
+        },
+        {
+            "agent_id": 3,
+            "name": "Agent 3",
+            "display_name": "Display Agent 3",
+            "description": "Agent with None permission",
+            "enabled": True,
+            "group_ids": "1,2",
+            "ingroup_permission": None,  # None should default to READ
+            "created_by": "other_user",
+            "create_time": 3,
+        },
+    ]
+
+    mock_query_agents.return_value = mock_agents
+    mock_get_user_tenant.return_value = {"user_role": "USER"}
+    mock_query_groups.return_value = [1, 2]
+
+    def convert_side_effect(x):
+        if not x or (isinstance(x, str) and x.strip() == ""):
+            return []
+        parts = str(x).split(",")
+        result = []
+        for part in parts:
+            stripped = part.strip()
+            if stripped and stripped.isdigit():
+                result.append(int(stripped))
+        return result
+    mock_convert_list.side_effect = convert_side_effect
+
+    mock_check_availability.return_value = (True, [])
+    mock_get_model.return_value = None
+
+    result = await list_all_agent_info_impl(tenant_id="test_tenant", user_id="current_user")
+
+    assert len(result) == 3
+    agent1 = next(a for a in result if a["agent_id"] == 1)
+    agent2 = next(a for a in result if a["agent_id"] == 2)
+    agent3 = next(a for a in result if a["agent_id"] == 3)
+    assert agent1["permission"] == PERMISSION_EDIT
+    assert agent2["permission"] == PERMISSION_READ
+    assert agent3["permission"] == PERMISSION_READ  # None defaults to READ
+
+
+@pytest.mark.asyncio
+@patch("backend.services.agent_service.get_model_by_model_id")
+@patch("backend.services.agent_service.check_agent_availability")
+@patch("backend.services.agent_service.convert_string_to_list")
+@patch("backend.services.agent_service.get_user_tenant_by_user_id")
+@patch("backend.services.agent_service.query_group_ids_by_user")
+@patch("backend.services.agent_service.query_all_agent_info_by_tenant_id")
+async def test_list_all_agent_info_impl_admin_gets_edit_permission(
+    mock_query_agents,
+    mock_query_groups,
+    mock_get_user_tenant,
+    mock_convert_list,
+    mock_check_availability,
+    mock_get_model,
+):
+    """Test that admin users (can_edit_all) get PERMISSION_EDIT regardless of ingroup_permission."""
+    from consts.const import PERMISSION_READ, PERMISSION_EDIT
+
+    mock_agents = [
+        {
+            "agent_id": 1,
+            "name": "Agent 1",
+            "display_name": "Display Agent 1",
+            "description": "Agent with READ permission",
+            "enabled": True,
+            "group_ids": "1,2",
+            "ingroup_permission": PERMISSION_READ,
+            "created_by": "other_user",
+            "create_time": 1,
+        },
+    ]
+
+    mock_query_agents.return_value = mock_agents
+    mock_get_user_tenant.return_value = {"user_role": "ADMIN"}  # Admin role
+    mock_query_groups.return_value = []
+
+    def convert_side_effect(x):
+        if not x or (isinstance(x, str) and x.strip() == ""):
+            return []
+        parts = str(x).split(",")
+        result = []
+        for part in parts:
+            stripped = part.strip()
+            if stripped and stripped.isdigit():
+                result.append(int(stripped))
+        return result
+    mock_convert_list.side_effect = convert_side_effect
+
+    mock_check_availability.return_value = (True, [])
+    mock_get_model.return_value = None
+
+    result = await list_all_agent_info_impl(tenant_id="test_tenant", user_id="admin_user")
+
+    assert len(result) == 1
+    assert result[0]["permission"] == PERMISSION_EDIT  # Admin gets EDIT
+
+
+@pytest.mark.asyncio
+@patch("backend.services.agent_service.get_model_by_model_id")
+@patch("backend.services.agent_service.check_agent_availability")
+@patch("backend.services.agent_service.convert_string_to_list")
+@patch("backend.services.agent_service.get_user_tenant_by_user_id")
+@patch("backend.services.agent_service.query_group_ids_by_user")
+@patch("backend.services.agent_service.query_all_agent_info_by_tenant_id")
+async def test_list_all_agent_info_impl_non_creator_no_group_overlap_hidden(
+    mock_query_agents,
+    mock_query_groups,
+    mock_get_user_tenant,
+    mock_convert_list,
+    mock_check_availability,
+    mock_get_model,
+):
+    """Test that non-creators without group overlap are hidden."""
+    mock_agents = [
+        {
+            "agent_id": 1,
+            "name": "Agent 1",
+            "display_name": "Display Agent 1",
+            "description": "Agent not created by current_user, no group overlap",
+            "enabled": True,
+            "group_ids": "5,6",  # No overlap with user's groups [1, 2]
+            "ingroup_permission": None,
+            "created_by": "other_user",
+            "create_time": 1,
+        },
+    ]
+
+    mock_query_agents.return_value = mock_agents
+    mock_get_user_tenant.return_value = {"user_role": "USER"}
+    mock_query_groups.return_value = [1, 2]
+
+    def convert_side_effect(x):
+        if not x or (isinstance(x, str) and x.strip() == ""):
+            return []
+        parts = str(x).split(",")
+        result = []
+        for part in parts:
+            stripped = part.strip()
+            if stripped and stripped.isdigit():
+                result.append(int(stripped))
+        return result
+    mock_convert_list.side_effect = convert_side_effect
+
+    mock_check_availability.return_value = (True, [])
+    mock_get_model.return_value = None
+
+    result = await list_all_agent_info_impl(tenant_id="test_tenant", user_id="current_user")
+
+    # Non-creator without group overlap should be hidden (no group overlap hides it)
+    assert len(result) == 0
+
+
+@pytest.mark.asyncio
+@patch("backend.services.agent_service.get_model_by_model_id")
+@patch("backend.services.agent_service.check_agent_availability")
+@patch("backend.services.agent_service.convert_string_to_list")
+@patch("backend.services.agent_service.get_user_tenant_by_user_id")
+@patch("backend.services.agent_service.query_group_ids_by_user")
+@patch("backend.services.agent_service.query_all_agent_info_by_tenant_id")
+async def test_list_all_agent_info_impl_creator_no_group_overlap_hidden(
+    mock_query_agents,
+    mock_query_groups,
+    mock_get_user_tenant,
+    mock_convert_list,
+    mock_check_availability,
+    mock_get_model,
+):
+    """Test that creators cannot see their own agents if no group overlap."""
+    mock_agents = [
+        {
+            "agent_id": 1,
+            "name": "Agent 1",
+            "display_name": "Display Agent 1",
+            "description": "Agent created by current_user, but no group overlap",
+            "enabled": True,
+            "group_ids": "5,6",  # No overlap with user's groups [1, 2]
+            "ingroup_permission": None,
+            "created_by": "current_user",
+            "create_time": 1,
+        },
+    ]
+
+    mock_query_agents.return_value = mock_agents
+    mock_get_user_tenant.return_value = {"user_role": "USER"}
+    mock_query_groups.return_value = [1, 2]
+
+    def convert_side_effect(x):
+        if not x or (isinstance(x, str) and x.strip() == ""):
+            return []
+        parts = str(x).split(",")
+        result = []
+        for part in parts:
+            stripped = part.strip()
+            if stripped and stripped.isdigit():
+                result.append(int(stripped))
+        return result
+    mock_convert_list.side_effect = convert_side_effect
+
+    mock_check_availability.return_value = (True, [])
+    mock_get_model.return_value = None
+
+    result = await list_all_agent_info_impl(tenant_id="test_tenant", user_id="current_user")
+
+    # Creator cannot see their own agent if no group overlap (no group overlap hides it regardless of creator)
+    assert len(result) == 0
 
 # Deprecated tests for mark_agents_as_new_impl have been removed as the API is cleaned up.


### PR DESCRIPTION
♻️ The agent should support setting in-group permissions. #2566
[Specification Details]
1. Add the `ingroup_permission` field to the `agent` database table and modify the corresponding logic.
[Test Result]
private 其他开发者不可见：
<img width="2243" height="1196" alt="image" src="https://github.com/user-attachments/assets/cc4bd262-a5d3-4668-ab1c-b2f08d70b953" />
<img width="2269" height="1078" alt="image" src="https://github.com/user-attachments/assets/87be58a7-c628-4d56-bd74-dbb8cef92ee7" />
read_only 不可编辑：
<img width="2241" height="1141" alt="image" src="https://github.com/user-attachments/assets/73b58a50-cefd-4c99-9ab9-8ddc21450436" />
edit 组内可编辑：
<img width="2256" height="1148" alt="image" src="https://github.com/user-attachments/assets/f555de8d-43fc-45b0-b701-e9d7e17f4baf" />

