### PR TITLE
🐛 Bugfix: Fix iData tool call error.

### DIFF
--- a/docker/sql/v2.2.0_0527_add_custom_headers_to_mcp_record_t.sql
+++ b/docker/sql/v2.2.0_0527_add_custom_headers_to_mcp_record_t.sql
@@ -1,0 +1,26 @@
+-- Migration: Add custom_headers column to mcp_record_t
+-- Date: 2026-05-26
+-- Description: Add custom_headers field to store custom HTTP headers for MCP server requests
+
+SET search_path TO nexent;
+
+BEGIN;
+
+-- Add custom_headers column if it doesn't exist
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'nexent'
+        AND table_name = 'mcp_record_t'
+        AND column_name = 'custom_headers'
+    ) THEN
+        ALTER TABLE nexent.mcp_record_t
+        ADD COLUMN custom_headers JSON DEFAULT NULL;
+    END IF;
+END $$;
+
+-- Add comment to the column
+COMMENT ON COLUMN nexent.mcp_record_t.custom_headers IS 'Custom HTTP headers as JSON object for MCP server requests';
+
+COMMIT;

--- a/frontend/app/[locale]/agents/components/agentConfig/tool/ToolTestPanel.tsx
+++ b/frontend/app/[locale]/agents/components/agentConfig/tool/ToolTestPanel.tsx
@@ -133,9 +133,9 @@ export default function ToolTestPanel({
           const paramType = paramInfo?.type || DEFAULT_TYPE;
 
           // Check if this is the KB selector parameter and KB selection is enabled
-          // Haotian uses dataset_ids, others use index_names
-          const isKbSelectorParam = paramName === "index_names" && toolRequiresKbSelection && toolKbType !== "haotian_search"
-            || paramName === "dataset_ids" && toolRequiresKbSelection && toolKbType === "haotian_search";
+          // Haotian and iData use dataset_ids, others use index_names
+          const isKbSelectorParam = paramName === "index_names" && toolRequiresKbSelection && toolKbType !== "haotian_search" && toolKbType !== "idata_search"
+            || paramName === "dataset_ids" && toolRequiresKbSelection && (toolKbType === "haotian_search" || toolKbType === "idata_search");
 
           if (isKbSelectorParam && selectedKbIds.length > 0) {
             // Use the selected KB IDs from configParams as default
@@ -205,9 +205,9 @@ export default function ToolTestPanel({
     if (!toolRequiresKbSelection) return;
 
     // Determine which field to sync based on tool type
-    const isHaotian = toolKbType === "haotian_search";
-    const fieldName = isHaotian ? `param_dataset_ids` : `param_index_names`;
-    const stateKey = isHaotian ? "dataset_ids" : "index_names";
+    const isHaotianOrIdata = toolKbType === "haotian_search" || toolKbType === "idata_search";
+    const fieldName = isHaotianOrIdata ? `param_dataset_ids` : `param_index_names`;
+    const stateKey = isHaotianOrIdata ? "dataset_ids" : "index_names";
     const currentValue = form.getFieldValue(fieldName);
 
     // Only update if the value is different
@@ -332,11 +332,11 @@ export default function ToolTestPanel({
         // Determine the correct parameter name based on tool type
         if (tool?.name === "dify_search") {
           kbSelectionConfig = { dataset_ids: JSON.stringify(selectedKbIds) };
-        } else if (tool?.name === "haotian_search") {
-          // Haotian uses dataset_ids as an array (not JSON string)
+        } else if (tool?.name === "haotian_search" || tool?.name === "idata_search") {
+          // Haotian and iData use dataset_ids as an array (not JSON string)
           kbSelectionConfig = { dataset_ids: selectedKbIds };
         } else {
-          // knowledge_base_search, datamate_search, idata_search use index_names
+          // knowledge_base_search, datamate_search use index_names
           kbSelectionConfig = { index_names: selectedKbIds };
         }
       }
@@ -347,13 +347,13 @@ export default function ToolTestPanel({
       const configs = (configParams || []).reduce(
         (acc: Record<string, any>, param: ToolParam) => {
           // Skip index_names when KB selection is enabled (provided via kbSelectionConfig)
-          // For haotian_search: skip only index_names (dataset_ids is handled by kbSelectionConfig)
+          // For haotian_search and idata_search: skip only index_names (dataset_ids is handled by kbSelectionConfig)
           // For other KB tools: skip both index_names and dataset_ids
           if (toolRequiresKbSelection) {
             if (param.name === "index_names") {
               return acc;
             }
-            if (param.name === "dataset_ids" && tool?.name !== "haotian_search") {
+            if (param.name === "dataset_ids" && tool?.name !== "haotian_search" && tool?.name !== "idata_search") {
               return acc;
             }
           }
@@ -445,7 +445,7 @@ export default function ToolTestPanel({
                         const formValue = currentFormValues[`param_${paramName}`];
 
                         // Check if this is a KB selector parameter
-                        const isKbSelectorParam = paramName === "index_names" && toolRequiresKbSelection;
+                        const isKbSelectorParam = (paramName === "index_names" || paramName === "dataset_ids") && toolRequiresKbSelection;
 
                         // Handle KB selector parameters - use selectedKbIds
                         if (isKbSelectorParam) {
@@ -507,7 +507,7 @@ export default function ToolTestPanel({
                           const paramType = paramInfo?.type || DEFAULT_TYPE;
 
                           // Check if this is a KB selector parameter
-                          const isKbSelectorParam = paramName === "index_names" && toolRequiresKbSelection;
+                          const isKbSelectorParam = (paramName === "index_names" || paramName === "dataset_ids") && toolRequiresKbSelection;
 
                           if (manualValue !== undefined) {
                             // KB selector parameters should keep their array form


### PR DESCRIPTION
🐛 Bugfix: Fix iData tool call error. 
[Specification Details]
1. Modify the front-end component logic to pass the `dataset_ids` field for idata and haotian knowledge base retrieval.
[Test Result]
<img width="681" height="1192" alt="img_v3_02124_811be189-6903-4639-b34c-f0c77ffea87g" src="https://github.com/user-attachments/assets/78837f42-0722-479d-9dbd-668b4b043cb4" />

close #3053 