### PR TITLE
🐛 Bugfix: prevent save modal from showing when selecting an agent for the first time

### DIFF
--- a/frontend/app/[locale]/agents/components/agentManage/AgentList.tsx
+++ b/frontend/app/[locale]/agents/components/agentManage/AgentList.tsx
@@ -97,10 +97,12 @@ export default function AgentList({
       return;
     }
 
-    // First check if there are unsaved changes BEFORE switching to new agent
-    const canSwitch = await checkUnsavedChanges.saveWithModal();
-    if (!canSwitch) {
-      return;
+    // Only guard when leaving an existing agent or exiting create mode
+    if (currentAgentId !== null || useAgentConfigStore.getState().isCreatingMode) {
+      const canSwitch = await checkUnsavedChanges.saveWithModal();
+      if (!canSwitch) {
+        return;
+      }
     }
 
     // Load agent detail and set as current


### PR DESCRIPTION
The saveWithModal guard was triggered unconditionally when clicking any agent, including the initial selection when no agent was being edited. Now it only fires when leaving an existing agent or exiting create mode.