### PR TITLE
🐛 Bugfix: Fixed an issue where starting a container resulted in an unclear error message when no MCP image was available. #2293

### DIFF
--- a/backend/apps/remote_mcp_app.py
+++ b/backend/apps/remote_mcp_app.py
@@ -387,7 +387,13 @@ async def add_mcp_from_config(
             except MCPContainerError as e:
                 logger.error(
                     f"Failed to start MCP container {service_name}: {e}")
-                errors.append(f"{service_name}: {str(e)}")
+                error_str = str(e)
+                # Check if error is related to image not found
+                if "not found" in error_str.lower() or "404" in error_str:
+                    errors.append(
+                        f"{service_name}: Image not found - MCP service startup image is missing")
+                else:
+                    errors.append(f"{service_name}: {error_str}")
             except Exception as e:
                 logger.error(
                     f"Unexpected error adding MCP {service_name}: {e}")

--- a/frontend/hooks/useMcpConfig.ts
+++ b/frontend/hooks/useMcpConfig.ts
@@ -255,7 +255,11 @@ export function useMcpConfig(options: UseMcpConfigOptions = {}) {
         options.onContainerAdded?.();
         return { success: true, messageKey: "mcpService.message.addContainerSuccess" };
       } else {
-        return { success: false, message: result.message, messageKey: "mcpConfig.message.addContainerFailed" };
+        return { 
+          success: false, 
+          message: result.message, 
+          messageKey: (result as any).messageKey || "mcpConfig.message.addContainerFailed" 
+        };
       }
     } catch (error) {
       log.error("Failed to add container:", error);

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -1082,6 +1082,7 @@
   "mcpService.message.invalidUploadParameters": "Invalid upload parameters",
   "mcpService.message.serviceNameAlreadyExists": "MCP service name already exists",
   "mcpService.message.fileTooLarge": "File size exceeds limit",
+  "mcpService.message.missingMcpImage": "Failed to add container: MCP service startup image is missing",
 
   "agentConfig.tools.refreshSuccess": "Tool list refreshed successfully",
   "agentConfig.tools.refreshFailed": "Failed to refresh tool list",

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -1084,6 +1084,7 @@
   "mcpService.message.invalidUploadParameters": "上传参数无效",
   "mcpService.message.serviceNameAlreadyExists": "MCP服务名称已存在",
   "mcpService.message.fileTooLarge": "文件大小超过限制",
+  "mcpService.message.missingMcpImage": "添加容器失败：缺少mcp服务启动镜像",
 
   "agentConfig.tools.refreshSuccess": "工具列表已刷新",
   "agentConfig.tools.refreshFailed": "刷新工具列表失败",

--- a/frontend/services/mcpService.ts
+++ b/frontend/services/mcpService.ts
@@ -433,17 +433,30 @@ export const addMcpFromConfig = async (mcpConfig: { mcpServers: Record<string, {
       };
     } else {
       let errorMessage = data.detail || data.message || t('mcpService.message.addFromConfigFailed');
+      let messageKey: string | undefined;
 
       if (response.status === 400) {
-        errorMessage = data.detail || t('mcpService.message.invalidConfig');
+        const rawError = data.detail || data.message || '';
+        // Check if error is related to image not found
+        const errorLower = rawError.toLowerCase();
+        if (rawError && (errorLower.includes('image not found') || 
+            errorLower.includes('mcp service startup image is missing') ||
+            (errorLower.includes('not found') && errorLower.includes('image')))) {
+          messageKey = 'mcpService.message.missingMcpImage';
+          errorMessage = t('mcpService.message.missingMcpImage');
+        } else {
+          errorMessage = rawError || t('mcpService.message.invalidConfig');
+        }
       } else if (response.status === 503) {
+        messageKey = 'mcpService.message.dockerServiceUnavailable';
         errorMessage = t('mcpService.message.dockerServiceUnavailable');
       }
 
       return {
         success: false,
         data: null,
-        message: errorMessage
+        message: errorMessage,
+        messageKey: messageKey
       };
     }
   } catch (error) {
@@ -451,7 +464,8 @@ export const addMcpFromConfig = async (mcpConfig: { mcpServers: Record<string, {
     return {
       success: false,
       data: null,
-      message: t('mcpService.message.networkError')
+      message: t('mcpService.message.networkError'),
+      messageKey: 'mcpService.message.networkError'
     };
   }
 };

--- a/test/backend/app/test_remote_mcp_app.py
+++ b/test/backend/app/test_remote_mcp_app.py
@@ -1155,6 +1155,163 @@ class TestAddMCPFromConfig:
     @patch('apps.remote_mcp_app.get_current_user_info')
     @patch('apps.remote_mcp_app.MCPContainerManager')
     @patch('apps.remote_mcp_app.check_mcp_name_exists', return_value=False)
+    def test_add_mcp_from_config_image_not_found_lowercase(self, mock_check_name, mock_container_manager_class, mock_get_user_info):
+        """Test adding MCP server when image not found (lowercase 'not found')"""
+        from consts.exceptions import MCPContainerError
+
+        mock_get_user_info.return_value = ("user123", "tenant456", "en")
+
+        mock_container_manager = MagicMock()
+        mock_container_manager_class.return_value = mock_container_manager
+        # Error message contains "not found" (lowercase)
+        mock_container_manager.start_mcp_container = AsyncMock(
+            side_effect=MCPContainerError("Container startup failed: Container startup failed: 404 Client Error for http+docker://localnpipe/v1.52/images/create?tag=latest&fromImage=nexent%2Fnexent-mcp: Not Found (\"failed to resolve reference \"docker.io/nexent/nexent-mcp:latest\": docker.io/nexent/nexent-mcp:latest: not found\")"))
+
+        response = client.post(
+            "/mcp/add-from-config",
+            json={
+                "mcpServers": {
+                    "test-service": {
+                        "command": "npx",
+                        "args": ["-y", "test-mcp"],
+                        "port": 5020
+                    }
+                }
+            },
+            headers={"Authorization": "Bearer test_token"}
+        )
+
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        data = response.json()
+        assert "All MCP servers failed" in data["detail"]
+        assert "Image not found - MCP service startup image is missing" in data["detail"]
+        assert "test-service" in data["detail"]
+
+    @patch('apps.remote_mcp_app.get_current_user_info')
+    @patch('apps.remote_mcp_app.MCPContainerManager')
+    @patch('apps.remote_mcp_app.check_mcp_name_exists', return_value=False)
+    def test_add_mcp_from_config_image_not_found_uppercase(self, mock_check_name, mock_container_manager_class, mock_get_user_info):
+        """Test adding MCP server when image not found (uppercase 'Not Found')"""
+        from consts.exceptions import MCPContainerError
+
+        mock_get_user_info.return_value = ("user123", "tenant456", "en")
+
+        mock_container_manager = MagicMock()
+        mock_container_manager_class.return_value = mock_container_manager
+        # Error message contains "Not Found" (uppercase)
+        mock_container_manager.start_mcp_container = AsyncMock(
+            side_effect=MCPContainerError("Container startup failed: Image Not Found"))
+
+        response = client.post(
+            "/mcp/add-from-config",
+            json={
+                "mcpServers": {
+                    "test-service": {
+                        "command": "npx",
+                        "args": ["-y", "test-mcp"],
+                        "port": 5020
+                    }
+                }
+            },
+            headers={"Authorization": "Bearer test_token"}
+        )
+
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        data = response.json()
+        assert "All MCP servers failed" in data["detail"]
+        assert "Image not found - MCP service startup image is missing" in data["detail"]
+        assert "test-service" in data["detail"]
+
+    @patch('apps.remote_mcp_app.get_current_user_info')
+    @patch('apps.remote_mcp_app.MCPContainerManager')
+    @patch('apps.remote_mcp_app.check_mcp_name_exists', return_value=False)
+    def test_add_mcp_from_config_image_not_found_with_404(self, mock_check_name, mock_container_manager_class, mock_get_user_info):
+        """Test adding MCP server when image not found (contains '404')"""
+        from consts.exceptions import MCPContainerError
+
+        mock_get_user_info.return_value = ("user123", "tenant456", "en")
+
+        mock_container_manager = MagicMock()
+        mock_container_manager_class.return_value = mock_container_manager
+        # Error message contains "404"
+        mock_container_manager.start_mcp_container = AsyncMock(
+            side_effect=MCPContainerError("Container startup failed: 404 Client Error for http+docker://localnpipe/v1.52/images/create"))
+
+        response = client.post(
+            "/mcp/add-from-config",
+            json={
+                "mcpServers": {
+                    "test-service": {
+                        "command": "npx",
+                        "args": ["-y", "test-mcp"],
+                        "port": 5020
+                    }
+                }
+            },
+            headers={"Authorization": "Bearer test_token"}
+        )
+
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        data = response.json()
+        assert "All MCP servers failed" in data["detail"]
+        assert "Image not found - MCP service startup image is missing" in data["detail"]
+        assert "test-service" in data["detail"]
+
+    @patch('apps.remote_mcp_app.get_current_user_info')
+    @patch('apps.remote_mcp_app.MCPContainerManager')
+    @patch('apps.remote_mcp_app.add_remote_mcp_server_list')
+    @patch('apps.remote_mcp_app.check_mcp_name_exists', return_value=False)
+    def test_add_mcp_from_config_image_not_found_multiple_services(self, mock_check_name, mock_add_server, mock_container_manager_class, mock_get_user_info):
+        """Test adding multiple MCP servers when one has image not found error"""
+        from consts.exceptions import MCPContainerError
+
+        mock_get_user_info.return_value = ("user123", "tenant456", "en")
+
+        mock_container_manager = MagicMock()
+        mock_container_manager_class.return_value = mock_container_manager
+        # First service fails with image not found, second succeeds
+        mock_container_manager.start_mcp_container = AsyncMock(side_effect=[
+            MCPContainerError("Container startup failed: Image not found"),
+            {
+                "container_id": "container-2",
+                "mcp_url": "http://localhost:5021/mcp",
+                "host_port": "5021",
+                "status": "started",
+                "container_name": "service2-user1234"
+            }
+        ])
+        mock_add_server.return_value = None
+
+        response = client.post(
+            "/mcp/add-from-config",
+            json={
+                "mcpServers": {
+                    "service1": {
+                        "command": "npx",
+                        "args": ["-y", "service1"],
+                        "port": 5020
+                    },
+                    "service2": {
+                        "command": "npx",
+                        "args": ["-y", "service2"],
+                        "port": 5021
+                    }
+                }
+            },
+            headers={"Authorization": "Bearer test_token"}
+        )
+
+        assert response.status_code == HTTPStatus.OK
+        data = response.json()
+        assert data["status"] == "success"
+        assert len(data["results"]) == 1
+        assert data["results"][0]["service_name"] == "service2"
+        assert len(data["errors"]) == 1
+        assert "Image not found - MCP service startup image is missing" in data["errors"][0]
+
+    @patch('apps.remote_mcp_app.get_current_user_info')
+    @patch('apps.remote_mcp_app.MCPContainerManager')
+    @patch('apps.remote_mcp_app.check_mcp_name_exists', return_value=False)
     def test_add_mcp_from_config_unexpected_error_in_loop(self, mock_check_name, mock_container_manager_class, mock_get_user_info):
         """Test adding MCP server when unexpected exception occurs in loop (covers line 253-255)"""
         mock_get_user_info.return_value = ("user123", "tenant456", "en")


### PR DESCRIPTION
🐛 Bugfix: Fixed an issue where starting a container resulted in an unclear error message when no MCP image was available. #2293
[Specification Detail]
1. When no mirror is available, the backend returns a specific error message, and the frontend adds internationalized error messages.
[Test Result]
![img_v3_02vk_ce80515f-1852-4912-8e9c-57d88483a5bg](https://github.com/user-attachments/assets/6235e65f-4107-4804-98c3-39947045b5f3)
