### PR TITLE
Bugfix: Ensure "more" button is visible only during hover

### DIFF
--- a/frontend/app/[locale]/chat/components/chatLeftSidebar.tsx
+++ b/frontend/app/[locale]/chat/components/chatLeftSidebar.tsx
@@ -103,6 +103,7 @@ export function ChatSidebar({
   const { today, week, older } = categorizeConversations(conversationManagement.conversationList);
   const [editingId, setEditingId] = useState<number | null>(null);
   const [collapsed, setCollapsed] = useState(false);
+  const [openDropdownId, setOpenDropdownId] = useState<number | null>(null);
 
   const onToggleSidebar = () => setCollapsed((prev) => !prev);
 
@@ -208,8 +209,9 @@ export function ChatSidebar({
             </Tooltip>
             </div>
 
-            <div className="shrink-0 w-9 flex items-center justify-center">
+            <div className={`shrink-0 w-9 flex items-center justify-center invisible group-hover:visible ${openDropdownId === conversation.conversation_id ? "!visible" : ""}`}>
               <Dropdown
+              onOpenChange={(open) => setOpenDropdownId(open ? conversation.conversation_id : null)}
               menu={{
                 items: [
                   {


### PR DESCRIPTION
Bugfix: Ensure "more" button is visible only during hover
<img width="687" height="631" alt="image" src="https://github.com/user-attachments/assets/b169f459-85a9-4a48-b171-21ab651052e2" />
