### PR TITLE
🐛 Bugfix: The agent_run process cannot invoke the MCP service with authentication.

### DIFF
--- a/backend/agents/create_agent_info.py
+++ b/backend/agents/create_agent_info.py
@@ -388,7 +388,7 @@ async def create_agent_run_info(
         version_no=version_no,
     )
 
-    remote_mcp_list = await get_remote_mcp_server_list(tenant_id=tenant_id)
+    remote_mcp_list = await get_remote_mcp_server_list(tenant_id=tenant_id, is_need_auth=True)
     default_mcp_url = urljoin(LOCAL_MCP_SERVER, "sse")
     remote_mcp_list.append({
         "remote_mcp_server_name": "nexent",

--- a/backend/apps/remote_mcp_app.py
+++ b/backend/apps/remote_mcp_app.py
@@ -181,6 +181,7 @@ async def get_remote_proxies(
         remote_mcp_server_list = await get_remote_mcp_server_list(
             tenant_id=effective_tenant_id,
             user_id=user_id,
+            is_need_auth=False
         )
         return JSONResponse(
             status_code=HTTPStatus.OK,

--- a/backend/services/remote_mcp_service.py
+++ b/backend/services/remote_mcp_service.py
@@ -156,7 +156,7 @@ async def update_remote_mcp_server_list(
     )
 
 
-async def get_remote_mcp_server_list(tenant_id: str, user_id: str | None = None) -> list[dict]:
+async def get_remote_mcp_server_list(tenant_id: str, user_id: str | None = None, is_need_auth: bool = True) -> list[dict]:
     mcp_records = get_mcp_records_by_tenant(tenant_id=tenant_id)
     mcp_records_list = []
     can_edit_all = False
@@ -173,13 +173,16 @@ async def get_remote_mcp_server_list(tenant_id: str, user_id: str | None = None)
             permission = PERMISSION_EDIT if can_edit_all or str(
                 created_by) == str(user_id) else PERMISSION_READ
 
-        mcp_records_list.append({
+        record_dict = {
             "remote_mcp_server_name": record["mcp_name"],
             "remote_mcp_server": record["mcp_server"],
             "status": record["status"],
             "permission": permission,
-            "mcp_id": record.get("mcp_id")
-        })
+            "mcp_id": record.get("mcp_id"),
+        }
+        if is_need_auth:
+            record_dict["authorization_token"] = record.get("authorization_token")
+        mcp_records_list.append(record_dict)
     return mcp_records_list
 
 

--- a/test/backend/agents/test_create_agent_info.py
+++ b/test/backend/agents/test_create_agent_info.py
@@ -1689,7 +1689,7 @@ class TestCreateAgentRunInfo:
                 allow_memory_search=True,
                 version_no=1,
             )
-            mock_get_mcp.assert_called_once_with(tenant_id="tenant_1")
+            mock_get_mcp.assert_called_once_with(tenant_id="tenant_1", is_need_auth=True)
             mock_filter.assert_called_once_with("agent_config", {
                 "test_server": {
                     "remote_mcp_server_name": "test_server",
@@ -2117,6 +2117,55 @@ class TestCreateAgentRunInfo:
                 allow_memory_search=True,
                 version_no=0,  # Fallback to draft version 0
             )
+            # Verify that get_remote_mcp_server_list was called with is_need_auth=True
+            mock_get_mcp.assert_called_once_with(tenant_id="tenant_1", is_need_auth=True)
+
+    @pytest.mark.asyncio
+    async def test_create_agent_run_info_is_need_auth_true_includes_token(self):
+        """Test that get_remote_mcp_server_list is called with is_need_auth=True and returns authorization_token"""
+        mock_agent_run_info.reset_mock()
+        with patch('backend.agents.create_agent_info.join_minio_file_description_to_query') as mock_join_query, \
+                patch('backend.agents.create_agent_info.create_model_config_list') as mock_create_models, \
+                patch('backend.agents.create_agent_info.get_remote_mcp_server_list', new_callable=AsyncMock) as mock_get_mcp, \
+                patch('backend.agents.create_agent_info.create_agent_config') as mock_create_agent, \
+                patch('backend.agents.create_agent_info.filter_mcp_servers_and_tools') as mock_filter, \
+                patch('backend.agents.create_agent_info.urljoin') as mock_urljoin, \
+                patch('backend.agents.create_agent_info.threading') as mock_threading, \
+                patch('backend.agents.create_agent_info.query_current_version_no') as mock_version_no:
+
+            mock_join_query.return_value = "processed_query"
+            mock_create_models.return_value = ["model_config"]
+            # Mock return value with authorization_token (when is_need_auth=True)
+            mock_get_mcp.return_value = [
+                {
+                    "remote_mcp_server_name": "test_server",
+                    "remote_mcp_server": "http://test.server",
+                    "status": True,
+                    "authorization_token": "secret_token_123",
+                    "mcp_id": 1
+                }
+            ]
+            mock_create_agent.return_value = "agent_config"
+            mock_urljoin.return_value = "http://nexent.mcp/sse"
+            mock_filter.return_value = ["http://test.server"]
+            mock_threading.Event.return_value = "stop_event"
+            mock_version_no.return_value = 1
+
+            await create_agent_run_info(
+                agent_id="agent_1",
+                minio_files=[],
+                query="test query",
+                history=[],
+                user_id="user_1",
+                tenant_id="tenant_1",
+                language="zh"
+            )
+
+            # Verify that get_remote_mcp_server_list was called with is_need_auth=True
+            mock_get_mcp.assert_called_once_with(tenant_id="tenant_1", is_need_auth=True)
+            
+            # Verify that the returned data includes authorization_token (used in mcp_host construction)
+            assert mock_get_mcp.return_value[0]["authorization_token"] == "secret_token_123"
 
 
 class TestJoinMinioFileDescriptionToQuery:

--- a/test/backend/app/test_remote_mcp_app.py
+++ b/test/backend/app/test_remote_mcp_app.py
@@ -412,7 +412,7 @@ class TestGetRemoteProxies:
         assert data["remote_mcp_server_list"][1]["permission"] == "READ_ONLY"
 
         mock_get_user_info.assert_called_once()
-        mock_get_list.assert_called_once_with(tenant_id="tenant456", user_id="user123")
+        mock_get_list.assert_called_once_with(tenant_id="tenant456", user_id="user123", is_need_auth=False)
 
     @patch('apps.remote_mcp_app.get_current_user_info')
     @patch('apps.remote_mcp_app.get_remote_mcp_server_list')
@@ -428,8 +428,8 @@ class TestGetRemoteProxies:
         )
 
         assert response.status_code == HTTPStatus.OK
-        # Verify that explicit tenant_id is used
-        mock_get_list.assert_called_once_with(tenant_id="explicit_tenant789", user_id="user123")
+        # Verify that explicit tenant_id is used and is_need_auth=False
+        mock_get_list.assert_called_once_with(tenant_id="explicit_tenant789", user_id="user123", is_need_auth=False)
 
     @patch('apps.remote_mcp_app.get_current_user_info')
     @patch('apps.remote_mcp_app.get_remote_mcp_server_list')
@@ -446,6 +446,51 @@ class TestGetRemoteProxies:
         assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
         data = response.json()
         assert "Failed to get remote MCP proxy" in data["detail"]
+
+    @patch('apps.remote_mcp_app.get_current_user_info')
+    @patch('apps.remote_mcp_app.get_remote_mcp_server_list')
+    def test_get_remote_proxies_is_need_auth_false_excludes_token(self, mock_get_list, mock_get_user_info):
+        """Test that get_remote_mcp_server_list is called with is_need_auth=False and excludes authorization_token"""
+        mock_get_user_info.return_value = ("user123", "tenant456", "en")
+        # Mock return value without authorization_token (when is_need_auth=False)
+        mock_server_list = [
+            {
+                "remote_mcp_server_name": "server1",
+                "remote_mcp_server": "http://server1.com",
+                "status": True,
+                "permission": "EDIT",
+                "mcp_id": 1
+            },
+            {
+                "remote_mcp_server_name": "server2",
+                "remote_mcp_server": "http://server2.com",
+                "status": False,
+                "permission": "READ_ONLY",
+                "mcp_id": 2
+            }
+        ]
+        mock_get_list.return_value = mock_server_list
+
+        response = client.get(
+            "/mcp/list",
+            headers={"Authorization": "Bearer test_token"}
+        )
+
+        assert response.status_code == HTTPStatus.OK
+        data = response.json()
+        assert "remote_mcp_server_list" in data
+        assert len(data["remote_mcp_server_list"]) == 2
+        
+        # Verify that authorization_token is not present in the response
+        assert "authorization_token" not in data["remote_mcp_server_list"][0]
+        assert "authorization_token" not in data["remote_mcp_server_list"][1]
+        
+        # Verify that other fields are present
+        assert data["remote_mcp_server_list"][0]["mcp_id"] == 1
+        assert data["remote_mcp_server_list"][1]["mcp_id"] == 2
+        
+        # Verify that get_remote_mcp_server_list was called with is_need_auth=False
+        mock_get_list.assert_called_once_with(tenant_id="tenant456", user_id="user123", is_need_auth=False)
 
 
 class TestGetMCPRecord:

--- a/test/backend/services/test_remote_mcp_service.py
+++ b/test/backend/services/test_remote_mcp_service.py
@@ -483,6 +483,107 @@ class TestGetRemoteMcpServerList(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result[0]["permission"], "EDIT")
         self.assertEqual(result[1]["permission"], "EDIT")
 
+    @patch('backend.services.remote_mcp_service.get_mcp_records_by_tenant')
+    async def test_get_list_with_is_need_auth_true(self, mock_get):
+        """Test getting server list with is_need_auth=True (default) includes authorization_token"""
+        mock_get.return_value = [
+            {
+                "mcp_name": "n1",
+                "mcp_server": "u1",
+                "status": True,
+                "authorization_token": "token123",
+                "mcp_id": 1
+            },
+            {
+                "mcp_name": "n2",
+                "mcp_server": "u2",
+                "status": False,
+                "authorization_token": None,
+                "mcp_id": 2
+            }
+        ]
+
+        result = await get_remote_mcp_server_list('tid', is_need_auth=True)
+
+        self.assertEqual(len(result), 2)
+        self.assertIn("authorization_token", result[0])
+        self.assertEqual(result[0]["authorization_token"], "token123")
+        self.assertIn("authorization_token", result[1])
+        self.assertIsNone(result[1]["authorization_token"])
+
+    @patch('backend.services.remote_mcp_service.get_mcp_records_by_tenant')
+    async def test_get_list_with_is_need_auth_false(self, mock_get):
+        """Test getting server list with is_need_auth=False excludes authorization_token"""
+        mock_get.return_value = [
+            {
+                "mcp_name": "n1",
+                "mcp_server": "u1",
+                "status": True,
+                "authorization_token": "token123",
+                "mcp_id": 1
+            },
+            {
+                "mcp_name": "n2",
+                "mcp_server": "u2",
+                "status": False,
+                "authorization_token": "token456",
+                "mcp_id": 2
+            }
+        ]
+
+        result = await get_remote_mcp_server_list('tid', is_need_auth=False)
+
+        self.assertEqual(len(result), 2)
+        self.assertNotIn("authorization_token", result[0])
+        self.assertNotIn("authorization_token", result[1])
+        # Verify other fields are still present
+        self.assertEqual(result[0]["remote_mcp_server_name"], "n1")
+        self.assertEqual(result[0]["mcp_id"], 1)
+        self.assertEqual(result[1]["remote_mcp_server_name"], "n2")
+        self.assertEqual(result[1]["mcp_id"], 2)
+
+    @patch('backend.services.remote_mcp_service.get_mcp_records_by_tenant')
+    async def test_get_list_default_is_need_auth_true(self, mock_get):
+        """Test that default behavior (is_need_auth not specified) includes authorization_token"""
+        mock_get.return_value = [
+            {
+                "mcp_name": "n1",
+                "mcp_server": "u1",
+                "status": True,
+                "authorization_token": "token123",
+                "mcp_id": 1
+            }
+        ]
+
+        result = await get_remote_mcp_server_list('tid')
+
+        self.assertEqual(len(result), 1)
+        self.assertIn("authorization_token", result[0])
+        self.assertEqual(result[0]["authorization_token"], "token123")
+
+    @patch('backend.services.remote_mcp_service.get_user_tenant_by_user_id')
+    @patch('backend.services.remote_mcp_service.get_mcp_records_by_tenant')
+    async def test_get_list_with_user_id_and_is_need_auth_false(self, mock_get, mock_get_user_tenant):
+        """Test getting server list with user_id and is_need_auth=False"""
+        mock_get_user_tenant.return_value = {"user_role": "USER"}
+        mock_get.return_value = [
+            {
+                "mcp_name": "n1",
+                "mcp_server": "u1",
+                "status": True,
+                "created_by": "user123",
+                "authorization_token": "token123",
+                "mcp_id": 1
+            }
+        ]
+
+        result = await get_remote_mcp_server_list('tid', user_id="user123", is_need_auth=False)
+
+        self.assertEqual(len(result), 1)
+        self.assertNotIn("authorization_token", result[0])
+        self.assertEqual(result[0]["permission"], "EDIT")
+        self.assertEqual(result[0]["mcp_id"], 1)
+
 
 class TestCheckMcpHealthAndUpdateDb(unittest.IsolatedAsyncioTestCase):
     """Test check_mcp_health_and_update_db"""


### PR DESCRIPTION
🐛 Bugfix: The agent_run process cannot invoke the MCP service with authentication. #2086
[Specification Details] 
1. When querying the mcp list, add the parameter is_need_auth to determine whether an auth_token should be returned.
2. Modify test cases.
[Test Results]
智能体正常调用：
<img width="1015" height="635" alt="image" src="https://github.com/user-attachments/assets/945ef122-7498-43b4-8080-cd503acddf9a" />
list接口不返auth_token：
<img width="854" height="377" alt="image" src="https://github.com/user-attachments/assets/53d2401d-0b1d-438d-9024-14693efa89a9" />
