### PR TITLE
✨ feat: increase agent max_steps default to 15 and widen bounds to 30

### DIFF
--- a/backend/agents/create_agent_info.py
+++ b/backend/agents/create_agent_info.py
@@ -477,7 +477,7 @@ async def create_agent_config(
             agent_id=agent_id
         ),
         tools=tool_list + _get_skill_script_tools(agent_id, tenant_id, version_no),
-        max_steps=agent_info.get("max_steps", 10),
+        max_steps=agent_info.get("max_steps", 15),
         model_name=model_name,
         provide_run_summary=agent_info.get("provide_run_summary", False),
         managed_agents=managed_agents,

--- a/backend/consts/model.py
+++ b/backend/consts/model.py
@@ -437,7 +437,7 @@ class AgentInfoRequest(BaseModel):
     author: Optional[str] = None
     model_name: Optional[str] = None
     model_id: Optional[int] = None
-    max_steps: Optional[int] = None
+    max_steps: Optional[int] = Field(default=None, ge=1, le=30)
     provide_run_summary: Optional[bool] = None
     duty_prompt: Optional[str] = None
     constraint_prompt: Optional[str] = None

--- a/backend/database/agent_db.py
+++ b/backend/database/agent_db.py
@@ -158,7 +158,7 @@ def create_agent(agent_info, tenant_id: str, user_id: str):
     :return: Created agent object
     """
     info_with_metadata = dict(agent_info)
-    info_with_metadata.setdefault("max_steps", 5)
+    info_with_metadata.setdefault("max_steps", 15)
     info_with_metadata.update({
         "tenant_id": tenant_id,
         "version_no": 0,  # Default to draft version

--- a/backend/services/agent_service.py
+++ b/backend/services/agent_service.py
@@ -1401,9 +1401,9 @@ async def import_agent_by_agent_id(
                                                  enabled=True,
                                                  params=tool.params))
     # check the validity of the agent parameters
-    if import_agent_info.max_steps <= 0 or import_agent_info.max_steps > 20:
+    if import_agent_info.max_steps <= 0 or import_agent_info.max_steps > 30:
         raise ValueError(
-            f"Invalid max steps: {import_agent_info.max_steps}. max steps must be greater than 0 and less than 20.")
+            f"Invalid max steps: {import_agent_info.max_steps}. max steps must be greater than 0 and less than 30.")
     if not import_agent_info.name.isidentifier():
         raise ValueError(
             f"Invalid agent name: {import_agent_info.name}. agent name must be a valid python variable name.")

--- a/frontend/app/[locale]/agents/components/agentInfo/AgentGenerateDetail.tsx
+++ b/frontend/app/[locale]/agents/components/agentInfo/AgentGenerateDetail.tsx
@@ -159,7 +159,7 @@ export default function AgentGenerateDetail({}) {
       agentAuthor: editedAgent.author || user?.email || (isSpeedMode ? "Default User" : ""),
       mainAgentModel: editedAgent.model,
       mainAgentModelId: editedAgent.model_id,
-      mainAgentMaxStep: editedAgent.max_step || 5,
+      mainAgentMaxStep: editedAgent.max_step || 15,
       agentDescription: editedAgent.description || "",
       group_ids: normalizeNumberArray(editedAgent.group_ids || []),
       ingroup_permission: editedAgent.ingroup_permission || "READ_ONLY",
@@ -861,14 +861,14 @@ export default function AgentGenerateDetail({}) {
                               {
                                 type: "number",
                                 min: 1,
-                                max: 20,
+                                max: 30,
                                 message: t("businessLogic.config.maxSteps"),
                               },
                             ]}
                           >
                             <InputNumber
                               min={1}
-                              max={20}
+                              max={30}
                               style={{ width: "100%" }}
                               onBlur={() => {
                                 const value = form.getFieldValue("mainAgentMaxStep");

--- a/frontend/stores/agentConfigStore.ts
+++ b/frontend/stores/agentConfigStore.ts
@@ -155,7 +155,7 @@ function createEmptyEditableAgent(llmConfig?: { id: number | null; name: string;
     author: "",
     model: llmConfig?.name || "",
     model_id: llmConfig?.id || 0,
-    max_step: 5,
+    max_step: 15,
     provide_run_summary: false,
     tools: [],
     skills: [],

--- a/sdk/nexent/core/agents/agent_model.py
+++ b/sdk/nexent/core/agents/agent_model.py
@@ -80,7 +80,7 @@ class AgentConfig(BaseModel):
     description: str = Field(description="Agent description")
     prompt_templates: Optional[Dict[str, Any]] = Field(description="Prompt templates", default=None)
     tools: List[ToolConfig] = Field(description="List of tool information")
-    max_steps: int = Field(description="Maximum number of steps for current Agent", default=5)
+    max_steps: int = Field(description="Maximum number of steps for current Agent", default=15, ge=1, le=30)
     model_name: str = Field(description="Model alias from ModelConfig")
     provide_run_summary: Optional[bool] = Field(description="Whether to provide run summary to upper-level Agent", default=False)
     instructions: Optional[str] = Field(description="Additional instructions to prepend to system prompt", default=None)

--- a/test/backend/services/test_agent_service.py
+++ b/test/backend/services/test_agent_service.py
@@ -9673,7 +9673,7 @@ async def test_import_agent_by_agent_id_invalid_max_steps():
     mock_agent_info.description = "desc"
     mock_agent_info.business_description = "biz"
     mock_agent_info.author = "author"
-    mock_agent_info.max_steps = 25  # Too high (> 20)
+    mock_agent_info.max_steps = 35  # Too high (> 30)
     mock_agent_info.provide_run_summary = True
     mock_agent_info.duty_prompt = "duty"
     mock_agent_info.constraint_prompt = "constraint"

--- a/test/sdk/core/agents/test_agent_model.py
+++ b/test/sdk/core/agents/test_agent_model.py
@@ -1144,7 +1144,7 @@ class TestAgentConfig:
             model_name="default-model"
         )
         assert config.prompt_templates is None
-        assert config.max_steps == 5
+        assert config.max_steps == 15
         assert config.provide_run_summary is False
         assert config.instructions is None
         assert config.managed_agents == []
@@ -1222,9 +1222,29 @@ class TestAgentConfig:
             description="Max steps",
             tools=[],
             model_name="test",
-            max_steps=100
+            max_steps=30
         )
-        assert config_max.max_steps == 100
+        assert config_max.max_steps == 30
+
+    def test_agent_config_max_steps_rejects_out_of_bounds(self):
+        """Test AgentConfig rejects max_steps values outside 1-30 range."""
+        with pytest.raises(Exception):
+            agent_model_module.AgentConfig(
+                name="too_high",
+                description="Too high steps",
+                tools=[],
+                model_name="test",
+                max_steps=31
+            )
+
+        with pytest.raises(Exception):
+            agent_model_module.AgentConfig(
+                name="too_low",
+                description="Too low steps",
+                tools=[],
+                model_name="test",
+                max_steps=0
+            )
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Increase `max_steps` default from 5 → 15, and max limit from 20 → 30, across all three layers (SDK, Backend, Frontend).

## Problem
The previous `max_steps` configuration had **inconsistent defaults** (5, 10, 5 across different files) and a hardcoded validation bound of 20 on the import path only. The normal create/update API path had **no validation at all**, allowing arbitrary values.

## Changes

### SDK (`sdk/nexent/core/agents/agent_model.py`)
- Changed `AgentConfig.max_steps` default from 5 to 15
- Added Pydantic `Field(ge=1, le=30)` validation — the source of truth now enforces 1–30 bounds

### Backend (`backend/`)
- **`database/agent_db.py`**: `setdefault("max_steps", 5)` → `setdefault("max_steps", 15)`
- **`agents/create_agent_info.py`**: `.get("max_steps", 10)` → `.get("max_steps", 15)` — fixed inconsistent default
- **`services/agent_service.py`**: Import validation `> 20` → `> 30`, error message updated
- **`consts/model.py`**: Added `Field(default=None, ge=1, le=30)` to `AgentInfoRequest.max_steps` — closes validation gap on create/update API path

### Frontend (`frontend/`)
- **`stores/agentConfigStore.ts`**: `max_step: 5` → `max_step: 15`
- **`AgentGenerateDetail.tsx`**: Form fallback `|| 5` → `|| 15`, Form rule `max: 20` → `max: 30`, InputNumber `max={20}` → `max={30}`

### Intentionally unchanged
- `backend/agents/skill_creation_agent.py:56`: `max_steps=5` left unchanged (internal utility agent, low step count is appropriate)
- Existing agents in the database retain their current `max_steps` values; only new agents get default 15
- `keep_recent_steps` (default=4) remains unchanged — `4 <= 15` so no context compression cap is applied

## Impact
- Agents can take up to 3x more steps before termination (15 vs 5)
- Higher potential token usage per agent run
- Fewer "step limit reached" interruptions
- Import path now accepts max_steps up to 30