### PR TITLE
🐛 Bugfix:  Ensure knowledge_base_names is always included in template con…

### DIFF
--- a/backend/prompts/utils/prompt_generate_en.yaml
+++ b/backend/prompts/utils/prompt_generate_en.yaml
@@ -252,8 +252,8 @@ USER_PROMPT: |-
   {% if knowledge_base_names %}
   ### Knowledge Base Configuration Note:
   When generating few-shot examples, if using the knowledge_base_search tool, you MUST use the following actual configured knowledge base names:
-  {{knowledge_base_names}}
-  Please use these names directly in examples, e.g.: knowledge_base_search(query="xxx", index_names=[{{knowledge_base_names}}])
+  {{ knowledge_base_names | default('') }}
+  Please use these names directly in examples, e.g.: knowledge_base_search(query="xxx", index_names=[{{ knowledge_base_names | default('') }}])
   {% endif %}
 
 

--- a/backend/prompts/utils/prompt_generate_zh.yaml
+++ b/backend/prompts/utils/prompt_generate_zh.yaml
@@ -248,8 +248,8 @@ USER_PROMPT: |-
   {% if knowledge_base_names %}
   ### 知识库配置说明：
   在生成 few-shot 示例时，如果使用 knowledge_base_search 工具，必须使用以下实际配置的知识库名称：
-  {{knowledge_base_names}}
-  请将这些名称直接用于示例中，例如：knowledge_base_search(query="xxx", index_names=[{{knowledge_base_names}}])
+  {{ knowledge_base_names | default('') }}
+  请将这些名称直接用于示例中，例如：knowledge_base_search(query="xxx", index_names=[{{ knowledge_base_names | default('') }}])
   {% endif %}
 
 

--- a/backend/services/prompt_service.py
+++ b/backend/services/prompt_service.py
@@ -385,10 +385,14 @@ def join_info_for_generate_system_prompt(prompt_for_generate, sub_agent_info_lis
         "assistant_description": assistant_description
     }
 
-    # Add knowledge base display names for few-shot examples if available
+    # Always add knowledge_base_names to context (empty string when not available).
+    # This is necessary because Jinja2 StrictUndefined raises an error for any
+    # undefined variable, even inside an {% if %} block.
     if knowledge_base_display_names:
         kb_names_str = ", ".join(f'"{name}"' for name in knowledge_base_display_names)
-        template_context["knowledge_base_names"] = kb_names_str
+    else:
+        kb_names_str = ""
+    template_context["knowledge_base_names"] = kb_names_str
 
     # Generate content using template
     content = Template(prompt_for_generate["USER_PROMPT"], undefined=StrictUndefined).render(template_context)

--- a/test/backend/services/test_prompt_service.py
+++ b/test/backend/services/test_prompt_service.py
@@ -1245,8 +1245,9 @@ class TestPromptService(unittest.TestCase):
 
         # Assert
         template_vars = mock_template_instance.render.call_args[0][0]
-        # knowledge_base_names should not be in template vars when not provided
-        self.assertNotIn("knowledge_base_names", template_vars)
+        # knowledge_base_names should always be in template vars (empty string when not provided)
+        self.assertIn("knowledge_base_names", template_vars)
+        self.assertEqual(template_vars["knowledge_base_names"], "")
 
     @patch('backend.services.prompt_service.get_knowledge_name_map_by_index_names')
     @patch('backend.services.prompt_service.query_tool_instances_by_id')


### PR DESCRIPTION
🔧 Fix: Ensure knowledge_base_names is always included in template context

- Updated prompt generation logic to always include knowledge_base_names in the template context, defaulting to an empty string when not available. This change prevents errors related to undefined variables in Jinja2 templates.
- Modified YAML files for English and Chinese prompts to reflect the updated syntax for knowledge_base_names, ensuring consistency in few-shot example generation.
- 
<img width="1687" height="1215" alt="image" src="https://github.com/user-attachments/assets/d39e2349-917d-4396-bfd4-bb8eb3e5bf8f" />
