### PR TITLE
🐛 Bugfix    Update pagination logic in DataMateClient and adjust related parame…

### DIFF
--- a/sdk/nexent/core/tools/datamate_search_tool.py
+++ b/sdk/nexent/core/tools/datamate_search_tool.py
@@ -85,7 +85,7 @@ class DataMateSearchTool(Tool):
         threshold: float = Field(
             description="Default similarity threshold for search results", default=0.2),
         kb_page: int = Field(
-            description="Page index when listing knowledge bases from DataMate", default=0),
+            description="Page index when listing knowledge bases from DataMate", default=1),
         kb_page_size: int = Field(
             description="Page size when listing knowledge bases from DataMate", default=20),
     ):

--- a/sdk/nexent/core/tools/knowledge_base_search_tool.py
+++ b/sdk/nexent/core/tools/knowledge_base_search_tool.py
@@ -36,6 +36,7 @@ class KnowledgeBaseSearchTool(Tool):
             "description_zh": "要执行的搜索查询词"
         },
         "index_names": {
+            "type": "array",
             "description": "The list of index names to search",
             "description_zh": "要索引的知识库"
         },
@@ -97,9 +98,9 @@ class KnowledgeBaseSearchTool(Tool):
         self.running_prompt_en = "Searching the knowledge base..."
 
 
-    def forward(self, query: str, index_names: str) -> str:
+    def forward(self, query: str, index_names: List[str]) -> str:
         # Parse index_names from string (always required)
-        search_index_names = [name.strip() for name in index_names.split(",") if name.strip()]
+        search_index_names = index_names
 
         # Use the instance search_mode
         search_mode = self.search_mode

--- a/sdk/nexent/datamate/datamate_client.py
+++ b/sdk/nexent/datamate/datamate_client.py
@@ -134,44 +134,65 @@ class DataMateClient:
 
     def list_knowledge_bases(
         self,
-        page: int = 0,
+        page: int = 1,
         size: int = 20,
         authorization: Optional[str] = None
     ) -> List[Dict[str, Any]]:
         """
-        Get list of knowledge bases from DataMate.
+        Get list of all knowledge bases from DataMate by paginating through all pages.
+
+        Always starts from page 1, reads the total page count from the first response,
+        then fetches all remaining pages and aggregates the results.
 
         Args:
-            page: Page index (default: 0)
-            size: Page size (default: 20)
-            authorization: Optional authorization header
+            page: Ignored; pagination always starts from page 1 (kept for backward compat).
+            size: Page size for each request (default: 20).
+            authorization: Optional authorization header.
 
         Returns:
-            List of knowledge base dictionaries with their IDs and metadata.
+            Aggregated list of all knowledge base dictionaries with their IDs and metadata.
 
         Raises:
-            RuntimeError: If the API request fails
+            RuntimeError: If any API request fails.
         """
         try:
             url = self._build_url("/api/knowledge-base/list")
-            payload = {"page": page, "size": size}
             headers = self._build_headers(authorization)
 
+            all_knowledge_bases: List[Dict[str, Any]] = []
+
+            # Always start from page 1 to get totalPages
+            current_page = 1
+            total_pages = 1
+
+            while current_page <= total_pages:
+                payload = {"page": current_page, "size": size}
+                logger.info(
+                    f"Fetching DataMate knowledge bases from: {url}, page={current_page}, size={size}")
+
+                response = self._make_request(
+                    "POST", url, headers, json=payload,
+                    error_message="Failed to get knowledge base list")
+                data = response.json()
+
+                page_content: List[Dict[str, Any]] = []
+                if data.get("data"):
+                    page_content = data.get("data", {}).get("content", [])
+
+                    # Read totalPages from the first page response only
+                    if current_page == 1:
+                        total_pages = data.get("data", {}).get("totalPages", 1)
+
+                all_knowledge_bases.extend(page_content)
+                logger.info(
+                    f"Fetched page {current_page}/{total_pages} "
+                    f"({len(page_content)} items, cumulative: {len(all_knowledge_bases)})")
+                current_page += 1
+
             logger.info(
-                f"Fetching DataMate knowledge bases from: {url}, page={page}, size={size}")
-
-            response = self._make_request(
-                "POST", url, headers, json=payload, error_message="Failed to get knowledge base list")
-            data = response.json()
-
-            # Extract knowledge base list from response
-            knowledge_bases = []
-            if data.get("data"):
-                knowledge_bases = data.get("data").get("content", [])
-
-            logger.info(
-                f"Successfully fetched {len(knowledge_bases)} knowledge bases from DataMate")
-            return knowledge_bases
+                f"Successfully fetched {len(all_knowledge_bases)} knowledge bases from DataMate "
+                f"across {total_pages} page(s)")
+            return all_knowledge_bases
 
         except httpx.HTTPError as e:
             logger.error(

--- a/test/sdk/core/tools/test_knowledge_base_search_tool.py
+++ b/test/sdk/core/tools/test_knowledge_base_search_tool.py
@@ -248,10 +248,10 @@ class TestKnowledgeBaseSearchTool:
         mock_results = create_mock_search_result(2)
         knowledge_base_search_tool.vdb_core.hybrid_search.return_value = mock_results
 
-        # Pass index_names as parameter (comma-separated string)
-        result = knowledge_base_search_tool.forward("test query", index_names="custom_index1,custom_index2")
+        # Pass index_names as a list parameter (forward expects List[str])
+        knowledge_base_search_tool.forward("test query", index_names=["custom_index1", "custom_index2"])
 
-        # Verify vdb_core was called with parsed index names
+        # Verify vdb_core was called with the index names as-is
         knowledge_base_search_tool.vdb_core.hybrid_search.assert_called_once_with(
             index_names=["custom_index1", "custom_index2"],
             query_text="test query",
@@ -329,7 +329,8 @@ class TestKnowledgeBaseSearchTool:
         mock_results = create_mock_search_result(1)
         knowledge_base_search_tool.vdb_core.hybrid_search.return_value = mock_results
 
-        result = knowledge_base_search_tool.forward("test query", index_names="single_index")
+        # Pass index_names as a list parameter (forward expects List[str])
+        knowledge_base_search_tool.forward("test query", index_names=["single_index"])
 
         # Verify vdb_core was called with single index
         knowledge_base_search_tool.vdb_core.hybrid_search.assert_called_once_with(
@@ -345,12 +346,12 @@ class TestKnowledgeBaseSearchTool:
         mock_results = create_mock_search_result(1)
         knowledge_base_search_tool.vdb_core.hybrid_search.return_value = mock_results
 
-        # Pass index_names with extra whitespace
-        result = knowledge_base_search_tool.forward("test query", index_names="  index1  ,  index2  ")
+        # Pass index_names as a list parameter (forward expects List[str])
+        knowledge_base_search_tool.forward("test query", index_names=["  index1  ", "  index2  "])
 
-        # Verify whitespace is stripped
+        # Verify vdb_core was called with the index names as-is (no stripping performed)
         knowledge_base_search_tool.vdb_core.hybrid_search.assert_called_once_with(
-            index_names=["index1", "index2"],
+            index_names=["  index1  ", "  index2  "],
             query_text="test query",
             embedding_model=knowledge_base_search_tool.embedding_model,
             top_k=5

--- a/test/sdk/datamate/test_datamate_client.py
+++ b/test/sdk/datamate/test_datamate_client.py
@@ -368,7 +368,7 @@ class TestListKnowledgeBasesEdgeCases:
 
         client._http_client.post.assert_called_once_with(
             "http://datamate.local:30000/api/knowledge-base/list",
-            json={"page": 0, "size": 20},
+            json={"page": 1, "size": 20},
             headers={},
             timeout=client.timeout,
         )


### PR DESCRIPTION
✨ Update pagination logic in DataMateClient and adjust related parameters in search tools

- Changed default page index from 0 to 1 in DataMateClient and DataMateSearchTool for consistency.
- Updated KnowledgeBaseSearchTool to accept index_names as a list instead of a comma-separated string.
- Modified tests to reflect changes in parameter handling and pagination behavior.
https://github.com/ModelEngine-Group/nexent/issues/2734

<img width="2192" height="1698" alt="image" src="https://github.com/user-attachments/assets/e3d7a45a-7b47-45d7-922a-ea03041872eb" />
