### PR TITLE
✨ Change provideRunSummary param from read-only to editable

### DIFF
--- a/frontend/app/[locale]/agents/components/agentInfo/AgentGenerateDetail.tsx
+++ b/frontend/app/[locale]/agents/components/agentInfo/AgentGenerateDetail.tsx
@@ -220,6 +220,7 @@ export default function AgentGenerateDetail({
       dutyPrompt: editedAgent.duty_prompt || "",
       constraintPrompt: editedAgent.constraint_prompt || "",
       fewShotsPrompt: editedAgent.few_shots_prompt || "",
+      provideRunSummary: editedAgent.provide_run_summary || false,
     };
 
     if (isCreatingMode) {
@@ -254,7 +255,7 @@ export default function AgentGenerateDetail({
       });
     }
 
-  }, [currentAgentId, defaultLlmModel?.id, isCreatingMode, editedAgent.ingroup_permission]);
+  }, [currentAgentId, defaultLlmModel?.id, isCreatingMode, editedAgent.ingroup_permission, editedAgent.provide_run_summary]);
 
   // Default to selecting all groups when creating a new agent.
   // Only applies when groups are loaded and no group is selected yet.
@@ -573,6 +574,7 @@ export default function AgentGenerateDetail({
             constraint_prompt: generatedContent.constraintPrompt || formValues.constraintPrompt,
             few_shots_prompt: generatedContent.fewShotsPrompt || formValues.fewShotsPrompt,
             ingroup_permission: formValues.ingroup_permission || "READ_ONLY",
+            provide_run_summary: formValues.provideRunSummary || false,
           };
 
           // Update profile info in global agent config store
@@ -798,6 +800,28 @@ export default function AgentGenerateDetail({
                     onBlur={() => {
                       const value = form.getFieldValue("mainAgentMaxStep");
                       updateProfileInfo({ max_step: value || 1 });
+                    }}
+                  />
+                </Form.Item>
+
+                <Form.Item
+                  name="provideRunSummary"
+                  label={t("agent.provideRunSummary")}
+                  rules={[
+                    {
+                      required: true,
+                      message: t("agent.provideRunSummary.error"),
+                    },
+                  ]}
+                  className="mb-3"
+                >
+                  <Select
+                    options={[
+                      { value: true, label: t("common.yes") },
+                      { value: false, label: t("common.no") },
+                    ]}
+                    onChange={(value) => {
+                      updateProfileInfo({ provide_run_summary: value });
                     }}
                   />
                 </Form.Item>

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -294,6 +294,8 @@
   "agent.author": "Author",
   "agent.authorPlaceholder": "Please enter author name",
   "agent.author.hint": "Default: {{email}}",
+  "agent.provideRunSummary": "Provide Run Summary",
+  "agent.provideRunSummary.error": "Please select whether to provide run summary",
   "agent.description": "Agent Description",
   "agent.descriptionPlaceholder": "Please enter agent description",
   "agent.userGroup": "User Group",

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -297,6 +297,8 @@
   "agent.author": "作者",
   "agent.authorPlaceholder": "请输入作者名称",
   "agent.author.hint": "默认：{{email}}",
+  "agent.provideRunSummary": "提供运行摘要",
+  "agent.provideRunSummary.error": "请选择是否提供运行摘要",
   "agent.description": "智能体描述",
   "agent.userGroup": "用户组",
   "agent.userGroup.empty": "暂无用户组",

--- a/frontend/types/agentConfig.ts
+++ b/frontend/types/agentConfig.ts
@@ -19,6 +19,7 @@ export type AgentProfileInfo = Partial<
     | "model"
     | "model_id"
     | "max_step"
+    | "provide_run_summary"
     | "description"
     | "duty_prompt"
     | "constraint_prompt"


### PR DESCRIPTION
#2392 
provideRunSummary param controls whether to send a run summary to the parent agent when used as sub-agent.
Default as false.
<img width="702" height="771" alt="image" src="https://github.com/user-attachments/assets/8aa771b8-d551-4506-82cf-7a89670aee23" />

<img width="689" height="846" alt="image" src="https://github.com/user-attachments/assets/6fd1f5cf-a588-48cf-a73f-4b2f6a8980d6" />
