### PR TITLE
Bugfix: force refresh agent info when needed

### DIFF
--- a/frontend/app/[locale]/agents/AgentVersionCard.tsx
+++ b/frontend/app/[locale]/agents/AgentVersionCard.tsx
@@ -259,6 +259,7 @@ export function VersionCardItem({
               ...agentResult.data,
               permission: permissionFromList,
             });
+            store.triggerForceRefresh();
           }
         }
       } else {

--- a/frontend/app/[locale]/agents/components/agentInfo/AgentGenerateDetail.tsx
+++ b/frontend/app/[locale]/agents/components/agentInfo/AgentGenerateDetail.tsx
@@ -67,6 +67,7 @@ export default function AgentGenerateDetail({
   const isCreatingMode = useAgentConfigStore((state) => state.isCreatingMode);
   const editedAgent = useAgentConfigStore((state) => state.editedAgent);
   const currentAgentId = useAgentConfigStore((state) => state.currentAgentId);
+  const forceRefreshKey = useAgentConfigStore((state) => state.forceRefreshKey);
   const updateBusinessInfo = useAgentConfigStore((state) => state.updateBusinessInfo);
   const updateProfileInfo = useAgentConfigStore((state) => state.updateProfileInfo);
 
@@ -309,7 +310,7 @@ export default function AgentGenerateDetail({
       });
     }
 
-  }, [currentAgentId, defaultLlmModel?.id, isCreatingMode, editedAgent]);
+  }, [currentAgentId, defaultLlmModel?.id, isCreatingMode, forceRefreshKey]);
 
   // Default to selecting all groups when creating a new agent.
   // Only applies when groups are loaded and no group is selected yet.

--- a/frontend/stores/agentConfigStore.ts
+++ b/frontend/stores/agentConfigStore.ts
@@ -56,6 +56,11 @@ interface AgentConfigStoreState {
   editedAgent: EditableAgent;
   hasUnsavedChanges: boolean;
   isCreatingMode: boolean; // true when user is in create mode, even if currentAgentId is null
+  /**
+   * Incremented counter to signal downstream UI to force-refresh.
+   * Components that depend on this key will re-initialize when it changes.
+   */
+  forceRefreshKey: number;
 
   /**
    * Set current agent (null = create mode).
@@ -67,6 +72,12 @@ interface AgentConfigStoreState {
    * Enter create mode. Sets isCreatingMode to true and resets state.
    */
   enterCreateMode: () => void;
+
+  /**
+   * Trigger a UI force-refresh by incrementing forceRefreshKey.
+   * Call this after operations like rollback that need to force-reload form state.
+   */
+  triggerForceRefresh: () => void;
 
 
   /**
@@ -353,6 +364,7 @@ export const useAgentConfigStore = create<AgentConfigStoreState>((set, get) => (
   editedAgent: { ...emptyEditableAgent },
   hasUnsavedChanges: false,
   isCreatingMode: false,
+  forceRefreshKey: 0,
 
   setCurrentAgent: (agent) => {
     const baselineAgent = agent ? toEditable(agent) : null;
@@ -364,6 +376,7 @@ export const useAgentConfigStore = create<AgentConfigStoreState>((set, get) => (
       editedAgent,
       hasUnsavedChanges: false,
       isCreatingMode: false, // Exit create mode when selecting an agent
+      forceRefreshKey: 0,
     });
   },
 
@@ -375,7 +388,12 @@ export const useAgentConfigStore = create<AgentConfigStoreState>((set, get) => (
       editedAgent: { ...emptyEditableAgent },
       hasUnsavedChanges: false,
       isCreatingMode: true,
+      forceRefreshKey: 0,
     });
+  },
+
+  triggerForceRefresh: () => {
+    set((state) => ({ forceRefreshKey: state.forceRefreshKey + 1 }));
   },
 
   updateTools: (tools) => {
@@ -494,6 +512,7 @@ export const useAgentConfigStore = create<AgentConfigStoreState>((set, get) => (
       editedAgent: { ...emptyEditableAgent },
       hasUnsavedChanges: false,
       isCreatingMode: false,
+      forceRefreshKey: 0,
     });
   },
 


### PR DESCRIPTION
目前点击新建智能体会报错，定位是editedAgent变化导致组件频繁挂载报错，新增强制刷新功能，回滚时主动调用，避免组件频繁挂载
<img width="652" height="283" alt="image" src="https://github.com/user-attachments/assets/81f661e3-8d5a-477e-8539-fa79518a91a7" />
