### PR TITLE
🐛 Bugfix: Solving the problem of duplicate tool instances in intelligent agents #2647

### DIFF
--- a/backend/database/tool_db.py
+++ b/backend/database/tool_db.py
@@ -37,7 +37,7 @@ def create_or_update_tool_by_tool_info(tool_info, tenant_id: str, user_id: str, 
     Args:
         tool_info: Dictionary containing tool information
         tenant_id: Tenant ID for filtering, mandatory
-        user_id: Optional user ID for filtering
+        user_id: User ID for updating (will be set as the last updater)
         version_no: Version number to filter. Default 0 = draft/editing state
 
     Returns:
@@ -48,9 +48,10 @@ def create_or_update_tool_by_tool_info(tool_info, tenant_id: str, user_id: str, 
 
     with get_db_session() as session:
         # Query if there is an existing ToolInstance
+        # Note: Do not filter by user_id to avoid creating duplicate instances
+        # for the same agent_id and tool_id when different users save
         query = session.query(ToolInstance).filter(
             ToolInstance.tenant_id == tenant_id,
-            ToolInstance.user_id == user_id,
             ToolInstance.agent_id == tool_info_dict['agent_id'],
             ToolInstance.delete_flag != 'Y',
             ToolInstance.tool_id == tool_info_dict['tool_id'],
@@ -63,7 +64,12 @@ def create_or_update_tool_by_tool_info(tool_info, tenant_id: str, user_id: str, 
                 if hasattr(tool_instance, key):
                     setattr(tool_instance, key, value)
         else:
-            create_tool(tool_info_dict, version_no)
+            # Create a new ToolInstance
+            new_tool_instance = ToolInstance(
+                **filter_property(tool_info_dict, ToolInstance))
+            session.add(new_tool_instance)
+            session.flush()  # Flush to get the ID
+            tool_instance = new_tool_instance
         return tool_instance
 
 

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -869,7 +869,7 @@ check_super_admin_user_exists() {
   # Check if super admin user exists in Supabase
   local email="suadmin@nexent.com"
   local curl_container="nexent-config"
-  
+
   # Determine which container to use for curl command
   if [ "$DEPLOYMENT_MODE" = "infrastructure" ] || ! docker ps | grep -q "nexent-config"; then
     if docker ps | grep -q "supabase-db-mini"; then
@@ -895,7 +895,7 @@ check_super_admin_user_exists() {
   # This is less reliable but works when database access is not available
   local test_response
   test_response=$(docker exec "$curl_container" bash -c "curl -s -X POST http://kong:8000/auth/v1/token?grant_type=password -H \"apikey: ${SUPABASE_KEY}\" -H \"Content-Type: application/json\" -d '{\"email\":\"${email}\",\"password\":\"dummy_password_check\"}'" 2>/dev/null)
-  
+
   if echo "$test_response" | grep -q '"error_code":"invalid_credentials"'; then
     return 0  # User exists (wrong password means user exists)
   elif echo "$test_response" | grep -q '"error_code":"email_not_confirmed"'; then
@@ -972,7 +972,7 @@ create_default_super_admin_user() {
   local check_result
   check_super_admin_user_exists
   check_result=$?
-  
+
   if [ $check_result -eq 0 ]; then
     echo "   ✅ Super admin user (${email}) already exists."
     echo "   💡 Skipping user creation. If you need to reset the password, please do so manually."
@@ -1041,7 +1041,7 @@ main_deploy() {
   echo "--------------------------------"
   echo ""
 
-  APP_VERSION="latest"
+  APP_VERSION="$(get_app_version)"
   if [ -z "$APP_VERSION" ]; then
     echo "❌ Failed to get app version, please check the backend/consts/const.py file"
     exit 1
@@ -1086,12 +1086,12 @@ main_deploy() {
   # Special handling for infrastructure mode
   if [ "$DEPLOYMENT_MODE" = "infrastructure" ]; then
     generate_env_for_infrastructure || { echo "❌ Environment generation failed"; exit 1; }
-    
+
     # Create default super admin user (only for full version)
     if [ "$DEPLOYMENT_VERSION" = "full" ]; then
       create_default_super_admin_user || { echo "❌ Default super admin user creation failed"; exit 1; }
     fi
-    
+
     echo "🎉 Infrastructure deployment completed successfully!"
     echo "     You can now start the core services manually using dev containers"
     echo "     Environment file available at: $(cd .. && pwd)/.env"

--- a/test/backend/database/test_tool_db.py
+++ b/test/backend/database/test_tool_db.py
@@ -228,14 +228,42 @@ def test_create_or_update_tool_by_tool_info_create_new(monkeypatch, mock_session
     mock_ctx.__exit__.return_value = None
     monkeypatch.setattr(
         "backend.database.tool_db.get_db_session", lambda: mock_ctx)
-    monkeypatch.setattr("backend.database.tool_db.create_tool", MagicMock())
+    monkeypatch.setattr(
+        "backend.database.tool_db.filter_property", lambda data, model: data)
+
+    # Mock ToolInstance class - needs to have column attributes for query building
+    mock_tool_instance = MockToolInstance()
+
+    # Create a Mock class that can be used both as a class (for query) and instantiated
+    class MockToolInstanceClass:
+        tenant_id = MagicMock()
+        agent_id = MagicMock()
+        tool_id = MagicMock()
+        delete_flag = MagicMock()
+        version_no = MagicMock()
+
+        def __init__(self, **kwargs):
+            # Copy attributes from mock_tool_instance
+            for key, value in mock_tool_instance.__dict__.items():
+                setattr(self, key, value)
+            # Update with any kwargs passed
+            for key, value in kwargs.items():
+                setattr(self, key, value)
+
+    monkeypatch.setattr(
+        "backend.database.tool_db.ToolInstance", MockToolInstanceClass)
+
+    session.add = MagicMock()
+    session.flush = MagicMock()
 
     tool_info = MagicMock()
     tool_info.__dict__ = {"agent_id": 1, "tool_id": 1}
 
     result = create_or_update_tool_by_tool_info(tool_info, "tenant1", "user1")
 
-    assert result is None
+    assert isinstance(result, MockToolInstanceClass)
+    session.add.assert_called_once()
+    session.flush.assert_called_once()
 
 
 def test_query_all_tools(monkeypatch, mock_session):


### PR DESCRIPTION
🐛 Bugfix: Solving the problem of duplicate tool instances in intelligent agents #2647
[Specification Details]
1. When updating the tool_instance table, do not use user_id as a query condition to ensure that there is only one tool_instance record for the same tool.
2. Modify test cases.
[Test Result]
admin创建的智能体，包含三个工具：
<img width="2241" height="911" alt="image" src="https://github.com/user-attachments/assets/e52705fe-fb5f-4418-90ae-040e444482dd" />
开发者再次保存，工具数量没有增加且能够正常使用：
<img width="2239" height="948" alt="image" src="https://github.com/user-attachments/assets/b224511f-dcab-4460-b702-8738a6aae97e" />
<img width="1043" height="932" alt="image" src="https://github.com/user-attachments/assets/2f806618-7440-4a50-8774-44edcfddca70" />
