### PR TITLE
[WIP]🐛 Bugfix: Enhance code parsing to support multiple LLM output formats

### DIFF
--- a/backend/prompts/managed_system_prompt_template_en.yaml
+++ b/backend/prompts/managed_system_prompt_template_en.yaml
@@ -61,8 +61,8 @@ system_prompt: |-
      - Write code in simple Python
      - Follow Python coding standards and Python syntax
      - Call tools correctly according to format specifications
-     - To distinguish between code execution and displaying user code, use 'Code: \n```<RUN>\n' to start executing code and '```<END_CODE>' to indicate its completion. Use 'Code: \n```<DISPLAY:language_type>\n' to start displaying code and '```<END_DISPLAY_CODE>' to indicate its completion.
-     - Note that executed code is not visible to users. If users need to see the code, use 'Code: \n```<DISPLAY:language_type>\n' as the start and '```<END_DISPLAY_CODE>' to denote displayed code.
+     - To distinguish between code execution and displaying user code, use 'Code: \n```python\n' to start executing code and '```' to indicate its completion. Use 'Code: \n```DISPLAY:language_type\n' to start displaying code and '```' to indicate its completion.
+     - Note that executed code is not visible to users. If users need to see the code, use 'Code: \n```DISPLAY:language_type\n' as the start and '```' to denote displayed code.
 
   3. Observe Results:
      - View code execution results
@@ -113,7 +113,7 @@ system_prompt: |-
   {{ constraint }}
 
   ### Python Code Specifications
-  1. If it is considered to be code that needs to be executed, the code content begins with 'code: \n```<RUN>\n' and ends with '```<END_CODE>'. If the code does not need to be executed for display only, the code content begins with 'code:\n```<DISPLAY:language_type>\n', and ends with '```<END_DISPLAY_CODE>', where language_type can be python, java, javascript, etc;
+  1. If it is considered to be code that needs to be executed, the code content begins with 'code: \n```python\n' and ends with '```'. If the code does not need to be executed for display only, the code content begins with 'code:\n```DISPLAY:language_type\n', and ends with '```', where language_type can be python, java, javascript, etc;
   2. Only use defined variables, variables will persist between multiple calls;
   3. Use "print()" function to let the next model call see corresponding variable information;
   4. Use tool input parameters correctly, use keyword arguments, not dictionary format;

--- a/backend/prompts/managed_system_prompt_template_zh.yaml
+++ b/backend/prompts/managed_system_prompt_template_zh.yaml
@@ -134,24 +134,24 @@ system_prompt: |-
 
      - **精确读取**：如只需特定文件（如示例、参考文档），可指定 additional_files：
 
-     ```<RUN>
+     ```python
 
      skill_content = read_skill_md("skill_name", ["examples.md", "reference/api_doc"])
 
      print(skill_content)
 
-     ```<END_CODE>
+     ```
 
      注意：当 additional_files 非空时，默认不再自动读取 SKILL.md，如需同时读取请显式指定。
 
      - **加载技能配置**：如果技能需要读取配置变量，可先调用 `read_skill_config("skill_name")` 读取配置字符串，通过 `json.loads` 方法转化为配置字典，再从中获取所需值：
-     ```<RUN>
+     ```python
      import json
      config = json.loads(read_skill_config("skill_name"))
      # 返回示例: {"key_a": {"key2": "value2"}, "others": {...}}
      value = config["key1"]["key2"]
      print(value)
-     ```<END_CODE>
+     ```
 
   3. **遵循技能指南**：技能内容注入后，严格按其中的步骤执行。不要跳过技能指南中的步骤，也不要用自行编写的代码替代技能定义的流程。
 
@@ -159,7 +159,7 @@ system_prompt: |-
 
      代码：
 
-     ```<RUN>
+     ```python
 
      # 参数使用 -- 前缀传递命令行参数
      # 布尔参数传 True 即可（如 --wait）
@@ -168,7 +168,7 @@ system_prompt: |-
 
      print(result)
 
-     ```<END_CODE>
+     ```
 
      注意：只执行技能指南中明确声明的脚本路径，绝不自行构造脚本路径。
 
@@ -182,7 +182,7 @@ system_prompt: |-
 
      - **示例**：
 
-     ```<RUN>
+     ```python
 
      # 技能内容提示"请参考 examples.md 获取详细示例"
 
@@ -190,7 +190,7 @@ system_prompt: |-
 
      print(additional_info)
 
-     ```<END_CODE>
+     ```
 
   {%- endif %}
 
@@ -223,9 +223,9 @@ system_prompt: |-
 
      - 根据格式规范正确调用工具
 
-     - 考虑到代码执行与展示用户代码的区别，使用'代码：\n```<RUN>\n'开头，并以'```<END_CODE>'表达运行代码，使用'代码：\n```<DISPLAY:语言类型>\n'开头，并以'```<END_DISPLAY_CODE>'表达展示代码
+     - 考虑到代码执行与展示用户代码的区别，使用 '代码：\n```python\n' 开头并以 '```' 结尾表示运行代码，使用 '代码：\n```DISPLAY:语言类型\n' 开头并以 '```' 结尾表示展示代码
 
-     - 注意运行的代码不会被用户看到，所以如果用户需要看到代码，你需要使用'代码：\n```<DISPLAY:语言类型>\n'开头，并以'```<END_DISPLAY_CODE>'表达展示代码。
+     - 注意运行的代码不会被用户看到，所以如果用户需要看到代码，你需要使用 '代码：\n```DISPLAY:语言类型\n' 开头并以 '```' 结尾表示展示代码。
 
 
   3. 观察结果：
@@ -350,7 +350,7 @@ system_prompt: |-
 
   ### python代码规范
 
-  1. 如果认为是需要执行的代码，代码内容以'代码：\n```<RUN>\n'开头，并以'```<END_CODE>'标识符结尾。如果是不需要执行仅用于展示的代码，代码内容以'代码：\n```<DISPLAY:语言类型>\n'开头，并以'```<END_DISPLAY_CODE>'标识符结尾，其中语言类型例如python、java、javascript等；
+  1. 如果认为是需要执行的代码，代码内容以 '代码：\n```python\n' 开头并以 '```' 结尾；如果是不需要执行仅用于展示的代码，代码内容以 '代码：\n```DISPLAY:语言类型\n' 开头并以 '```' 结尾，其中语言类型例如 python、java、javascript 等；
 
   2. 只使用已定义的变量，变量将在多次调用之间持续保持；
 

--- a/backend/prompts/manager_system_prompt_template_en.yaml
+++ b/backend/prompts/manager_system_prompt_template_en.yaml
@@ -62,8 +62,8 @@ system_prompt: |-
      - Write code in simple Python
      - Follow Python coding standards and Python syntax
      - Correctly call tools or agents to solve problems
-     - To distinguish between code execution and displaying user code, use 'Code: \n```<RUN>\n' to start executing code and '```<END_CODE>' to indicate its completion. Use 'Code: \n```<DISPLAY:language_type>\n' to start displaying code and '```<END_DISPLAY_CODE>' to indicate its completion.
-     - Note that executed code is not visible to users. If users need to see the code, use 'Code: \n```<DISPLAY:language_type>\n' as the start and '```<END_DISPLAY_CODE>' to denote displayed code.
+     - To distinguish between code execution and displaying user code, use 'Code: \n```python\n' to start executing code and '```' to indicate its completion. Use 'Code: \n```DISPLAY:language_type\n' to start displaying code and '```' to indicate its completion.
+     - Note that executed code is not visible to users. If users need to see the code, use 'Code: \n```DISPLAY:language_type\n' as the start and '```' to denote displayed code.
 
   3. Observe Results:
      - View code execution results
@@ -141,7 +141,7 @@ system_prompt: |-
   {{ constraint }}
   
   ### Python Code Specifications
-  1. If it is considered to be code that needs to be executed, the code content begins with 'code: \n```<RUN>\n' and ends with '```<END_CODE>'. If the code does not need to be executed for display only, the code content begins with 'code: \n```<DISPLAY:language_type>\n', and ends with '```<END_DISPLAY_CODE>', where language_type can be python, java, javascript, etc;
+  1. If it is considered to be code that needs to be executed, the code content begins with 'code: \n```python\n' and ends with '```'. If the code does not need to be executed for display only, the code content begins with 'code: \n```DISPLAY:language_type\n', and ends with '```', where language_type can be python, java, javascript, etc;
   2. Only use defined variables, variables will persist between multiple calls;
   3. Use "print()" function to let the next model call see corresponding variable information;
   4. Use tool/agent input parameters correctly, use keyword arguments, not dictionary format;

--- a/backend/prompts/manager_system_prompt_template_zh.yaml
+++ b/backend/prompts/manager_system_prompt_template_zh.yaml
@@ -66,32 +66,32 @@ system_prompt: |-
   2. **加载技能**：根据不同场景选择读取方式：
      - **首次加载**：调用 `read_skill_md("skill_name")` 读取技能的完整执行指南（默认读取 SKILL.md）
      - **精确读取**：如只需特定文件（如示例、参考文档），可指定 additional_files：
-     ```<RUN>
+     ```python
      skill_content = read_skill_md("skill_name", ["examples.md", "reference/api_doc"])
      print(skill_content)
-     ```<END_CODE>
+     ```
      注意：当 additional_files 非空时，默认不再自动读取 SKILL.md，如需同时读取请显式指定。
 
      - **加载技能配置**：如果技能需要读取配置变量，可先调用 `read_skill_config("skill_name")` 读取配置字符串，通过 `json.loads` 方法转化为配置字典，再从中获取所需值：
-     ```<RUN>
+     ```python
      import json
      config = json.loads(read_skill_config("skill_name"))
      # 返回示例: {"key_a": {"key2": "value2"}, "others": {...}}
      value = config["key1"]["key2"]
      print(value)
-     ```<END_CODE>
+     ```
 
   3. **遵循技能指南**：技能内容注入后，严格按其中的步骤执行。不要跳过技能指南中的步骤，也不要用自行编写的代码替代技能定义的流程。
 
   4. **执行技能脚本**：如果技能指南中引用了附加脚本（形如 `<use_script path="script_path" />`），使用以下格式调用：
      代码：
-     ```<RUN>
+     ```python
      # 参数使用 -- 前缀传递命令行参数
      # 布尔参数传 True 即可（如 --wait）
      # 列表参数会自动展开（如 --names ["vm1", "vm2"] -> --names vm1 vm2）
      result = run_skill_script("skill_name", "script_path", {"--param1": "value1", "--flag": True})
      print(result)
-     ```<END_CODE>
+     ```
      注意：只执行技能指南中明确声明的脚本路径，绝不自行构造脚本路径。
 
   5. **整合输出**：根据技能指南要求的输出格式，结合脚本执行结果生成最终回答。
@@ -100,11 +100,11 @@ system_prompt: |-
      - **引用模板识别**：注意技能内容中形如 `<reference path="file_path" />` 或自然语言式的引用声明（如"详见 examples.md"、"请参考 reference/api_doc"）
      - **自动补全**：发现引用后，尝试读取被引用的文件获取更多信息
      - **示例**：
-     ```<RUN>
+     ```python
      # 技能内容提示"请参考 examples.md 获取详细示例"
      additional_info = read_skill_md("skill_name", ["examples.md"])
      print(additional_info)
-     ```<END_CODE>
+     ```
   {%- endif %}
 
   ### 执行流程
@@ -122,8 +122,8 @@ system_prompt: |-
      - 用简单的Python编写代码
      - 遵循python代码规范和python语法
      - 正确调用工具或助手解决问题
-     - 考虑到代码执行与展示用户代码的区别，使用'代码：\n```<RUN>\n'开头，并以'```<END_CODE>'表达运行代码，使用'代码：\n```<DISPLAY:语言类型>\n'开头，并以'```<END_DISPLAY_CODE>'表达展示代码
-     - 注意运行的代码不会被用户看到，所以如果用户需要看到代码，你需要使用'代码：\n```<DISPLAY:语言类型>\n'开头，并以'```<END_DISPLAY_CODE>'表达展示代码。
+     - 考虑到代码执行与展示用户代码的区别，使用 '代码：\n```python\n' 开头并以 '```' 结尾表示运行代码，使用 '代码：\n```DISPLAY:语言类型\n' 开头并以 '```' 结尾表示展示代码
+     - 注意运行的代码不会被用户看到，所以如果用户需要看到代码，你需要使用 '代码：\n```DISPLAY:语言类型\n' 开头并以 '```' 结尾表示展示代码。
 
   3. 观察结果：
      - 查看代码执行结果
@@ -215,7 +215,7 @@ system_prompt: |-
   {{ constraint }}
 
   ### python代码规范
-  1. 如果认为是需要执行的代码，代码内容以'代码：\n```<RUN>\n'开头，并以'```<END_CODE>'标识符结尾。如果是不需要执行仅用于展示的代码，代码内容以'代码：\n```<DISPLAY:语言类型>\n'开头，并以'```<END_DISPLAY_CODE>'标识符结尾，其中语言类型例如python、java、javascript等；
+  1. 如果认为是需要执行的代码，代码内容以 '代码：\n```python\n' 开头并以 '```' 结尾；如果是不需要执行仅用于展示的代码，代码内容以 '代码：\n```DISPLAY:语言类型\n' 开头并以 '```' 结尾，其中语言类型例如 python、java、javascript 等；
   2. 只使用已定义的变量，变量将在多次调用之间持续保持；
   3. 使用“print()”函数让下一次的模型调用看到对应变量信息；
   4. 正确使用工具/助手的入参，使用关键字参数，不要用字典形式；

--- a/backend/prompts/utils/prompt_generate_en.yaml
+++ b/backend/prompts/utils/prompt_generate_en.yaml
@@ -53,8 +53,8 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
      - Write code in simple Python
      - Follow Python coding standards and Python syntax
      - Call tools/assistants correctly according to format specifications
-     - To distinguish between code execution and displaying user code, use 'Code: \n```<RUN>\n' to start executing code and '```<END_CODE>' to indicate its completion. Use 'Code: \n```<DISPLAY:language_type>\n' to start displaying code and '```<END_DISPLAY_CODE>' to indicate its completion.
-     - Note that executed code is not visible to users. If users need to see the code, use 'Code: \n```<DISPLAY:language_type>\n' as the start and '```<END_DISPLAY_CODE>' to denote displayed code.
+     - To distinguish between code execution and displaying user code, use 'Code: \n```python\n' to start executing code and '```' to indicate its completion. Use 'Code: \n```DISPLAY:language_type\n' to start displaying code and '```' to indicate its completion.
+     - Note that executed code is not visible to users. If users need to see the code, use 'Code: \n```DISPLAY:language_type\n' as the start and '```' to denote displayed code.
 
   3. Observe Results:
      - View code execution results
@@ -62,7 +62,7 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
   After thinking, when you believe you can answer the user's question, you can generate a final answer directly to the user without generating code and stop the loop.
   
   ### Python Code Specifications
-  1. If it is considered to be code that needs to be executed, the code content begins with 'Code:\n```<RUN>\n' and ends with '```<END_CODE>'. If the code does not need to be executed for display only, the code content begins with 'Code:\n```<DISPLAY:language_type>\n', and ends with '```<END_DISPLAY_CODE>', where language_type can be python, java, javascript, etc.;
+  1. If it is considered to be code that needs to be executed, the code content begins with 'Code:\n```python\n' and ends with '```'. If the code does not need to be executed for display only, the code content begins with 'Code:\n```DISPLAY:language_type\n', and ends with '```', where language_type can be python, java, javascript, etc.;
   2. Only use defined variables, variables will persist between multiple calls;
   3. Use "print()" function to let the next model call see corresponding variable information;
   4. Use tool/assistant input parameters correctly, use keyword arguments, not dictionary format;
@@ -78,18 +78,18 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
   
   Think: I will first use the knowledge_base_search tool to find if there is relevant information in the local knowledge base.
   Code:
-  ```<RUN>
+  ```python
   knowledge_info = knowledge_base_search(query="Oriental Pearl Tower introduction", index_names=["local_knowledge_base1", "local_knowledge_base2"])
   print(knowledge_info)
-  ```<END_CODE>
+  ```
   Observe Results: No results found for query "Oriental Pearl Tower introduction". The search results are insufficient to support an answer.
   
   Think: Since no relevant information was found in the local knowledge base, I need to use the web_search tool to query network information.
   Code:
-  ```<RUN>
+  ```python
   web_info = web_search(query="Oriental Pearl Tower introduction")
   print(web_info)
-  ```<END_CODE>
+  ```
   Observe Results: The Oriental Pearl TV Tower is located in Lujiazui, Pudong New Area, Shanghai, China... 
   
   Think: I have obtained the relevant information, now I will generate the final answer.
@@ -101,10 +101,10 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
   
   Think: I need to call the travel planning assistant to plan the trip.
   Code:
-  ```<RUN>
+  ```python
   itinerary_result = travel_planning_assistant(task="Help me plan tomorrow's trip from Shanghai to Beijing")
   print(itinerary_result)
-  ```<END_CODE>
+  ```
   Observe Results: Tomorrow's trip planning from Shanghai to Beijing, including transportation, accommodation, attractions, etc.
   
   Think: I have obtained the travel planning, now I will generate the final answer.
@@ -116,18 +116,18 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
   
   Think: I need to first get weather data, then let the analysis assistant help me analyze.
   Code:
-  ```<RUN>
+  ```python
   weather_data = weather_api(city="Beijing")
   print(weather_data)
-  ```<END_CODE>
+  ```
   Observe Results: {"temperature": 25, "humidity": "60%", "condition": "sunny"}
   
   Think: Now I have weather data, let the analysis assistant help me analyze this data.
   Code:
-  ```<RUN>
+  ```python
   analysis_result = data_analysis_assistant(task="Analyze today's weather data: temperature 25 degrees, humidity 60%, sunny")
   print(analysis_result)
-  ```<END_CODE>
+  ```
   Observe Results: Today's weather is suitable, temperature is moderate, humidity is normal, suitable for outdoor activities.
   
   Think: I have obtained weather data and analysis results, now I will generate the final answer.
@@ -144,10 +144,10 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
 
   Task 5: "Write a Python quick sort code"
 
-  Think: I need to write a Python code directly, this code is only for display, so I start with 'Code:\n```<DISPLAY:python>\n'.
+  Think: I need to write a Python code directly, this code is only for display, so I start with 'Code:\n```DISPLAY:python\n'.
 
   Code:
-  ```<DISPLAY:python>
+  ```DISPLAY:python
   def quick_sort(arr):
     if len(arr) <= 1:
       return arr
@@ -157,12 +157,13 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
     middle = [x for x in arr if x == pivot]
     right = [x for x in arr if x > pivot]
     return quick_sort(left) + middle + quick_sort(right)
-  ```<END_DISPLAY_CODE>
+  ```
   Observe Results: The Python quick sort code.
 
   Think: I have obtained the Python quick sort code, now I will generate the final answer.
   The Python quick sort code is as follows:
-  ```<DISPLAY:python>
+  Code:
+  ```DISPLAY:python
   def quick_sort(arr):
     if len(arr) <= 1:
       return arr
@@ -171,7 +172,8 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
     middle = [x for x in arr if x == pivot]
     right = [x for x in arr if x > pivot]
     return quick_sort(left) + middle + quick_sort(right)
-  ```<END_DISPLAY_CODE>
+  ```
+  ```
 
   ---
 

--- a/backend/prompts/utils/prompt_generate_en.yaml
+++ b/backend/prompts/utils/prompt_generate_en.yaml
@@ -173,7 +173,6 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
     right = [x for x in arr if x > pivot]
     return quick_sort(left) + middle + quick_sort(right)
   ```
-  ```
 
   ---
 

--- a/backend/prompts/utils/prompt_generate_zh.yaml
+++ b/backend/prompts/utils/prompt_generate_zh.yaml
@@ -78,7 +78,7 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
   思考：我先使用knowledge_base_search工具查找本地知识库是否有相关信息。
   代码：
   ```python
-  knowledge_info = knowledge_base_search(query="东方明珠 介绍", index_names=["本地知识库1"， "本地知识库2"])
+  knowledge_info = knowledge_base_search(query="东方明珠 介绍", index_names=["本地知识库1", "本地知识库2"])
   print(knowledge_info)
   ```
   观察结果：未找到查询"东方明珠 介绍"的结果。检索结果难以支撑回答。

--- a/backend/prompts/utils/prompt_generate_zh.yaml
+++ b/backend/prompts/utils/prompt_generate_zh.yaml
@@ -52,8 +52,8 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
      - 用简单的Python编写代码
      - 遵循python代码规范和python语法
      - 根据格式规范正确调用工具/助手
-     - 考虑到代码执行与展示用户代码的区别，使用'代码：\n```<RUN>\n'开头，并以'```<END_CODE>'表达运行代码，使用'代码：\n```<DISPLAY:语言类型>\n'开头，并以'```<END_DISPLAY_CODE>'表达展示代码
-     - 注意运行的代码不会被用户看到，所以如果用户需要看到代码，你需要使用'代码：\n```<DISPLAY:语言类型>\n'开头，并以'```<END_DISPLAY_CODE>'表达展示代码。
+     - 考虑到代码执行与展示用户代码的区别，使用 '代码：\n```python\n' 开头并以 '```' 结尾表示运行代码，使用 '代码：\n```DISPLAY:语言类型\n' 开头并以 '```' 结尾表示展示代码
+     - 注意运行的代码不会被用户看到，所以如果用户需要看到代码，你需要使用 '代码：\n```DISPLAY:语言类型\n' 开头并以 '```' 结尾表示展示代码。
 
   3. 观察结果：
      - 查看代码执行结果
@@ -61,7 +61,7 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
   在思考结束后，当Agent认为可以回答用户问题，那么可以不生成代码，直接生成最终回答给到用户并停止循环。
 
   ### python代码规范
-  1. 如果认为是需要执行的代码，代码内容以'代码：\n```<RUN>\n'开头，并以'```<END_CODE>'标识符结尾。如果是不需要执行仅用于展示的代码，代码内容以'代码：\n```<DISPLAY:语言类型>\n'开头，并以'```<END_DISPLAY_CODE>'标识符结尾，其中语言类型例如python、java、javascript等；
+  1. 如果认为是需要执行的代码，代码内容以 '代码：\n```python\n' 开头并以 '```' 结尾；如果是不需要执行仅用于展示的代码，代码内容以 '代码：\n```DISPLAY:语言类型\n' 开头并以 '```' 结尾，其中语言类型例如 python、java、javascript 等；
   2. 只使用已定义的变量，变量将在多次调用之间持续保持；
   3. 使用“print()”函数让下一次的模型调用看到对应变量信息；
   4. 正确使用工具/助手的入参，使用关键字参数，不要用字典形式；
@@ -77,18 +77,18 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
   
   思考：我先使用knowledge_base_search工具查找本地知识库是否有相关信息。
   代码：
-  ```<RUN>
+  ```python
   knowledge_info = knowledge_base_search(query="东方明珠 介绍", index_names=["本地知识库1"， "本地知识库2"])
   print(knowledge_info)
-  ```<END_CODE>
+  ```
   观察结果：未找到查询"东方明珠 介绍"的结果。检索结果难以支撑回答。
   
   思考：从本地知识库中没有找到相关信息，我需要使用web_search工具查询网络信息。
   代码：
-  ```<RUN>
+  ```python
   web_info = web_search(query="东方明珠 介绍")
   print(web_info)
-  ```<END_CODE>
+  ```
   观察结果：东方明珠广播电视塔位于中国上海市浦东新区陆家嘴... 
   
   思考：我已经获得了有关信息，现在我将生成最终回答。
@@ -100,10 +100,10 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
   
   思考：我需要调用旅程规划助手来规划出行。
   代码：
-  ```<RUN>
+  ```python
   itinerary_result = travel_planning_assistant(task="帮我规划明天从上海出发去北京的行程")
   print(itinerary_result)
-  ```<END_CODE>
+  ```
   观察结果：明天从上海出发去北京的行程规划，包括交通、住宿、景点等。
   
   思考：我已经获得了出行规划，现在我将生成最终回答。
@@ -115,18 +115,18 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
   
   思考：我需要先获取天气数据，然后让分析助手帮我分析。
   代码：
-  ```<RUN>
+  ```python
   weather_data = weather_api(city="北京")
   print(weather_data)
-  ```<END_CODE>
+  ```
   观察结果：{"temperature": 25, "humidity": 60%, "condition": "晴天"}
   
   思考：现在我有天气数据了，让分析助手帮我分析这些数据。
   代码：
-  ```<RUN>
+  ```python
   analysis_result = data_analysis_assistant(task="分析今天的天气数据：温度25度，湿度60%，晴天")
   print(analysis_result)
-  ```<END_CODE>
+  ```
   观察结果：今天天气适宜，温度适中，湿度正常，适合户外活动。
   
   思考：我已经获得了天气数据和分析结果，现在我将生成最终回答。
@@ -143,9 +143,9 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
   
   任务5："帮我用Python写一个快速排序的代码"
 
-  思考：我需要直接写一个python代码，此代码仅用于展示，因此我以'代码：\n```<DISPLAY:python>\n'开头。
+  思考：我需要直接写一个python代码，此代码仅用于展示，因此我以'代码：\n```DISPLAY:python\n'开头。
   代码：
-  ```<DISPLAY:python>
+  ```DISPLAY:python
   def quick_sort(arr):
     if len(arr) <= 1:
       return arr
@@ -154,13 +154,13 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
     middle = [x for x in arr if x == pivot]
     right = [x for x in arr if x > pivot]
     return quick_sort(left) + middle + quick_sort(right)
-  ```<END_DISPLAY_CODE>
+  ```
   观察结果：快速排序的python代码。
-  
+
   思考：我已经获得了快速排序的python代码，现在我将生成最终回答。
   快速排序的python代码如下：
   代码：
-  ```<DISPLAY:python>
+  ```DISPLAY:python
   def quick_sort(arr):
     if len(arr) <= 1:
       return arr
@@ -169,7 +169,7 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
     middle = [x for x in arr if x == pivot]
     right = [x for x in arr if x > pivot]
     return quick_sort(left) + middle + quick_sort(right)
-  ```<END_DISPLAY_CODE>
+  ```
 
   ---
 

--- a/sdk/nexent/core/agents/core_agent.py
+++ b/sdk/nexent/core/agents/core_agent.py
@@ -27,10 +27,14 @@ if TYPE_CHECKING:
 
 
 def parse_code_blobs(text: str) -> str:
-    """Extract code blocs from the LLM's output for execution.
+    """Extract code blocks from the LLM's output for execution.
 
-    This function is used to parse code that needs to be executed, so it only handles
-    <RUN> format and legacy python formats.
+    Supports multiple formats:
+    1. Standard markdown: ```python ... ```
+    2. XML tool_call format: <tool_call>...<tool>...</tool>...</tool_call>
+    3. FunctionCall format: <FunctionCallBegin>...</FunctionCallEnd>
+    4. Invoke format: <invoke name="tool">...</invoke> (Anthropic/Claude style)
+    5. Direct Python code (fallback)
 
     Args:
         text (`str`): LLM's output text to parse.
@@ -41,19 +45,29 @@ def parse_code_blobs(text: str) -> str:
     Raises:
         ValueError: If no valid code block is found in the text.
     """
-    # First try to match the new <RUN> format for execution
-    # <END_CODE> is optional - match both with and without it
-    run_pattern = r"```<RUN>\s*\n(.*?)\n```(?:<END_CODE>)?"
-    run_matches = re.findall(run_pattern, text, re.DOTALL)
-
-    if run_matches:
-        return "\n\n".join(match.strip() for match in run_matches)
-
-    # Fallback to original patterns: py|python (for execution)
+    # Match standard python code blocks: ```python or ```py
     pattern = r"```(?:py|python)\s*\n(.*?)\n```"
     matches = re.findall(pattern, text, re.DOTALL)
     if matches:
         return "\n\n".join(match.strip() for match in matches)
+
+    # Handle XML tool_call format (for models like MiniMax with native agent support)
+    if "<tool_call>" in text and "</tool_call>" in text:
+        tool_code = _parse_xml_tool_call(text)
+        if tool_code:
+            return tool_code
+
+    # Handle FunctionCall format: <FunctionCallBegin>...<FunctionCallEnd>
+    if "<FunctionCallBegin>" in text and "<FunctionCallEnd>" in text:
+        tool_code = _parse_function_call(text)
+        if tool_code:
+            return tool_code
+
+    # Handle Invoke format: <invoke name="tool">...</invoke> (Anthropic/Claude style)
+    if "<invoke name=" in text and "</invoke>" in text:
+        tool_code = _parse_invoke_format(text)
+        if tool_code:
+            return tool_code
 
     # Maybe the LLM outputted a code blob directly
     try:
@@ -71,30 +85,226 @@ def parse_code_blobs(text: str) -> str:
             Make sure to include code with the correct pattern for execution:
             Thoughts: Your thoughts
             Code:
-            ```<RUN>
+            ```python
             # Your python code here (for execution)
-            ```<END_CODE>
+            ```
             """
         ).strip()
     )
+
+
+def _parse_xml_tool_call(text: str) -> str | None:
+    """Parse XML tool_call format and convert to Python code.
+
+    Supports multiple variants:
+    ```xml
+    <!-- Variant 1: with <param> tags -->
+    <tool_call>
+    <tool name="tool_name">
+    <param name="param1">value1</param>
+    </tool>
+    </tool_call>
+
+    <!-- Variant 2: direct attribute style -->
+    <tool_call>
+    <tool name="tool_name">
+    param1="value1"
+    </tool>
+    </tool_call>
+    ```
+    To:
+    ```python
+    tool_name(param1="value1")
+    ```
+
+    Args:
+        text: Input text containing tool_call XML format.
+
+    Returns:
+        Python code string if parsing succeeds, None otherwise.
+    """
+    code_lines = []
+
+    # Find all <tool name="..."> blocks
+    tool_pattern = r"<tool\s+name=\"([^\"]+)\">"
+    param_pattern = r"<param\s+name=\"([^\"]+)\">([^<]*)</param>"
+    direct_param_pattern = r"(\w+)=\"([^\"]*)\""
+
+    for tool_match in re.finditer(tool_pattern, text):
+        tool_name = tool_match.group(1)
+        tool_start = tool_match.start()
+
+        # Find the end of this tool block
+        remaining = text[tool_start:]
+        tool_end_match = re.search(r"</tool>", remaining)
+        if not tool_end_match:
+            continue
+
+        tool_content = remaining[:tool_end_match.end()]
+        params = []
+
+        # Try to extract params with <param name="...">...</param> format first
+        param_matches = list(re.finditer(param_pattern, tool_content))
+        if param_matches:
+            for param_match in param_matches:
+                param_name = param_match.group(1)
+                param_value = param_match.group(2).strip()
+                escaped = param_value.replace('\\', '\\\\').replace('"', '\\"')
+                params.append(f'{param_name}="{escaped}"')
+        else:
+            # Fallback: try direct attribute format: param_name="value"
+            for direct_match in re.finditer(direct_param_pattern, tool_content):
+                param_name = direct_match.group(1)
+                param_value = direct_match.group(2)
+                escaped = param_value.replace('\\', '\\\\').replace('"', '\\"')
+                params.append(f'{param_name}="{escaped}"')
+
+        # Build function call
+        if params:
+            code_lines.append(f"{tool_name}({', '.join(params)})")
+        else:
+            code_lines.append(f"{tool_name}()")
+
+    if code_lines:
+        return "\n".join(code_lines)
+
+    return None
+
+
+def _parse_function_call(text: str) -> str | None:
+    """Parse FunctionCall format and convert to Python code.
+
+    Converts:
+    ```json
+    <FunctionCallBegin>
+    {
+      tool => "tool_name",
+      args => {
+        param1="value1",
+        param2="value2"
+      }
+    }
+    <FunctionCallEnd>
+    ```
+    To:
+    ```python
+    tool_name(param1="value1", param2="value2")
+    ```
+
+    Args:
+        text: Input text containing FunctionCall format.
+
+    Returns:
+        Python code string if parsing succeeds, None otherwise.
+    """
+    code_lines = []
+
+    # Find all FunctionCall blocks
+    pattern = r"<FunctionCallBegin>\s*\{([^}]+)\}\s*<FunctionCallEnd>"
+    matches = re.findall(pattern, text, re.DOTALL)
+
+    for match in matches:
+        # Extract tool name
+        tool_match = re.search(r'tool\s*=>\s*"([^"]+)"', match)
+        if not tool_match:
+            tool_match = re.search(r'tool\s*=\s*"([^"]+)"', match)
+
+        if not tool_match:
+            continue
+
+        tool_name = tool_match.group(1)
+
+        # Extract all parameters from args block
+        args_match = re.search(r'args\s*=>?\s*\{([^}]*)\}', match, re.DOTALL)
+        if not args_match:
+            # No args, just tool call
+            code_lines.append(f"{tool_name}()")
+            continue
+
+        args_content = args_match.group(1)
+        params = []
+
+        # Parse each parameter: param_name="value" or param_name="value"
+        # Handle both => and = operators
+        param_pattern = r'(\w+)\s*=>?\s*"([^"]*)"'
+        for param_match in re.finditer(param_pattern, args_content):
+            param_name = param_match.group(1)
+            param_value = param_match.group(2)
+            params.append(f'{param_name}="{param_value}"')
+
+        if params:
+            code_lines.append(f"{tool_name}({', '.join(params)})")
+        else:
+            code_lines.append(f"{tool_name}()")
+
+    if code_lines:
+        return "\n".join(code_lines)
+
+    return None
+
+
+def _parse_invoke_format(text: str) -> str | None:
+    """Parse Invoke format and convert to Python code.
+
+    Converts Anthropic/Claude style tool calls:
+    ```xml
+    <invoke name="read_skill_md">
+    <parameter name="skill_name">scientific-brainstorming</parameter>
+    </invoke>
+    ```
+    To:
+    ```python
+    read_skill_md(skill_name="scientific-brainstorming")
+    ```
+
+    Args:
+        text: Input text containing Invoke format.
+
+    Returns:
+        Python code string if parsing succeeds, None otherwise.
+    """
+    code_lines = []
+
+    # Find all <invoke name="..."> blocks
+    invoke_pattern = r'<invoke\s+name="([^"]+)"[^>]*>(.*?)</invoke>'
+    matches = re.findall(invoke_pattern, text, re.DOTALL)
+
+    for tool_name, tool_content in matches:
+        params = []
+
+        # Extract all <parameter name="...">...</parameter> blocks
+        param_pattern = r'<parameter\s+name="([^"]+)"[^>]*>([^<]*)</parameter>'
+        for param_match in re.finditer(param_pattern, tool_content):
+            param_name = param_match.group(1)
+            param_value = param_match.group(2).strip()
+
+            # Escape quotes in the value
+            escaped = param_value.replace('\\', '\\\\').replace('"', '\\"')
+            params.append(f'{param_name}="{escaped}"')
+
+        # Build function call
+        if params:
+            code_lines.append(f"{tool_name}({', '.join(params)})")
+        else:
+            code_lines.append(f"{tool_name}()")
+
+    if code_lines:
+        return "\n".join(code_lines)
+
+    return None
 
 
 def convert_code_format(text):
     """
     Convert code blocks to markdown format for display.
 
-    This function is used to convert code blocks in final answers to markdown format,
-    so it handles <DISPLAY:language> format and legacy formats.
+    This function converts <DISPLAY:language> format to standard markdown format.
     """
-    # Handle new format: ```<DISPLAY:language> to ```language
+    # Handle format: ```<DISPLAY:language> to ```language
     text = re.sub(r'```<DISPLAY:(\w+)>', r'```\1', text)
 
     # Handle legacy format: ```code:language to ```language
     text = re.sub(r'```code:(\w+)', r'```\1', text)
-
-    # Restore <END_CODE> if it was affected by the above replacement
-    text = text.replace("```<END_CODE>", "```")
-    text = text.replace("```<END_DISPLAY_CODE>", "```")
 
     # Clean up any remaining ```< patterns
     text = text.replace("```<", "```")
@@ -181,7 +391,7 @@ Additional Args:
 
         # Add new step in logs
         memory_step.model_input_messages = input_messages
-        stop_sequences = ["<END_CODE>", "Observation:", "Calling tools:", "<END_CODE"]
+        stop_sequences = ["Observation:", "Calling tools:"]
 
         # Prepare additional arguments
         additional_args: dict[str, Any] = {}

--- a/sdk/nexent/core/agents/core_agent.py
+++ b/sdk/nexent/core/agents/core_agent.py
@@ -46,7 +46,9 @@ def parse_code_blobs(text: str) -> str:
         ValueError: If no valid code block is found in the text.
     """
     # Match standard python code blocks: ```python or ```py
-    pattern = r"```(?:py|python)\s*\n(.*?)\n```"
+    # Allow the closing fence to appear either on its own line or immediately
+    # after the final code token.
+    pattern = r"```(?:py|python)\s*\n(.*?)\n?```"
     matches = re.findall(pattern, text, re.DOTALL)
     if matches:
         return "\n\n".join(match.strip() for match in matches)

--- a/test/assets/test_prompt.yaml
+++ b/test/assets/test_prompt.yaml
@@ -62,8 +62,7 @@ system_prompt: |-
   3. 每次使用email_send工具发送邮件时，邮件内容必须基于search_agent的搜索结果生成。
   
   ### python代码规范 ###
-  1. 代码内容必须以以'代码：\n```<RUN>\n'开头，并以'```<END_CODE>'标识符结尾，否则你将失败。
-  2. 如果认为是需要执行的代码，代码内容以'代码：\n```<RUN>\n'开头，并以'```<END_CODE>'标识符结尾。如果是不需要执行仅用于展示的代码，代码内容以'代码：\n```<DISPLAY:语言类型>\n'开头，并以'```<END_CODE>'标识符结尾，其中语言类型例如python、java、javascript等；
+  1. 如果认为是需要执行的代码，代码内容以 '代码：\n```python\n' 开头并以 '```' 结尾；如果是不需要执行仅用于展示的代码，代码内容以 '代码：\n```DISPLAY:语言类型\n' 开头并以 '```' 结尾，其中语言类型例如 python、java、javascript 等；
   2. 只使用已定义的变量，变量将在多次调用之间持续保持。使用'print()'函数让下一次的模型调用看到对应变量信息
   3. 正确使用工具和Agent的入参，使用关键字参数，不要用字典形式。
   4. 避免在一轮对话中进行过多的工具调用，这会导致输出格式难以预测。
@@ -76,18 +75,18 @@ system_prompt: |-
   
   思考: 首先，我将使用search_agent搜索关于人工智能的最新研究。
   代码:
-  ```<RUN>
+  ```python
   search_results = search_agent(task="最新的人工智能研究")
   print(search_results)
-  ```<END_CODE>
+  ```
   观察结果:
   {"summary": "最新的人工智能研究集中在机器学习和深度学习领域，特别是在自然语言处理和图像识别方面取得了显著进展。", "details": "具体的研究包括但不限于：1. 使用Transformer模型改进自然语言理解；2. 利用卷积神经网络提升图像识别精度。"}
   
   思考: 我已经获取了关于人工智能的最新研究信息，现在我将使用email_send工具将这些信息发送到指定邮箱。
   代码:
-  ```<RUN>
+  ```python
   email_send(address="user@example.com", content=search_results["summary"])
-  ```<END_CODE>
+  ```
   
   思考：我将生成最终回答。
   已经将关于人工智能的最新研究信息发送到指定邮箱。

--- a/test/assets/test_sub_prompt.yaml
+++ b/test/assets/test_sub_prompt.yaml
@@ -42,8 +42,7 @@ system_prompt: |-
   2. 如果knowledge_base_search未找到相关信息，则使用web_search工具进行网络搜索。
   
   ### python代码规范 ###
-  1. 代码内容必须以以'代码：\n```<RUN>\n'开头，并以'```<END_CODE>'标识符结尾，否则你将失败。
-  2. 如果认为是需要执行的代码，代码内容以'代码：\n```<RUN>\n'开头，并以'```<END_CODE>'标识符结尾。如果是不需要执行仅用于展示的代码，代码内容以'代码：\n```<DISPLAY:语言类型>\n'开头，并以'```<END_CODE>'标识符结尾，其中语言类型例如python、java、javascript等；
+  1. 如果认为是需要执行的代码，代码内容以 '代码：\n```python\n' 开头并以 '```' 结尾；如果是不需要执行仅用于展示的代码，代码内容以 '代码：\n```DISPLAY:语言类型\n' 开头并以 '```' 结尾，其中语言类型例如 python、java、javascript 等；
   2. 只使用已定义的变量，变量将在多次调用之间持续保持。使用'print()'函数让下一次的模型调用看到对应变量信息
   3. 正确使用工具的入参，使用关键字参数，不要用字典形式。
   4. 避免在一轮对话中进行过多的工具调用，这会导致输出格式难以预测。
@@ -56,19 +55,19 @@ system_prompt: |-
   
   思考：我先使用knowledge_base_search工具查找本地知识库是否有相关信息。
   代码：
-  ```<RUN>
+  ```python
   knowledge_info = knowledge_base_search(query="东方明珠 介绍")
   print(knowledge_info)
-  ```<END_CODE>
+  ```
   观察结果：
   未找到查询"东方明珠 介绍"的结果。检索结果难以支撑回答。
   
   思考：从本地知识库中没有找到相关信息，我需要使用web_search工具查询网络信息。
   代码：
-  ```<RUN>
+  ```python
   web_info = web_search(query="东方明珠 介绍")
   print(web_info)
-  ```<END_CODE>
+  ```
   观察结果：
   [东方明珠相关信息]
   
@@ -81,10 +80,10 @@ system_prompt: |-
   
   思考：我将使用knowledge_base_search工具查找公司内部关于项目管理的政策。
   代码：
-  ```<RUN>
+  ```python
   policy_info = knowledge_base_search(query="公司内部关于项目管理的政策")
   print(policy_info)
-  ```<END_CODE>
+  ```
   观察结果：
   [公司内部项目管理政策的相关信息]
   
@@ -97,19 +96,19 @@ system_prompt: |-
   
   思考：我先使用knowledge_base_search工具查找本地知识库是否有相关信息。
   代码：
-  ```<RUN>
+  ```python
   knowledge_info = knowledge_base_search(query="量子计算 最新研究进展")
   print(knowledge_info)
-  ```<END_CODE>
+  ```
   观察结果：
   未找到查询"量子计算 最新研究进展"的结果。检索结果难以支撑回答。
   
   思考：从本地知识库中没有找到相关信息，我需要使用web_search工具查询网络信息。
   代码：
-  ```<RUN>
+  ```python
   web_info = web_search(query="量子计算 最新研究进展")
   print(web_info)
-  ```<END_CODE>
+  ```
   观察结果：
   [量子计算最新研究进展的相关信息]
   

--- a/test/sdk/core/agents/test_core_agent.py
+++ b/test/sdk/core/agents/test_core_agent.py
@@ -222,49 +222,8 @@ MessageObserver = _module_mocks["sdk.nexent.core.utils.observer"].MessageObserve
 # Tests for parse_code_blobs function
 # ----------------------------------------------------------------------------
 
-def test_parse_code_blobs_run_format():
-    """Test parse_code_blobs with ```<RUN>\\ncontent\\n```<END_CODE> pattern."""
-    text = """Here is some code:
-```<RUN>
-print("Hello World")
-x = 42
-```<END_CODE>
-And some more text."""
-
-    result = core_agent_module.parse_code_blobs(text)
-    expected = "print(\"Hello World\")\nx = 42"
-    assert result == expected
-
-
-def test_parse_code_blobs_run_format_without_end_code():
-    """Test parse_code_blobs with ```<RUN>\\ncontent\\n``` pattern (without END_CODE)."""
-    text = """Here is some code:
-```<RUN>
-print("Hello World")
-```
-And some more text."""
-
-    result = core_agent_module.parse_code_blobs(text)
-    expected = "print(\"Hello World\")"
-    assert result == expected
-
-
-def test_parse_code_blobs_multiple_run_blocks():
-    """Test parse_code_blobs with multiple ```<RUN> blocks."""
-    text = """```<RUN>
-first_block()
-```<END_CODE>
-```<RUN>
-second_block()
-```<END_CODE>"""
-
-    result = core_agent_module.parse_code_blobs(text)
-    expected = "first_block()\n\nsecond_block()"
-    assert result == expected
-
-
 def test_parse_code_blobs_python_match():
-    """Test parse_code_blobs with ```python\\ncontent\\n``` pattern (legacy format)."""
+    """Test parse_code_blobs with ```python\\ncontent\\n``` pattern."""
     text = """Here is some code:
 ```python
 print("Hello World")
@@ -338,7 +297,7 @@ def test_parse_code_blobs_display_only_raises():
 ```<DISPLAY:python>
 def hello():
     return "Hello"
-```<END_DISPLAY_CODE>
+```
 And some more text."""
 
     with pytest.raises(ValueError) as exc_info:
@@ -399,24 +358,6 @@ def test_convert_code_format_display_replacements():
     original_text = """Here is code:
 ```<DISPLAY:python>
 print('hello')
-```<END_DISPLAY_CODE>
-And some more text."""
-
-    expected_text = """Here is code:
-```python
-print('hello')
-```
-And some more text."""
-
-    transformed = core_agent_module.convert_code_format(original_text)
-    assert transformed == expected_text
-
-
-def test_convert_code_format_display_without_end_code():
-    """Validate convert_code_format handles <DISPLAY:language> without <END_DISPLAY_CODE>."""
-    original_text = """Here is code:
-```<DISPLAY:python>
-print('hello')
 ```
 And some more text."""
 
@@ -448,11 +389,11 @@ And some more text."""
     assert transformed == expected_text
 
 
-def test_convert_code_format_restore_end_code():
-    """Test that <END_CODE> is properly restored after replacements."""
+def test_convert_code_format_simple_display():
+    """Test that simple <DISPLAY:language> format is converted to standard markdown."""
     original_text = """```<DISPLAY:python>
 print('hello')
-```<END_CODE>"""
+```"""
 
     expected_text = """```python
 print('hello')
@@ -476,10 +417,10 @@ def test_convert_code_format_multiple_displays():
     """Test convert_code_format with multiple DISPLAY blocks."""
     original_text = """```<DISPLAY:python>
 first()
-```<END_DISPLAY_CODE>
+```
 ```<DISPLAY:javascript>
 second()
-```<END_DISPLAY_CODE>"""
+```"""
 
     expected_text = """```python
 first()
@@ -497,7 +438,7 @@ def test_convert_code_format_mixed_with_code():
     original_text = """Some text before
 ```<DISPLAY:python>
 print('displayed')
-```<END_DISPLAY_CODE>
+```
 Some text after"""
 
     expected_text = """Some text before
@@ -635,7 +576,7 @@ def test_convert_code_format_preserves_content():
 def complex_function():
     """Docstring with special chars: <>&'"""
     return "Hello 世界"
-```<END_DISPLAY_CODE>'''
+```'''
 
     transformed = core_agent_module.convert_code_format(code)
 
@@ -647,7 +588,7 @@ def complex_function():
 def test_convert_code_format_handles_empty_end_tags():
     """Test convert_code_format with empty DISPLAY blocks."""
     text = """```<DISPLAY:python>
-```<END_DISPLAY_CODE>"""
+```"""
     transformed = core_agent_module.convert_code_format(text)
     expected = """```python
 ```"""
@@ -659,11 +600,11 @@ def test_convert_code_format_complex_nested():
     text = '''# Start
 ```<DISPLAY:python>
 # Python code
-```<END_DISPLAY_CODE>
+```
 Middle
 ```<DISPLAY:javascript>
 // JavaScript
-```<END_DISPLAY_CODE>
+```
 End'''
 
     transformed = core_agent_module.convert_code_format(text)
@@ -678,26 +619,26 @@ End'''
 # Additional edge case tests
 # ----------------------------------------------------------------------------
 
-def test_convert_code_format_code_end_tag_restoration():
-    """Test that ```<END_CODE> is properly restored to ```."""
+def test_convert_code_format_remaining_lt_cleanup():
+    """Test that remaining ```< patterns are cleaned up."""
     text = """Some code:
 ```<DISPLAY:python>
 print('hello')
-```<END_CODE>
+```
 More text."""
 
     transformed = core_agent_module.convert_code_format(text)
 
     assert "```python" in transformed
-    assert "```<END_CODE>" not in transformed
+    assert "```<END_DISPLAY_CODE>" not in transformed
     assert "```\n" in transformed or '```"' in transformed or transformed.endswith("```")
 
 
-def test_parse_code_blobs_whitespace_only_run_block():
-    """Test parse_code_blobs with whitespace-only RUN block."""
-    text = """```<RUN>
+def test_parse_code_blobs_whitespace_only_py_block():
+    """Test parse_code_blobs with whitespace-only python block."""
+    text = """```python
    
-```<END_CODE>"""
+```"""
 
     result = core_agent_module.parse_code_blobs(text)
     assert result.strip() == ""
@@ -724,7 +665,7 @@ def test_convert_code_format_unicode_content():
 def hello():
     return "你好世界"
 print("🎉")
-```<END_DISPLAY_CODE>"""
+```"""
 
     transformed = core_agent_module.convert_code_format(text)
 
@@ -738,7 +679,7 @@ def test_convert_code_format_dedent_removal():
     text = """```<DISPLAY:python>
 def test():
     pass
-```<END_DISPLAY_CODE>"""
+```"""
 
     transformed = core_agent_module.convert_code_format(text)
     # Should not have leftover ```< patterns
@@ -794,10 +735,10 @@ def test_convert_code_format_both_legacy_and_display():
     """Test convert_code_format handles both legacy and new format together."""
     text = """```code:python
 legacy_code()
-```<END_CODE>
+```
 ```<DISPLAY:python>
 new_code()
-```<END_DISPLAY_CODE>"""
+```"""
 
     transformed = core_agent_module.convert_code_format(text)
 


### PR DESCRIPTION
#2766 
1. 使用smolagent默认代码块识别方式``  ```python xxx```  ``来识别可执行的代码块
2. 使用`` ```DISPLAY:python xxxx``` ``来识别需要展示的代码块
3. 增强对多种LLM执行代码格式的识别，以应对minimax遵从性不高的问题