### PR TITLE
🐛 Bugfix: Fix various issues when the Agent's permissions are set to …

### DIFF
--- a/frontend/app/[locale]/agents/AgentVersionCard.tsx
+++ b/frontend/app/[locale]/agents/AgentVersionCard.tsx
@@ -28,6 +28,7 @@ import {
   DescriptionsProps,
   Modal,
   Dropdown,
+  Tooltip,
   theme
 } from "antd";
 import { ExclamationCircleFilled } from '@ant-design/icons';
@@ -148,6 +149,13 @@ export function VersionCardItem({
 
   const { tools: toolList } = useToolList();
   const { agents: agentList } = useAgentList(user?.tenantId ?? null);
+
+  // Get current agent's permission from agent list
+  const currentAgent = useMemo(() => {
+    return agentList.find((a: Agent) => a.id === String(agentId));
+  }, [agentList, agentId]);
+
+  const isReadOnly = currentAgent?.permission === "READ_ONLY";
 
   // Modal state
   const [compareModalOpen, setCompareModalOpen] = useState(false);
@@ -366,15 +374,28 @@ export function VersionCardItem({
                 items: [
                   {
                     key: 'edit',
-                    label: t("common.edit"),
+                    label: isReadOnly ? (
+                      <Tooltip title={t("agent.noEditPermission")}>
+                        <span>{t("common.edit")}</span>
+                      </Tooltip>
+                    ) : (
+                      t("common.edit")
+                    ),
                     icon: <Edit size={14} />,
+                    disabled: isReadOnly,
                     onClick: () => setEditModalOpen(true)
                   },
                   {
                     key: 'rollback',
-                    label: t("agent.version.rollback"),
+                    label: isReadOnly ? (
+                      <Tooltip title={t("agent.noEditPermission")}>
+                        <span>{t("agent.version.rollback")}</span>
+                      </Tooltip>
+                    ) : (
+                      t("agent.version.rollback")
+                    ),
                     icon: <RotateCcw size={14} />,
-                    disabled: isCurrentVersion || version.status.toLowerCase() === "disabled",
+                    disabled: isReadOnly || isCurrentVersion || version.status.toLowerCase() === "disabled",
                     onClick: handleRollbackClick
                   },
                   {
@@ -382,9 +403,15 @@ export function VersionCardItem({
                   },
                   {
                     key: 'delete',
-                    label: t("common.delete"),
+                    label: isReadOnly ? (
+                      <Tooltip title={t("agent.noEditPermission")}>
+                        <span>{t("common.delete")}</span>
+                      </Tooltip>
+                    ) : (
+                      t("common.delete")
+                    ),
                     icon: <Trash2 size={14} />,
-                    disabled: isCurrentVersion,
+                    disabled: isReadOnly || isCurrentVersion,
                     danger: true,
                     onClick: handleDeleteClick,
                   },

--- a/frontend/app/[locale]/agents/components/agentConfig/ToolManagement.tsx
+++ b/frontend/app/[locale]/agents/components/agentConfig/ToolManagement.tsx
@@ -75,7 +75,15 @@ export default function ToolManagement({
   const { t } = useTranslation("common");
   const queryClient = useQueryClient();
 
-  const editable = currentAgentId || isCreatingMode;
+  // Get current agent permission from store
+  const currentAgentPermission = useAgentConfigStore(
+    (state) => state.currentAgentPermission
+  );
+
+  // Check if current agent is read-only (only when agent is selected and permission is READ_ONLY)
+  const isReadOnly = !isCreatingMode && currentAgentId !== undefined && currentAgentPermission === "READ_ONLY";
+
+  const editable = (currentAgentId || isCreatingMode) && !isReadOnly;
 
   // Get state from store
   const originalSelectedTools = useAgentConfigStore(
@@ -423,8 +431,16 @@ export default function ToolManagement({
                           );
                           const isDisabledDueToVlm = isToolDisabledDueToVlm(tool.name, isVlmConfigured);
                           const isDisabledDueToEmbedding = isToolDisabledDueToEmbedding(tool.name, isEmbeddingConfigured);
-                          const isDisabled = isDisabledDueToVlm || isDisabledDueToEmbedding;
-                          return (
+                          const isDisabled = isDisabledDueToVlm || isDisabledDueToEmbedding || isReadOnly;
+                          // Tooltip priority: permission > VLM > Embedding
+                          const tooltipTitle = isReadOnly
+                            ? t("agent.noEditPermission")
+                            : isDisabledDueToVlm
+                            ? t("toolPool.vlmDisabledTooltip")
+                            : isDisabledDueToEmbedding
+                            ? t("toolPool.embeddingDisabledTooltip")
+                            : undefined;
+                          const toolCard = (
                             <div
                               key={tool.id}
                               className={`border-2 rounded-md p-2 flex items-center justify-between transition-all duration-300 ease-in-out min-h-[52px] shadow-sm ${
@@ -491,6 +507,13 @@ export default function ToolManagement({
                               />
                             </div>
                           );
+                          return tooltipTitle ? (
+                            <Tooltip key={tool.id} title={tooltipTitle}>
+                              {toolCard}
+                            </Tooltip>
+                          ) : (
+                            toolCard
+                          );
                         })}
                       </div>
                     ),
@@ -513,8 +536,16 @@ export default function ToolManagement({
                 const isSelected = originalSelectedToolIdsSet.has(tool.id);
                 const isDisabledDueToVlm = isToolDisabledDueToVlm(tool.name, isVlmConfigured);
                 const isDisabledDueToEmbedding = isToolDisabledDueToEmbedding(tool.name, isEmbeddingConfigured);
-                const isDisabled = isDisabledDueToVlm || isDisabledDueToEmbedding;
-                return (
+                const isDisabled = isDisabledDueToVlm || isDisabledDueToEmbedding || isReadOnly;
+                // Tooltip priority: permission > VLM > Embedding
+                const tooltipTitle = isReadOnly
+                  ? t("agent.noEditPermission")
+                  : isDisabledDueToVlm
+                  ? t("toolPool.vlmDisabledTooltip")
+                  : isDisabledDueToEmbedding
+                  ? t("toolPool.embeddingDisabledTooltip")
+                  : undefined;
+                const toolCard = (
                   <div
                     key={tool.id}
                     className={`border-2 rounded-md p-2 flex items-center justify-between transition-all duration-300 ease-in-out min-h-[52px] shadow-sm ${
@@ -578,6 +609,13 @@ export default function ToolManagement({
                       }
                     />
                   </div>
+                );
+                return tooltipTitle ? (
+                  <Tooltip key={tool.id} title={tooltipTitle}>
+                    {toolCard}
+                  </Tooltip>
+                ) : (
+                  toolCard
                 );
               })}
             </div>

--- a/frontend/app/[locale]/agents/components/agentManage/AgentList.tsx
+++ b/frontend/app/[locale]/agents/components/agentManage/AgentList.tsx
@@ -506,7 +506,13 @@ export default function AgentList({
                       </span>
                     </Tooltip>
 
-                    <Tooltip title={t("agent.contextMenu.delete")}>
+                    <Tooltip
+                      title={
+                        agent.permission === "READ_ONLY"
+                          ? t("agent.noEditPermission")
+                          : t("agent.contextMenu.delete")
+                      }
+                    >
                       <span>
                         <Button
                           type="text"
@@ -514,7 +520,12 @@ export default function AgentList({
                           icon={
                             <Trash2
                               className="w-4 h-4"
-                              style={{ color: token.colorError }}
+                              style={{
+                                color:
+                                  agent.permission === "READ_ONLY"
+                                    ? token.colorTextDisabled
+                                    : token.colorError,
+                              }}
                             />
                           }
                           onClick={(e) => {
@@ -522,6 +533,7 @@ export default function AgentList({
                             e.stopPropagation();
                             handleDeleteAgentWithConfirm(agent);
                           }}
+                          disabled={agent.permission === "READ_ONLY"}
                           className="agent-action-button agent-action-button-red"
                         />
                       </span>


### PR DESCRIPTION
🐛 Bugfix: Fix various issues when the Agent's permissions are set to READ_ONLY. #2510 #2551
[Specification Details]
1. When the Agent permission is READ_ONLY, agents cannot be deleted, and versions cannot be published or edited.
2. List of tools that can be disabled when Agent permission is READ_ONLY
[Test Result]
<img width="2267" height="1224" alt="image" src="https://github.com/user-attachments/assets/6e63ba40-e292-4f64-9e3c-274006e7732d" />
