### PR TITLE
🐛 Bugfix: Clicking on the tenant name does not respond and the tenant name is not selected #2496

### DIFF
--- a/frontend/app/[locale]/tenant-resources/components/UserManageComp.tsx
+++ b/frontend/app/[locale]/tenant-resources/components/UserManageComp.tsx
@@ -283,12 +283,10 @@ function TenantList({
                   ? "bg-blue-50 border border-blue-200"
                   : "hover:bg-gray-50"
               }`}
+              onClick={() => onSelect(tenant.tenant_id)}
             >
               <div className="flex items-center justify-between">
-                <div
-                  className="flex-1"
-                  onClick={() => onSelect(tenant.tenant_id)}
-                >
+                <div className="flex-1">
                   {tenant.tenant_name || t("tenantResources.tenants.unnamed")}
                 </div>
                 <div className="opacity-0 group-hover:opacity-100 flex space-x-1">


### PR DESCRIPTION
修改了点击事件的触发逻辑至外框 #2496
<img width="223" height="38" alt="image" src="https://github.com/user-attachments/assets/eea4889d-ccae-4782-a197-4fd04ba0868c" />
