### PR TITLE
🐛 Bugfix: Fix the agent version display in resource management page. #2490

### DIFF
--- a/frontend/app/[locale]/space/components/AgentCard.tsx
+++ b/frontend/app/[locale]/space/components/AgentCard.tsx
@@ -153,7 +153,7 @@ export default function AgentCard({ agent, onRefresh }: AgentCardProps) {
       try {
         const result = await clearAgentNewMark(agent.id);
         if (result?.success) {
-          setIsNewAgent(false); 
+          setIsNewAgent(false);
           queryClient.invalidateQueries({ queryKey: ["agents"] });
         } else {
           log.warn("Failed to clear NEW mark for agent", agent.id, result);
@@ -266,9 +266,13 @@ export default function AgentCard({ agent, onRefresh }: AgentCardProps) {
                 e.stopPropagation();
                 handleDelete();
               }}
-              disabled={isDeleting}
+              disabled={isDeleting || agent.permission === "READ_ONLY"}
               className="p-2 rounded-md hover:bg-red-50 dark:hover:bg-red-900/20 text-slate-400 hover:text-red-600 dark:hover:text-red-400 transition-colors disabled:opacity-50"
-              title={t("space.actions.delete", "Delete")}
+              title={
+                agent.permission === "READ_ONLY"
+                  ? t("agent.noEditPermission")
+                  : t("space.actions.delete", "Delete")
+              }
             >
               <Trash2 className="h-4 w-4" />
             </button>

--- a/frontend/app/[locale]/tenant-resources/components/resources/AgentList.tsx
+++ b/frontend/app/[locale]/tenant-resources/components/resources/AgentList.tsx
@@ -144,8 +144,18 @@ export default function AgentList({ tenantId }: { tenantId: string | null }) {
 
     try {
       const agentId = Number(agent.id);
-      // Get selected version for this agent (default to 0 for current version)
-      const selectedVersionNo = selectedVersions.get(agentId) ?? 0;
+      const isPublished = agent.is_published === true;
+
+      // For published agents, use selected version or current_version_no
+      // For unpublished agents, use version_no=0 (draft)
+      let selectedVersionNo: number;
+      if (isPublished) {
+        const currentVersionNo = agent.current_version_no || 0;
+        selectedVersionNo = selectedVersions.get(agentId) ?? currentVersionNo;
+      } else {
+        selectedVersionNo = 0;
+      }
+
       const res = await searchAgentInfo(agentId, tenantId ?? undefined, selectedVersionNo);
       if (res.success && res.data) {
         const detail = res.data;
@@ -281,28 +291,32 @@ export default function AgentList({ tenantId }: { tenantId: string | null }) {
       width: "10%",
       render: (_: unknown, record: AgentListRow) => {
         const agentId = Number(record.id);
+        const isPublished = record.is_published === true;
+
+        // If not published, show "无已发布版本"
+        if (!isPublished) {
+          return <span className="text-gray-400">{t("agent.version.noPublished")}</span>;
+        }
+
         const versions = agentVersions.get(agentId) || [];
         const isLoading = loadingVersions.get(agentId) || false;
-        // Default to 0 (current version) if not selected
+        const currentVersionNo = record.current_version_no || 0;
+
+        // Default to current_version_no if not selected, fallback to first version
+        // Must have a default value, cannot be undefined
         const selectedVersionNo = selectedVersions.has(agentId)
           ? selectedVersions.get(agentId)!
-          : 0;
+          : currentVersionNo > 0 ? currentVersionNo : (versions[0]?.version_no || undefined);
 
-        // Build options: current version (0) first, then other versions
-        const options = [
-          {
-            label: t("agent.version.current"),
-            value: 0,
-          },
-          ...versions.map((version) => ({
-            label: version.version_name,
-            value: version.version_no,
-          })),
-        ];
+        // Build options: only published versions (no draft version 0)
+        const options = versions.map((version) => ({
+          label: version.version_name,
+          value: version.version_no,
+        }));
 
         return (
           <Select
-            placeholder={t("agent.version.current")}
+            placeholder={t("agent.version.select")}
             value={selectedVersionNo}
             loading={isLoading}
             onDropdownVisibleChange={(open) => handleVersionDropdownOpen(agentId, open)}
@@ -446,7 +460,10 @@ export default function AgentList({ tenantId }: { tenantId: string | null }) {
               name="display_name"
               label={t("agent.displayName")}
             >
-              <Input placeholder={t("agent.displayNamePlaceholder")} readOnly />
+              <Input
+                placeholder={t("agent.displayName")}
+                readOnly
+              />
             </Form.Item>
 
             <Form.Item
@@ -461,7 +478,7 @@ export default function AgentList({ tenantId }: { tenantId: string | null }) {
                   <div style={{ position: "relative" }}>
                     <TextArea
                       value={form.getFieldValue("description")}
-                      placeholder={t("agent.descriptionPlaceholder")}
+                      placeholder={t("agent.description")}
                       autoSize={{ minRows: 4, maxRows: 6 }}
                       style={{ resize: "none", paddingRight: 32 }}
                       readOnly
@@ -496,7 +513,7 @@ export default function AgentList({ tenantId }: { tenantId: string | null }) {
                   <div style={{ position: "relative" }}>
                     <TextArea
                       value={form.getFieldValue("duty_prompt")}
-                      placeholder={t("agent.dutyPromptPlaceholder")}
+                      placeholder={t("systemPrompt.card.duty.title")}
                       autoSize={{ minRows: 5, maxRows: 8 }}
                       style={{ resize: "none", paddingRight: 32 }}
                       readOnly
@@ -531,7 +548,7 @@ export default function AgentList({ tenantId }: { tenantId: string | null }) {
                   <div style={{ position: "relative" }}>
                     <TextArea
                       value={form.getFieldValue("constraint_prompt")}
-                      placeholder={t("agent.constraintPromptPlaceholder")}
+                      placeholder={t("systemPrompt.card.constraint.title")}
                       autoSize={{ minRows: 5, maxRows: 8 }}
                       style={{ resize: "none", paddingRight: 32 }}
                       readOnly
@@ -566,7 +583,7 @@ export default function AgentList({ tenantId }: { tenantId: string | null }) {
                   <div style={{ position: "relative" }}>
                     <TextArea
                       value={form.getFieldValue("few_shots_prompt")}
-                      placeholder={t("agent.fewShotsPromptPlaceholder")}
+                      placeholder={t("systemPrompt.card.fewShots.title")}
                       autoSize={{ minRows: 5, maxRows: 8 }}
                       style={{ resize: "none", paddingRight: 32 }}
                       readOnly

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -298,6 +298,8 @@
   "agent.llmModel": "LLM Model",
   "agent.version": "Version",
   "agent.version.current": "Current Version",
+  "agent.version.select": "Select Version",
+  "agent.version.noPublished": "No Published Versions",
   "agent.status.unpublished": "Unpublished",
   "agent.unavailableReasons.duplicate_name": "Duplicate Agent Variable Name",
   "agent.unavailableReasons.duplicate_display_name": "Duplicate Agent Name",

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -300,6 +300,8 @@
   "agent.llmModel": "大语言模型",
   "agent.version": "版本",
   "agent.version.current": "当前版本",
+  "agent.version.select": "选择版本",
+  "agent.version.noPublished": "无已发布版本",
   "agent.status.unpublished": "未发布",
   "agent.unavailableReasons.duplicate_name": "智能体变量名重复",
   "agent.unavailableReasons.duplicate_display_name": "智能体名称重复",


### PR DESCRIPTION
🐛 Bugfix: Fix the agent version display in resource management page. #2490
[Specification Details]
1. The "Unreleased Agent Versions" section displays "No Released Versions," while "Released Agent Versions" provides a dropdown menu.
2. In the agent space, the permission of the agent is also used to determine whether the deletion operation can be performed.
[Test Result]
![53007825-2a75-47d6-85ed-add12112bb44](https://github.com/user-attachments/assets/4ed07d94-a262-4769-a565-368d2e43c02e)
![9a4c3eb2-96b7-4208-bcf1-06e079f49584](https://github.com/user-attachments/assets/aa1e744f-c1ca-4670-a1a3-bda77db4546f)
