### PR TITLE
✨File preview: Add file preview backend service

### DIFF
--- a/.github/workflows/auto-unit-test.yml
+++ b/.github/workflows/auto-unit-test.yml
@@ -48,6 +48,9 @@ jobs:
           uv pip install -e "../sdk[dev]"
           cd ..
 
+      - name: Install LibreOffice
+        run: sudo apt-get update && sudo apt-get install -y libreoffice
+
       - name: Run all tests and collect coverage
         run: |
           source backend/.venv/bin/activate && python test/run_all_test.py

--- a/backend/apps/data_process_app.py
+++ b/backend/apps/data_process_app.py
@@ -11,6 +11,7 @@ from consts.model import (
     ConvertStateRequest,
     TaskRequest,
 )
+from consts.exceptions import OfficeConversionException
 from data_process.tasks import process_and_forward, process_sync
 from services.data_process_service import get_data_process_service
 
@@ -310,4 +311,36 @@ async def convert_state(request: ConvertStateRequest):
         raise HTTPException(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
             detail=f"Error converting state: {str(e)}"
+        )
+
+
+@router.post("/convert_to_pdf")
+async def convert_office_to_pdf(
+        object_name: str = Form(...),
+        pdf_object_name: str = Form(...)
+):
+    """
+    Convert an Office document stored in MinIO to PDF.
+
+    Parameters:
+        object_name: Source Office file path in MinIO
+        pdf_object_name: Destination PDF path in MinIO
+    """
+    try:
+        await service.convert_office_to_pdf_impl(
+            object_name=object_name,
+            pdf_object_name=pdf_object_name,
+        )
+        return JSONResponse(status_code=HTTPStatus.OK, content={"success": True})
+    except OfficeConversionException as exc:
+        logger.error(f"Office conversion failed for '{object_name}': {exc}")
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail=str(exc)
+        )
+    except Exception as exc:
+        logger.error(f"Unexpected error during conversion for '{object_name}': {exc}")
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail=f"Office conversion failed: {exc}"
         )

--- a/backend/apps/file_management_app.py
+++ b/backend/apps/file_management_app.py
@@ -9,22 +9,29 @@ import httpx
 from fastapi import APIRouter, Body, File, Form, Header, HTTPException, Path as PathParam, Query, UploadFile
 from fastapi.responses import JSONResponse, RedirectResponse, StreamingResponse
 
+from consts.exceptions import FileTooLargeException, NotFoundException, OfficeConversionException, UnsupportedFileTypeException
 from consts.model import ProcessParams
 from services.file_management_service import upload_to_minio, upload_files_impl, \
-    get_file_url_impl, get_file_stream_impl, delete_file_impl, list_files_impl
+    get_file_url_impl, get_file_stream_impl, delete_file_impl, list_files_impl, \
+    preview_file_impl
 from utils.file_management_utils import trigger_data_process
 
 logger = logging.getLogger("file_management_app")
 
 
-def build_content_disposition_header(filename: Optional[str]) -> str:
+def build_content_disposition_header(filename: Optional[str], inline: bool = False) -> str:
     """
     Build a Content-Disposition header that keeps the original filename.
+
+    Args:
+        filename: Original filename to include in header
+        inline: If True, use 'inline' disposition (for preview); otherwise 'attachment' (for download)
 
     - ASCII filenames are returned directly.
     - Non-ASCII filenames include both an ASCII fallback and RFC 5987 encoded value
       so modern browsers keep the original name.
     """
+    disposition = "inline" if inline else "attachment"
     safe_name = (filename or "download").strip() or "download"
 
     def _sanitize_ascii(value: str) -> str:
@@ -40,26 +47,26 @@ def build_content_disposition_header(filename: Optional[str]) -> str:
 
     try:
         safe_name.encode("ascii")
-        return f'attachment; filename="{_sanitize_ascii(safe_name)}"'
+        return f'{disposition}; filename="{_sanitize_ascii(safe_name)}"'
     except UnicodeEncodeError:
         try:
             encoded = quote(safe_name, safe="")
         except Exception:
             # quote failure, fallback to sanitized ASCII only
             logger.warning("Failed to encode filename '%s', using fallback", safe_name)
-            return f'attachment; filename="{_sanitize_ascii(safe_name)}"'
+            return f'{disposition}; filename="{_sanitize_ascii(safe_name)}"'
 
         fallback = _sanitize_ascii(
             safe_name.encode("ascii", "ignore").decode("ascii") or "download"
         )
-        return f'attachment; filename="{fallback}"; filename*=UTF-8\'\'{encoded}'
+        return f'{disposition}; filename="{fallback}"; filename*=UTF-8\'\'{encoded}'
     except Exception as exc:  # pragma: no cover
         logger.warning(
             "Failed to encode filename '%s': %s. Using fallback.",
             safe_name,
             exc,
         )
-        return 'attachment; filename="download"'
+        return f'{disposition}; filename="download"'
 
 # Create API router
 file_management_runtime_router = APIRouter(prefix="/file")
@@ -567,3 +574,69 @@ async def get_storage_file_batch_urls(
         "failed_count": sum(1 for r in results if not r.get("success", False)),
         "results": results
     }
+
+@file_management_config_router.get("/preview/{object_name:path}")
+async def preview_file(
+    object_name: str = PathParam(..., description="File object name to preview"),
+    filename: Optional[str] = Query(None, description="Original filename for display (optional)")
+):
+    """
+    Preview file inline in browser 
+    
+    - **object_name**: File object name in storage
+    - **filename**: Original filename for Content-Disposition header (optional)
+    
+    Returns file stream with Content-Disposition: inline for browser preview
+    """
+    try:
+        # Get file stream from preview service
+        file_stream, content_type = await preview_file_impl(object_name=object_name)
+        
+        # Use provided filename or extract from object_name
+        display_filename = filename
+        if not display_filename:
+            display_filename = object_name.split("/")[-1] if "/" in object_name else object_name
+        
+        # Build Content-Disposition header for inline display
+        content_disposition = build_content_disposition_header(display_filename, inline=True)
+
+        return StreamingResponse(
+            file_stream,
+            media_type=content_type,
+            headers={
+                "Content-Disposition": content_disposition,
+                "Cache-Control": "public, max-age=3600",
+                "ETag": f'"{object_name}"',
+            }
+        )
+    
+    except FileTooLargeException as e:
+        logger.warning(f"[preview_file] File too large: object_name={object_name}, error={str(e)}")
+        raise HTTPException(
+            status_code=HTTPStatus.REQUEST_ENTITY_TOO_LARGE,
+            detail=str(e)
+        )
+    except NotFoundException as e:
+        logger.error(f"[preview_file] File not found: object_name={object_name}, error={str(e)}")
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND,
+            detail=f"File not found: {object_name}"
+        )
+    except UnsupportedFileTypeException as e:
+        logger.error(f"[preview_file] Unsupported file type: object_name={object_name}, error={str(e)}")
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail=f"File format not supported for preview: {str(e)}"
+        )
+    except OfficeConversionException as e:
+        logger.error(f"[preview_file] Conversion failed: object_name={object_name}, error={str(e)}")
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail=f"Failed to preview file: {str(e)}"
+        )
+    except Exception as e:
+        logger.error(f"[preview_file] Unexpected error: object_name={object_name}, error={str(e)}")
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail=f"Failed to preview file: {str(e)}"
+        )

--- a/backend/consts/const.py
+++ b/backend/consts/const.py
@@ -36,6 +36,21 @@ UPLOAD_FOLDER = os.getenv('UPLOAD_FOLDER', 'uploads')
 ROOT_DIR = os.getenv("ROOT_DIR")
 
 
+# Preview Configuration
+FILE_PREVIEW_SIZE_LIMIT = 100 * 1024 * 1024  # 100MB
+# Limit concurrent Office-to-PDF conversions
+MAX_CONCURRENT_CONVERSIONS = 5 
+# Supported Office file MIME types
+OFFICE_MIME_TYPES = [
+    'application/msword',  # .doc
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',  # .docx
+    'application/vnd.ms-excel',  # .xls
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',  # .xlsx
+    'application/vnd.ms-powerpoint',  # .ppt
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation'  # .pptx
+]
+
+
 # Supabase Configuration
 SUPABASE_URL = os.getenv('SUPABASE_URL')
 SUPABASE_KEY = os.getenv('SUPABASE_KEY')

--- a/backend/consts/exceptions.py
+++ b/backend/consts/exceptions.py
@@ -115,6 +115,21 @@ class IncorrectInviteCodeException(Exception):
     pass
 
 
+class OfficeConversionException(Exception):
+    """Raised when Office-to-PDF conversion via data-process service fails."""
+    pass
+
+
+class UnsupportedFileTypeException(Exception):
+    """Raised when a file type is not supported for the requested operation."""
+    pass
+
+
+class FileTooLargeException(Exception):
+    """Raised when a file exceeds the maximum allowed size for the requested operation."""
+    pass
+
+
 class UserRegistrationException(Exception):
     """Raised when user registration fails."""
     pass

--- a/backend/database/attachment_db.py
+++ b/backend/database/attachment_db.py
@@ -169,6 +169,42 @@ def get_file_size_from_minio(object_name: str, bucket: Optional[str] = None) -> 
     return minio_client.get_file_size(object_name, bucket)
 
 
+def file_exists(object_name: str, bucket: Optional[str] = None) -> bool:
+    """
+    Check if a file exists in the bucket.
+    
+    Args:
+        object_name: Object name in storage
+        bucket: Bucket name, if not specified will use default bucket
+        
+    Returns:
+        bool: True if file exists, False otherwise
+    """
+    try:
+        return minio_client.file_exists(object_name, bucket)
+    except Exception:
+        return False
+
+
+def copy_file(source_object: str, dest_object: str, bucket: Optional[str] = None) -> Dict[str, Any]:
+    """
+    Copy a file within the same bucket (atomic operation in MinIO).
+    
+    Args:
+        source_object: Source object name
+        dest_object: Destination object name
+        bucket: Bucket name, if not specified will use default bucket
+        
+    Returns:
+        Dict[str, Any]: Result containing success flag and error message (if any)
+    """
+    success, result = minio_client.copy_file(source_object, dest_object, bucket)
+    if success:
+        return {"success": True, "object_name": result}
+    else:
+        return {"success": False, "error": result}
+
+
 def list_files(prefix: str = "", bucket: Optional[str] = None) -> List[Dict[str, Any]]:
     """
     List files in bucket
@@ -269,6 +305,7 @@ def get_content_type(file_path: str) -> str:
                   '.pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
                   '.txt': 'text/plain',
                   '.csv': 'text/csv',
+                  '.md': 'text/markdown',
                   '.html': 'text/html',
                   '.htm': 'text/html',
                   '.json': 'application/json',

--- a/backend/database/client.py
+++ b/backend/database/client.py
@@ -213,6 +213,33 @@ class MinioClient:
         """
         return self._storage_client.get_file_stream(object_name, bucket)
 
+    def file_exists(self, object_name: str, bucket: Optional[str] = None) -> bool:
+        """
+        Check if file exists in MinIO
+
+        Args:
+            object_name: Object name
+            bucket: Bucket name, if not specified use default bucket
+
+        Returns:
+            bool: True if file exists, False otherwise
+        """
+        return self._storage_client.exists(object_name, bucket)
+
+    def copy_file(self, source_object: str, dest_object: str, bucket: Optional[str] = None) -> Tuple[bool, str]:
+        """
+        Copy a file within the same bucket (atomic operation)
+
+        Args:
+            source_object: Source object name
+            dest_object: Destination object name
+            bucket: Bucket name, if not specified use default bucket
+
+        Returns:
+            Tuple[bool, str]: (Success status, Destination object name or error message)
+        """
+        return self._storage_client.copy_file(source_object, dest_object, bucket)
+
 
 # Create global database and MinIO client instances
 db_client = PostgresClient()

--- a/backend/services/data_process_service.py
+++ b/backend/services/data_process_service.py
@@ -4,6 +4,7 @@ import concurrent.futures
 import io
 import logging
 import os
+import shutil
 import tempfile
 import threading
 import time
@@ -18,10 +19,16 @@ from celery import states, chain
 from transformers import CLIPProcessor, CLIPModel
 from nexent.data_process.core import DataProcessCore
 
-from consts.const import CLIP_MODEL_PATH, IMAGE_FILTER, REDIS_BACKEND_URL, REDIS_URL
+from consts.const import CLIP_MODEL_PATH, IMAGE_FILTER, MAX_CONCURRENT_CONVERSIONS, REDIS_BACKEND_URL, REDIS_URL
+from consts.exceptions import OfficeConversionException
 from consts.model import BatchTaskRequest
+from database.attachment_db import delete_file, file_exists, get_file_size_from_minio, get_file_stream, upload_file
+from utils.file_management_utils import convert_office_to_pdf
 from data_process.app import app as celery_app
 from data_process.tasks import process, forward
+
+# Limit concurrent LibreOffice processes to avoid resource exhaustion
+_conversion_semaphore = asyncio.Semaphore(MAX_CONCURRENT_CONVERSIONS)
 from data_process.utils import get_task_info, get_all_task_ids_from_redis
 
 # Configure logging
@@ -550,6 +557,81 @@ class DataProcessService:
             "processing_time": processing_time,
             "chunking_strategy": chunking_strategy
         }
+
+    async def convert_office_to_pdf_impl(self, object_name: str, pdf_object_name: str) -> None:
+        """Full conversion pipeline: download → convert → upload → validate → cleanup.
+
+        All five steps run inside data-process so that LibreOffice only needs to be
+        installed in this container.
+
+        Args:
+            object_name: Source Office file path in MinIO.
+            pdf_object_name: Destination PDF path in MinIO (final, not temp).
+        """
+        async with _conversion_semaphore:
+            temp_dir = None
+            try:
+                temp_dir = tempfile.mkdtemp(prefix='office_convert_')
+
+                # Step 1: Download original Office file from MinIO
+                original_stream = get_file_stream(object_name)
+                if original_stream is None:
+                    raise OfficeConversionException(f"Source file not found in storage: {object_name}")
+
+                original_filename = os.path.basename(object_name)
+                input_path = os.path.join(temp_dir, original_filename)
+                with open(input_path, 'wb') as f:
+                    while chunk := original_stream.read(8192):
+                        f.write(chunk)
+
+                # Step 2: Local conversion using LibreOffice
+                try:
+                    pdf_path = await convert_office_to_pdf(input_path, temp_dir, timeout=30)
+                except Exception as exc:
+                    raise OfficeConversionException(f"LibreOffice conversion failed: {exc}") from exc
+
+                # Step 3: Upload converted PDF to MinIO
+                result = upload_file(file_path=pdf_path, object_name=pdf_object_name)
+                if not result.get('success'):
+                    raise OfficeConversionException(
+                        f"Failed to upload PDF to MinIO: {result.get('error', 'Unknown error')}"
+                    )
+
+                # Step 4: Validate the uploaded PDF (header check + minimum size)
+                remote_size = get_file_size_from_minio(pdf_object_name)
+                if remote_size <= 0:
+                    raise OfficeConversionException("PDF validation failed: cannot read remote file size")
+                if remote_size < 100:
+                    raise OfficeConversionException(
+                        f"PDF validation failed: file too small ({remote_size} bytes)"
+                    )
+                remote_stream = get_file_stream(pdf_object_name)
+                if remote_stream is None:
+                    raise OfficeConversionException("PDF validation failed: cannot read uploaded file")
+                try:
+                    header = remote_stream.read(5)
+                finally:
+                    try:
+                        remote_stream.close()
+                    except Exception:
+                        pass
+                if not header.startswith(b'%PDF-'):
+                    raise OfficeConversionException("PDF validation failed: invalid PDF header")
+
+            except OfficeConversionException:
+                # Clean up any partially-uploaded remote PDF so a future retry starts clean
+                if file_exists(pdf_object_name):
+                    delete_file(pdf_object_name)
+                raise
+            except Exception as exc:
+                raise OfficeConversionException(f"Unexpected error during conversion: {exc}") from exc
+            finally:
+                # Step 5: Clean up local temporary directory
+                if temp_dir and os.path.exists(temp_dir):
+                    try:
+                        shutil.rmtree(temp_dir)
+                    except Exception as cleanup_err:
+                        logger.warning(f"Failed to cleanup temp dir '{temp_dir}': {cleanup_err}")
 
     def convert_celery_states_to_custom(self, process_celery_state: Optional[str], forward_celery_state: Optional[str]) -> str:
         """Map Celery task states to a custom frontend state string.

--- a/backend/services/file_management_service.py
+++ b/backend/services/file_management_service.py
@@ -1,20 +1,33 @@
 import asyncio
+import hashlib
 import logging
 import os
 from io import BytesIO
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
+import httpx
 from fastapi import UploadFile
 
-from consts.const import UPLOAD_FOLDER, MAX_CONCURRENT_UPLOADS, MODEL_CONFIG_MAPPING
+from consts.const import (
+    DATA_PROCESS_SERVICE,
+    FILE_PREVIEW_SIZE_LIMIT,
+    MAX_CONCURRENT_UPLOADS,
+    MODEL_CONFIG_MAPPING,
+    OFFICE_MIME_TYPES,
+    UPLOAD_FOLDER,
+)
+from consts.exceptions import FileTooLargeException, NotFoundException, OfficeConversionException, UnsupportedFileTypeException
 from database.attachment_db import (
-    upload_fileobj,
-    get_file_url,
-    get_content_type,
-    get_file_stream,
+    copy_file,
     delete_file,
-    list_files
+    file_exists,
+    get_content_type,
+    get_file_size_from_minio,
+    get_file_stream,
+    get_file_url,
+    list_files,
+    upload_fileobj,
 )
 from services.vectordatabase_service import ElasticSearchService, get_vector_db_core
 from utils.config_utils import tenant_config_manager, get_model_name_from_config
@@ -27,6 +40,10 @@ from nexent.core.models import OpenAILongContextModel
 upload_dir = Path(UPLOAD_FOLDER)
 upload_dir.mkdir(exist_ok=True)
 upload_semaphore = asyncio.Semaphore(MAX_CONCURRENT_UPLOADS)
+
+# Per-file locks prevent duplicate conversions of the same file
+_conversion_locks: dict[str, asyncio.Lock] = {}
+_conversion_locks_guard = asyncio.Lock()
 
 logger = logging.getLogger("file_management_service")
 
@@ -196,3 +213,132 @@ def get_llm_model(tenant_id: str):
         ssl_verify=main_model_config.get("ssl_verify", True),
     )
     return long_text_to_text_model
+
+
+async def preview_file_impl(object_name: str) -> Tuple[BytesIO, str]:
+    """
+    Preview a file by returning its contents as a stream.
+
+    Args:
+        object_name: File object name in storage
+
+    Returns:
+        Tuple[BytesIO, str]: (file_stream, content_type)
+    """
+    file_size = get_file_size_from_minio(object_name)
+    if file_size > FILE_PREVIEW_SIZE_LIMIT:
+        raise FileTooLargeException(
+            f"File size {file_size} bytes exceeds the {FILE_PREVIEW_SIZE_LIMIT // (1024 * 1024)} MB preview limit"
+        )
+
+    content_type = get_content_type(object_name)
+
+    # PDF, images, and text files - return directly
+    if content_type == 'application/pdf' or content_type.startswith('image/') or content_type in ['text/plain', 'text/csv', 'text/markdown']:
+        file_stream = get_file_stream(object_name)
+        if file_stream is None:
+            raise NotFoundException("File not found or failed to read from storage")
+        return file_stream, content_type
+
+    # Office documents - convert to PDF with caching
+    elif content_type in OFFICE_MIME_TYPES:
+        name_without_ext = object_name.rsplit('.', 1)[0] if '.' in object_name else object_name
+        hash_suffix = hashlib.md5(object_name.encode()).hexdigest()[:8]
+        pdf_object_name = f"converted/{name_without_ext}_{hash_suffix}.pdf"
+        temp_pdf_object_name = f"converting/{name_without_ext}_{hash_suffix}.pdf.tmp"
+
+        # Fast path: return from cache without acquiring any lock
+        cached_stream = _get_cached_pdf_stream(pdf_object_name)
+        if cached_stream is not None:
+            return cached_stream, 'application/pdf'
+
+        # Slow path: convert with locking
+        file_stream = await _convert_office_to_cached_pdf(object_name, pdf_object_name, temp_pdf_object_name)
+        return file_stream, 'application/pdf'
+
+    # Unsupported file type
+    else:
+        raise UnsupportedFileTypeException(f"Unsupported file type for preview: {content_type}")
+
+
+def _get_cached_pdf_stream(pdf_object_name: str) -> Optional[BytesIO]:
+    """
+    Return the cached PDF stream if available, or None if missing or corrupted.
+
+    If the file exists but cannot be read, the corrupted entry is deleted so
+    a subsequent call will trigger a fresh conversion.
+    """
+    if file_exists(pdf_object_name):
+        file_stream = get_file_stream(pdf_object_name)
+        if file_stream is None:
+            logger.warning(f"Corrupted cache detected (cannot read), deleting: {pdf_object_name}")
+            delete_file(pdf_object_name)
+            return None
+        return file_stream
+    return None
+
+
+async def _convert_office_to_cached_pdf(
+    object_name: str,
+    pdf_object_name: str,
+    temp_pdf_object_name: str,
+) -> BytesIO:
+    """
+    Convert an Office document to PDF and store the result in MinIO.
+
+    Args:
+        object_name: Source Office file path in MinIO
+        pdf_object_name: Final cached PDF path in MinIO
+        temp_pdf_object_name: Temporary PDF path used during conversion
+
+    Returns:
+        BytesIO stream of the converted PDF
+    """
+    # Get or create a lock for this specific file to prevent duplicate conversions
+    async with _conversion_locks_guard:
+        if object_name not in _conversion_locks:
+            _conversion_locks[object_name] = asyncio.Lock()
+        file_lock = _conversion_locks[object_name]
+
+    async with file_lock:
+        # Double-check: another request may have completed the conversion while we waited
+        cached_stream = _get_cached_pdf_stream(pdf_object_name)
+        if cached_stream is not None:
+            return cached_stream
+
+        # Conversion semaphore is enforced inside the data-process service
+        try:
+            # Request conversion: data-process downloads, converts, uploads to temp path, validates
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                response = await client.post(
+                    f"{DATA_PROCESS_SERVICE}/tasks/convert_to_pdf",
+                    data={
+                        "object_name": object_name,
+                        "pdf_object_name": temp_pdf_object_name,
+                    },
+                )
+            if response.status_code != 200:
+                raise Exception(
+                    f"data-process conversion returned {response.status_code}: {response.text}"
+                )
+
+            # Atomic move from temp to final location, then clean up temp
+            copy_result = copy_file(source_object=temp_pdf_object_name, dest_object=pdf_object_name)
+            if not copy_result.get('success'):
+                raise Exception(f"Failed to finalize PDF cache: {copy_result.get('error', 'Unknown error')}")
+            delete_file(temp_pdf_object_name)
+
+        except Exception as e:
+            if file_exists(temp_pdf_object_name):
+                delete_file(temp_pdf_object_name)
+            logger.error(f"Office conversion failed: {str(e)}")
+            raise OfficeConversionException(f"Failed to convert Office document to PDF: {str(e)}") from e
+
+    # Clean up the file lock (prevents memory leak for many unique files)
+    async with _conversion_locks_guard:
+        _conversion_locks.pop(object_name, None)
+
+    file_stream = get_file_stream(pdf_object_name)
+    if file_stream is None:
+        raise NotFoundException("Converted PDF not found or failed to read from storage")
+    return file_stream

--- a/backend/utils/file_management_utils.py
+++ b/backend/utils/file_management_utils.py
@@ -1,5 +1,7 @@
+import asyncio
 import logging
 import os
+import subprocess
 import traceback
 from pathlib import Path
 from typing import List
@@ -336,4 +338,67 @@ def get_file_size(source_type: str, path_or_url: str) -> int:
     except Exception as e:
         logging.error(f"Error getting file size for {path_or_url}: {str(e)}")
         return 0
+
+
+async def convert_office_to_pdf(input_path: str, output_dir: str, timeout: int = 30) -> str:
+    """
+    Convert Office document to PDF using LibreOffice.
+    
+    Args:
+        input_path: Path to input Office file
+        output_dir: Directory for output PDF file
+        timeout: Conversion timeout in seconds (default: 30s)
+        
+    Returns:
+        str: Path to generated PDF file
+    """
+    if not os.path.exists(input_path):
+        raise FileNotFoundError(f"Input file not found: {input_path}")
+
+    def _run_libreoffice_conversion():
+        """Synchronous LibreOffice conversion to run in thread executor."""
+        cmd = [
+            'libreoffice',
+            '--headless',
+            '--convert-to', 'pdf',
+            '--outdir', output_dir,
+            input_path
+        ]
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout
+        )
+    
+    try:
+        # Run blocking subprocess in thread executor to avoid blocking event loop
+        result = await asyncio.to_thread(_run_libreoffice_conversion)
+        
+        if result.returncode != 0:
+            error_msg = result.stderr or result.stdout or "Unknown conversion error"
+            logger.error(f"LibreOffice conversion failed: {error_msg}")
+            raise RuntimeError(f"Office to PDF conversion failed: {error_msg}")
+        
+        # Find generated PDF file
+        input_filename = os.path.basename(input_path)
+        pdf_filename = os.path.splitext(input_filename)[0] + '.pdf'
+        pdf_path = os.path.join(output_dir, pdf_filename)
+        
+        if not os.path.exists(pdf_path):
+            raise RuntimeError(f"Converted PDF not found: {pdf_path}")
+        
+        return pdf_path
+        
+    except subprocess.TimeoutExpired:
+        logger.error(f"Office to PDF conversion timeout after {timeout}s: {input_path}")
+        raise TimeoutError(f"Office to PDF conversion timeout (>{timeout}s)")
+        
+    except FileNotFoundError as e:
+        # LibreOffice executable not found in PATH
+        logger.error(f"LibreOffice not available: {str(e)}")
+        raise FileNotFoundError(
+            "LibreOffice is not installed or not available in PATH. "
+        ) from e
+
 

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -272,6 +272,7 @@ services:
         mc admin policy attach myadmin readwrite --user=$MINIO_ACCESS_KEY
         mc mb myadmin/$MINIO_DEFAULT_BUCKET
         mc anonymous set download myadmin/$MINIO_DEFAULT_BUCKET
+        mc ilm rule add myadmin/$MINIO_DEFAULT_BUCKET --prefix 'converted/' --expiry-days 7 --id expire-converted-pdfs
         wait $$MINIO_PID
       "
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -298,6 +298,7 @@ services:
         mc admin policy attach myadmin readwrite --user=$MINIO_ACCESS_KEY
         mc mb myadmin/$MINIO_DEFAULT_BUCKET
         mc anonymous set download myadmin/$MINIO_DEFAULT_BUCKET
+        mc ilm rule add myadmin/$MINIO_DEFAULT_BUCKET --prefix 'converted/' --expiry-days 7 --id expire-converted-pdfs
         wait $$MINIO_PID
       "
 

--- a/make/data_process/Dockerfile
+++ b/make/data_process/Dockerfile
@@ -24,6 +24,9 @@ RUN apt-get update && \
         libreoffice \
         libgl1 \
         coreutils \
+        fontconfig \
+        fonts-noto-cjk \
+    && fc-cache -fv \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/sdk/nexent/storage/minio.py
+++ b/sdk/nexent/storage/minio.py
@@ -396,3 +396,35 @@ class MinIOStorageClient(StorageClient):
         except ClientError:
             return False
 
+    def copy_file(
+        self,
+        source_object: str,
+        dest_object: str,
+        bucket: Optional[str] = None
+    ) -> Tuple[bool, str]:
+        """
+        Copy a file within the same bucket.
+
+        Args:
+            source_object: Source object name
+            dest_object: Destination object name
+            bucket: Bucket name, if not specified use default bucket
+
+        Returns:
+            Tuple[bool, str]: (Success status, Destination object name or error message)
+        """
+        bucket = bucket or self.default_bucket
+        if bucket is None:
+            return False, "Bucket name is required"
+
+        try:
+            copy_source = {"Bucket": bucket, "Key": source_object}
+            self.client.copy_object(
+                Bucket=bucket,
+                Key=dest_object,
+                CopySource=copy_source
+            )
+            return True, dest_object
+        except Exception as e:
+            logger.error(f"Failed to copy object {source_object} to {dest_object}: {e}")
+            return False, str(e)

--- a/sdk/nexent/storage/storage_client_base.py
+++ b/sdk/nexent/storage/storage_client_base.py
@@ -217,3 +217,25 @@ class StorageClient(ABC):
         """
         pass
 
+    @abstractmethod
+    def copy_file(
+        self,
+        source_object: str,
+        dest_object: str,
+        bucket: Optional[str] = None
+    ) -> Tuple[bool, str]:
+        """
+        Copy a file within the same bucket.
+
+        Args:
+            source_object: Source object name
+            dest_object: Destination object name
+            bucket: Bucket name, if not specified use default bucket
+
+        Returns:
+            Tuple[bool, str]: (Success status, Destination object name or error message)
+        """
+        pass
+
+ 
+

--- a/test/backend/app/test_data_process_app.py
+++ b/test/backend/app/test_data_process_app.py
@@ -8,6 +8,18 @@ from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
 
+# Install consts.exceptions at module level so OfficeConversionException is bound
+# in the app module's namespace on first import.
+_exc_mod = types.ModuleType("consts.exceptions")
+
+
+class _OfficeConversionException(Exception):
+    """Stub exception for Office document conversion failures."""
+
+
+_exc_mod.OfficeConversionException = _OfficeConversionException  # type: ignore[attr-defined]
+sys.modules["consts.exceptions"] = _exc_mod
+
 
 class _TaskRequest(BaseModel):
     source: str
@@ -135,6 +147,14 @@ class _ServiceStub:
         if process_celery_state == "SUCCESS" and forward_celery_state == "SUCCESS":
             return "COMPLETED"
         return "WAIT_FOR_PROCESSING"
+
+    async def convert_office_to_pdf_impl(self, object_name: str, pdf_object_name: str) -> None:
+        """Stub: raise OfficeConversionException for sentinel inputs, otherwise succeed."""
+        from consts.exceptions import OfficeConversionException
+        if object_name == "fail.docx":
+            raise OfficeConversionException("conversion failed")
+        if object_name == "err.docx":
+            raise RuntimeError("unexpected error")
 
 
 @pytest.fixture(autouse=True)
@@ -451,3 +471,47 @@ def test_convert_state_http_exception(monkeypatch):
     resp = client.post("/tasks/convert_state",
                        json={"process_state": "PENDING", "forward_state": ""})
     assert resp.status_code == HTTPStatus.NOT_ACCEPTABLE
+
+
+def test_convert_to_pdf_success():
+    """Valid request returns 200 {success: True}."""
+    app = _build_app()
+    client = TestClient(app)
+    resp = client.post(
+        "/tasks/convert_to_pdf",
+        data={"object_name": "uploads/doc.docx", "pdf_object_name": "converted/doc.pdf"},
+    )
+    assert resp.status_code == HTTPStatus.OK
+    assert resp.json()["success"] is True
+
+
+def test_convert_to_pdf_office_conversion_exception(monkeypatch):
+    """OfficeConversionException from service maps to HTTP 500."""
+    app = _build_app()
+    client = TestClient(app)
+    # Trigger the sentinel path in _ServiceStub
+    resp = client.post(
+        "/tasks/convert_to_pdf",
+        data={"object_name": "fail.docx", "pdf_object_name": "converted/fail.pdf"},
+    )
+    assert resp.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+    assert "conversion failed" in resp.json()["detail"]
+
+
+def test_convert_to_pdf_unexpected_exception():
+    """Unexpected RuntimeError from service also maps to HTTP 500."""
+    app = _build_app()
+    client = TestClient(app)
+    resp = client.post(
+        "/tasks/convert_to_pdf",
+        data={"object_name": "err.docx", "pdf_object_name": "converted/err.pdf"},
+    )
+    assert resp.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+
+
+def test_convert_to_pdf_missing_params():
+    """Missing required form fields returns HTTP 422 Unprocessable Entity."""
+    app = _build_app()
+    client = TestClient(app)
+    resp = client.post("/tasks/convert_to_pdf", data={})
+    assert resp.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/test/backend/app/test_file_management_app.py
+++ b/test/backend/app/test_file_management_app.py
@@ -55,6 +55,12 @@ async def _stub_preprocess_files_generator(*_: Any, **__: Any) -> AsyncGenerator
     yield "data: {\"type\": \"progress\", \"progress\": 0}\n\n"
     yield "data: {\"type\": \"complete\", \"progress\": 100}\n\n"
 
+async def _stub_preview_file_impl(object_name: str):
+    """Default stub for preview_file_impl"""
+    from io import BytesIO
+    return BytesIO(b"PDF content"), "application/pdf"
+
+sfms_stub.preview_file_impl = _stub_preview_file_impl
 sfms_stub.upload_to_minio = _stub_upload_to_minio
 sfms_stub.upload_files_impl = _stub_upload_files_impl
 sfms_stub.get_file_url_impl = _stub_get_file_url_impl
@@ -101,8 +107,19 @@ class ProcessParams:  # minimal stub
         self.index_name = index_name
         self.authorization = authorization
 model_stub.ProcessParams = ProcessParams
-sys.modules["consts.model"] = model_stub
+sys.modules.setdefault("consts.model", model_stub)
 setattr(consts_pkg, "model", model_stub)
+
+# Stub consts.exceptions with real exception classes so isinstance checks work
+exceptions_stub = types.ModuleType("consts.exceptions")
+class NotFoundException(Exception): pass
+class OfficeConversionException(Exception): pass
+class UnsupportedFileTypeException(Exception): pass
+exceptions_stub.NotFoundException = NotFoundException
+exceptions_stub.OfficeConversionException = OfficeConversionException
+exceptions_stub.UnsupportedFileTypeException = UnsupportedFileTypeException
+sys.modules["consts.exceptions"] = exceptions_stub
+setattr(consts_pkg, "exceptions", exceptions_stub)
 
 
 # Import the module under test after stubbing deps
@@ -442,6 +459,40 @@ def test_build_content_disposition_header_exception_handling(monkeypatch):
     result = file_management_app.build_content_disposition_header("测试.pdf")
     assert 'attachment; filename=' in result
     assert 'filename*=UTF-8' not in result
+
+
+def test_build_content_disposition_header_inline_ascii():
+    """Test build_content_disposition_header with inline=True for ASCII filename"""
+    result = file_management_app.build_content_disposition_header("test.pdf", inline=True)
+    assert result == 'inline; filename="test.pdf"'
+    assert 'attachment' not in result
+
+
+def test_build_content_disposition_header_inline_non_ascii():
+    """Test build_content_disposition_header with inline=True for non-ASCII filename"""
+    result = file_management_app.build_content_disposition_header("测试文档.pdf", inline=True)
+    assert 'inline; filename=' in result
+    assert 'attachment' not in result
+    assert 'filename*=UTF-8' in result
+
+
+def test_build_content_disposition_header_inline_false_explicit():
+    """Test build_content_disposition_header with inline=False explicitly"""
+    result = file_management_app.build_content_disposition_header("test.pdf", inline=False)
+    assert result == 'attachment; filename="test.pdf"'
+    assert 'inline' not in result
+
+
+def test_build_content_disposition_header_inline_exception_handling(monkeypatch):
+    """Test build_content_disposition_header inline mode exception handling"""
+    def boom(_value: str, safe: str = "") -> str:
+        raise RuntimeError("quote failure")
+
+    monkeypatch.setattr("backend.apps.file_management_app.quote", boom)
+
+    result = file_management_app.build_content_disposition_header("中文.pdf", inline=True)
+    assert 'inline; filename=' in result
+    assert 'attachment' not in result
 
 
 # --- Tests for get_storage_file with filename parameter ---
@@ -870,5 +921,236 @@ def test_build_datamate_url_from_parts_empty_base_url():
     with pytest.raises(Exception) as ei:
         file_management_app._build_datamate_url_from_parts("", "123", "456")
     assert "base_url is required" in str(ei.value)
+
+
+# --- Tests for preview_file endpoint ---
+
+@pytest.mark.asyncio
+async def test_preview_file_pdf_success(monkeypatch):
+    """Test previewing a PDF file returns StreamingResponse with inline disposition"""
+    from io import BytesIO
+    
+    async def fake_preview(object_name):
+        return BytesIO(b"PDF content"), "application/pdf"
+    
+    monkeypatch.setattr(file_management_app, "preview_file_impl", fake_preview)
+    
+    resp = await file_management_app.preview_file(
+        object_name="documents/test.pdf",
+        filename="test.pdf"
+    )
+    
+    assert resp.media_type == "application/pdf"
+    content_disposition = resp.headers.get("content-disposition", "")
+    assert "inline" in content_disposition
+    assert "test.pdf" in content_disposition
+    assert resp.headers.get("cache-control") == "public, max-age=3600"
+
+
+@pytest.mark.asyncio
+async def test_preview_file_image_success(monkeypatch):
+    """Test previewing an image file returns correct content type"""
+    from io import BytesIO
+    
+    async def fake_preview(object_name):
+        return BytesIO(b"PNG image data"), "image/png"
+    
+    monkeypatch.setattr(file_management_app, "preview_file_impl", fake_preview)
+    
+    resp = await file_management_app.preview_file(
+        object_name="images/photo.png",
+        filename="photo.png"
+    )
+    
+    assert resp.media_type == "image/png"
+    content_disposition = resp.headers.get("content-disposition", "")
+    assert "inline" in content_disposition
+
+
+@pytest.mark.asyncio
+async def test_preview_file_text_success(monkeypatch):
+    """Test previewing a text file returns correct content type"""
+    from io import BytesIO
+    
+    async def fake_preview(object_name):
+        return BytesIO(b"Hello World"), "text/plain"
+    
+    monkeypatch.setattr(file_management_app, "preview_file_impl", fake_preview)
+    
+    resp = await file_management_app.preview_file(
+        object_name="files/readme.txt",
+        filename="readme.txt"
+    )
+    
+    assert resp.media_type == "text/plain"
+    content_disposition = resp.headers.get("content-disposition", "")
+    assert "inline" in content_disposition
+
+
+@pytest.mark.asyncio
+async def test_preview_file_without_filename_extracts_from_path(monkeypatch):
+    """Test previewing without filename parameter extracts name from object_name"""
+    from io import BytesIO
+    
+    async def fake_preview(object_name):
+        return BytesIO(b"PDF content"), "application/pdf"
+    
+    monkeypatch.setattr(file_management_app, "preview_file_impl", fake_preview)
+    
+    resp = await file_management_app.preview_file(
+        object_name="folder/subfolder/document.pdf",
+        filename=None
+    )
+    
+    content_disposition = resp.headers.get("content-disposition", "")
+    assert "document.pdf" in content_disposition
+
+
+@pytest.mark.asyncio
+async def test_preview_file_chinese_filename(monkeypatch):
+    """Test previewing with Chinese filename uses UTF-8 encoding"""
+    from io import BytesIO
+    
+    async def fake_preview(object_name):
+        return BytesIO(b"PDF content"), "application/pdf"
+    
+    monkeypatch.setattr(file_management_app, "preview_file_impl", fake_preview)
+    
+    resp = await file_management_app.preview_file(
+        object_name="documents/test.pdf",
+        filename="测试文档.pdf"
+    )
+    
+    content_disposition = resp.headers.get("content-disposition", "")
+    assert "inline" in content_disposition
+    assert "filename*=UTF-8" in content_disposition or "测试文档" in content_disposition
+
+
+@pytest.mark.asyncio
+async def test_preview_file_not_found_error(monkeypatch):
+    """Test previewing a non-existent file returns 404"""
+    async def fake_preview(object_name):
+        raise Exception("File not found")
+    
+    monkeypatch.setattr(file_management_app, "preview_file_impl", fake_preview)
+    
+    with pytest.raises(Exception) as ei:
+        await file_management_app.preview_file(
+            object_name="nonexistent/file.pdf",
+            filename=None
+        )
+    assert "File not found" in str(ei.value)
+
+
+@pytest.mark.asyncio
+async def test_preview_file_unsupported_format_error(monkeypatch):
+    """Test previewing an unsupported file format returns 400"""
+    _UnsupportedFileTypeException = sys.modules["consts.exceptions"].UnsupportedFileTypeException
+
+    async def fake_preview(object_name):
+        raise _UnsupportedFileTypeException("Unsupported file format for preview")
+
+    monkeypatch.setattr(file_management_app, "preview_file_impl", fake_preview)
+    
+    with pytest.raises(Exception) as ei:
+        await file_management_app.preview_file(
+            object_name="files/archive.zip",
+            filename=None
+        )
+    assert "not supported for preview" in str(ei.value)
+
+
+@pytest.mark.asyncio
+async def test_preview_file_internal_error(monkeypatch):
+    """Test previewing with internal error returns 500"""
+    async def fake_preview(object_name):
+        raise Exception("Internal server error")
+    
+    monkeypatch.setattr(file_management_app, "preview_file_impl", fake_preview)
+    
+    with pytest.raises(Exception) as ei:
+        await file_management_app.preview_file(
+            object_name="files/test.pdf",
+            filename=None
+        )
+    assert "Failed to preview file" in str(ei.value)
+
+
+@pytest.mark.asyncio
+async def test_preview_file_office_converted_to_pdf(monkeypatch):
+    """Test previewing an Office document returns converted PDF"""
+    from io import BytesIO
+    
+    async def fake_preview(object_name):
+        # Office documents are converted to PDF by preview_file_impl
+        return BytesIO(b"Converted PDF content"), "application/pdf"
+    
+    monkeypatch.setattr(file_management_app, "preview_file_impl", fake_preview)
+    
+    resp = await file_management_app.preview_file(
+        object_name="documents/report.docx",
+        filename="report.docx"
+    )
+    
+    # Content type should be PDF after conversion
+    assert resp.media_type == "application/pdf"
+    content_disposition = resp.headers.get("content-disposition", "")
+    assert "inline" in content_disposition
+
+
+@pytest.mark.asyncio
+async def test_preview_file_has_etag_header(monkeypatch):
+    """Test preview response includes ETag header for caching"""
+    from io import BytesIO
+    
+    async def fake_preview(object_name):
+        return BytesIO(b"PDF content"), "application/pdf"
+    
+    monkeypatch.setattr(file_management_app, "preview_file_impl", fake_preview)
+    
+    resp = await file_management_app.preview_file(
+        object_name="documents/test.pdf",
+        filename="test.pdf"
+    )
+    
+    etag = resp.headers.get("etag", "")
+    assert "documents/test.pdf" in etag
+
+
+@pytest.mark.asyncio
+async def test_preview_file_simple_object_name_without_slash(monkeypatch):
+    """Test previewing with simple object name without slash"""
+    from io import BytesIO
+    
+    async def fake_preview(object_name):
+        return BytesIO(b"PDF content"), "application/pdf"
+    
+    monkeypatch.setattr(file_management_app, "preview_file_impl", fake_preview)
+    
+    resp = await file_management_app.preview_file(
+        object_name="simple.pdf",
+        filename=None
+    )
+    
+    content_disposition = resp.headers.get("content-disposition", "")
+    assert "simple.pdf" in content_disposition
+
+
+@pytest.mark.asyncio
+async def test_preview_file_does_not_exist_error(monkeypatch):
+    """Test previewing with 'does not exist' error message returns 404"""
+    _NotFoundException = sys.modules["consts.exceptions"].NotFoundException
+
+    async def fake_preview(object_name):
+        raise _NotFoundException("The specified key does not exist")
+
+    monkeypatch.setattr(file_management_app, "preview_file_impl", fake_preview)
+    
+    with pytest.raises(Exception) as ei:
+        await file_management_app.preview_file(
+            object_name="missing/file.pdf",
+            filename=None
+        )
+    assert "File not found" in str(ei.value)
 
 

--- a/test/backend/database/test_attachment_db.py
+++ b/test/backend/database/test_attachment_db.py
@@ -26,6 +26,14 @@ sys.modules['consts.const'] = consts_mock.const
 boto3_mock = MagicMock()
 sys.modules['boto3'] = boto3_mock
 
+# Mock minio module
+minio_mock = MagicMock()
+minio_commonconfig_mock = MagicMock()
+minio_commonconfig_mock.CopySource = MagicMock()
+minio_mock.commonconfig = minio_commonconfig_mock
+sys.modules['minio'] = minio_mock
+sys.modules['minio.commonconfig'] = minio_commonconfig_mock
+
 # Mock nexent.storage modules
 nexent_mock = MagicMock()
 nexent_storage_mock = MagicMock()
@@ -58,6 +66,8 @@ with patch('backend.database.attachment_db.minio_client', minio_client_mock):
         download_file,
         get_file_url,
         get_file_size_from_minio,
+        file_exists,
+        copy_file,
         list_files,
         delete_file,
         get_file_stream,
@@ -484,4 +494,83 @@ class TestGetContentType:
         assert get_content_type('test.JPG') == 'image/jpeg'
         assert get_content_type('test.PNG') == 'image/png'
         assert get_content_type('test.PDF') == 'application/pdf'
+
+
+class TestFileExists:
+    """Test cases for file_exists function"""
+
+    def test_file_exists_returns_true_when_file_exists(self):
+        """Test file_exists returns True when file exists in bucket"""
+        with patch('backend.database.attachment_db.minio_client') as mock_client:
+            mock_client.file_exists.return_value = True
+            
+            result = file_exists('test/file.txt')
+            
+            assert result is True
+            mock_client.file_exists.assert_called_once_with('test/file.txt', None)
+
+    def test_file_exists_returns_false_when_file_not_exists(self):
+        """Test file_exists returns False when file does not exist"""
+        with patch('backend.database.attachment_db.minio_client') as mock_client:
+            mock_client.file_exists.return_value = False
+            
+            result = file_exists('nonexistent/file.txt')
+            
+            assert result is False
+            mock_client.file_exists.assert_called_once_with('nonexistent/file.txt', None)
+
+    def test_file_exists_with_custom_bucket(self):
+        """Test file_exists with custom bucket parameter"""
+        with patch('backend.database.attachment_db.minio_client') as mock_client:
+            mock_client.file_exists.return_value = True
+            
+            result = file_exists('test/file.txt', bucket='custom-bucket')
+            
+            assert result is True
+            mock_client.file_exists.assert_called_once_with('test/file.txt', 'custom-bucket')
+
+    def test_file_exists_handles_any_exception(self):
+        """Test file_exists handles any exception and returns False"""
+        with patch('backend.database.attachment_db.minio_client') as mock_client:
+            mock_client.file_exists.side_effect = RuntimeError('Connection failed')
+            
+            result = file_exists('test/file.txt')
+            
+            assert result is False
+            mock_client.file_exists.assert_called_once_with('test/file.txt', None)
+
+
+class TestCopyFile:
+    """Test cases for copy_file function"""
+
+    def test_copy_file_success(self):
+        """Test successful file copy"""
+        with patch('backend.database.attachment_db.minio_client') as mock_client:
+            mock_client.copy_file.return_value = (True, 'dest/file.pdf')
+            
+            result = copy_file('source/file.pdf', 'dest/file.pdf')
+            
+            assert result['success'] is True
+            assert result['object_name'] == 'dest/file.pdf'
+            mock_client.copy_file.assert_called_once_with('source/file.pdf', 'dest/file.pdf', None)
+
+    def test_copy_file_with_custom_bucket(self):
+        """Test copy_file with custom bucket"""
+        with patch('backend.database.attachment_db.minio_client') as mock_client:
+            mock_client.copy_file.return_value = (True, 'dest/file.pdf')
+            
+            result = copy_file('source/file.pdf', 'dest/file.pdf', bucket='custom-bucket')
+            
+            assert result['success'] is True
+            mock_client.copy_file.assert_called_once_with('source/file.pdf', 'dest/file.pdf', 'custom-bucket')
+
+    def test_copy_file_failure(self):
+        """Test copy_file handles errors"""
+        with patch('backend.database.attachment_db.minio_client') as mock_client:
+            mock_client.copy_file.return_value = (False, 'Copy failed')
+            
+            result = copy_file('source/file.pdf', 'dest/file.pdf')
+            
+            assert result['success'] is False
+            assert 'Copy failed' in result['error']
 

--- a/test/backend/database/test_client.py
+++ b/test/backend/database/test_client.py
@@ -346,6 +346,107 @@ class TestMinioClient:
         mock_storage_client.get_file_stream.assert_called_once_with(
             'file.txt', 'bucket')
 
+    @patch('backend.database.client.create_storage_client_from_config')
+    @patch('backend.database.client.MinIOStorageConfig')
+    def test_minio_client_file_exists_true(self, mock_config_class, mock_create_client):
+        """Test MinioClient.file_exists returns True when file exists"""
+        MinioClient._instance = None
+
+        mock_storage_client = MagicMock()
+        mock_storage_client.exists.return_value = True
+        mock_create_client.return_value = mock_storage_client
+        mock_config_class.return_value = MagicMock()
+
+        client = MinioClient()
+        result = client.file_exists('file.txt', 'bucket')
+
+        assert result is True
+        mock_storage_client.exists.assert_called_once_with('file.txt', 'bucket')
+
+    @patch('backend.database.client.create_storage_client_from_config')
+    @patch('backend.database.client.MinIOStorageConfig')
+    def test_minio_client_file_exists_false(self, mock_config_class, mock_create_client):
+        """Test MinioClient.file_exists returns False when file does not exist"""
+        MinioClient._instance = None
+
+        mock_storage_client = MagicMock()
+        mock_storage_client.exists.return_value = False
+        mock_create_client.return_value = mock_storage_client
+        mock_config_class.return_value = MagicMock()
+
+        client = MinioClient()
+        result = client.file_exists('file.txt', 'bucket')
+
+        assert result is False
+        mock_storage_client.exists.assert_called_once_with('file.txt', 'bucket')
+
+    @patch('backend.database.client.create_storage_client_from_config')
+    @patch('backend.database.client.MinIOStorageConfig')
+    def test_minio_client_copy_file_success(self, mock_config_class, mock_create_client):
+        """Test MinioClient.copy_file successfully copies file"""
+        MinioClient._instance = None
+
+        mock_storage_client = MagicMock()
+        mock_storage_client.copy_file.return_value = (True, 'dest/file.pdf')
+        mock_create_client.return_value = mock_storage_client
+        mock_config = MagicMock()
+        mock_config.default_bucket = 'test-bucket'
+        mock_config_class.return_value = mock_config
+
+        client = MinioClient()
+        success, result = client.copy_file('source/file.pdf', 'dest/file.pdf', 'bucket')
+
+        assert success is True
+        assert result == 'dest/file.pdf'
+        mock_storage_client.copy_file.assert_called_once_with(
+            'source/file.pdf',
+            'dest/file.pdf',
+            'bucket'
+        )
+
+    @patch('backend.database.client.create_storage_client_from_config')
+    @patch('backend.database.client.MinIOStorageConfig')
+    def test_minio_client_copy_file_with_default_bucket(self, mock_config_class, mock_create_client):
+        """Test MinioClient.copy_file uses default bucket when not specified"""
+        MinioClient._instance = None
+
+        mock_storage_client = MagicMock()
+        mock_storage_client.copy_file.return_value = (True, 'dest/file.pdf')
+        mock_create_client.return_value = mock_storage_client
+        mock_config = MagicMock()
+        mock_config.default_bucket = 'default-bucket'
+        mock_config_class.return_value = mock_config
+
+        client = MinioClient()
+        success, result = client.copy_file('source/file.pdf', 'dest/file.pdf')
+
+        assert success is True
+        assert result == 'dest/file.pdf'
+        mock_storage_client.copy_file.assert_called_once_with(
+            'source/file.pdf',
+            'dest/file.pdf',
+            None
+        )
+
+    @patch('backend.database.client.create_storage_client_from_config')
+    @patch('backend.database.client.MinIOStorageConfig')
+    def test_minio_client_copy_file_failure(self, mock_config_class, mock_create_client):
+        """Test MinioClient.copy_file handles errors properly"""
+        MinioClient._instance = None
+
+        mock_storage_client = MagicMock()
+        mock_storage_client.copy_file.return_value = (False, 'Copy failed')
+        mock_create_client.return_value = mock_storage_client
+        mock_config = MagicMock()
+        mock_config.default_bucket = 'test-bucket'
+        mock_config_class.return_value = mock_config
+
+        client = MinioClient()
+        success, result = client.copy_file('source/file.pdf', 'dest/file.pdf')
+
+        assert success is False
+        assert 'Copy failed' in result
+
 
 class TestGetDbSession:
     """Test cases for get_db_session context manager"""

--- a/test/backend/services/test_data_process_service.py
+++ b/test/backend/services/test_data_process_service.py
@@ -4,6 +4,7 @@ import os
 import io
 import base64
 import asyncio
+import types
 from unittest.mock import patch, MagicMock, AsyncMock
 import warnings
 from PIL import Image
@@ -42,7 +43,26 @@ mock_const.CLIP_MODEL_PATH = "mock_clip_path"
 mock_const.IMAGE_FILTER = True
 mock_const.REDIS_BACKEND_URL = "redis://mock:6379/0"
 mock_const.REDIS_URL = "redis://mock:6379/0"
+mock_const.MAX_CONCURRENT_CONVERSIONS = 3
 sys.modules['consts.const'] = mock_const
+
+# Stub consts.exceptions with a *real* exception class so assertRaises works correctly
+_exceptions_mod = types.ModuleType('consts.exceptions')
+
+
+class OfficeConversionException(Exception):
+    """Stub OfficeConversionException used in tests."""
+
+
+_exceptions_mod.OfficeConversionException = OfficeConversionException
+sys.modules['consts.exceptions'] = _exceptions_mod
+
+# Stub utils.file_management_utils (new import in data_process_service)
+if 'utils.file_management_utils' not in sys.modules:
+    import types as _types
+    _utils_mod = _types.ModuleType('utils.file_management_utils')
+    _utils_mod.convert_office_to_pdf = AsyncMock()
+    sys.modules['utils.file_management_utils'] = _utils_mod
 
 # from backend.services.data_process_service import DataProcessService, get_data_process_service
 with patch('data_process.utils.get_task_info') as mock_get_task_info, \
@@ -51,6 +71,21 @@ with patch('data_process.utils.get_task_info') as mock_get_task_info, \
 
 
 class TestDataProcessService(unittest.TestCase):
+
+    class _NopSemaphore:
+        """Drop-in asyncio.Semaphore that never blocks.
+
+        asyncio.Semaphore is bound to the event loop at creation time; using
+        asyncio.run() in tests creates a new loop each time, so the module-level
+        semaphore would deadlock. This stub avoids that issue completely.
+        """
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
     def setUp(self):
         """Set up test environment before each test"""
         # Create a clean instance for each test
@@ -60,17 +95,31 @@ class TestDataProcessService(unittest.TestCase):
         # Suppress warnings during tests
         warnings.filterwarnings('ignore', category=UserWarning)
 
+        # Replace module-level semaphore with a no-op to avoid asyncio loop issues
+        import backend.services.data_process_service as _dm
+        self._dm = _dm
+        self._orig_sem = _dm._conversion_semaphore
+        self._nop_sem = TestDataProcessService._NopSemaphore()
+        _dm._conversion_semaphore = self._nop_sem
+
         # Reset mocks for each test to prevent interference
-        # Do not import data_process.app here - use the already mocked module
         mock_celery_app = sys.modules['data_process.app'].app
         mock_celery_app.reset_mock()
         self.mock_celery_app = mock_celery_app
 
     def tearDown(self):
         """Clean up after each test"""
+        # Restore the original semaphore
+        self._dm._conversion_semaphore = self._orig_sem
         # Restore environment variables
         os.environ.clear()
         os.environ.update(self.original_env)
+
+    @staticmethod
+    def _make_stream(data: bytes):
+        """Return a BytesIO stream containing *data*."""
+        from io import BytesIO
+        return BytesIO(data)
 
     @patch('backend.services.data_process_service.redis.ConnectionPool.from_url')
     @patch('backend.services.data_process_service.redis.Redis')
@@ -2160,6 +2209,144 @@ class TestDataProcessService(unittest.TestCase):
         Test wrapper to run async test for convert_to_base64.
         """
         asyncio.run(self.async_test_convert_to_base64())
+
+
+    @patch('backend.services.data_process_service.convert_office_to_pdf',
+           new_callable=AsyncMock)
+    @patch('backend.services.data_process_service.upload_file')
+    @patch('backend.services.data_process_service.get_file_size_from_minio')
+    @patch('backend.services.data_process_service.get_file_stream')
+    @patch('shutil.rmtree')
+    @patch('tempfile.mkdtemp', return_value='/tmp/test_cv')
+    @patch('os.path.exists', return_value=True)
+    def test_convert_office_to_pdf_impl_success(
+        self, _exists, _mkdtemp, mock_rmtree,
+        mock_get_stream, mock_get_size, mock_upload, mock_convert
+    ):
+        """Happy path: full pipeline completes and temp dir is cleaned up."""
+        mock_get_stream.side_effect = [
+            self._make_stream(b'DOC data'),      # Step 1: original file
+            self._make_stream(b'%PDF-1.4 ok'),   # Step 4: header check
+        ]
+        mock_get_size.return_value = 208
+        mock_upload.return_value = {'success': True}
+        mock_convert.return_value = '/tmp/test_cv/doc.pdf'
+
+        with patch('builtins.open', MagicMock()):
+            asyncio.run(
+                self.service.convert_office_to_pdf_impl(
+                    'uploads/doc.docx', 'converted/doc.pdf'
+                )
+            )
+
+        mock_convert.assert_called_once()
+        mock_rmtree.assert_called_once_with('/tmp/test_cv')
+
+    @patch('backend.services.data_process_service.get_file_stream',
+           return_value=None)
+    @patch('shutil.rmtree')
+    @patch('tempfile.mkdtemp', return_value='/tmp/test_cv')
+    @patch('os.path.exists', return_value=True)
+    def test_convert_office_to_pdf_impl_source_not_found(
+        self, _exists, _mkdtemp, mock_rmtree, _get_stream
+    ):
+        """Source file missing → OfficeConversionException."""
+        # Prevent cleanup path from calling real delete_file
+        sys.modules['database.attachment_db'].file_exists = MagicMock(
+            return_value=False
+        )
+        with self.assertRaises(OfficeConversionException) as ctx:
+            asyncio.run(
+                self.service.convert_office_to_pdf_impl(
+                    'uploads/missing.docx', 'converted/missing.pdf'
+                )
+            )
+        self.assertIn('Source file not found', str(ctx.exception))
+
+    @patch('backend.services.data_process_service.convert_office_to_pdf',
+           new_callable=AsyncMock)
+    @patch('backend.services.data_process_service.get_file_stream')
+    @patch('shutil.rmtree')
+    @patch('tempfile.mkdtemp', return_value='/tmp/test_cv')
+    @patch('os.path.exists', return_value=True)
+    def test_convert_office_to_pdf_impl_libreoffice_failure(
+        self, _exists, _mkdtemp, mock_rmtree, mock_get_stream, mock_convert
+    ):
+        """LibreOffice error → OfficeConversionException."""
+        mock_get_stream.return_value = self._make_stream(b'DOC data')
+        mock_convert.side_effect = RuntimeError('soffice not found')
+        sys.modules['database.attachment_db'].file_exists = MagicMock(
+            return_value=False
+        )
+        with patch('builtins.open', MagicMock()):
+            with self.assertRaises(OfficeConversionException) as ctx:
+                asyncio.run(
+                    self.service.convert_office_to_pdf_impl(
+                        'uploads/doc.docx', 'converted/doc.pdf'
+                    )
+                )
+        self.assertIn('LibreOffice conversion failed', str(ctx.exception))
+
+    @patch('backend.services.data_process_service.convert_office_to_pdf',
+           new_callable=AsyncMock)
+    @patch('backend.services.data_process_service.upload_file')
+    @patch('backend.services.data_process_service.get_file_stream')
+    @patch('shutil.rmtree')
+    @patch('tempfile.mkdtemp', return_value='/tmp/test_cv')
+    @patch('os.path.exists', return_value=True)
+    def test_convert_office_to_pdf_impl_upload_failure(
+        self, _exists, _mkdtemp, mock_rmtree,
+        mock_get_stream, mock_upload, mock_convert
+    ):
+        """Upload failure → OfficeConversionException with error detail."""
+        mock_get_stream.return_value = self._make_stream(b'DOC data')
+        mock_convert.return_value = '/tmp/test_cv/doc.pdf'
+        mock_upload.return_value = {'success': False, 'error': 'quota exceeded'}
+        sys.modules['database.attachment_db'].file_exists = MagicMock(
+            return_value=False
+        )
+        with patch('builtins.open', MagicMock()):
+            with self.assertRaises(OfficeConversionException) as ctx:
+                asyncio.run(
+                    self.service.convert_office_to_pdf_impl(
+                        'uploads/doc.docx', 'converted/doc.pdf'
+                    )
+                )
+        self.assertIn('Failed to upload PDF', str(ctx.exception))
+
+    @patch('backend.services.data_process_service.delete_file')
+    @patch('backend.services.data_process_service.file_exists', return_value=True)
+    @patch('backend.services.data_process_service.convert_office_to_pdf',
+           new_callable=AsyncMock)
+    @patch('backend.services.data_process_service.upload_file')
+    @patch('backend.services.data_process_service.get_file_size_from_minio')
+    @patch('backend.services.data_process_service.get_file_stream')
+    @patch('shutil.rmtree')
+    @patch('tempfile.mkdtemp', return_value='/tmp/test_cv')
+    @patch('os.path.exists', return_value=True)
+    def test_convert_office_to_pdf_impl_invalid_pdf_header(
+        self, _exists, _mkdtemp, mock_rmtree,
+        mock_get_stream, mock_get_size, mock_upload, mock_convert,
+        mock_file_exists, mock_delete_file
+    ):
+        """Invalid PDF header → OfficeConversionException; remote file deleted."""
+        mock_get_stream.side_effect = [
+            self._make_stream(b'DOC data'),      # Step 1: original file
+            self._make_stream(b'NOT-PDF'),       # Step 4: header check
+        ]
+        mock_get_size.return_value = 208
+        mock_upload.return_value = {'success': True}
+        mock_convert.return_value = '/tmp/test_cv/doc.pdf'
+
+        with patch('builtins.open', MagicMock()):
+            with self.assertRaises(OfficeConversionException) as ctx:
+                asyncio.run(
+                    self.service.convert_office_to_pdf_impl(
+                        'uploads/doc.docx', 'converted/doc.pdf'
+                    )
+                )
+        self.assertIn('invalid PDF header', str(ctx.exception))
+        mock_delete_file.assert_called_once_with('converted/doc.pdf')
 
 
 if __name__ == '__main__':

--- a/test/backend/services/test_file_management_service.py
+++ b/test/backend/services/test_file_management_service.py
@@ -82,6 +82,7 @@ def setup_patches():
         patch('backend.database.attachment_db.get_file_stream', MagicMock()),
         patch('backend.database.attachment_db.delete_file', MagicMock()),
         patch('backend.database.attachment_db.list_files', MagicMock()),
+        patch('backend.services.file_management_service.get_file_size_from_minio', MagicMock(return_value=0)),
         patch('backend.services.file_management_service.save_upload_file', AsyncMock()),
         patch('backend.services.file_management_service.upload_semaphore', MagicMock()),
         patch('backend.services.file_management_service.upload_dir',
@@ -1011,3 +1012,441 @@ class TestGetLlmModel:
         assert mock_tenant_config.get_model_config.call_count == 2
         assert mock_tenant_config.get_model_config.call_args_list[0][1]["tenant_id"] == "tenant1"
         assert mock_tenant_config.get_model_config.call_args_list[1][1]["tenant_id"] == "tenant2"
+
+
+class TestPreviewFileImpl:
+    """Test cases for preview_file_impl function"""
+
+    @pytest.mark.asyncio
+    async def test_preview_pdf_file_success(self):
+        """Test previewing a PDF file returns stream directly"""
+        from backend.services.file_management_service import preview_file_impl
+        
+        mock_stream = BytesIO(b"PDF content")
+        
+        with patch('backend.services.file_management_service.get_content_type', return_value='application/pdf'), \
+             patch('backend.services.file_management_service.get_file_stream', return_value=mock_stream):
+            
+            result_stream, result_type = await preview_file_impl("test/document.pdf")
+            
+            assert result_type == 'application/pdf'
+            assert result_stream == mock_stream
+
+    @pytest.mark.asyncio
+    async def test_preview_image_file_success(self):
+        """Test previewing an image file returns stream directly"""
+        from backend.services.file_management_service import preview_file_impl
+        
+        mock_stream = BytesIO(b"PNG content")
+        
+        with patch('backend.services.file_management_service.get_content_type', return_value='image/png'), \
+             patch('backend.services.file_management_service.get_file_stream', return_value=mock_stream):
+            
+            result_stream, result_type = await preview_file_impl("test/image.png")
+            
+            assert result_type == 'image/png'
+            assert result_stream == mock_stream
+
+    @pytest.mark.asyncio
+    async def test_preview_text_file_success(self):
+        """Test previewing a text file returns stream directly"""
+        from backend.services.file_management_service import preview_file_impl
+        
+        mock_stream = BytesIO(b"Text content")
+        
+        with patch('backend.services.file_management_service.get_content_type', return_value='text/plain'), \
+             patch('backend.services.file_management_service.get_file_stream', return_value=mock_stream):
+            
+            result_stream, result_type = await preview_file_impl("test/readme.txt")
+            
+            assert result_type == 'text/plain'
+            assert result_stream == mock_stream
+
+    @pytest.mark.asyncio
+    async def test_preview_csv_file_success(self):
+        """Test previewing a CSV file returns stream directly"""
+        from backend.services.file_management_service import preview_file_impl
+        
+        mock_stream = BytesIO(b"col1,col2\nval1,val2")
+        
+        with patch('backend.services.file_management_service.get_content_type', return_value='text/csv'), \
+             patch('backend.services.file_management_service.get_file_stream', return_value=mock_stream):
+            
+            result_stream, result_type = await preview_file_impl("test/data.csv")
+            
+            assert result_type == 'text/csv'
+            assert result_stream == mock_stream
+
+    @pytest.mark.asyncio
+    async def test_preview_markdown_file_success(self):
+        """Test previewing a Markdown file returns stream directly"""
+        from backend.services.file_management_service import preview_file_impl
+        
+        mock_stream = BytesIO(b"# Heading\nContent")
+        
+        with patch('backend.services.file_management_service.get_content_type', return_value='text/markdown'), \
+             patch('backend.services.file_management_service.get_file_stream', return_value=mock_stream):
+            
+            result_stream, result_type = await preview_file_impl("test/readme.md")
+            
+            assert result_type == 'text/markdown'
+            assert result_stream == mock_stream
+
+    @pytest.mark.asyncio
+    async def test_preview_office_docx_with_cache_hit(self):
+        """Test previewing a Word document with cached PDF available"""
+        from backend.services.file_management_service import preview_file_impl
+        
+        mock_pdf_stream = BytesIO(b"Cached PDF content")
+        
+        with patch('backend.services.file_management_service.get_content_type', 
+                   return_value='application/vnd.openxmlformats-officedocument.wordprocessingml.document'), \
+             patch('backend.services.file_management_service.file_exists', return_value=True), \
+             patch('backend.services.file_management_service.get_file_stream', return_value=mock_pdf_stream):
+            
+            result_stream, result_type = await preview_file_impl("test/document.docx")
+            
+            assert result_type == 'application/pdf'
+            assert result_stream == mock_pdf_stream
+
+    @pytest.mark.asyncio
+    async def test_preview_office_docx_cache_miss_convert_success(self):
+        """Cache miss: delegates conversion to data-process via HTTP, then serves resulting PDF."""
+        from backend.services.file_management_service import preview_file_impl
+
+        mock_pdf_stream = BytesIO(b"%PDF-1.4 converted content")
+
+        # Simulate data-process returning HTTP 200
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = ""
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        mock_http_ctx = MagicMock()
+        mock_http_ctx.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_http_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch('backend.services.file_management_service.get_content_type',
+                   return_value='application/vnd.openxmlformats-officedocument.wordprocessingml.document'), \
+             patch('backend.services.file_management_service.file_exists', return_value=False), \
+             patch('backend.services.file_management_service.get_file_stream',
+                   return_value=mock_pdf_stream), \
+             patch('httpx.AsyncClient', return_value=mock_http_ctx), \
+             patch('backend.services.file_management_service.copy_file',
+                   return_value={'success': True}), \
+             patch('backend.services.file_management_service.delete_file'):
+
+            result_stream, result_type = await preview_file_impl("test/document.docx")
+
+            assert result_type == 'application/pdf'
+            assert result_stream == mock_pdf_stream
+            mock_client.post.assert_called_once()
+            url_called = mock_client.post.call_args[0][0]
+            assert "convert_to_pdf" in url_called
+
+    @pytest.mark.asyncio
+    async def test_preview_office_conversion_failure(self):
+        """HTTP error from data-process service propagates as conversion failure."""
+        from backend.services.file_management_service import preview_file_impl
+
+        # Simulate data-process returning HTTP 500
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        mock_http_ctx = MagicMock()
+        mock_http_ctx.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_http_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch('backend.services.file_management_service.get_content_type',
+                   return_value='application/vnd.openxmlformats-officedocument.wordprocessingml.document'), \
+             patch('backend.services.file_management_service.file_exists', return_value=False), \
+             patch('httpx.AsyncClient', return_value=mock_http_ctx), \
+             patch('backend.services.file_management_service.delete_file'):
+
+            with pytest.raises(Exception) as exc_info:
+                await preview_file_impl("test/document.docx")
+
+            assert "Failed to convert Office document to PDF" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_preview_unsupported_file_type(self):
+        """Test previewing an unsupported file type raises exception"""
+        from backend.services.file_management_service import preview_file_impl
+        
+        with patch('backend.services.file_management_service.get_content_type', 
+                   return_value='application/octet-stream'):
+            
+            with pytest.raises(Exception) as exc_info:
+                await preview_file_impl("test/unknown.bin")
+            
+            assert "Unsupported file type for preview" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_preview_file_not_found(self):
+        """Test previewing a non-existent file raises exception"""
+        from backend.services.file_management_service import preview_file_impl
+        
+        with patch('backend.services.file_management_service.get_content_type', return_value='application/pdf'), \
+             patch('backend.services.file_management_service.get_file_stream', return_value=None):
+            
+            with pytest.raises(Exception) as exc_info:
+                await preview_file_impl("test/nonexistent.pdf")
+            
+            assert "File not found" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_preview_file_too_large(self):
+        """Test that files exceeding FILE_PREVIEW_SIZE_LIMIT raise FileTooLargeException"""
+        from backend.services.file_management_service import preview_file_impl, FILE_PREVIEW_SIZE_LIMIT
+
+        oversized = FILE_PREVIEW_SIZE_LIMIT + 1
+        with patch('backend.services.file_management_service.get_file_size_from_minio', return_value=oversized):
+            with pytest.raises(Exception) as exc_info:
+                await preview_file_impl("test/large_file.pdf")
+
+        assert str(FILE_PREVIEW_SIZE_LIMIT // (1024 * 1024)) in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("content_type,expected_direct", [
+        ('application/pdf', True),
+        ('image/jpeg', True),
+        ('image/png', True),
+        ('image/gif', True),
+        ('image/webp', True),
+        ('text/plain', True),
+        ('text/csv', True),
+        ('text/markdown', True),
+        ('application/vnd.openxmlformats-officedocument.wordprocessingml.document', False),
+        ('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', False),
+        ('application/vnd.openxmlformats-officedocument.presentationml.presentation', False),
+        ('application/msword', False),
+        ('application/vnd.ms-excel', False),
+        ('application/vnd.ms-powerpoint', False),
+    ])
+    async def test_preview_file_type_routing(self, content_type, expected_direct):
+        """Test that different file types are routed correctly"""
+        from backend.services.file_management_service import preview_file_impl
+        
+        mock_stream = BytesIO(b"test content")
+        get_stream_call_count = 0
+        
+        def mock_get_file_stream(object_name):
+            nonlocal get_stream_call_count
+            get_stream_call_count += 1
+            return mock_stream
+        
+        with patch('backend.services.file_management_service.get_content_type', return_value=content_type), \
+             patch('backend.services.file_management_service.file_exists', return_value=True), \
+             patch('backend.services.file_management_service.get_file_stream', side_effect=mock_get_file_stream):
+            
+            result_stream, result_type = await preview_file_impl("test/file")
+            
+            assert result_stream == mock_stream
+            if expected_direct:
+                # Direct file types should call get_file_stream once
+                assert get_stream_call_count == 1
+                assert result_type == content_type
+            else:
+                # Office files return PDF type
+                assert result_type == 'application/pdf'
+
+
+class TestGetCachedPdfStream:
+    """Unit tests for _get_cached_pdf_stream helper."""
+
+    def test_returns_stream_when_cache_valid(self):
+        """Returns the stream when file exists and is readable."""
+        from backend.services.file_management_service import _get_cached_pdf_stream
+
+        mock_stream = BytesIO(b"%PDF-1.4")
+        with patch('backend.services.file_management_service.file_exists', return_value=True), \
+             patch('backend.services.file_management_service.get_file_stream', return_value=mock_stream):
+            result = _get_cached_pdf_stream("converted/doc_abc12345.pdf")
+            assert result is mock_stream
+
+    def test_returns_none_when_file_not_exist(self):
+        """Returns None immediately when the cached file does not exist."""
+        from backend.services.file_management_service import _get_cached_pdf_stream
+
+        with patch('backend.services.file_management_service.file_exists', return_value=False):
+            result = _get_cached_pdf_stream("converted/doc_abc12345.pdf")
+            assert result is None
+
+    def test_deletes_and_returns_none_when_cache_corrupted(self):
+        """Deletes the corrupted cache entry and returns None when stream cannot be read."""
+        from backend.services.file_management_service import _get_cached_pdf_stream
+
+        with patch('backend.services.file_management_service.file_exists', return_value=True), \
+             patch('backend.services.file_management_service.get_file_stream', return_value=None), \
+             patch('backend.services.file_management_service.delete_file') as mock_delete:
+            result = _get_cached_pdf_stream("converted/doc_abc12345.pdf")
+            assert result is None
+            mock_delete.assert_called_once_with("converted/doc_abc12345.pdf")
+
+
+class TestConvertOfficeToCachedPdf:
+    """Unit tests for _convert_office_to_cached_pdf helper."""
+
+    @pytest.mark.asyncio
+    async def test_returns_stream_on_double_check_cache_hit(self):
+        """If another coroutine completes conversion while we waited for the lock, serves from cache."""
+        from backend.services.file_management_service import _convert_office_to_cached_pdf
+
+        mock_stream = BytesIO(b"%PDF-1.4 already done")
+        # file_exists returns False on the outer check but the helper is called after lock acquisition
+        with patch('backend.services.file_management_service._get_cached_pdf_stream',
+                   return_value=mock_stream):
+            result = await _convert_office_to_cached_pdf(
+                "docs/report.docx",
+                "converted/docs/report_deadbeef.pdf",
+                "converting/docs/report_deadbeef.pdf.tmp",
+            )
+            assert result is mock_stream
+
+    @pytest.mark.asyncio
+    async def test_full_conversion_success(self):
+        """Happy path: calls data-process, copies result, deletes temp, returns stream."""
+        from backend.services.file_management_service import _convert_office_to_cached_pdf
+
+        final_stream = BytesIO(b"%PDF-1.4 fresh")
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = ""
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        mock_http_ctx = MagicMock()
+        mock_http_ctx.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_http_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch('backend.services.file_management_service._get_cached_pdf_stream',
+                   return_value=None), \
+             patch('httpx.AsyncClient', return_value=mock_http_ctx), \
+             patch('backend.services.file_management_service.copy_file',
+                   return_value={'success': True}), \
+             patch('backend.services.file_management_service.delete_file') as mock_delete, \
+             patch('backend.services.file_management_service.file_exists', return_value=False), \
+             patch('backend.services.file_management_service.get_file_stream',
+                   return_value=final_stream):
+
+            result = await _convert_office_to_cached_pdf(
+                "docs/report.docx",
+                "converted/docs/report_deadbeef.pdf",
+                "converting/docs/report_deadbeef.pdf.tmp",
+            )
+
+        assert result is final_stream
+        mock_client.post.assert_called_once()
+        called_url = mock_client.post.call_args[0][0]
+        assert "convert_to_pdf" in called_url
+        # Temp file should be deleted after successful copy
+        mock_delete.assert_called_with("converting/docs/report_deadbeef.pdf.tmp")
+
+    @pytest.mark.asyncio
+    async def test_http_error_raises_office_conversion_exception(self):
+        """Non-200 HTTP response from data-process raises OfficeConversionException."""
+        from backend.services.file_management_service import _convert_office_to_cached_pdf
+        from consts.exceptions import OfficeConversionException
+
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+        mock_response.text = "Service Unavailable"
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        mock_http_ctx = MagicMock()
+        mock_http_ctx.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_http_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch('backend.services.file_management_service._get_cached_pdf_stream',
+                   return_value=None), \
+             patch('httpx.AsyncClient', return_value=mock_http_ctx), \
+             patch('backend.services.file_management_service.file_exists', return_value=False), \
+             patch('backend.services.file_management_service.delete_file'):
+
+            with pytest.raises(OfficeConversionException) as exc_info:
+                await _convert_office_to_cached_pdf(
+                    "docs/report.docx",
+                    "converted/docs/report_deadbeef.pdf",
+                    "converting/docs/report_deadbeef.pdf.tmp",
+                )
+
+        assert "Failed to convert Office document to PDF" in str(exc_info.value)
+        assert "503" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_copy_failure_raises_office_conversion_exception(self):
+        """copy_file failure raises OfficeConversionException and cleans up temp file."""
+        from backend.services.file_management_service import _convert_office_to_cached_pdf
+        from consts.exceptions import OfficeConversionException
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = ""
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        mock_http_ctx = MagicMock()
+        mock_http_ctx.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_http_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch('backend.services.file_management_service._get_cached_pdf_stream',
+                   return_value=None), \
+             patch('httpx.AsyncClient', return_value=mock_http_ctx), \
+             patch('backend.services.file_management_service.copy_file',
+                   return_value={'success': False, 'error': 'bucket full'}), \
+             patch('backend.services.file_management_service.file_exists', return_value=True), \
+             patch('backend.services.file_management_service.delete_file') as mock_delete:
+
+            with pytest.raises(OfficeConversionException):
+                await _convert_office_to_cached_pdf(
+                    "docs/report.docx",
+                    "converted/docs/report_deadbeef.pdf",
+                    "converting/docs/report_deadbeef.pdf.tmp",
+                )
+
+        # Cleanup: temp file must be deleted on failure
+        mock_delete.assert_called_with("converting/docs/report_deadbeef.pdf.tmp")
+
+    @pytest.mark.asyncio
+    async def test_converted_pdf_not_readable_raises_not_found(self):
+        """Raises NotFoundException when the final PDF cannot be read after successful conversion."""
+        from backend.services.file_management_service import _convert_office_to_cached_pdf
+        from consts.exceptions import NotFoundException
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = ""
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        mock_http_ctx = MagicMock()
+        mock_http_ctx.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_http_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch('backend.services.file_management_service._get_cached_pdf_stream',
+                   return_value=None), \
+             patch('httpx.AsyncClient', return_value=mock_http_ctx), \
+             patch('backend.services.file_management_service.copy_file',
+                   return_value={'success': True}), \
+             patch('backend.services.file_management_service.delete_file'), \
+             patch('backend.services.file_management_service.file_exists', return_value=False), \
+             patch('backend.services.file_management_service.get_file_stream', return_value=None):
+
+            with pytest.raises(NotFoundException):
+                await _convert_office_to_cached_pdf(
+                    "docs/report.docx",
+                    "converted/docs/report_deadbeef.pdf",
+                    "converting/docs/report_deadbeef.pdf.tmp",
+                )

--- a/test/backend/utils/test_file_management_utils.py
+++ b/test/backend/utils/test_file_management_utils.py
@@ -704,3 +704,98 @@ async def test_get_all_files_status_redis_total_chunks_none(fmu, monkeypatch):
     # total_chunks should remain from task state (12) since redis_total is None
     assert out["/p9"]["total_chunks"] == 12
 
+
+class TestConvertOfficeToPdf:
+    """Test cases for convert_office_to_pdf function"""
+
+    @pytest.mark.asyncio
+    async def test_convert_office_to_pdf_success(self, fmu, monkeypatch):
+        """Test successful Office to PDF conversion"""
+        import subprocess
+        
+        mock_result = types.SimpleNamespace(returncode=0, stderr="", stdout="")
+        
+        monkeypatch.setattr(fmu.os.path, "exists", lambda p: True)
+        monkeypatch.setattr(fmu.os.path, "basename", lambda p: "document.docx")
+        monkeypatch.setattr(fmu.subprocess, "run", lambda *a, **k: mock_result)
+        
+        result = await fmu.convert_office_to_pdf('/tmp/document.docx', '/tmp/output')
+        
+        assert result == '/tmp/output/document.pdf'
+
+    @pytest.mark.asyncio
+    async def test_convert_office_to_pdf_input_not_found(self, fmu, monkeypatch):
+        """Test conversion failure when input file does not exist"""
+        monkeypatch.setattr(fmu.os.path, "exists", lambda p: False)
+        
+        with pytest.raises(FileNotFoundError) as exc_info:
+            await fmu.convert_office_to_pdf('/tmp/nonexistent.docx', '/tmp/output')
+        
+        assert "Input file not found" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_convert_office_to_pdf_libreoffice_error(self, fmu, monkeypatch):
+        """Test conversion failure when LibreOffice returns error"""
+        mock_result = types.SimpleNamespace(returncode=1, stderr="Error: LibreOffice crashed", stdout="")
+        
+        monkeypatch.setattr(fmu.os.path, "exists", lambda p: True)
+        monkeypatch.setattr(fmu.subprocess, "run", lambda *a, **k: mock_result)
+        
+        with pytest.raises(RuntimeError) as exc_info:
+            await fmu.convert_office_to_pdf('/tmp/document.docx', '/tmp/output')
+        
+        assert "Office to PDF conversion failed" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_convert_office_to_pdf_timeout(self, fmu, monkeypatch):
+        """Test conversion failure due to timeout"""
+        import subprocess
+        
+        monkeypatch.setattr(fmu.os.path, "exists", lambda p: True)
+        
+        def raise_timeout(*a, **k):
+            raise subprocess.TimeoutExpired(cmd='libreoffice', timeout=30)
+        
+        monkeypatch.setattr(fmu.subprocess, "run", raise_timeout)
+        
+        with pytest.raises(TimeoutError) as exc_info:
+            await fmu.convert_office_to_pdf('/tmp/document.docx', '/tmp/output', timeout=30)
+        
+        assert "timeout" in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_convert_office_to_pdf_libreoffice_not_installed(self, fmu, monkeypatch):
+        """Test conversion failure when LibreOffice is not installed"""
+        monkeypatch.setattr(fmu.os.path, "exists", lambda p: True)
+        
+        def raise_file_not_found(*a, **k):
+            raise FileNotFoundError("[Errno 2] No such file or directory: 'libreoffice'")
+        
+        monkeypatch.setattr(fmu.subprocess, "run", raise_file_not_found)
+        
+        with pytest.raises(FileNotFoundError) as exc_info:
+            await fmu.convert_office_to_pdf('/tmp/document.docx', '/tmp/output')
+        
+        assert "LibreOffice is not installed" in str(exc_info.value)
+        assert "not available in PATH" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_convert_office_to_pdf_output_not_found(self, fmu, monkeypatch):
+        """Test conversion failure when output PDF is not generated"""
+        mock_result = types.SimpleNamespace(returncode=0, stderr="", stdout="")
+        
+        def exists_side_effect(path):
+            # Input file exists, output PDF does not
+            if 'document.docx' in path:
+                return True
+            return False
+        
+        monkeypatch.setattr(fmu.os.path, "exists", exists_side_effect)
+        monkeypatch.setattr(fmu.os.path, "basename", lambda p: "document.docx")
+        monkeypatch.setattr(fmu.subprocess, "run", lambda *a, **k: mock_result)
+        
+        with pytest.raises(RuntimeError) as exc_info:
+            await fmu.convert_office_to_pdf('/tmp/document.docx', '/tmp/output')
+        
+        assert "Converted PDF not found" in str(exc_info.value)
+

--- a/test/sdk/storage/test_minio.py
+++ b/test/sdk/storage/test_minio.py
@@ -883,3 +883,92 @@ class TestMinIOStorageClientExists:
 
         assert exists is False
 
+
+class TestMinIOStorageClientCopyFile:
+    """Test cases for copy_file method"""
+
+    @patch('nexent.storage.minio.boto3')
+    def test_copy_file_success(self, mock_boto3):
+        """Test successful file copy within the same bucket"""
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.head_bucket.return_value = None
+
+        client = MinIOStorageClient(
+            endpoint="http://localhost:9000",
+            access_key="minioadmin",
+            secret_key="minioadmin",
+            default_bucket="test-bucket"
+        )
+
+        success, result = client.copy_file('src.txt', 'dst.txt', 'test-bucket')
+
+        assert success is True
+        assert result == 'dst.txt'
+        mock_client.copy_object.assert_called_once_with(
+            Bucket='test-bucket',
+            Key='dst.txt',
+            CopySource={'Bucket': 'test-bucket', 'Key': 'src.txt'}
+        )
+
+    @patch('nexent.storage.minio.boto3')
+    def test_copy_file_uses_default_bucket(self, mock_boto3):
+        """Test copy_file falls back to default bucket when bucket is not specified"""
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.head_bucket.return_value = None
+
+        client = MinIOStorageClient(
+            endpoint="http://localhost:9000",
+            access_key="minioadmin",
+            secret_key="minioadmin",
+            default_bucket="test-bucket"
+        )
+
+        success, result = client.copy_file('src.txt', 'dst.txt')
+
+        assert success is True
+        assert result == 'dst.txt'
+        mock_client.copy_object.assert_called_once_with(
+            Bucket='test-bucket',
+            Key='dst.txt',
+            CopySource={'Bucket': 'test-bucket', 'Key': 'src.txt'}
+        )
+
+    @patch('nexent.storage.minio.boto3')
+    def test_copy_file_without_bucket(self, mock_boto3):
+        """Test copy_file fails when no bucket is configured"""
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+
+        client = MinIOStorageClient(
+            endpoint="http://localhost:9000",
+            access_key="minioadmin",
+            secret_key="minioadmin"
+        )
+
+        success, result = client.copy_file('src.txt', 'dst.txt')
+
+        assert success is False
+        assert result == "Bucket name is required"
+        mock_client.copy_object.assert_not_called()
+
+    @patch('nexent.storage.minio.boto3')
+    def test_copy_file_exception(self, mock_boto3):
+        """Test copy_file returns failure on unexpected exception"""
+        mock_client = MagicMock()
+        mock_boto3.client.return_value = mock_client
+        mock_client.head_bucket.return_value = None
+        mock_client.copy_object.side_effect = Exception("copy failed")
+
+        client = MinIOStorageClient(
+            endpoint="http://localhost:9000",
+            access_key="minioadmin",
+            secret_key="minioadmin",
+            default_bucket="test-bucket"
+        )
+
+        success, result = client.copy_file('src.txt', 'dst.txt')
+
+        assert success is False
+        assert "copy failed" in result


### PR DESCRIPTION
1.添加文件预览接口/preview/{object_name:path}
2.添加文件预览逻辑。
office文件：使用LibreOffice将Office文件转换为PDF并将转换后的PDF缓存回MinIO，设置为7天有效期。（重构为LibreOffice 在 data_process 容器中运行，backend 通过 HTTP 调用）
其他文件：直接返回文件流。
3.添加对应单元测试文件