### PR TITLE
security: restrict .env file permissions to 0600 in deploy scripts

### DIFF
--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -506,6 +506,7 @@ select_deployment_mode() {
       # Add new ROOT_DIR to .env
       echo "# Root dir" >> .env
       echo "ROOT_DIR=\"$ROOT_DIR\"" >> .env
+      chmod 600 .env
     fi
   elif grep -q "^ROOT_DIR=" .env; then
   # Check if ROOT_DIR already exists in .env (second priority)
@@ -522,6 +523,7 @@ select_deployment_mode() {
 
     echo "# Root dir" >> .env
     echo "ROOT_DIR=\"$ROOT_DIR\"" >> .env
+    chmod 600 .env
   fi
   echo ""
   echo "--------------------------------"
@@ -551,6 +553,7 @@ update_env_var() {
 
   # Ensure the .env file exists
   touch "$env_file"
+  chmod 600 "$env_file"
 
   if grep -q "^${key}=" "$env_file"; then
     # Key exists, so update it. Escape \ and & for sed's replacement string.
@@ -708,6 +711,7 @@ select_deployment_version() {
 
   # Ensure the .env file exists
   touch "$env_file"
+  chmod 600 "$env_file"
 
   if grep -q "^${key}=" "$env_file"; then
     # Key exists, so update it. Escape \ and & for sed's replacement string.

--- a/docker/generate_env.sh
+++ b/docker/generate_env.sh
@@ -25,10 +25,12 @@ prepare_env_file() {
   if [ -f ".env" ]; then
     echo "   📋 Copying docker/.env to root directory..."
     cp ".env" "../.env"
+    chmod 600 "../.env"
     echo "   ✅ Copied docker/.env to ../.env"
   elif [ -f ".env.example" ]; then
     echo "   📋 docker/.env not found, copying .env.example to root directory..."
     cp ".env.example" "../.env"
+    chmod 600 "../.env"
     echo "   ✅ Copied docker/.env.example to ../.env"
   else
     echo "   ❌ ERROR Neither docker/.env nor docker/.env.example exists in docker directory"

--- a/docker/start-monitoring.sh
+++ b/docker/start-monitoring.sh
@@ -28,6 +28,7 @@ fi
 if [ ! -f "$MONITORING_DIR/monitoring.env" ]; then
     echo "📋 Creating monitoring.env from example..."
     cp "$MONITORING_DIR/monitoring.env.example" "$MONITORING_DIR/monitoring.env"
+    chmod 600 "$MONITORING_DIR/monitoring.env"
     echo "⚠️  Please review and update $MONITORING_DIR/monitoring.env as needed"
 fi
 

--- a/docker/upgrade.sh
+++ b/docker/upgrade.sh
@@ -203,7 +203,7 @@ run_deploy() {
   # Stop and remove any existing containers before redeployment
   docker compose -p nexent down -v
   log "INFO" "🚀 Starting deploy..."
-  (cd "$SCRIPT_DIR" && cp .env.example .env && bash "$DEPLOY_SCRIPT" "${DEPLOY_ARGS[@]}")
+  (cd "$SCRIPT_DIR" && cp .env.example .env && chmod 600 .env && bash "$DEPLOY_SCRIPT" "${DEPLOY_ARGS[@]}")
 
 }
 


### PR DESCRIPTION
## Summary

The deployment scripts in `docker/` create `.env` files containing plaintext secrets (e.g. `ELASTIC_PASSWORD`, `NEXENT_POSTGRES_PASSWORD`, `MINIO_ROOT_PASSWORD`, `DASHBOARD_PASSWORD`, `SUPABASE_POSTGRES_PASSWORD`, API tokens, and `SSH_PRIVATE_KEY_PATH`) but do not restrict their permissions. Under the default `umask` on most Linux distributions (`022`), these files end up mode `0644` — world-readable. Any unprivileged local user on the deployment host can therefore read production credentials by simply `cat`-ing the file.

This is a local information disclosure / insecure default permissions issue (CWE-276 / CWE-732, with overlap to CWE-532 for sensitive data written to a readable file).

**Affected locations:**
- `docker/deploy.sh` — `update_env_var()` (around line 553) and `select_deployment_version()` (around line 711) `touch` the env file without setting permissions; `select_deployment_mode()` appends secrets to `.env` similarly.
- `docker/generate_env.sh` — `prepare_env_file()` copies `.env` / `.env.example` to the project root without chmod.
- `docker/start-monitoring.sh` — copies `monitoring.env.example` to `monitoring.env` without chmod.
- `docker/upgrade.sh` — `run_deploy()` copies `.env.example` to `.env` without chmod.

## Fix

Apply `chmod 600` immediately after each location that creates or copies a `.env`-style file, so the file is only readable/writable by its owner. The change is minimal and idempotent — `chmod 600` is safe to call on a freshly-touched file and on re-runs.

```diff
   touch "$env_file"
+  chmod 600 "$env_file"
```

…and equivalent one-liners in the other four locations. Total diff: +8 / −1 across 4 files.

## Why this matters / exploitability

- **Preconditions:** an unprivileged shell account on the deployment host (a CI runner with multiple users, a shared bastion, a container that mounts the host workspace, an ops user with reduced privileges, etc.).
- **Impact:** direct disclosure of database, object store, dashboard, and Supabase credentials, plus an SSH key path. These are typically usable from the same host or laterally against the listed services.
- **No network/auth boundary** is needed — the issue is local file permissions, so no framework or reverse-proxy mitigation applies.

The fix provides defence-in-depth even on single-tenant hosts: it prevents accidental disclosure via misconfigured backups, log shippers, or non-root processes that scan the working tree.

## Testing

- Ran `bash -n` on each modified script — all parse cleanly.
- Verified by hand that `touch f && chmod 600 f && stat -c '%a' f` yields `600`, and that subsequent `sed -i` / append operations in the scripts continue to work (mode is preserved by in-place edits and by the existing `sed -i.bak` flow on Linux).
- Walked the `deploy.sh` flow for the three create-paths (fresh `.env`, existing `.env` with `ROOT_DIR`, existing `.env` without `ROOT_DIR`) — `chmod 600` is reached in each path that writes secrets.
- Confirmed the change is a no-op when the file already has stricter permissions and a tightening when it had `0644`.

## Adversarial review

Before submitting, we tried to disprove this. We considered whether the deployment is implicitly assumed to be single-tenant (in which case the fix would be cosmetic), whether Docker / compose somehow re-permissions the file, and whether an existing `umask` directive in the scripts already restricted creation. None of those hold: the scripts are documented for general operator use, nothing in the repo sets a restrictive `umask` before these writes, and `docker compose` reads the file but does not change its mode. The preconditions to exploit (a local unprivileged account) do not already grant access to the secrets in question, so the fix delivers a real reduction in attack surface rather than redundant hardening.

cc @lewiswigmore
