### PR TITLE
Hide model api key for security

### DIFF
--- a/frontend/app/[locale]/models/components/model/ModelEditDialog.tsx
+++ b/frontend/app/[locale]/models/components/model/ModelEditDialog.tsx
@@ -289,6 +289,7 @@ export const ModelEditDialog = ({
             value={form.apiKey}
             onChange={(e) => handleFormChange("apiKey", e.target.value)}
             autoComplete="new-password"
+            visibilityToggle={false}
           />
         </div>
 
@@ -461,7 +462,7 @@ export const ProviderConfigEditDialog = ({
           <label className="block mb-1 text-sm font-medium text-gray-700">
             {t('model.dialog.label.apiKey')}
           </label>
-          <Input.Password value={apiKey} onChange={(e) => setApiKey(e.target.value)} />
+          <Input.Password value={apiKey} onChange={(e) => setApiKey(e.target.value)} visibilityToggle={false} />
         </div>
         {!isEmbeddingModel && (
           <div>


### PR DESCRIPTION
#2802 

After configuration, the model API key can only be edited, but cannot be viewed, by either other managers or the creator himself.

<img width="688" height="556" alt="image" src="https://github.com/user-attachments/assets/d8a95651-9dd1-4177-9317-daa033b0d705" />
