### PR TITLE
feat: support multi-turn compare sessions

### DIFF
--- a/frontend/app/[locale]/agents/components/agentInfo/DebugConfig.tsx
+++ b/frontend/app/[locale]/agents/components/agentInfo/DebugConfig.tsx
@@ -149,6 +149,7 @@ export default function DebugConfig({ agentId }: DebugConfigProps) {
   const editedAgent = useAgentConfigStore((state) => state.editedAgent);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
+  const prevAgentIdRef = useRef<number | null | undefined>(undefined);
   // Maintain an independent step ID counter per Agent
   const stepIdCounter = useRef<{ current: number }>({ current: 0 });
   const [isComparePanelOpen, setIsComparePanelOpen] = useState(false);
@@ -160,6 +161,12 @@ export default function DebugConfig({ agentId }: DebugConfigProps) {
     agentId === undefined || agentId === null || Number.isNaN(Number(agentId))
       ? undefined
       : Number(agentId);
+  const comparePersistenceKey =
+    parsedAgentId === undefined
+      ? "debug-compare:anonymous"
+      : `debug-compare:agent-${parsedAgentId}`;
+  const comparePersistenceFallbackKeys =
+    parsedAgentId === undefined ? [] : ["debug-compare:anonymous"];
 
   const {
     leftMessages: compareLeftMessages,
@@ -181,6 +188,8 @@ export default function DebugConfig({ agentId }: DebugConfigProps) {
       agent_id: parsedAgentId,
       model_id: side === "left" ? compareLeftModelId ?? undefined : compareRightModelId ?? undefined,
     }),
+    persistenceKey: comparePersistenceKey,
+    persistenceFallbackKeys: comparePersistenceFallbackKeys,
     getHistory: () =>
       messages
         .filter((msg) => msg.isComplete !== false && msg.content?.trim())
@@ -189,6 +198,15 @@ export default function DebugConfig({ agentId }: DebugConfigProps) {
 
   // Reset debug state when agentId changes
   useEffect(() => {
+    const normalizedAgentId = parsedAgentId ?? null;
+    const previousAgentId = prevAgentIdRef.current;
+    prevAgentIdRef.current = normalizedAgentId;
+    const hasSwitchedAgent =
+      previousAgentId !== undefined &&
+      previousAgentId !== null &&
+      normalizedAgentId !== null &&
+      previousAgentId !== normalizedAgentId;
+
     // Clear debug history
     setMessages([]);
     // Reset step ID counter
@@ -239,11 +257,14 @@ export default function DebugConfig({ agentId }: DebugConfigProps) {
       }
     }
 
-    // Reset compare state when switching agents
-    setIsComparePanelOpen(false);
-    stopCompare();
-    resetCompareState();
-  }, [agentId, resetCompareState, stopCompare]);
+    // Reset compare state only when switching to a different agent.
+    // On initial mount/re-mount with the same agent, keep persisted compare history.
+    if (hasSwitchedAgent) {
+      setIsComparePanelOpen(false);
+      stopCompare();
+      resetCompareState();
+    }
+  }, [agentId]);
 
   useEffect(() => {
     if (!hasMultipleLlmModels) {
@@ -566,15 +587,8 @@ export default function DebugConfig({ agentId }: DebugConfigProps) {
       // Enter compare mode: clear default chat history and compare outputs
       setMessages([]);
       stepIdCounter.current.current = 0;
-      if (isCompareStreaming) {
-        stopCompare();
-      }
-      resetCompareState();
-    } else {
-      if (isCompareStreaming) {
-        stopCompare();
-      }
-      resetCompareState();
+    } else if (isCompareStreaming) {
+      stopCompare();
     }
   };
 

--- a/frontend/app/[locale]/agents/components/agentInfo/DebugConfig.tsx
+++ b/frontend/app/[locale]/agents/components/agentInfo/DebugConfig.tsx
@@ -28,6 +28,7 @@ interface AgentDebuggingProps {
   onInputChange: (value: string) => void;
   onSend: () => void;
   isStreaming: boolean;
+  isCompareStreaming?: boolean;
   messages: ChatMessageType[];
   comparePanel?: React.ReactNode;
   showCompare?: boolean;
@@ -52,6 +53,7 @@ function AgentDebugging({
   onInputChange,
   onSend,
   isStreaming,
+  isCompareStreaming = false,
   messages,
   comparePanel,
   showCompare,
@@ -60,6 +62,7 @@ function AgentDebugging({
   isCompareMode,
 }: AgentDebuggingProps) {
   const { t } = useTranslation();
+  const isInputDisabled = isStreaming || (isCompareMode && isCompareStreaming);
 
   return (
     <div className="flex flex-col h-full min-h-0 p-4">
@@ -81,7 +84,7 @@ function AgentDebugging({
           onChange={(e) => onInputChange(e.target.value)}
           placeholder={t("agent.debug.placeholder")}
           onPressEnter={onSend}
-          disabled={isStreaming}
+          disabled={isInputDisabled}
         />
         <span className="px-2 py-1 text-xs rounded-md bg-gray-100 text-gray-600 whitespace-nowrap">
           {isCompareMode
@@ -122,6 +125,7 @@ function AgentDebugging({
           <button
             onClick={onSend}
             className="min-w-[56px] px-4 py-1.5 rounded-md flex items-center justify-center text-sm bg-blue-500 hover:bg-blue-600 text-white whitespace-nowrap"
+            disabled={isInputDisabled}
             style={{ border: "none" }}
           >
             {t("agent.debug.send")}
@@ -326,8 +330,15 @@ export default function DebugConfig({ agentId }: DebugConfigProps) {
 
   // Clear local history and reset the step counter
   const handleClearHistory = async () => {
-    setMessages([]);
-    stepIdCounter.current.current = 0;
+    if (isComparePanelOpen) {
+      if (isCompareStreaming) {
+        stopCompare();
+      }
+      resetCompareState();
+    } else {
+      setMessages([]);
+      stepIdCounter.current.current = 0;
+    }
     setInputQuestion("");
     // Clear cached error for this agent
     if (agentId !== undefined && agentId !== null && !isNaN(Number(agentId))) {
@@ -559,6 +570,11 @@ export default function DebugConfig({ agentId }: DebugConfigProps) {
         stopCompare();
       }
       resetCompareState();
+    } else {
+      if (isCompareStreaming) {
+        stopCompare();
+      }
+      resetCompareState();
     }
   };
 
@@ -582,6 +598,7 @@ export default function DebugConfig({ agentId }: DebugConfigProps) {
         onInputChange={setInputQuestion}
         onSend={handleSend}
         isStreaming={isStreaming}
+        isCompareStreaming={isCompareStreaming}
         messages={messages}
         comparePanel={comparePanel}
         showCompare={hasMultipleLlmModels}

--- a/frontend/app/[locale]/agents/components/agentInfo/useCompareStream.ts
+++ b/frontend/app/[locale]/agents/components/agentInfo/useCompareStream.ts
@@ -17,6 +17,7 @@ import { ChatMessageType } from "@/types/chat";
 
 type CompareSide = "left" | "right";
 type CompareHistoryItem = { role: string; content: string };
+type CompareHistoryMap = { left: CompareHistoryItem[]; right: CompareHistoryItem[] };
 type RunAgentParams = Parameters<typeof conversationService.runAgent>[0];
 
 interface UseCompareStreamOptions {
@@ -55,6 +56,11 @@ export function useCompareStream({
     left: number | null;
     right: number | null;
   }>({ left: null, right: null });
+  const compareHistoriesRef = useRef<CompareHistoryMap>({
+    left: [],
+    right: [],
+  });
+  const compareSessionIdRef = useRef(0);
   const compareStepIdCountersRef = useRef<{
     left: { current: number };
     right: { current: number };
@@ -89,7 +95,49 @@ export function useCompareStream({
     [translate]
   );
 
+  const cloneHistory = useCallback(
+    (history: CompareHistoryItem[]) => history.map((item) => ({ ...item })),
+    []
+  );
+
+  const ensureCompareConversationIds = useCallback(() => {
+    if (
+      compareConversationIdsRef.current.left !== null &&
+      compareConversationIdsRef.current.right !== null
+    ) {
+      return {
+        left: compareConversationIdsRef.current.left,
+        right: compareConversationIdsRef.current.right,
+      };
+    }
+
+    const baseId = -Math.abs(Date.now() + compareSessionIdRef.current);
+    const nextConversationIds = {
+      left: baseId,
+      right: baseId - 1,
+    };
+    compareConversationIdsRef.current = nextConversationIds;
+
+    return nextConversationIds;
+  }, []);
+
+  const appendCompareHistoryTurn = useCallback(
+    (side: CompareSide, question: string, answer: string) => {
+      compareHistoriesRef.current[side] = [
+        ...compareHistoriesRef.current[side],
+        { role: MESSAGE_ROLES.USER, content: question },
+        { role: MESSAGE_ROLES.ASSISTANT, content: answer },
+      ];
+    },
+    []
+  );
+
   const stopCompare = useCallback(async () => {
+    const hadActiveController =
+      compareAbortControllersRef.current.left !== null ||
+      compareAbortControllersRef.current.right !== null;
+    const hadInFlight = compareInFlightRef.current > 0;
+
     if (compareAbortControllersRef.current.left) {
       try {
         compareAbortControllersRef.current.left.abort(translate("agent.debug.userStop"));
@@ -112,14 +160,12 @@ export function useCompareStream({
       compareTimeoutRef.current = null;
     }
 
-    setIsCompareStreaming(false);
     setCompareStreamingLeft(false);
     setCompareStreamingRight(false);
     markCompareStopped(setLeftMessages);
     markCompareStopped(setRightMessages);
 
     const { left, right } = compareConversationIdsRef.current;
-    compareConversationIdsRef.current = { left: null, right: null };
 
     if (left != null) {
       try {
@@ -135,13 +181,26 @@ export function useCompareStream({
         log.error(translate("agent.debug.stopError"), error);
       }
     }
+
+    if (!hadActiveController && !hadInFlight) {
+      setIsCompareStreaming(false);
+    }
   }, [markCompareStopped, translate]);
 
   const resetCompareState = useCallback(() => {
+    compareSessionIdRef.current += 1;
     setLeftMessages([]);
     setRightMessages([]);
+    compareHistoriesRef.current = { left: [], right: [] };
+    compareConversationIdsRef.current = { left: null, right: null };
     compareStepIdCountersRef.current.left.current = 0;
     compareStepIdCountersRef.current.right.current = 0;
+    compareInFlightRef.current = 0;
+    compareAbortControllersRef.current = { left: null, right: null };
+    if (compareTimeoutRef.current) {
+      clearTimeout(compareTimeoutRef.current);
+      compareTimeoutRef.current = null;
+    }
     setIsCompareStreaming(false);
     setCompareStreamingLeft(false);
     setCompareStreamingRight(false);
@@ -154,17 +213,24 @@ export function useCompareStream({
       controller: AbortController;
       setSideMessages: Dispatch<SetStateAction<ChatMessageType[]>>;
       stepIdCounterRef: { current: number };
-      history: CompareHistoryItem[];
       question: string;
       onStreamEnd: () => void;
     }) => {
+      const sessionId = compareSessionIdRef.current;
+      const sideHistory = cloneHistory(compareHistoriesRef.current[params.side]);
+
       try {
         const requestParams = buildRunParams({
           side: params.side,
           question: params.question,
           conversationId: params.conversationId,
-          history: params.history,
+          history: sideHistory,
         });
+
+        const guardedSetSideMessages: Dispatch<SetStateAction<ChatMessageType[]>> = (value) => {
+          if (compareSessionIdRef.current !== sessionId) return;
+          params.setSideMessages(value);
+        };
 
         const reader = await conversationService.runAgent(
           requestParams,
@@ -173,9 +239,9 @@ export function useCompareStream({
 
         if (!reader) throw new Error(translate("agent.debug.nullResponse"));
 
-        await handleStreamResponse(
+        const streamResult = await handleStreamResponse(
           reader,
-          params.setSideMessages,
+          guardedSetSideMessages,
           resetCompareTimeout,
           params.stepIdCounterRef,
           () => {},
@@ -187,43 +253,81 @@ export function useCompareStream({
           true,
           t
         );
+
+        if (compareSessionIdRef.current === sessionId) {
+          appendCompareHistoryTurn(
+            params.side,
+            params.question,
+            streamResult.finalAnswer?.trim() || ""
+          );
+        }
       } catch (error) {
         const err = error as Error;
         const isUserStop =
           err.name === "AbortError" ||
           err.message === translate("agent.debug.userStop");
+
         if (isUserStop) {
-          markCompareStopped(params.setSideMessages);
+          if (compareSessionIdRef.current === sessionId) {
+            markCompareStopped(params.setSideMessages);
+          }
         } else {
           log.error(translate("agent.debug.streamError"), error);
           const errorMessage =
             error instanceof Error
               ? error.message
               : translate("agent.debug.processError");
-          params.setSideMessages((prev) => {
-            const newMessages = [...prev];
-            const lastMsg = newMessages[newMessages.length - 1];
-            if (lastMsg && lastMsg.role === MESSAGE_ROLES.ASSISTANT) {
-              lastMsg.content = errorMessage;
-              lastMsg.isComplete = true;
-              lastMsg.error = errorMessage;
-            }
-            return newMessages;
-          });
+          if (compareSessionIdRef.current === sessionId) {
+            params.setSideMessages((prev) => {
+              const newMessages = [...prev];
+              const lastMsg = newMessages[newMessages.length - 1];
+              if (lastMsg && lastMsg.role === MESSAGE_ROLES.ASSISTANT) {
+                lastMsg.content = errorMessage;
+                lastMsg.isComplete = true;
+                lastMsg.error = errorMessage;
+              }
+              return newMessages;
+            });
+          }
         }
       } finally {
-        compareInFlightRef.current -= 1;
-        if (compareInFlightRef.current <= 0) {
-          setIsCompareStreaming(false);
+        if (compareSessionIdRef.current === sessionId) {
+          compareAbortControllersRef.current[params.side] = null;
+          compareInFlightRef.current -= 1;
+          if (compareInFlightRef.current <= 0) {
+            setIsCompareStreaming(false);
+          }
+          params.onStreamEnd();
         }
-        params.onStreamEnd();
       }
     },
-    [buildRunParams, markCompareStopped, resetCompareTimeout, t, translate]
+    [
+      appendCompareHistoryTurn,
+      buildRunParams,
+      cloneHistory,
+      markCompareStopped,
+      resetCompareTimeout,
+      t,
+      translate,
+    ]
   );
 
   const runCompare = useCallback(
     async (question: string) => {
+      const conversationIds = ensureCompareConversationIds();
+      if (
+        compareHistoriesRef.current.left.length === 0 &&
+        compareHistoriesRef.current.right.length === 0 &&
+        getHistory
+      ) {
+        const baseHistory = getHistory() || [];
+        const clonedBaseHistory = cloneHistory(baseHistory);
+        compareHistoriesRef.current = {
+          left: clonedBaseHistory,
+          right: cloneHistory(baseHistory),
+        };
+      }
+
       setIsCompareStreaming(true);
       setCompareStreamingLeft(true);
       setCompareStreamingRight(true);
@@ -260,18 +364,9 @@ export function useCompareStream({
         isComplete: false,
       };
 
-      setLeftMessages([leftUserMessage, leftAssistantMessage]);
-      setRightMessages([rightUserMessage, rightAssistantMessage]);
+      setLeftMessages((prev) => [...prev, leftUserMessage, leftAssistantMessage]);
+      setRightMessages((prev) => [...prev, rightUserMessage, rightAssistantMessage]);
 
-      const baseId = -Math.abs(Date.now());
-      const leftConversationId = baseId;
-      const rightConversationId = baseId - 1;
-      compareConversationIdsRef.current = {
-        left: leftConversationId,
-        right: rightConversationId,
-      };
-
-      const history = getHistory ? getHistory() : [];
       const leftController = new AbortController();
       const rightController = new AbortController();
       compareAbortControllersRef.current = {
@@ -282,21 +377,19 @@ export function useCompareStream({
       await Promise.allSettled([
         runCompareStream({
           side: "left",
-          conversationId: leftConversationId,
+          conversationId: conversationIds.left,
           controller: leftController,
           setSideMessages: setLeftMessages,
           stepIdCounterRef: compareStepIdCountersRef.current.left,
-          history,
           question,
           onStreamEnd: () => setCompareStreamingLeft(false),
         }),
         runCompareStream({
           side: "right",
-          conversationId: rightConversationId,
+          conversationId: conversationIds.right,
           controller: rightController,
           setSideMessages: setRightMessages,
           stepIdCounterRef: compareStepIdCountersRef.current.right,
-          history,
           question,
           onStreamEnd: () => setCompareStreamingRight(false),
         }),
@@ -308,7 +401,7 @@ export function useCompareStream({
         compareTimeoutRef.current = null;
       }
     },
-    [getHistory, runCompareStream]
+    [cloneHistory, ensureCompareConversationIds, getHistory, runCompareStream]
   );
 
   return {

--- a/frontend/app/[locale]/agents/components/agentInfo/useCompareStream.ts
+++ b/frontend/app/[locale]/agents/components/agentInfo/useCompareStream.ts
@@ -2,6 +2,8 @@
 
 import {
   useCallback,
+  useEffect,
+  useMemo,
   useRef,
   useState,
   type Dispatch,
@@ -29,12 +31,51 @@ interface UseCompareStreamOptions {
     history: CompareHistoryItem[];
   }) => RunAgentParams;
   getHistory?: () => CompareHistoryItem[];
+  persistenceKey?: string;
+  persistenceEnabled?: boolean;
+  persistenceFallbackKeys?: string[];
+  debugStateLabel?: string;
 }
+
+const COMPARE_STORAGE_PREFIX = "agent-compare-session";
+const COMPARE_STORAGE_SCHEMA_VERSION = 1;
+const COMPARE_DEBUG_FLAG = "__NEXENT_COMPARE_DEBUG__";
+
+interface PersistedCompareSession {
+  version: number;
+  savedAt: number;
+  leftMessages: PersistedChatMessage[];
+  rightMessages: PersistedChatMessage[];
+  histories: CompareHistoryMap;
+  conversationIds: {
+    left: number | null;
+    right: number | null;
+  };
+}
+
+type PersistedChatMessage = {
+  id: string;
+  role: ChatMessageType["role"];
+  content: string;
+  timestamp: string;
+  isComplete?: boolean;
+  finalAnswer?: string;
+  error?: string;
+  steps?: ChatMessageType["steps"];
+  searchResults?: ChatMessageType["searchResults"];
+  images?: ChatMessageType["images"];
+  attachments?: ChatMessageType["attachments"];
+  thinking?: ChatMessageType["thinking"];
+};
 
 export function useCompareStream({
   t,
   buildRunParams,
   getHistory,
+  persistenceKey,
+  persistenceEnabled = true,
+  persistenceFallbackKeys = [],
+  debugStateLabel,
 }: UseCompareStreamOptions) {
   const translate = useCallback(
     (key: string, defaultText?: string) =>
@@ -69,6 +110,390 @@ export function useCompareStream({
     right: { current: 0 },
   });
   const compareInFlightRef = useRef(0);
+  const hasHydratedRef = useRef(false);
+  const pendingHydratedMessageCountsRef = useRef<{
+    left: number;
+    right: number;
+  } | null>(null);
+  const [debugPersistenceState, setDebugPersistenceState] = useState("");
+  const storageKey = persistenceKey
+    ? `${COMPARE_STORAGE_PREFIX}:${persistenceKey}`
+    : null;
+  const fallbackKeySignature = persistenceFallbackKeys.join("||");
+  const fallbackStorageKeys = useMemo(
+    () =>
+      persistenceFallbackKeys
+        .map((key) => `${COMPARE_STORAGE_PREFIX}:${key}`)
+        .filter((key) => key !== storageKey),
+    [fallbackKeySignature, storageKey]
+  );
+  const isPersistenceActive = Boolean(storageKey && persistenceEnabled);
+  const debugCompareLog = useCallback(
+    (event: string, payload?: Record<string, unknown>) => {
+      if (typeof window === "undefined") return;
+      const debugFlag = (window as unknown as { [key: string]: unknown })[
+        COMPARE_DEBUG_FLAG
+      ];
+      if (!debugFlag) return;
+      log.info(`[compare-persistence] ${event}`, {
+        storageKey,
+        persistenceEnabled,
+        ...payload,
+      });
+    },
+    [persistenceEnabled, storageKey]
+  );
+
+  const setDebugState = useCallback(
+    (event: string, extra?: string) => {
+      const label = debugStateLabel ? `[${debugStateLabel}]` : "";
+      setDebugPersistenceState(
+        `${label}${event}${extra ? ` ${extra}` : ""}`.trim()
+      );
+    },
+    [debugStateLabel]
+  );
+
+  const serializeMessages = useCallback(
+    (messages: ChatMessageType[]): PersistedChatMessage[] =>
+      messages.map((message) => ({
+        id: message.id,
+        role: message.role,
+        content: message.content,
+        timestamp: message.timestamp.toISOString(),
+        isComplete: message.isComplete,
+        finalAnswer: message.finalAnswer,
+        error: message.error,
+        steps: message.steps,
+        searchResults: message.searchResults,
+        images: message.images,
+        attachments: message.attachments,
+        thinking: message.thinking,
+      })),
+    []
+  );
+
+  const deserializeMessages = useCallback(
+    (messages: PersistedChatMessage[]) =>
+      messages.map((message) => ({
+        id: message.id,
+        role: message.role,
+        content: message.content,
+        timestamp: new Date(message.timestamp),
+        isComplete: message.isComplete,
+        finalAnswer: message.finalAnswer,
+        error: message.error,
+        steps: message.steps,
+        searchResults: message.searchResults,
+        images: message.images,
+        attachments: message.attachments,
+        thinking: message.thinking,
+      })),
+    []
+  );
+
+  const sanitizeHistory = useCallback(
+    (history: unknown): CompareHistoryItem[] => {
+      if (!Array.isArray(history)) return [];
+      return history
+        .filter(
+          (item): item is CompareHistoryItem =>
+            typeof item === "object" &&
+            item !== null &&
+            "role" in item &&
+            "content" in item &&
+            typeof (item as { role: unknown }).role === "string" &&
+            typeof (item as { content: unknown }).content === "string"
+        )
+        .map((item) => ({ role: item.role, content: item.content }));
+    },
+    []
+  );
+
+  const sanitizeSteps = useCallback((steps: unknown): ChatMessageType["steps"] => {
+    if (!Array.isArray(steps)) return undefined;
+    return steps as ChatMessageType["steps"];
+  }, []);
+
+  const sanitizeSearchResults = useCallback(
+    (searchResults: unknown): ChatMessageType["searchResults"] => {
+      if (!Array.isArray(searchResults)) return undefined;
+      return searchResults as ChatMessageType["searchResults"];
+    },
+    []
+  );
+
+  const sanitizeStringArray = useCallback((items: unknown): string[] | undefined => {
+    if (!Array.isArray(items)) return undefined;
+    return items.filter((item): item is string => typeof item === "string");
+  }, []);
+
+  const sanitizePersistedMessages = useCallback(
+    (messages: unknown): PersistedChatMessage[] => {
+      if (!Array.isArray(messages)) return [];
+      return messages
+        .filter(
+          (item): item is PersistedChatMessage =>
+            typeof item === "object" &&
+            item !== null &&
+            typeof (item as { id?: unknown }).id === "string" &&
+            ((item as { role?: unknown }).role === MESSAGE_ROLES.USER ||
+              (item as { role?: unknown }).role === MESSAGE_ROLES.ASSISTANT ||
+              (item as { role?: unknown }).role === MESSAGE_ROLES.SYSTEM) &&
+            typeof (item as { content?: unknown }).content === "string" &&
+            typeof (item as { timestamp?: unknown }).timestamp === "string"
+        )
+        .map((item) => ({
+          id: item.id,
+          role: item.role,
+          content: item.content,
+          timestamp: item.timestamp,
+          isComplete:
+            typeof item.isComplete === "boolean" ? item.isComplete : undefined,
+          finalAnswer:
+            typeof item.finalAnswer === "string" ? item.finalAnswer : undefined,
+          error: typeof item.error === "string" ? item.error : undefined,
+          steps: sanitizeSteps(item.steps),
+          searchResults: sanitizeSearchResults(item.searchResults),
+          images: sanitizeStringArray(item.images),
+          attachments: Array.isArray(item.attachments)
+            ? (item.attachments as ChatMessageType["attachments"])
+            : undefined,
+          thinking: Array.isArray(item.thinking) ? item.thinking : undefined,
+        }));
+    },
+    [sanitizeSearchResults, sanitizeSteps, sanitizeStringArray]
+  );
+
+  const cloneHistory = useCallback(
+    (history: CompareHistoryItem[]) => history.map((item) => ({ ...item })),
+    []
+  );
+
+  const readSnapshotByKey = useCallback(
+    (targetKey: string): PersistedCompareSession | null => {
+      if (!targetKey || typeof window === "undefined") return null;
+
+      try {
+        const raw = window.sessionStorage.getItem(targetKey);
+        if (!raw) return null;
+
+        const parsed = JSON.parse(raw) as Partial<PersistedCompareSession>;
+        if (parsed.version !== COMPARE_STORAGE_SCHEMA_VERSION) return null;
+        const leftMessages = sanitizePersistedMessages(parsed.leftMessages);
+        const rightMessages = sanitizePersistedMessages(parsed.rightMessages);
+        if (leftMessages.length === 0 && rightMessages.length === 0) {
+          return null;
+        }
+
+        return {
+          version: COMPARE_STORAGE_SCHEMA_VERSION,
+          savedAt: Number(parsed.savedAt) || Date.now(),
+          leftMessages,
+          rightMessages,
+          histories: {
+            left: sanitizeHistory(parsed.histories?.left),
+            right: sanitizeHistory(parsed.histories?.right),
+          },
+          conversationIds: {
+            left:
+              typeof parsed.conversationIds?.left === "number"
+                ? parsed.conversationIds.left
+                : null,
+            right:
+              typeof parsed.conversationIds?.right === "number"
+                ? parsed.conversationIds.right
+                : null,
+          },
+        };
+      } catch (error) {
+        log.error("Failed to load compare session from storage", error);
+        window.sessionStorage.removeItem(targetKey);
+        return null;
+      }
+    },
+    [sanitizeHistory, sanitizePersistedMessages]
+  );
+
+  const getPersistedSnapshot = useCallback(
+    (): { snapshot: PersistedCompareSession; sourceKey: string } | null => {
+      if (!isPersistenceActive || !storageKey || typeof window === "undefined") return null;
+
+      const primarySnapshot = readSnapshotByKey(storageKey);
+      if (primarySnapshot) {
+        return { snapshot: primarySnapshot, sourceKey: storageKey };
+      }
+
+      for (const fallbackKey of fallbackStorageKeys) {
+        const fallbackSnapshot = readSnapshotByKey(fallbackKey);
+        if (fallbackSnapshot) {
+          return { snapshot: fallbackSnapshot, sourceKey: fallbackKey };
+        }
+      }
+
+      return null;
+    },
+    [fallbackStorageKeys, isPersistenceActive, readSnapshotByKey, storageKey]
+  );
+
+  useEffect(() => {
+    hasHydratedRef.current = false;
+    pendingHydratedMessageCountsRef.current = null;
+
+    if (!isPersistenceActive || !storageKey || typeof window === "undefined") {
+      setDebugState("persistence-inactive");
+      hasHydratedRef.current = true;
+      return;
+    }
+
+    const restored = getPersistedSnapshot();
+    if (!restored) {
+      debugCompareLog("hydrate-miss");
+      setDebugState("hydrate-miss", `key=${storageKey}`);
+      setLeftMessages([]);
+      setRightMessages([]);
+      compareHistoriesRef.current = { left: [], right: [] };
+      compareConversationIdsRef.current = { left: null, right: null };
+      hasHydratedRef.current = true;
+      return;
+    }
+
+    const { snapshot, sourceKey } = restored;
+    pendingHydratedMessageCountsRef.current = {
+      left: snapshot.leftMessages.length,
+      right: snapshot.rightMessages.length,
+    };
+    setLeftMessages(deserializeMessages(snapshot.leftMessages));
+    setRightMessages(deserializeMessages(snapshot.rightMessages));
+    compareHistoriesRef.current = {
+      left: sanitizeHistory(snapshot.histories.left),
+      right: sanitizeHistory(snapshot.histories.right),
+    };
+    compareConversationIdsRef.current = {
+      left: snapshot.conversationIds.left,
+      right: snapshot.conversationIds.right,
+    };
+    compareStepIdCountersRef.current.left.current = 0;
+    compareStepIdCountersRef.current.right.current = 0;
+    debugCompareLog("hydrate-hit", {
+      leftMessages: snapshot.leftMessages.length,
+      rightMessages: snapshot.rightMessages.length,
+      sourceKey,
+    });
+    setDebugState(
+      "hydrate-hit",
+      `from=${sourceKey.split(":").slice(-1)[0]} left=${snapshot.leftMessages.length} right=${snapshot.rightMessages.length}`
+    );
+
+    if (sourceKey !== storageKey) {
+      const migratedPayload: PersistedCompareSession = {
+        ...snapshot,
+        histories: {
+          left: cloneHistory(snapshot.histories.left),
+          right: cloneHistory(snapshot.histories.right),
+        },
+        conversationIds: {
+          ...snapshot.conversationIds,
+        },
+      };
+      try {
+        window.sessionStorage.setItem(storageKey, JSON.stringify(migratedPayload));
+        window.sessionStorage.removeItem(sourceKey);
+        debugCompareLog("hydrate-migrate", { from: sourceKey, to: storageKey });
+        setDebugState(
+          "hydrate-migrate",
+          `from=${sourceKey.split(":").slice(-1)[0]} to=${storageKey.split(":").slice(-1)[0]}`
+        );
+      } catch (error) {
+        log.error("Failed to migrate compare session storage key", error);
+      }
+    }
+    hasHydratedRef.current = true;
+  }, [
+    cloneHistory,
+    debugCompareLog,
+    deserializeMessages,
+    fallbackStorageKeys,
+    getPersistedSnapshot,
+    isPersistenceActive,
+    setDebugState,
+    sanitizeHistory,
+    storageKey,
+  ]);
+
+  useEffect(() => {
+    if (!isPersistenceActive || !storageKey || typeof window === "undefined") return;
+    if (!hasHydratedRef.current) return;
+
+    const pendingHydratedMessageCounts = pendingHydratedMessageCountsRef.current;
+    if (pendingHydratedMessageCounts) {
+      const hasHydratedMessages =
+        leftMessages.length === pendingHydratedMessageCounts.left &&
+        rightMessages.length === pendingHydratedMessageCounts.right;
+      if (!hasHydratedMessages) {
+        debugCompareLog("persist-skip-hydration-pending", {
+          expectedLeft: pendingHydratedMessageCounts.left,
+          expectedRight: pendingHydratedMessageCounts.right,
+          currentLeft: leftMessages.length,
+          currentRight: rightMessages.length,
+        });
+        setDebugState(
+          "persist-skip-hydration",
+          `expected=${pendingHydratedMessageCounts.left}/${pendingHydratedMessageCounts.right} current=${leftMessages.length}/${rightMessages.length}`
+        );
+        return;
+      }
+      pendingHydratedMessageCountsRef.current = null;
+    }
+
+    const hasPersistData =
+      leftMessages.length > 0 ||
+      rightMessages.length > 0 ||
+      compareHistoriesRef.current.left.length > 0 ||
+      compareHistoriesRef.current.right.length > 0;
+
+    if (!hasPersistData) {
+      window.sessionStorage.removeItem(storageKey);
+      debugCompareLog("persist-clear");
+      setDebugState("persist-clear", `key=${storageKey}`);
+      return;
+    }
+
+    const payload: PersistedCompareSession = {
+      version: COMPARE_STORAGE_SCHEMA_VERSION,
+      savedAt: Date.now(),
+      leftMessages: serializeMessages(leftMessages),
+      rightMessages: serializeMessages(rightMessages),
+      histories: {
+        left: cloneHistory(compareHistoriesRef.current.left),
+        right: cloneHistory(compareHistoriesRef.current.right),
+      },
+      conversationIds: { ...compareConversationIdsRef.current },
+    };
+
+    try {
+      window.sessionStorage.setItem(storageKey, JSON.stringify(payload));
+      debugCompareLog("persist-save", {
+        leftMessages: leftMessages.length,
+        rightMessages: rightMessages.length,
+      });
+      setDebugState(
+        "persist-save",
+        `key=${storageKey.split(":").slice(-1)[0]} left=${leftMessages.length} right=${rightMessages.length}`
+      );
+    } catch (error) {
+      log.error("Failed to persist compare session to storage", error);
+    }
+  }, [
+    cloneHistory,
+    debugCompareLog,
+    isPersistenceActive,
+    leftMessages,
+    rightMessages,
+    serializeMessages,
+    setDebugState,
+    storageKey,
+  ]);
 
   const resetCompareTimeout = useCallback(() => {
     if (compareTimeoutRef.current) {
@@ -93,11 +518,6 @@ export function useCompareStream({
       });
     },
     [translate]
-  );
-
-  const cloneHistory = useCallback(
-    (history: CompareHistoryItem[]) => history.map((item) => ({ ...item })),
-    []
   );
 
   const ensureCompareConversationIds = useCallback(() => {
@@ -413,5 +833,6 @@ export function useCompareStream({
     runCompare,
     stopCompare,
     resetCompareState,
+    debugPersistenceState,
   };
 }

--- a/frontend/app/[locale]/agents/versions/AgentVersionCompareModal.tsx
+++ b/frontend/app/[locale]/agents/versions/AgentVersionCompareModal.tsx
@@ -155,6 +155,13 @@ export default function AgentVersionCompareModal({
     setCompareQuestion("");
   }, [selectedVersionNoA, selectedVersionNoB, resetCompareState, stopCompare]);
 
+  const handleClose = () => {
+    stopCompare();
+    resetCompareState();
+    setCompareQuestion("");
+    onCancel();
+  };
+
   const resolveVersionLabel = (versionNo: number | null | undefined) => {
     if (versionNo === null || versionNo === undefined) return "-";
     const matched = versionList?.find((v) => v.version_no === versionNo);
@@ -183,6 +190,7 @@ export default function AgentVersionCompareModal({
     if (versionNoA === null || versionNoA === undefined) return;
     if (versionNoB === null || versionNoB === undefined) return;
     if (versionNoA === versionNoB) return;
+    setCompareQuestion("");
     await runCompare(question);
   };
 
@@ -199,7 +207,7 @@ export default function AgentVersionCompareModal({
         </Flex>
       }
       open={open}
-      onCancel={onCancel}
+      onCancel={handleClose}
       footer={footer}
       width={800}
       centered

--- a/frontend/app/[locale]/agents/versions/AgentVersionCompareModal.tsx
+++ b/frontend/app/[locale]/agents/versions/AgentVersionCompareModal.tsx
@@ -75,6 +75,10 @@ export default function AgentVersionCompareModal({
     },
     [selectedVersionNoA, selectedVersionNoB, compareData]
   );
+  const comparePersistenceKey =
+    agentId === undefined || agentId === null
+      ? "version-compare:anonymous"
+      : `version-compare:agent-${agentId}`;
 
   const {
     leftMessages: compareLeftMessages,
@@ -96,6 +100,8 @@ export default function AgentVersionCompareModal({
       agent_id: agentId ?? undefined,
       version_no: resolveVersionNo(side) ?? undefined,
     }),
+    persistenceKey: comparePersistenceKey,
+    persistenceEnabled: open,
     getHistory: () => [],
   });
 
@@ -139,11 +145,9 @@ export default function AgentVersionCompareModal({
   useEffect(() => {
     if (!open) {
       stopCompare();
-      resetCompareState();
       setCompareQuestion("");
       return;
     }
-    resetCompareState();
     setCompareQuestion("");
   }, [open, resetCompareState, stopCompare]);
 
@@ -151,15 +155,21 @@ export default function AgentVersionCompareModal({
     if (isCompareStreaming) {
       stopCompare();
     }
-    resetCompareState();
     setCompareQuestion("");
   }, [selectedVersionNoA, selectedVersionNoB, resetCompareState, stopCompare]);
 
   const handleClose = () => {
     stopCompare();
-    resetCompareState();
     setCompareQuestion("");
     onCancel();
+  };
+
+  const handleClearCompareHistory = async () => {
+    if (isCompareStreaming) {
+      await stopCompare();
+    }
+    resetCompareState();
+    setCompareQuestion("");
   };
 
   const resolveVersionLabel = (versionNo: number | null | undefined) => {
@@ -429,6 +439,9 @@ export default function AgentVersionCompareModal({
                   {t("agent.version.compareQaHint")}
                 </div>
                 <Flex gap={8}>
+                  <Button onClick={handleClearCompareHistory} disabled={isCompareStreaming}>
+                    {t("agent.debug.clear")}
+                  </Button>
                   {isCompareStreaming && (
                     <Button danger onClick={stopCompare}>
                       {t("agent.debug.stop")}


### PR DESCRIPTION
本次改动将对比模式改为会话级多轮对话。快速配置调试中的对比模式和版本管理里的版本对比共用同一套 compare stream 逻辑，左右两侧会分别保留历史，支持继续追问；当面板或弹窗关闭时会完整重置会话，重新打开会创建新的对话。另外补了清空流程，并修复了版本对比发送后输入框不自动清空的问题。