### PR TITLE
fix: add enable_context_manager column to init.sql files

### DIFF
--- a/docker/init.sql
+++ b/docker/init.sql
@@ -316,6 +316,7 @@ CREATE TABLE IF NOT EXISTS nexent.ag_tenant_agent_t (
     enabled BOOLEAN DEFAULT FALSE,
     is_new BOOLEAN DEFAULT FALSE,
     provide_run_summary BOOLEAN DEFAULT FALSE,
+    enable_context_manager BOOLEAN DEFAULT FALSE,
     version_no INTEGER DEFAULT 0 NOT NULL,
     current_version_no INTEGER NULL,
     ingroup_permission VARCHAR(30),
@@ -373,6 +374,7 @@ COMMENT ON COLUMN nexent.ag_tenant_agent_t.is_new IS 'Whether this agent is mark
 COMMENT ON COLUMN nexent.ag_tenant_agent_t.version_no IS 'Version number. 0 = draft/editing state, >=1 = published snapshot';
 COMMENT ON COLUMN nexent.ag_tenant_agent_t.current_version_no IS 'Current published version number. NULL means no version published yet';
 COMMENT ON COLUMN nexent.ag_tenant_agent_t.ingroup_permission IS 'In-group permission: EDIT, READ_ONLY, PRIVATE';
+COMMENT ON COLUMN nexent.ag_tenant_agent_t.enable_context_manager IS 'Whether to enable context management (compression) for this agent';
 
 -- Create index for is_new queries
 CREATE INDEX IF NOT EXISTS idx_ag_tenant_agent_t_is_new

--- a/k8s/helm/nexent/charts/nexent-common/files/init.sql
+++ b/k8s/helm/nexent/charts/nexent-common/files/init.sql
@@ -316,6 +316,7 @@ CREATE TABLE IF NOT EXISTS nexent.ag_tenant_agent_t (
     enabled BOOLEAN DEFAULT FALSE,
     is_new BOOLEAN DEFAULT FALSE,
     provide_run_summary BOOLEAN DEFAULT FALSE,
+    enable_context_manager BOOLEAN DEFAULT FALSE,
     version_no INTEGER DEFAULT 0 NOT NULL,
     current_version_no INTEGER NULL,
     ingroup_permission VARCHAR(30),
@@ -373,6 +374,7 @@ COMMENT ON COLUMN nexent.ag_tenant_agent_t.is_new IS 'Whether this agent is mark
 COMMENT ON COLUMN nexent.ag_tenant_agent_t.version_no IS 'Version number. 0 = draft/editing state, >=1 = published snapshot';
 COMMENT ON COLUMN nexent.ag_tenant_agent_t.current_version_no IS 'Current published version number. NULL means no version published yet';
 COMMENT ON COLUMN nexent.ag_tenant_agent_t.ingroup_permission IS 'In-group permission: EDIT, READ_ONLY, PRIVATE';
+COMMENT ON COLUMN nexent.ag_tenant_agent_t.enable_context_manager IS 'Whether to enable context management (compression) for this agent';
 
 -- Create index for is_new queries
 CREATE INDEX IF NOT EXISTS idx_ag_tenant_agent_t_is_new


### PR DESCRIPTION
## Summary

- Add `enable_context_manager` BOOLEAN column to `ag_tenant_agent_t` table definition
- Add column comment describing the field purpose
- Sync `docker/init.sql` and `k8s/helm/nexent/charts/nexent-common/files/init.sql` with migration script `v2.0.4_0427_add_enable_context_manager_to_ag_tenant_agent_t.sql`

## Context

Migration script added the column but the init.sql files (used for fresh deployments) were not updated. This PR ensures new Docker/K8s deployments have the complete schema matching existing databases after migration.

## Changes

| File | Change |
|------|--------|
| `docker/init.sql` | Add column + comment |
| `k8s/helm/.../init.sql` | Add column + comment |