### PR TITLE
fix: skip empty streaming choices in prompt generation

### DIFF
--- a/backend/utils/llm_utils.py
+++ b/backend/utils/llm_utils.py
@@ -100,6 +100,10 @@ def call_llm_for_system_prompt(
         reasoning_content_seen = False
         content_tokens_seen = 0
         for chunk in current_request:
+            if not getattr(chunk, "choices", None):
+                logger.debug("Skipping streaming chunk without choices during prompt generation")
+                continue
+
             delta = chunk.choices[0].delta
             reasoning_content = getattr(delta, "reasoning_content", None)
             new_token = delta.content

--- a/test/backend/utils/test_llm_utils.py
+++ b/test/backend/utils/test_llm_utils.py
@@ -173,6 +173,34 @@ class TestCallLLMForSystemPrompt:
         # Verify AppException is raised with correct error code for unmapped errors
         assert exc_info.value.error_code == ErrorCode.MODEL_PROMPT_GENERATION_FAILED
 
+    def test_call_llm_for_system_prompt_skips_empty_choices_chunks(self, mocker: MockFixture):
+        mock_get_model_by_id = mocker.patch('backend.utils.llm_utils.get_model_by_model_id')
+        mock_get_model_name = mocker.patch('backend.utils.llm_utils.get_model_name_from_config')
+        mock_openai = mocker.patch('backend.utils.llm_utils.OpenAIModel')
+
+        mock_get_model_by_id.return_value = {"base_url": "http://x", "api_key": "k"}
+        mock_get_model_name.return_value = "deepseek-ai/DeepSeek-V4-Flash"
+
+        empty_choices_chunk = MagicMock()
+        empty_choices_chunk.choices = []
+
+        content_chunk = MagicMock()
+        content_chunk.choices = [MagicMock()]
+        content_chunk.choices[0].delta.content = "Generated prompt"
+
+        mock_instance = mock_openai.return_value
+        mock_instance.client = MagicMock()
+        mock_instance.client.chat.completions.create.return_value = [
+            empty_choices_chunk,
+            content_chunk,
+        ]
+        mock_instance._prepare_completion_kwargs.return_value = {}
+
+        res = call_llm_for_system_prompt(1, "u", "s")
+
+        assert res == "Generated prompt"
+
+
 
 class TestProcessThinkingTokens:
     def test_process_thinking_tokens_normal_token(self):

--- a/test/backend/utils/test_llm_utils.py
+++ b/test/backend/utils/test_llm_utils.py
@@ -178,7 +178,7 @@ class TestCallLLMForSystemPrompt:
         mock_get_model_name = mocker.patch('backend.utils.llm_utils.get_model_name_from_config')
         mock_openai = mocker.patch('backend.utils.llm_utils.OpenAIModel')
 
-        mock_get_model_by_id.return_value = {"base_url": "http://x", "api_key": "k"}
+        mock_get_model_by_id.return_value = {"base_url": "https://example.com", "api_key": "k"}
         mock_get_model_name.return_value = "deepseek-ai/DeepSeek-V4-Flash"
 
         empty_choices_chunk = MagicMock()


### PR DESCRIPTION
Fixes #3009.

Some OpenAI-compatible streaming providers can emit chunks with an empty `choices` array. In that case prompt generation crashed before reading the next content chunk.

This change skips chunks without choices before accessing `choices[0].delta`, matching the existing handling used elsewhere in the OpenAI streaming code.

Tested with:

```bash
PYTHONPATH=/repo:/repo/backend:/repo/sdk python -m pytest test/backend/utils/test_llm_utils.py -q
```

Result: 39 passed.
