### PR TITLE
fix: homepage hero rendering + modal mask api migration

### DIFF
--- a/frontend/app/[locale]/agents/components/agentConfig/McpConfigModal.tsx
+++ b/frontend/app/[locale]/agents/components/agentConfig/McpConfigModal.tsx
@@ -597,7 +597,7 @@ export default function McpConfigModal({
         onCancel={actionsLocked ? undefined : onCancel}
         width={1200}
         closable={!actionsLocked}
-        maskClosable={!actionsLocked}
+        mask={{ closable: !actionsLocked }}
         footer={[
           <Button key="cancel" onClick={onCancel} disabled={actionsLocked}>
             {actionsLocked

--- a/frontend/app/[locale]/agents/components/agentConfig/tool/ToolConfigModal.tsx
+++ b/frontend/app/[locale]/agents/components/agentConfig/tool/ToolConfigModal.tsx
@@ -1098,8 +1098,7 @@ export default function ToolConfigModal({
   return (
     <>
       <Modal
-        mask={true}
-        maskClosable={false}
+        mask={{ closable: false }}
         title={
           <div className="flex justify-between items-center w-full pr-8">
             <span>{`${tool?.name}`}</span>

--- a/frontend/app/[locale]/page.tsx
+++ b/frontend/app/[locale]/page.tsx
@@ -55,19 +55,18 @@ export default function Homepage() {
   const navigateToSpace = () => navigateWithPermissionCheck("/space");
 
   return (
-    <div className="w-full h-full flex flex-col items-center justify-center">
+    <div className="w-full min-h-full flex flex-col items-center justify-start px-4 py-6 md:px-6 md:py-8">
       {/* Hero area */}
-      <section className="relative w-full py-4 flex flex-col items-center justify-center text-center">
+      <section className="relative w-full py-4 flex flex-col items-center text-center">
         <div className="absolute inset-0 bg-grid-slate-200 dark:bg-grid-slate-800 [mask-image:radial-gradient(ellipse_at_center,white_20%,transparent_75%)] -z-10"></div>
         <motion.h2
           initial={{ opacity: 0, y: -20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.8, delay: 0.2 }}
-          className="text-4xl md:text-5xl lg:text-6xl font-bold text-slate-900 dark:text-white mb-4 tracking-tight"
+          className="text-3xl md:text-4xl lg:text-5xl font-bold leading-tight text-slate-900 dark:text-white mb-4 tracking-tight max-w-4xl"
         >
-          {t("page.title")}
-          <span className="text-blue-600 dark:text-blue-500">
-            {" "}
+          <span className="block">{t("page.title")}</span>
+          <span className="block mt-1 hero-gradient-text">
             {t("page.subtitle")}
           </span>
         </motion.h2>
@@ -87,7 +86,6 @@ export default function Homepage() {
           transition={{ duration: 0.8, delay: 0.4 }}
           className="flex flex-col sm:flex-row gap-4"
         >
-          
           <Button
             onClick={navigateToChat}
             className="bg-blue-600 hover:bg-blue-700 text-white px-8 py-6 rounded-full text-lg font-medium shadow-lg hover:shadow-xl transition-all duration-300 group"

--- a/frontend/app/[locale]/tenant-resources/components/resources/AgentList.tsx
+++ b/frontend/app/[locale]/tenant-resources/components/resources/AgentList.tsx
@@ -452,7 +452,7 @@ export default function AgentList({ tenantId }: { tenantId: string | null }) {
           </Button>
         ]}
         width={700}
-        maskClosable={false}
+        mask={{ closable: false }}
       >
         <Spin spinning={isLoadingDetail}>
           <Form form={form} layout="vertical">

--- a/frontend/app/[locale]/tenant-resources/components/resources/InvitationList.tsx
+++ b/frontend/app/[locale]/tenant-resources/components/resources/InvitationList.tsx
@@ -425,7 +425,7 @@ export default function InvitationList({ tenantId, refreshKey }: { tenantId: str
         okText={t("common.confirm")}
         cancelText={t("common.cancel")}
         width={600}
-        maskClosable={false}
+        mask={{ closable: false }}
       >
         <Form form={form} layout="vertical">
           {!editingInvitation && (

--- a/frontend/components/auth/AuthDialogs.tsx
+++ b/frontend/components/auth/AuthDialogs.tsx
@@ -41,7 +41,7 @@ export function AuthDialogs() {
         centered
         closable
         width={480}
-        maskClosable={false}
+        mask={{ closable: false }}
       >
         <div className="relative bg-white p-4 rounded-2xl">
           {/* Logo */}

--- a/frontend/components/auth/loginModal.tsx
+++ b/frontend/components/auth/loginModal.tsx
@@ -177,7 +177,7 @@ export function LoginModal() {
       width={420}
       centered
       forceRender
-      maskClosable={false}
+      mask={{ closable: false }}
       closable={true}
     >
       <div className="relative bg-white p-4 rounded-2xl">

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -66,6 +66,18 @@
   .bg-grid-slate-800 {
     background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' width='32' height='32' fill='none' stroke='rgb(30 41 59 / 0.8)'%3e%3cpath d='M0 .5H31.5V32'/%3e%3c/svg%3e");
   }
+
+  .hero-gradient-text {
+    background-image: linear-gradient(94deg, #2563eb 0%, #3b82f6 48%, #06b6d4 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    text-shadow: 0 2px 18px rgba(59, 130, 246, 0.18);
+  }
+
+  .dark .hero-gradient-text {
+    text-shadow: 0 2px 18px rgba(56, 189, 248, 0.22);
+  }
 }
 
 /* Ant Design Button Icon with Lucide icons */


### PR DESCRIPTION
抱歉，这个 PR 是对上周同一修复的重新提交。

By: Passion

## Summary
- fix homepage Hero title clipping and alignment by switching container to min-h-full and top-aligned layout
- redesign the main homepage heading into a smaller gradient art-style title with improved spacing/line height for better cross-viewport rendering
- replace deprecated Ant Design maskClosable usage with mask={{ closable: ... }} across Modal components to remove console warnings

## Changes
Homepage typography/layout updates in:
- frontend/app/[locale]/page.tsx
- frontend/styles/globals.css

Modal API migration in:
- frontend/components/auth/loginModal.tsx
- frontend/components/auth/AuthDialogs.tsx
- frontend/app/[locale]/tenant-resources/components/resources/AgentList.tsx
- frontend/app/[locale]/tenant-resources/components/resources/InvitationList.tsx
- frontend/app/[locale]/agents/components/agentConfig/McpConfigModal.tsx
- frontend/app/[locale]/agents/components/agentConfig/tool/ToolConfigModal.tsx

## Validation
- pnpm type-check (frontend) passes
- manual verification on /zh homepage for Hero title visibility and overall visual balance
- no remaining maskClosable references in frontend source

## Notes
- This PR includes a follow-up Hero title rendering adjustment for the text `Nexent 智能体 / 一个提示词，无限种可能` to avoid display inconsistencies on different viewport widths.