### PR TITLE
🐛 Bugfix: Unify model list logic to show only available LLMs

### DIFF
--- a/frontend/app/[locale]/knowledges/components/document/DocumentList.tsx
+++ b/frontend/app/[locale]/knowledges/components/document/DocumentList.tsx
@@ -283,7 +283,7 @@ const DocumentListContainer = forwardRef<DocumentListRef, DocumentListProps>(
           setIsLoadingModels(true);
           try {
             const models = await modelService.getLLMModels();
-            setAvailableModels(models);
+            setAvailableModels(models.filter(m => m.connect_status === "available"));
 
             // Determine initial selection order:
             // 1) Knowledge base's own configured model (server-side config)


### PR DESCRIPTION
#2387 

只有知识库总结时的LLM列表未做可用性过滤，已添加。
<img width="436" height="423" alt="image" src="https://github.com/user-attachments/assets/e5a363b7-cfed-422d-8cdc-4249e008ef82" />
<img width="514" height="336" alt="image" src="https://github.com/user-attachments/assets/27dafd88-1d01-4a99-b2c7-7afdafc2a18c" />
