### PR TITLE
🐛 Bugfix: Support viewing whether the agent version has been published as an A2A agent

### DIFF
--- a/backend/consts/model.py
+++ b/backend/consts/model.py
@@ -824,6 +824,7 @@ class VersionListItemResponse(BaseModel):
     source_version_no: Optional[int] = Field(None, description="Source version number if rollback")
     source_type: Optional[str] = Field(None, description="Source type: NORMAL / ROLLBACK")
     status: str = Field(..., description="Version status: RELEASED / DISABLED / ARCHIVED")
+    is_a2a: bool = Field(False, description="Whether this version is published as an A2A Server agent")
     created_by: str = Field(..., description="User who published this version")
     create_time: Optional[str] = Field(None, description="Publish timestamp")
 
@@ -843,6 +844,7 @@ class VersionDetailResponse(BaseModel):
     source_version_no: Optional[int] = Field(None, description="Source version number")
     source_type: Optional[str] = Field(None, description="Source type")
     status: str = Field(..., description="Version status")
+    is_a2a: bool = Field(False, description="Whether this version is published as an A2A Server agent")
     created_by: str = Field(..., description="User who published this version")
     create_time: Optional[str] = Field(None, description="Publish timestamp")
     agent_info: Optional[dict] = Field(None, description="Agent info snapshot")

--- a/backend/database/db_models.py
+++ b/backend/database/db_models.py
@@ -493,6 +493,7 @@ class AgentVersion(TableBase):
     source_version_no = Column(Integer, doc="Source version number. If this version is a rollback, record the source version")
     source_type = Column(String(30), doc="Source type: NORMAL (normal publish) / ROLLBACK (rollback and republish)")
     status = Column(String(30), default="RELEASED", doc="Version status: RELEASED / DISABLED / ARCHIVED")
+    is_a2a = Column(Boolean, default=False, doc="Whether this version is published as an A2A Server agent")
 
 
 class UserTokenInfo(TableBase):

--- a/backend/services/agent_version_service.py
+++ b/backend/services/agent_version_service.py
@@ -124,6 +124,7 @@ def publish_version_impl(
         'source_type': source_type,
         'source_version_no': source_version_no,
         'status': STATUS_RELEASED,
+        'is_a2a': publish_as_a2a,
         'created_by': user_id,
     }
     version_id = insert_version(version_data)

--- a/docker/init.sql
+++ b/docker/init.sql
@@ -977,6 +977,7 @@ CREATE TABLE IF NOT EXISTS nexent.ag_tenant_agent_version_t (
     source_version_no INTEGER NULL,
     source_type VARCHAR(30) NULL,
     status VARCHAR(30) DEFAULT 'RELEASED',
+    is_a2a BOOLEAN DEFAULT FALSE,
     created_by VARCHAR(100) NOT NULL,
     create_time TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP,
     updated_by VARCHAR(100),
@@ -1003,6 +1004,7 @@ COMMENT ON COLUMN nexent.ag_tenant_agent_version_t.release_note IS 'Release note
 COMMENT ON COLUMN nexent.ag_tenant_agent_version_t.source_version_no IS 'Source version number. If this version is a rollback, record the source version number.';
 COMMENT ON COLUMN nexent.ag_tenant_agent_version_t.source_type IS 'Source type: NORMAL (normal publish) / ROLLBACK (rollback and republish).';
 COMMENT ON COLUMN nexent.ag_tenant_agent_version_t.status IS 'Version status: RELEASED / DISABLED / ARCHIVED';
+COMMENT ON COLUMN nexent.ag_tenant_agent_version_t.is_a2a IS 'Whether this version is published as an A2A Server agent';
 COMMENT ON COLUMN nexent.ag_tenant_agent_version_t.created_by IS 'User who published this version';
 COMMENT ON COLUMN nexent.ag_tenant_agent_version_t.create_time IS 'Version creation timestamp';
 COMMENT ON COLUMN nexent.ag_tenant_agent_version_t.updated_by IS 'Last user who updated this version';

--- a/docker/sql/v2.0.2_0425_add_is_a2a_to_ag_tenant_agent_version_t.sql
+++ b/docker/sql/v2.0.2_0425_add_is_a2a_to_ag_tenant_agent_version_t.sql
@@ -1,0 +1,7 @@
+-- Add is_a2a column to ag_tenant_agent_version_t for tracking A2A Server agent publish status
+-- This field indicates whether this version was published as an A2A Server agent
+
+ALTER TABLE nexent.ag_tenant_agent_version_t
+ADD COLUMN IF NOT EXISTS is_a2a BOOLEAN DEFAULT FALSE;
+
+COMMENT ON COLUMN nexent.ag_tenant_agent_version_t.is_a2a IS 'Whether this version is published as an A2A Server agent';

--- a/frontend/app/[locale]/agents/AgentVersionCard.tsx
+++ b/frontend/app/[locale]/agents/AgentVersionCard.tsx
@@ -579,6 +579,7 @@ export function VersionCardItem({
         initialValues={{
           version_name: version.version_name,
           release_note: version.release_note,
+          is_a2a: version.is_a2a,
         }}
         onUpdated={() => {
           // Refresh version list using the proper invalidate function

--- a/frontend/app/[locale]/agents/versions/AgentVersionPubulishModal.tsx
+++ b/frontend/app/[locale]/agents/versions/AgentVersionPubulishModal.tsx
@@ -21,6 +21,7 @@ export interface AgentVersionPubulishModalProps {
   initialValues?: {
     version_name?: string;
     release_note?: string;
+    is_a2a?: boolean;
   };
   onPublished?: () => void;
   onUpdated?: () => void;
@@ -72,10 +73,11 @@ export default function AgentVersionPubulishModal({
     if (open) {
       if (isEdit && initialValues) {
         publishForm.setFieldsValue(initialValues);
+        setIsA2AAgent(initialValues.is_a2a ?? false);
       } else if (!isEdit) {
         publishForm.resetFields();
+        setIsA2AAgent(false);
       }
-      setIsA2AAgent(false);
     }
   }, [open, isEdit, initialValues, publishForm]);
 
@@ -232,7 +234,6 @@ export default function AgentVersionPubulishModal({
 
           <Form.Item
             label={t("agent.version.publishAsA2AAgent")}
-            name="publish_as_a2a"
             valuePropName="checked"
           >
             <Switch

--- a/frontend/services/agentVersionService.ts
+++ b/frontend/services/agentVersionService.ts
@@ -53,6 +53,7 @@ export interface AgentVersion {
   source_type: string;
   source_version_no: number;
   status: string;
+  is_a2a: boolean;
   create_time: string;
   update_time: string;
 }

--- a/k8s/helm/nexent/charts/nexent-common/files/init.sql
+++ b/k8s/helm/nexent/charts/nexent-common/files/init.sql
@@ -1018,6 +1018,7 @@ CREATE TABLE IF NOT EXISTS nexent.ag_tenant_agent_version_t (
     source_version_no INTEGER NULL,
     source_type VARCHAR(30) NULL,
     status VARCHAR(30) DEFAULT 'RELEASED',
+    is_a2a BOOLEAN DEFAULT FALSE,
     created_by VARCHAR(100) NOT NULL,
     create_time TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP,
     updated_by VARCHAR(100),
@@ -1044,6 +1045,7 @@ COMMENT ON COLUMN nexent.ag_tenant_agent_version_t.release_note IS 'Release note
 COMMENT ON COLUMN nexent.ag_tenant_agent_version_t.source_version_no IS 'Source version number. If this version is a rollback, record the source version number.';
 COMMENT ON COLUMN nexent.ag_tenant_agent_version_t.source_type IS 'Source type: NORMAL (normal publish) / ROLLBACK (rollback and republish).';
 COMMENT ON COLUMN nexent.ag_tenant_agent_version_t.status IS 'Version status: RELEASED / DISABLED / ARCHIVED';
+COMMENT ON COLUMN nexent.ag_tenant_agent_version_t.is_a2a IS 'Whether this version is published as an A2A Server agent';
 COMMENT ON COLUMN nexent.ag_tenant_agent_version_t.created_by IS 'User who published this version';
 COMMENT ON COLUMN nexent.ag_tenant_agent_version_t.create_time IS 'Version creation timestamp';
 COMMENT ON COLUMN nexent.ag_tenant_agent_version_t.updated_by IS 'Last user who updated this version';


### PR DESCRIPTION
当用户点击编辑，可以看到这个版本是否发布为符合A2A协议的Agent
<img width="1495" height="1192" alt="image" src="https://github.com/user-attachments/assets/81b24309-353f-43e7-afca-a20ea5a5a8ec" />
<img width="1492" height="1158" alt="image" src="https://github.com/user-attachments/assets/89cef618-3a87-4932-942b-4b03411bf8ef" />
