### PR TITLE
Add ASSET_OWNER role with OAuth registration and resource permissions 

### DIFF
--- a/backend/apps/agent_app.py
+++ b/backend/apps/agent_app.py
@@ -607,7 +607,15 @@ async def list_published_agents_api(
     """
     try:
         user_id, tenant_id, _ = get_current_user_info(authorization, request)
-        return await list_published_agents_impl(tenant_id=tenant_id, user_id=user_id)
+        agent_list = await list_published_agents_impl(
+            tenant_id=tenant_id, user_id=user_id
+        )
+        if tenant_id != ASSET_OWNER_TENANT_ID:
+            asset_agent_list = await list_published_agents_impl(
+                tenant_id=ASSET_OWNER_TENANT_ID, user_id=user_id
+            )
+            return agent_list + asset_agent_list
+        return agent_list
     except Exception as e:
         logger.error(f"Published agents list error: {str(e)}")
         raise HTTPException(

--- a/backend/apps/user_management_app.py
+++ b/backend/apps/user_management_app.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 from supabase_auth.errors import AuthApiError, AuthWeakPasswordError
 
+from consts.const import ASSET_OWNER_SIGNUP_USE_OAUTH_DETAIL
 from consts.model import UserSignInRequest, UserSignUpRequest, UpdatePasswordRequest
 from consts.exceptions import (
     NoInviteCodeException,
@@ -70,9 +71,14 @@ async def signup(request: UserSignUpRequest):
         raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
                             detail="INVITE_CODE_INVALID")
     except ValidationError as e:
-        logging.warning(
-            f"User registration rejected by feature flag: {str(e)}")
-        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=str(e))
+        detail = str(e)
+        if detail == ASSET_OWNER_SIGNUP_USE_OAUTH_DETAIL:
+            logging.warning(
+                "User registration rejected: asset owner invite requires OAuth")
+        else:
+            logging.warning(
+                f"User registration rejected by validation: {detail}")
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=detail)
     except UserRegistrationException as e:
         logging.error(
             f"User registration failed by registration service: {str(e)}")

--- a/backend/consts/const.py
+++ b/backend/consts/const.py
@@ -128,6 +128,9 @@ ASSET_OWNER_ATTACHMENTS_PREFIX = "attachments/asset_owner"
 ENABLE_ASSET_OWNER_ROLE = os.getenv(
     "ENABLE_ASSET_OWNER_ROLE", "false").lower() == "true"
 
+# HTTP detail key: asset owner must register via OAuth, not email/password signup.
+ASSET_OWNER_SIGNUP_USE_OAUTH_DETAIL = "ASSET_OWNER_USE_OAUTH"
+
 # Roles that can edit all resources within a tenant (permission = EDIT).
 # Keep this centralized to avoid drifting role logic across modules.
 CAN_EDIT_ALL_USER_ROLES = {"SU", "ADMIN", "SPEED", "ASSET_OWNER"}

--- a/backend/services/oauth_service.py
+++ b/backend/services/oauth_service.py
@@ -12,6 +12,9 @@ import jwt
 from pydantic import EmailStr, TypeAdapter, ValidationError as PydanticValidationError
 
 from consts.const import (
+    ASSET_OWNER_INVITE_CODE_TYPE,
+    ASSET_OWNER_ROLE,
+    ASSET_OWNER_TENANT_ID,
     DEFAULT_TENANT_ID,
     OAUTH_CALLBACK_BASE_URL,
     OAUTH_SSL_VERIFY,
@@ -19,6 +22,7 @@ from consts.const import (
     SUPABASE_JWT_SECRET,
 )
 from consts.exceptions import OAuthLinkError, OAuthProviderError
+from services.asset_owner_visibility import require_asset_owner_enabled
 from consts.oauth_providers import (
     get_all_provider_definitions,
     get_provider_definition,
@@ -359,6 +363,9 @@ def _role_from_invitation_type(code_type: str) -> str:
         return "ADMIN"
     if code_type == "DEV_INVITE":
         return "DEV"
+    if code_type == ASSET_OWNER_INVITE_CODE_TYPE:
+        require_asset_owner_enabled()
+        return ASSET_OWNER_ROLE
     return "USER"
 
 
@@ -431,7 +438,10 @@ async def complete_pending_oauth_account(
     supabase_user_id = create_resp.user.id
 
     tenant_id = invitation_info["tenant_id"]
+    if invitation_info.get("code_type") == ASSET_OWNER_INVITE_CODE_TYPE:
+        tenant_id = ASSET_OWNER_TENANT_ID
     user_role = _role_from_invitation_type(invitation_info.get("code_type", "USER_INVITE"))
+    is_asset_owner_registration = user_role == ASSET_OWNER_ROLE
 
     insert_user_tenant(
         user_id=supabase_user_id,
@@ -446,12 +456,13 @@ async def complete_pending_oauth_account(
         from utils.str_utils import convert_string_to_list
 
         group_ids = convert_string_to_list(group_ids)
-    if group_ids:
+    if group_ids and not is_asset_owner_registration:
         add_user_to_groups(supabase_user_id, group_ids, supabase_user_id)
 
     if user_role == "ADMIN":
         await generate_tts_stt_4_admin(tenant_id, supabase_user_id)
-    await init_tool_list_for_tenant(tenant_id, supabase_user_id)
+    if not is_asset_owner_registration:
+        await init_tool_list_for_tenant(tenant_id, supabase_user_id)
 
     create_or_update_oauth_account(
         user_id=supabase_user_id,

--- a/backend/services/user_management_service.py
+++ b/backend/services/user_management_service.py
@@ -28,14 +28,20 @@ from consts.const import (
     ASSET_OWNER_TENANT_ID,
     ASSET_OWNER_INVITE_CODE_TYPE,
     ASSET_OWNER_ROLE,
+    ASSET_OWNER_SIGNUP_USE_OAUTH_DETAIL,
 )
 
 from services.asset_owner_visibility import (
     filter_accessible_routes_for_asset_owner_feature,
     require_asset_owner_enabled,
 )
-from consts.const import INVITE_CODE, SUPABASE_URL, SUPABASE_KEY, DEFAULT_TENANT_ID
-from consts.exceptions import NoInviteCodeException, IncorrectInviteCodeException, UserRegistrationException, UnauthorizedError
+from consts.exceptions import (
+    NoInviteCodeException,
+    IncorrectInviteCodeException,
+    UserRegistrationException,
+    UnauthorizedError,
+    ValidationError,
+)
 from consts.error_code import ErrorCode
 from consts.exceptions import AppException
 
@@ -189,12 +195,14 @@ async def signup_user_with_invitation(email: EmailStr,
                 user_role = "DEV"
             elif code_type == ASSET_OWNER_INVITE_CODE_TYPE:
                 require_asset_owner_enabled()
-                user_role = ASSET_OWNER_ROLE
+                raise ValidationError(ASSET_OWNER_SIGNUP_USE_OAUTH_DETAIL)
 
             logging.info(
                 f"Invitation code {invite_code} validated successfully, will assign role: {user_role}")
 
         except IncorrectInviteCodeException:
+            raise
+        except ValidationError:
             raise
         except Exception as e:
             logging.error(

--- a/docker/sql/v2.2.0_0529_add_asset_owner_role_permissions.sql
+++ b/docker/sql/v2.2.0_0529_add_asset_owner_role_permissions.sql
@@ -1,0 +1,53 @@
+-- Migration: ASSET_OWNER role permissions and invitation type comment
+-- Date: 2026-05-29
+-- Description: Add ASSET_OWNER role permissions, SU asset-owner invite permissions,
+--              update invitation code_type comment, and ensure ag_skill_info_t.tenant_id exists
+-- Source: commit 15cece97692db2372a978cbdf21b5d5316e79f30 (init.sql)
+
+SET search_path TO nexent;
+
+BEGIN;
+
+COMMENT ON COLUMN nexent.tenant_invitation_code_t.code_type IS
+    'Invitation code type: ADMIN_INVITE, DEV_INVITE, USER_INVITE, ASSET_OWNER_INVITE';
+
+INSERT INTO nexent.role_permission_t
+    (role_permission_id, user_role, permission_category, permission_type, permission_subtype)
+VALUES
+    (188, 'SU', 'RESOURCE', 'INVITE.ASSET_OWNER', 'CREATE'),
+    (189, 'SU', 'RESOURCE', 'INVITE.ASSET_OWNER', 'READ'),
+    (190, 'SU', 'RESOURCE', 'INVITE.ASSET_OWNER', 'UPDATE'),
+    (191, 'SU', 'RESOURCE', 'INVITE.ASSET_OWNER', 'DELETE'),
+    (192, 'ASSET_OWNER', 'VISIBILITY', 'LEFT_NAV_MENU', '/'),
+    (193, 'ASSET_OWNER', 'VISIBILITY', 'LEFT_NAV_MENU', '/agents'),
+    (194, 'ASSET_OWNER', 'VISIBILITY', 'LEFT_NAV_MENU', '/knowledges'),
+    (195, 'ASSET_OWNER', 'VISIBILITY', 'LEFT_NAV_MENU', '/chat'),
+    (196, 'ASSET_OWNER', 'VISIBILITY', 'LEFT_NAV_MENU', '/space'),
+    (197, 'ASSET_OWNER', 'VISIBILITY', 'LEFT_NAV_MENU', '/market'),
+    (198, 'ASSET_OWNER', 'VISIBILITY', 'LEFT_NAV_MENU', '/models'),
+    (199, 'ASSET_OWNER', 'RESOURCE', 'AGENT', 'CREATE'),
+    (200, 'ASSET_OWNER', 'RESOURCE', 'AGENT', 'READ'),
+    (201, 'ASSET_OWNER', 'RESOURCE', 'AGENT', 'UPDATE'),
+    (202, 'ASSET_OWNER', 'RESOURCE', 'AGENT', 'DELETE'),
+    (203, 'ASSET_OWNER', 'RESOURCE', 'SKILL', 'CREATE'),
+    (204, 'ASSET_OWNER', 'RESOURCE', 'SKILL', 'READ'),
+    (205, 'ASSET_OWNER', 'RESOURCE', 'SKILL', 'UPDATE'),
+    (206, 'ASSET_OWNER', 'RESOURCE', 'SKILL', 'DELETE'),
+    (207, 'ASSET_OWNER', 'RESOURCE', 'KB', 'CREATE'),
+    (208, 'ASSET_OWNER', 'RESOURCE', 'KB', 'READ'),
+    (209, 'ASSET_OWNER', 'RESOURCE', 'KB', 'UPDATE'),
+    (210, 'ASSET_OWNER', 'RESOURCE', 'KB', 'DELETE'),
+    (211, 'ASSET_OWNER', 'RESOURCE', 'MCP', 'CREATE'),
+    (212, 'ASSET_OWNER', 'RESOURCE', 'MCP', 'READ'),
+    (213, 'ASSET_OWNER', 'RESOURCE', 'MCP', 'UPDATE'),
+    (214, 'ASSET_OWNER', 'RESOURCE', 'MCP', 'DELETE'),
+    (215, 'ASSET_OWNER', 'RESOURCE', 'MODEL', 'CREATE'),
+    (216, 'ASSET_OWNER', 'RESOURCE', 'MODEL', 'READ'),
+    (217, 'ASSET_OWNER', 'RESOURCE', 'MODEL', 'UPDATE'),
+    (218, 'ASSET_OWNER', 'RESOURCE', 'MODEL', 'DELETE'),
+    (219, 'ASSET_OWNER', 'RESOURCE', 'USER.ROLE', 'READ'),
+    (220, 'ASSET_OWNER', 'VISIBILITY', 'LEFT_NAV_MENU', '/users'),
+    (221, 'SU', 'VISIBILITY', 'LEFT_NAV_MENU', '/asset-owner-resources')
+ON CONFLICT (role_permission_id) DO NOTHING;
+
+COMMIT;

--- a/frontend/components/auth/registerModal.tsx
+++ b/frontend/components/auth/registerModal.tsx
@@ -312,6 +312,16 @@ export function RegisterModal() {
             value: values.inviteCode,
           },
         ]);
+      } else if (errorType === "ASSET_OWNER_USE_OAUTH") {
+        const errorMsg = t("auth.assetOwnerUseOAuth");
+        message.error(errorMsg);
+        form.setFields([
+          {
+            name: "inviteCode",
+            errors: [errorMsg],
+            value: values.inviteCode,
+          },
+        ]);
       }
       // Invalid email format
       else if (errorType === "INVALID_EMAIL_FORMAT") {

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -1103,6 +1103,7 @@
   "auth.registerAdmin": "Register Administrator Account",
   "auth.inviteCodeNotConfigured": "Admin invite code is not configured yet. Please contact system admin for help.",
   "auth.inviteCodeInvalid": "Invalid administrator invite code, please check and try again",
+  "auth.assetOwnerUseOAuth": "Asset owner accounts cannot be registered with email and password. Please sign in with GitHub, WeChat, or another OAuth provider and enter your asset owner invitation code to complete registration.",
   "auth.emailAlreadyExists": "This email is already registered, please use another email or try logging in",
   "auth.weakPassword": "Password is too weak, please set a more secure password",
   "auth.invalidEmailFormat": "Invalid email format, please check and try again",

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -1093,6 +1093,7 @@
   "auth.registerAdmin": "注册管理员账号",
   "auth.inviteCodeNotConfigured": "管理员注册功能暂未开放，请联系系统管理员配置邀请码",
   "auth.inviteCodeInvalid": "管理员邀请码错误，请检查后重新输入",
+  "auth.assetOwnerUseOAuth": "资产管理员账号不支持邮箱密码注册。请使用 GitHub、微信等 OAuth 方式登录，并填写资产管理员邀请码完成注册。",
   "auth.emailAlreadyExists": "该邮箱已被注册，请使用其他邮箱地址或尝试登录现有账号",
   "auth.weakPassword": "密码强度不够，请设置更安全的密码",
   "auth.invalidEmailFormat": "邮箱格式不正确，请检查后重新输入",

--- a/frontend/services/authService.ts
+++ b/frontend/services/authService.ts
@@ -197,7 +197,8 @@ export const authService = {
       if (!response.ok) {
         return {
           error: {
-            message: data.message || "Registration failed",
+            message:
+              data.detail || data.message || "Registration failed",
             code: response.status,
             data: data.data || null,
           },

--- a/test/backend/app/test_agent_app.py
+++ b/test/backend/app/test_agent_app.py
@@ -18,7 +18,7 @@ from fastapi import FastAPI
 from fastapi.responses import StreamingResponse
 from fastapi.testclient import TestClient
 
-from consts.const import ASSET_OWNER_TENANT_ID
+from consts.const import AGENT_PROMPTS_HIDDEN_FLAG, ASSET_OWNER_TENANT_ID
 
 # Filter out deprecation warnings from third-party libraries
 warnings.filterwarnings(
@@ -429,6 +429,34 @@ def test_search_agent_info_api_with_version_no(mocker, mock_auth_header):
     assert response.status_code == 200
     mock_get_agent_info.assert_called_once_with(
         123, "auth_tenant_id", 2, "user_id")
+
+
+def test_search_agent_info_api_masks_asset_owner_prompts(mocker, mock_auth_header):
+    """Non-asset-owner callers see masked prompts for asset-owner-scoped agents."""
+    mock_get_user_id = mocker.patch("apps.agent_app.get_current_user_id")
+    mock_get_agent_info = mocker.patch(
+        "apps.agent_app.get_agent_info_impl", new_callable=AsyncMock)
+    mock_get_user_id.return_value = ("user_id", "regular_tenant")
+    mock_get_agent_info.return_value = {
+        "agent_id": 1,
+        "tenant_id": ASSET_OWNER_TENANT_ID,
+        "duty_prompt": "secret duty",
+        "constraint_prompt": "secret constraint",
+        "few_shots_prompt": "secret few",
+    }
+
+    response = config_client.post(
+        "/agent/search_info",
+        json={"agent_id": 1},
+        headers=mock_auth_header,
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["duty_prompt"] is None
+    assert body["constraint_prompt"] is None
+    assert body["few_shots_prompt"] is None
+    assert body[AGENT_PROMPTS_HIDDEN_FLAG] is True
 
 
 # get_agent_by_name_api Tests
@@ -923,6 +951,23 @@ def test_list_all_agent_info_api_with_explicit_tenant_id(mocker, mock_auth_heade
         tenant_id="auth_tenant", user_id="test_user")
     mock_list_all_agent.assert_any_call(
         tenant_id=ASSET_OWNER_TENANT_ID, user_id="test_user")
+
+
+def test_list_all_agent_info_api_asset_owner_tenant_single_query(mocker, mock_auth_header):
+    """Asset-owner tenant callers only query their own tenant (no merge)."""
+    mock_get_user_info = mocker.patch("apps.agent_app.get_current_user_info")
+    mock_list_all_agent = mocker.patch(
+        "apps.agent_app.list_all_agent_info_impl", new_callable=AsyncMock)
+    mock_get_user_info.return_value = ("ao_user", ASSET_OWNER_TENANT_ID, "en")
+    mock_list_all_agent.return_value = [{"agent_id": 1, "name": "AO Agent"}]
+
+    response = config_client.get("/agent/list", headers=mock_auth_header)
+
+    assert response.status_code == 200
+    mock_list_all_agent.assert_called_once_with(
+        tenant_id=ASSET_OWNER_TENANT_ID, user_id="ao_user"
+    )
+    assert len(response.json()) == 1
 
 
 def test_list_all_agent_info_api_exception(mocker, mock_auth_header):
@@ -1925,9 +1970,9 @@ def test_list_published_agents_api_success(mocker, mock_auth_header):
         "apps.agent_app.list_published_agents_impl", new_callable=AsyncMock)
 
     mock_get_user_info.return_value = ("test_user_id", "test_tenant_id", "en")
-    mock_list_published_agents.return_value = [
-        {"agent_id": 1, "name": "Agent 1", "published_version_no": 1},
-        {"agent_id": 2, "name": "Agent 2", "published_version_no": 2}
+    mock_list_published_agents.side_effect = [
+        [{"agent_id": 1, "name": "Agent 1", "published_version_no": 1}],
+        [{"agent_id": 2, "name": "Asset Agent", "published_version_no": 1}],
     ]
 
     response = config_client.get(
@@ -1936,10 +1981,33 @@ def test_list_published_agents_api_success(mocker, mock_auth_header):
     )
 
     assert response.status_code == 200
-    mock_list_published_agents.assert_called_once_with(
+    assert mock_list_published_agents.call_count == 2
+    mock_list_published_agents.assert_any_call(
         tenant_id="test_tenant_id", user_id="test_user_id"
     )
+    mock_list_published_agents.assert_any_call(
+        tenant_id=ASSET_OWNER_TENANT_ID, user_id="test_user_id"
+    )
     assert len(response.json()) == 2
+
+
+def test_list_published_agents_api_asset_owner_tenant_single_query(mocker, mock_auth_header):
+    """Asset-owner tenant callers only query published agents once (no merge)."""
+    mock_get_user_info = mocker.patch("apps.agent_app.get_current_user_info")
+    mock_list_published_agents = mocker.patch(
+        "apps.agent_app.list_published_agents_impl", new_callable=AsyncMock)
+    mock_get_user_info.return_value = ("ao_user", ASSET_OWNER_TENANT_ID, "en")
+    mock_list_published_agents.return_value = [
+        {"agent_id": 1, "name": "AO Agent", "published_version_no": 1},
+    ]
+
+    response = config_client.get("/agent/published_list", headers=mock_auth_header)
+
+    assert response.status_code == 200
+    mock_list_published_agents.assert_called_once_with(
+        tenant_id=ASSET_OWNER_TENANT_ID, user_id="ao_user"
+    )
+    assert len(response.json()) == 1
 
 
 def test_list_published_agents_api_exception(mocker, mock_auth_header):

--- a/test/backend/app/test_northbound_knowledge_app.py
+++ b/test/backend/app/test_northbound_knowledge_app.py
@@ -1,0 +1,247 @@
+"""
+Unit tests for northbound_knowledge_app ASSET_OWNER-scoped endpoints.
+"""
+
+import os
+import sys
+import types
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+backend_dir = os.path.abspath(os.path.join(current_dir, "../../../backend"))
+if backend_dir not in sys.path:
+    sys.path.insert(0, backend_dir)
+
+# ---------------------------------------------------------------------------
+# Stub services package (mirrors test_northbound_base_app.py)
+# ---------------------------------------------------------------------------
+services_pkg = types.ModuleType("services")
+services_pkg.__path__ = [os.path.join(backend_dir, "services")]
+sys.modules["services"] = services_pkg
+
+
+@dataclass
+class NorthboundContext:
+    request_id: str
+    tenant_id: str
+    user_id: str
+    authorization: str
+    token_id: int = 0
+
+
+northbound_service_module = types.ModuleType("services.northbound_service")
+northbound_service_module.NorthboundContext = NorthboundContext
+sys.modules["services.northbound_service"] = northbound_service_module
+
+file_mgmt_module = types.ModuleType("services.file_management_service")
+file_mgmt_module.upload_files_impl = AsyncMock()
+file_mgmt_module.get_file_url_impl = AsyncMock()
+file_mgmt_module.get_file_stream_impl = AsyncMock()
+file_mgmt_module.check_file_access = MagicMock(return_value=True)
+sys.modules["services.file_management_service"] = file_mgmt_module
+
+redis_service_module = types.ModuleType("services.redis_service")
+redis_service_module.get_redis_service = MagicMock()
+sys.modules["services.redis_service"] = redis_service_module
+
+vectordb_service_module = types.ModuleType("services.vectordatabase_service")
+
+
+class _ElasticSearchServiceStub:
+    @staticmethod
+    def list_indices(*args, **kwargs):
+        return {"indices": ["kb1"]}
+
+    @staticmethod
+    def delete_documents(index_name, path_or_url, vdb_core):
+        return {"message": "Documents deleted successfully", "deleted": 1}
+
+
+vectordb_service_module.ElasticSearchService = _ElasticSearchServiceStub
+vectordb_service_module.get_vector_db_core = MagicMock()
+sys.modules["services.vectordatabase_service"] = vectordb_service_module
+
+consts_module = types.ModuleType("consts")
+consts_module.__path__ = [os.path.join(backend_dir, "consts")]
+sys.modules["consts"] = consts_module
+
+consts_exceptions_module = types.ModuleType("consts.exceptions")
+consts_exceptions_module.LimitExceededError = type("LimitExceededError", (Exception,), {})
+consts_exceptions_module.UnauthorizedError = type("UnauthorizedError", (Exception,), {})
+sys.modules["consts.exceptions"] = consts_exceptions_module
+
+consts_model_module = types.ModuleType("consts.model")
+consts_model_module.ProcessParams = type(
+    "ProcessParams",
+    (),
+    {"__init__": lambda self, **kwargs: None},
+)
+sys.modules["consts.model"] = consts_model_module
+
+consts_const_module = types.ModuleType("consts.const")
+consts_const_module.ASSET_OWNER_TENANT_ID = "asset_owner_tenant_id"
+
+
+class VectorDatabaseType:
+    ELASTICSEARCH = "elasticsearch"
+
+
+consts_const_module.VectorDatabaseType = VectorDatabaseType
+sys.modules["consts.const"] = consts_const_module
+
+utils_auth_module = types.ModuleType("utils.auth_utils")
+utils_auth_module.generate_session_jwt = MagicMock(return_value="jwt-token")
+sys.modules["utils.auth_utils"] = utils_auth_module
+
+utils_fm_module = types.ModuleType("utils.file_management_utils")
+utils_fm_module.trigger_data_process = AsyncMock(return_value={"status": "ok"})
+sys.modules["utils.file_management_utils"] = utils_fm_module
+
+northbound_app_module = types.ModuleType("apps.northbound_app")
+northbound_app_module._get_northbound_context = AsyncMock()
+sys.modules["apps.northbound_app"] = northbound_app_module
+
+file_management_app_module = types.ModuleType("apps.file_management_app")
+file_management_app_module.build_content_disposition_header = MagicMock(
+    return_value='attachment; filename="file.txt"'
+)
+sys.modules["apps.file_management_app"] = file_management_app_module
+
+from apps.northbound_knowledge_app import router  # noqa: E402
+from consts.const import ASSET_OWNER_TENANT_ID  # noqa: E402
+from consts.exceptions import LimitExceededError  # noqa: E402
+
+ASSET_CTX = NorthboundContext(
+    request_id="req-1",
+    tenant_id=ASSET_OWNER_TENANT_ID,
+    user_id="ao_user",
+    authorization="Bearer token",
+)
+REGULAR_CTX = NorthboundContext(
+    request_id="req-2",
+    tenant_id="regular_tenant",
+    user_id="user1",
+    authorization="Bearer token",
+)
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_northbound_context():
+    with patch(
+        "apps.northbound_knowledge_app._get_northbound_context",
+        new_callable=AsyncMock,
+    ) as mock_ctx:
+        yield mock_ctx
+
+
+class TestRequireAssetOwnerContext:
+    def test_non_asset_owner_tenant_returns_403(self, client, mock_northbound_context):
+        mock_northbound_context.return_value = REGULAR_CTX
+        response = client.get("/nb/v1/knowledge/indices")
+        assert response.status_code == 403
+        assert "asset administrators" in response.json()["detail"]
+
+
+class TestGetListIndices:
+    def test_success_for_asset_owner(self, client, mock_northbound_context):
+        mock_northbound_context.return_value = ASSET_CTX
+        response = client.get("/nb/v1/knowledge/indices")
+        assert response.status_code == 200
+        assert response.json()["indices"] == ["kb1"]
+
+    def test_rate_limit_returns_429(self, client, mock_northbound_context):
+        mock_northbound_context.return_value = ASSET_CTX
+        with patch(
+            "apps.northbound_knowledge_app.ElasticSearchService.list_indices",
+            side_effect=LimitExceededError("too many"),
+        ):
+            response = client.get("/nb/v1/knowledge/indices")
+        assert response.status_code == 429
+
+    def test_generic_error_returns_500(self, client, mock_northbound_context):
+        mock_northbound_context.return_value = ASSET_CTX
+        with patch(
+            "apps.northbound_knowledge_app.get_vector_db_core",
+            side_effect=RuntimeError("db down"),
+        ):
+            response = client.get("/nb/v1/knowledge/indices")
+        assert response.status_code == 500
+        assert "Error listing knowledge bases" in response.json()["detail"]
+
+
+class TestUploadFiles:
+    def test_missing_file_field_returns_client_error(self, client, mock_northbound_context):
+        mock_northbound_context.return_value = ASSET_CTX
+        response = client.post(
+            "/nb/v1/knowledge/file/upload",
+            data={"index_name": "kb1"},
+            files=[],
+        )
+        # FastAPI rejects missing required multipart file field before handler runs
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_empty_file_list_returns_400(self, mock_northbound_context):
+        from apps.northbound_knowledge_app import upload_files
+
+        mock_northbound_context.return_value = ASSET_CTX
+        request = MagicMock()
+        with patch(
+            "apps.northbound_knowledge_app._require_asset_owner_context",
+            new_callable=AsyncMock,
+            return_value=ASSET_CTX,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await upload_files(request=request, file=[], index_name="kb1")
+        assert exc_info.value.status_code == 400
+
+    def test_no_valid_uploads_returns_400(self, client, mock_northbound_context):
+        mock_northbound_context.return_value = ASSET_CTX
+        file_mgmt_module.upload_files_impl.return_value = (["err"], [], [])
+        response = client.post(
+            "/nb/v1/knowledge/file/upload",
+            data={"index_name": "kb1"},
+            files=[("file", ("test.txt", b"data", "text/plain"))],
+        )
+        assert response.status_code == 400
+        assert "No valid files" in response.json()["detail"]
+
+
+class TestGetStorageFile:
+    def test_access_denied_returns_403(self, client, mock_northbound_context):
+        mock_northbound_context.return_value = ASSET_CTX
+        file_mgmt_module.check_file_access.return_value = False
+        response = client.get("/nb/v1/knowledge/file/download/some/object")
+        assert response.status_code == 403
+        assert "permission" in response.json()["detail"].lower()
+        file_mgmt_module.check_file_access.return_value = True
+
+
+class TestDeleteDocuments:
+    def test_redis_cleanup_failure_still_returns_200(self, client, mock_northbound_context):
+        mock_northbound_context.return_value = ASSET_CTX
+        redis_mock = MagicMock()
+        redis_mock.delete_document_records.side_effect = RuntimeError("redis down")
+        redis_service_module.get_redis_service.return_value = redis_mock
+
+        response = client.delete(
+            "/nb/v1/knowledge/indices/kb1/documents",
+            params={"path_or_url": "minio://path/doc.pdf"},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert "Redis cleanup encountered an error" in body["message"]
+        assert "redis_cleanup_error" in body

--- a/test/backend/app/test_skill_app.py
+++ b/test/backend/app/test_skill_app.py
@@ -609,6 +609,34 @@ class TestGetSkillEndpoint:
             assert response.status_code == 404
 
 
+class TestAssetOwnerSkillVisibility:
+    """Test ASSET_OWNER skill visibility enforcement at the app layer."""
+
+    def test_get_skill_file_tree_denied_for_non_asset_owner_tenant(self, mocker):
+        """Non-asset-owner callers receive a denial payload for asset-owner skills."""
+        asset_owner_tenant_id = "asset_owner_tenant_id"
+
+        with patch("backend.apps.skill_app.can_view_skill", return_value=False), \
+             patch("backend.apps.skill_app.get_current_user_id", return_value=("user123", "regular_tenant")), \
+             patch("backend.apps.skill_app.SkillService") as mock_service_class:
+            mock_service = MagicMock()
+            mock_service_class.return_value = mock_service
+            mock_service.get_skill.return_value = {
+                "name": "ao_skill",
+                "tenant_id": asset_owner_tenant_id,
+            }
+
+            app = FastAPI()
+            app.include_router(skill_app.router)
+            client = TestClient(app)
+
+            response = client.get("/skills/ao_skill/files")
+
+            assert response.status_code == 200
+            assert response.json() == {"content": "您无权限查看"}
+            mock_service.get_skill_file_tree.assert_not_called()
+
+
 # ===== Update Skill Endpoint Tests =====
 class TestUpdateSkillEndpoint:
     """Test PUT /skills/{skill_name} endpoint."""

--- a/test/backend/app/test_user_management_app.py
+++ b/test/backend/app/test_user_management_app.py
@@ -33,7 +33,14 @@ patch('backend.database.client.minio_client', minio_mock).start()
 patch('elasticsearch.Elasticsearch', return_value=MagicMock()).start()
 
 # Import exception classes
-from consts.exceptions import NoInviteCodeException, IncorrectInviteCodeException, UserRegistrationException, UnauthorizedError, AppException
+from consts.exceptions import (
+    NoInviteCodeException,
+    IncorrectInviteCodeException,
+    UserRegistrationException,
+    UnauthorizedError,
+    AppException,
+    ValidationError,
+)
 from consts.error_code import ErrorCode
 from supabase_auth.errors import AuthApiError, AuthWeakPasswordError
 
@@ -239,6 +246,23 @@ class TestUserSignup:
             data = response.json()
             assert data["detail"] == "INVITE_CODE_INVALID"
 
+    def test_signup_validation_error_returns_400(self):
+        """Test registration rejected by ASSET_OWNER feature flag returns 400."""
+        with patch("apps.user_management_app.signup_user_with_invitation") as mock_signup:
+            mock_signup.side_effect = ValidationError("ASSET_OWNER feature is not enabled")
+
+            response = client.post(
+                "/user/signup",
+                json={
+                    "email": "owner@example.com",
+                    "password": "password123",
+                    "invite_code": "AO123",
+                },
+            )
+
+            assert response.status_code == HTTPStatus.BAD_REQUEST
+            assert "ASSET_OWNER feature is not enabled" in response.json()["detail"]
+
     def test_signup_registration_service_exception(self):
         """Test registration fails due to service error"""
         with patch('apps.user_management_app.signup_user_with_invitation') as mock_signup:
@@ -314,6 +338,22 @@ class TestUserSignup:
 
 class TestUserSignin:
     """Test user signin endpoint"""
+
+    def test_signin_validation_error_returns_400(self):
+        """Test login rejected by ASSET_OWNER feature flag returns 400."""
+        with patch("apps.user_management_app.signin_user") as mock_signin:
+            mock_signin.side_effect = ValidationError("ASSET_OWNER feature is not enabled")
+
+            response = client.post(
+                "/user/signin",
+                json={
+                    "email": "owner@example.com",
+                    "password": "password123",
+                },
+            )
+
+            assert response.status_code == HTTPStatus.BAD_REQUEST
+            assert "ASSET_OWNER feature is not enabled" in response.json()["detail"]
 
     def test_signin_success(self):
         """Test successful user login"""

--- a/test/backend/services/test_agent_service.py
+++ b/test/backend/services/test_agent_service.py
@@ -8685,6 +8685,60 @@ async def test_list_all_agent_info_impl_admin_gets_edit_permission(
 @patch("backend.services.agent_service.get_user_tenant_by_user_id")
 @patch("backend.services.agent_service.query_group_ids_by_user")
 @patch("backend.services.agent_service.query_all_agent_info_by_tenant_id")
+async def test_list_all_agent_info_impl_asset_owner_agent_read_only_for_admin(
+    mock_query_agents,
+    mock_query_groups,
+    mock_get_user_tenant,
+    mock_convert_list,
+    mock_check_availability,
+    mock_get_model,
+):
+    """ASSET_OWNER-scoped agents are READ_ONLY for non-ASSET_OWNER roles even when admin."""
+    from consts.const import ASSET_OWNER_TENANT_ID, PERMISSION_EDIT, PERMISSION_READ
+
+    mock_agents = [
+        {
+            "agent_id": 99,
+            "name": "Asset Agent",
+            "display_name": "Asset Agent",
+            "description": "Asset owner scoped",
+            "enabled": True,
+            "group_ids": "1",
+            "ingroup_permission": PERMISSION_EDIT,
+            "created_by": "admin_user",
+            "tenant_id": ASSET_OWNER_TENANT_ID,
+            "create_time": 1,
+        },
+    ]
+
+    mock_query_agents.return_value = mock_agents
+    mock_get_user_tenant.return_value = {"user_role": "ADMIN"}
+    mock_query_groups.return_value = [1]
+
+    def convert_side_effect(x):
+        if not x or (isinstance(x, str) and x.strip() == ""):
+            return []
+        return [int(p.strip()) for p in str(x).split(",") if p.strip().isdigit()]
+
+    mock_convert_list.side_effect = convert_side_effect
+    mock_check_availability.return_value = (True, [])
+    mock_get_model.return_value = None
+
+    result = await list_all_agent_info_impl(
+        tenant_id=ASSET_OWNER_TENANT_ID, user_id="admin_user"
+    )
+
+    assert len(result) == 1
+    assert result[0]["permission"] == PERMISSION_READ
+
+
+@pytest.mark.asyncio
+@patch("backend.services.agent_service.get_model_by_model_id")
+@patch("backend.services.agent_service.check_agent_availability")
+@patch("backend.services.agent_service.convert_string_to_list")
+@patch("backend.services.agent_service.get_user_tenant_by_user_id")
+@patch("backend.services.agent_service.query_group_ids_by_user")
+@patch("backend.services.agent_service.query_all_agent_info_by_tenant_id")
 async def test_list_all_agent_info_impl_non_creator_no_group_overlap_hidden(
     mock_query_agents,
     mock_query_groups,

--- a/test/backend/services/test_asset_owner_visibility.py
+++ b/test/backend/services/test_asset_owner_visibility.py
@@ -1,0 +1,149 @@
+"""Unit tests for ASSET_OWNER visibility helpers."""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from consts.const import (
+    ASSET_OWNER_ROLE,
+    ASSET_OWNER_TENANT_ID,
+    PERMISSION_EDIT,
+    PERMISSION_READ,
+)
+
+PROMPTS_HIDDEN_FLAG = "prompts_hidden"
+from consts.exceptions import ValidationError
+from backend.services import asset_owner_visibility as aov
+
+ASSET_OWNER_RESOURCES_ROUTE = aov.ASSET_OWNER_RESOURCES_ROUTE
+
+
+class TestRequireAssetOwnerEnabled:
+    @patch("backend.services.asset_owner_visibility.ENABLE_ASSET_OWNER_ROLE", False)
+    def test_raises_when_feature_disabled(self):
+        with pytest.raises(ValidationError, match="ASSET_OWNER feature is not enabled"):
+            aov.require_asset_owner_enabled()
+
+    @patch("backend.services.asset_owner_visibility.ENABLE_ASSET_OWNER_ROLE", True)
+    def test_no_op_when_feature_enabled(self):
+        aov.require_asset_owner_enabled()
+
+
+class TestFilterAccessibleRoutes:
+    @patch("backend.services.asset_owner_visibility.ENABLE_ASSET_OWNER_ROLE", True)
+    def test_returns_routes_unchanged_when_enabled(self):
+        routes = ["/home", ASSET_OWNER_RESOURCES_ROUTE, "/settings"]
+        assert aov.filter_accessible_routes_for_asset_owner_feature(routes) == routes
+
+    @patch("backend.services.asset_owner_visibility.ENABLE_ASSET_OWNER_ROLE", False)
+    def test_removes_asset_owner_route_when_disabled(self):
+        routes = ["/home", ASSET_OWNER_RESOURCES_ROUTE, "/settings"]
+        result = aov.filter_accessible_routes_for_asset_owner_feature(routes)
+        assert ASSET_OWNER_RESOURCES_ROUTE not in result
+        assert result == ["/home", "/settings"]
+
+
+class TestCanViewSkill:
+    def test_asset_owner_skill_visible_to_asset_owner_tenant(self):
+        assert aov.can_view_skill(ASSET_OWNER_TENANT_ID, ASSET_OWNER_TENANT_ID) is True
+
+    def test_asset_owner_skill_hidden_from_other_tenants(self):
+        assert aov.can_view_skill("regular_tenant", ASSET_OWNER_TENANT_ID) is False
+
+    def test_regular_skill_visible_to_any_tenant(self):
+        assert aov.can_view_skill("regular_tenant", "other_tenant") is True
+        assert aov.can_view_skill(None, "other_tenant") is True
+
+
+class TestResolveAgentListPermission:
+    def test_asset_owner_agent_read_only_for_non_asset_owner_role(self):
+        agent = {"tenant_id": ASSET_OWNER_TENANT_ID, "created_by": "user1", "ingroup_permission": PERMISSION_EDIT}
+        result = aov.resolve_agent_list_permission(
+            user_role="ADMIN",
+            agent=agent,
+            user_id="user1",
+            can_edit_all=True,
+        )
+        assert result == PERMISSION_READ
+
+    def test_asset_owner_role_creator_gets_edit_on_asset_owner_agent(self):
+        agent = {"tenant_id": ASSET_OWNER_TENANT_ID, "created_by": "user1", "ingroup_permission": PERMISSION_READ}
+        result = aov.resolve_agent_list_permission(
+            user_role=ASSET_OWNER_ROLE,
+            agent=agent,
+            user_id="user1",
+            can_edit_all=False,
+        )
+        assert result == PERMISSION_EDIT
+
+    def test_regular_agent_creator_gets_edit(self):
+        agent = {"tenant_id": "tenant_a", "created_by": "user1", "ingroup_permission": PERMISSION_READ}
+        result = aov.resolve_agent_list_permission(
+            user_role="USER",
+            agent=agent,
+            user_id="user1",
+            can_edit_all=False,
+        )
+        assert result == PERMISSION_EDIT
+
+    def test_regular_agent_uses_ingroup_permission_when_not_creator(self):
+        agent = {"tenant_id": "tenant_a", "created_by": "other", "ingroup_permission": PERMISSION_READ}
+        result = aov.resolve_agent_list_permission(
+            user_role="USER",
+            agent=agent,
+            user_id="user1",
+            can_edit_all=False,
+        )
+        assert result == PERMISSION_READ
+
+
+class TestApplyAgentDetailPromptVisibility:
+    def test_masks_prompts_for_non_asset_owner_viewer(self):
+        agent_info = {
+            "tenant_id": ASSET_OWNER_TENANT_ID,
+            "duty_prompt": "duty",
+            "constraint_prompt": "constraint",
+            "few_shots_prompt": "few",
+        }
+        result = aov.apply_agent_detail_prompt_visibility("regular_tenant", agent_info)
+        assert result["duty_prompt"] is None
+        assert result["constraint_prompt"] is None
+        assert result["few_shots_prompt"] is None
+        assert result[PROMPTS_HIDDEN_FLAG] is True
+        assert agent_info["duty_prompt"] == "duty"
+
+    def test_no_mask_for_asset_owner_tenant_viewer(self):
+        agent_info = {
+            "tenant_id": ASSET_OWNER_TENANT_ID,
+            "duty_prompt": "duty",
+            "constraint_prompt": "constraint",
+            "few_shots_prompt": "few",
+        }
+        result = aov.apply_agent_detail_prompt_visibility(ASSET_OWNER_TENANT_ID, agent_info)
+        assert result["duty_prompt"] == "duty"
+        assert PROMPTS_HIDDEN_FLAG not in result
+
+    def test_no_mask_for_regular_agent(self):
+        agent_info = {
+            "tenant_id": "tenant_a",
+            "duty_prompt": "duty",
+            "constraint_prompt": "constraint",
+            "few_shots_prompt": "few",
+        }
+        result = aov.apply_agent_detail_prompt_visibility("regular_tenant", agent_info)
+        assert result["duty_prompt"] == "duty"
+        assert PROMPTS_HIDDEN_FLAG not in result
+
+
+class TestPostprocessKnowledgeVisibility:
+    def test_passthrough_items(self):
+        items = [{"knowledge_id": 1}, {"knowledge_id": 2}]
+        result = aov.postprocess_knowledge_visibility(items, "ADMIN", "tenant_a")
+        assert result is items
+        assert result == items

--- a/test/backend/services/test_file_management_service.py
+++ b/test/backend/services/test_file_management_service.py
@@ -799,6 +799,35 @@ class TestCheckFileAccess:
         assert check_file_access("system/config.json", "user123") is False
         assert check_file_access("preview/file.pdf", "user123") is False
 
+    def test_check_file_access_asset_owner_prefix_requires_asset_owner_tenant(self):
+        """Asset-owner attachment paths are restricted to the asset-owner tenant."""
+        from backend.services.file_management_service import check_file_access
+        from consts.const import ASSET_OWNER_TENANT_ID
+
+        path = "attachments/asset_owner/user1/doc.pdf"
+        assert check_file_access(path, "user1", ASSET_OWNER_TENANT_ID) is True
+        assert check_file_access(path, "user1", "regular_tenant") is False
+
+
+class TestResolveMinioUploadFolder:
+    """Test cases for resolve_minio_upload_folder asset-owner branch."""
+
+    def test_asset_owner_tenant_uses_dedicated_prefix(self):
+        from backend.services.file_management_service import resolve_minio_upload_folder
+        from consts.const import ASSET_OWNER_TENANT_ID
+
+        result = resolve_minio_upload_folder(
+            folder="attachments",
+            user_id="user123",
+            uploader_tenant_id=ASSET_OWNER_TENANT_ID,
+        )
+        assert result == "attachments/asset_owner/user123"
+
+    def test_knowledge_base_unchanged_for_non_asset_owner(self):
+        from backend.services.file_management_service import resolve_minio_upload_folder
+
+        assert resolve_minio_upload_folder("knowledge_base", "user123", "tenant_a") == "knowledge_base"
+
 
 class TestCheckFileAccessBatch:
     """Test cases for check_file_access_batch function"""

--- a/test/backend/services/test_invitation_service.py
+++ b/test/backend/services/test_invitation_service.py
@@ -100,6 +100,7 @@ sys.modules["services.asset_owner_visibility"] = _asset_owner_visibility_stub
 setattr(_services_pkg, "asset_owner_visibility", _asset_owner_visibility_stub)
 setattr(_services_pkg, "group_service", sys.modules["services.group_service"])
 
+from consts.const import ASSET_OWNER_INVITE_CODE_TYPE, ASSET_OWNER_TENANT_ID
 from consts.exceptions import NotFoundException, UnauthorizedError, DuplicateError
 from backend.services.invitation_service import (
     create_invitation_code,
@@ -1378,3 +1379,164 @@ def test_update_invitation_code_status_same_day_not_expired(
     # Should return False because status didn't change (today is not expired)
     assert result is False
     mock_modify_invitation.assert_not_called()
+
+
+@patch("backend.services.invitation_service.ENABLE_ASSET_OWNER_ROLE", True)
+@patch("backend.services.invitation_service.get_user_tenant_by_user_id")
+@patch("backend.services.invitation_service._generate_unique_invitation_code")
+@patch("backend.services.invitation_service.add_invitation")
+@patch("backend.services.invitation_service.query_invitation_by_id")
+@patch("backend.services.invitation_service.update_invitation_code_status")
+@patch("backend.services.invitation_service.query_invitation_by_code")
+def test_create_asset_owner_invite_success(
+    mock_query_invitation_by_code,
+    mock_update_status,
+    mock_query_invitation,
+    mock_add_invitation,
+    mock_generate_code,
+    mock_get_user_info,
+    mock_user_info,
+):
+    """SU can create ASSET_OWNER_INVITE with virtual tenant and empty groups."""
+    mock_user_info["user_role"] = "SU"
+    mock_get_user_info.return_value = mock_user_info
+    mock_generate_code.return_value = "AO1234"
+    mock_add_invitation.return_value = 99
+    mock_query_invitation.return_value = {"status": "IN_USE"}
+    mock_query_invitation_by_code.return_value = None
+
+    result = create_invitation_code(
+        tenant_id="ignored_tenant",
+        code_type=ASSET_OWNER_INVITE_CODE_TYPE,
+        user_id="su_user",
+    )
+
+    assert result["code_type"] == ASSET_OWNER_INVITE_CODE_TYPE
+    assert result["group_ids"] == []
+    mock_add_invitation.assert_called_once_with(
+        tenant_id=ASSET_OWNER_TENANT_ID,
+        invitation_code="AO1234",
+        code_type=ASSET_OWNER_INVITE_CODE_TYPE,
+        group_ids=[],
+        capacity=1,
+        expiry_date=None,
+        status="IN_USE",
+        created_by="su_user",
+    )
+
+
+@patch("backend.services.invitation_service.ENABLE_ASSET_OWNER_ROLE", True)
+@patch("backend.services.invitation_service.get_user_tenant_by_user_id")
+def test_create_asset_owner_invite_admin_forbidden(mock_get_user_info, mock_user_info):
+    """ADMIN cannot create ASSET_OWNER_INVITE codes."""
+    mock_user_info["user_role"] = "ADMIN"
+    mock_get_user_info.return_value = mock_user_info
+
+    with pytest.raises(UnauthorizedError, match="not authorized to create ADMIN_INVITE codes"):
+        create_invitation_code(
+            tenant_id="test_tenant",
+            code_type=ASSET_OWNER_INVITE_CODE_TYPE,
+            user_id="admin_user",
+        )
+
+
+@patch("backend.services.invitation_service.ENABLE_ASSET_OWNER_ROLE", False)
+@patch("backend.services.invitation_service.get_user_tenant_by_user_id")
+def test_create_asset_owner_invite_feature_disabled(mock_get_user_info, mock_user_info):
+    """Creating ASSET_OWNER_INVITE when feature is disabled raises UnauthorizedError."""
+    mock_user_info["user_role"] = "SU"
+    mock_get_user_info.return_value = mock_user_info
+
+    with pytest.raises(UnauthorizedError, match="ASSET_OWNER feature is not enabled"):
+        create_invitation_code(
+            tenant_id="test_tenant",
+            code_type=ASSET_OWNER_INVITE_CODE_TYPE,
+            user_id="su_user",
+        )
+
+
+@patch("backend.services.invitation_service.query_invitation_by_id")
+@patch("backend.services.invitation_service.modify_invitation")
+@patch("backend.services.invitation_service.update_invitation_code_status")
+@patch("backend.services.invitation_service.get_user_tenant_by_user_id")
+def test_update_asset_owner_invite_su_success(
+    mock_get_user_info,
+    mock_update_status,
+    mock_modify_invitation,
+    mock_query_invitation_by_id,
+    mock_user_info,
+):
+    """SU can update ASSET_OWNER_INVITE invitation codes."""
+    mock_user_info["user_role"] = "SU"
+    mock_get_user_info.return_value = mock_user_info
+    mock_query_invitation_by_id.return_value = {
+        "invitation_id": 10,
+        "code_type": ASSET_OWNER_INVITE_CODE_TYPE,
+    }
+    mock_modify_invitation.return_value = True
+
+    assert update_invitation_code(10, {"capacity": 2}, "su_user") is True
+    mock_modify_invitation.assert_called_once()
+
+
+@patch("backend.services.invitation_service.query_invitation_by_id")
+@patch("backend.services.invitation_service.get_user_tenant_by_user_id")
+def test_update_asset_owner_invite_admin_forbidden(
+    mock_get_user_info,
+    mock_query_invitation_by_id,
+    mock_user_info,
+):
+    """ADMIN cannot update ASSET_OWNER_INVITE invitation codes."""
+    mock_user_info["user_role"] = "ADMIN"
+    mock_get_user_info.return_value = mock_user_info
+    mock_query_invitation_by_id.return_value = {
+        "invitation_id": 10,
+        "code_type": ASSET_OWNER_INVITE_CODE_TYPE,
+    }
+
+    with pytest.raises(UnauthorizedError, match="not authorized to update invitation codes"):
+        update_invitation_code(10, {"capacity": 2}, "admin_user")
+
+
+@patch("backend.services.invitation_service.query_invitations_with_pagination")
+@patch("backend.services.invitation_service.get_user_tenant_by_user_id")
+def test_get_invitations_list_asset_owner_tenant_su_success(
+    mock_get_user_info,
+    mock_query_invitations,
+    mock_user_info,
+):
+    """SU can list invitations for the asset-owner virtual tenant."""
+    mock_user_info["user_role"] = "SU"
+    mock_get_user_info.return_value = mock_user_info
+    mock_query_invitations.return_value = {"items": [], "total": 0}
+
+    result = get_invitations_list(
+        tenant_id=ASSET_OWNER_TENANT_ID,
+        page=1,
+        page_size=10,
+        user_id="su_user",
+    )
+
+    assert result["total"] == 0
+    mock_query_invitations.assert_called_once()
+
+
+@patch("backend.services.invitation_service.get_user_tenant_by_user_id")
+def test_get_invitations_list_asset_owner_tenant_admin_forbidden(
+    mock_get_user_info,
+    mock_user_info,
+):
+    """ADMIN cannot list asset-owner tenant invitations."""
+    mock_user_info["user_role"] = "ADMIN"
+    mock_get_user_info.return_value = mock_user_info
+
+    with pytest.raises(
+        UnauthorizedError,
+        match="not authorized to view asset owner invitations",
+    ):
+        get_invitations_list(
+            tenant_id=ASSET_OWNER_TENANT_ID,
+            page=1,
+            page_size=10,
+            user_id="admin_user",
+        )

--- a/test/backend/services/test_tenant_service.py
+++ b/test/backend/services/test_tenant_service.py
@@ -203,6 +203,25 @@ class TestGetTenantsPaginated:
             assert len(result["data"]) == 3
             assert result["data"] == tenant_infos
 
+    def test_get_tenants_paginated_excludes_asset_owner_virtual_tenant(self, service_mocks):
+        """Virtual ASSET_OWNER tenant must not appear in admin tenant listings."""
+        from consts.const import ASSET_OWNER_TENANT_ID
+
+        tenant_ids = ["tenant1", ASSET_OWNER_TENANT_ID, "tenant2"]
+        tenant_infos = [
+            {"tenant_id": "tenant1", "tenant_name": "Tenant 1", "default_group_id": "g1"},
+            {"tenant_id": "tenant2", "tenant_name": "Tenant 2", "default_group_id": "g2"},
+        ]
+
+        with patch("backend.services.tenant_service.get_all_tenant_ids", return_value=tenant_ids), \
+             patch("backend.services.tenant_service.get_tenant_info", side_effect=tenant_infos):
+            result = get_tenants_paginated(page=1, page_size=20)
+
+        assert result["total"] == 2
+        returned_ids = [t["tenant_id"] for t in result["data"]]
+        assert ASSET_OWNER_TENANT_ID not in returned_ids
+        assert returned_ids == ["tenant1", "tenant2"]
+
     def test_get_tenants_paginated_with_missing_configs(self, service_mocks):
         """Test get_tenants_paginated when some tenants have missing configs"""
         # Setup

--- a/test/backend/services/test_user_management_service.py
+++ b/test/backend/services/test_user_management_service.py
@@ -41,8 +41,23 @@ asset_owner_visibility_mock.require_asset_owner_enabled = lambda: None
 sys.modules['services.asset_owner_visibility'] = asset_owner_visibility_mock
 setattr(services_pkg, 'asset_owner_visibility', asset_owner_visibility_mock)
 
-from consts.exceptions import NoInviteCodeException, IncorrectInviteCodeException, UserRegistrationException, UnauthorizedError, AppException
+from consts.exceptions import (
+    NoInviteCodeException,
+    IncorrectInviteCodeException,
+    UserRegistrationException,
+    UnauthorizedError,
+    AppException,
+    ValidationError,
+)
 from consts.error_code import ErrorCode
+from consts.const import (
+    ASSET_OWNER_ROLE,
+    ASSET_OWNER_SIGNUP_USE_OAUTH_DETAIL,
+    ASSET_OWNER_INVITE_CODE_TYPE,
+    ASSET_OWNER_TENANT_ID,
+)
+
+ASSET_OWNER_RESOURCES_ROUTE = "/asset-owner-resources"
 
 # Patch storage factory and MinIO config validation to avoid errors during initialization
 # These patches must be started before any imports that use MinioClient
@@ -696,6 +711,25 @@ class TestSignupUserWithInvitation(unittest.IsolatedAsyncioTestCase):
             await signup_user_with_invitation("test@example.com", "Password123", "INVALID")
 
         self.assertIn("is not available", str(context.exception))
+
+    @patch('backend.services.user_management_service.get_invitation_by_code')
+    @patch('backend.services.user_management_service.check_invitation_available')
+    async def test_signup_user_with_asset_owner_invite_rejected(self, mock_check_available, mock_get_invite_code):
+        """Asset owner invite codes must use OAuth registration, not email signup."""
+        mock_check_available.return_value = True
+        mock_get_invite_code.return_value = {
+            "invitation_id": 1,
+            "code_type": ASSET_OWNER_INVITE_CODE_TYPE,
+            "group_ids": [],
+            "tenant_id": "asset_owner_tenant_id",
+        }
+
+        with self.assertRaises(ValidationError) as context:
+            await signup_user_with_invitation(
+                "owner@example.com", "Password123", invite_code="ASSET123"
+            )
+
+        self.assertEqual(str(context.exception), ASSET_OWNER_SIGNUP_USE_OAUTH_DETAIL)
 
     @patch('backend.services.user_management_service.get_invitation_by_code')
     @patch('backend.services.user_management_service.check_invitation_available')
@@ -1847,6 +1881,104 @@ class TestUpdatePassword(unittest.IsolatedAsyncioTestCase):
 class TestIntegrationScenarios(unittest.IsolatedAsyncioTestCase):
     """Integration test scenarios"""
 
+
+class TestAssetOwnerUserManagement(unittest.IsolatedAsyncioTestCase):
+    """ASSET_OWNER-specific user management behavior."""
+
+    @patch("backend.services.asset_owner_visibility.ENABLE_ASSET_OWNER_ROLE", False)
+    @patch("backend.services.user_management_service.filter_accessible_routes_for_asset_owner_feature")
+    def test_format_role_permissions_excludes_asset_owner_route_when_disabled(
+        self, mock_filter_routes,
+    ):
+        import backend.services.asset_owner_visibility as aov
+
+        mock_filter_routes.side_effect = aov.filter_accessible_routes_for_asset_owner_feature
+        from backend.services.user_management_service import format_role_permissions
+
+        permissions = [
+            {
+                "permission_category": "MENU",
+                "permission_type": "LEFT_NAV_MENU",
+                "permission_subtype": ASSET_OWNER_RESOURCES_ROUTE,
+            },
+            {
+                "permission_category": "MENU",
+                "permission_type": "LEFT_NAV_MENU",
+                "permission_subtype": "/home",
+            },
+        ]
+        result = format_role_permissions(permissions)
+        assert ASSET_OWNER_RESOURCES_ROUTE not in result["accessibleRoutes"]
+        assert "/home" in result["accessibleRoutes"]
+
+    @patch("backend.services.user_management_service.require_asset_owner_enabled")
+    @patch("backend.services.user_management_service.get_jwt_expiry_seconds")
+    @patch("backend.services.user_management_service.calculate_expires_at")
+    @patch("backend.services.user_management_service.get_supabase_client")
+    @patch("backend.services.user_management_service.get_user_tenant_by_user_id")
+    async def test_signin_asset_owner_feature_disabled_signs_out(
+        self,
+        mock_get_user_tenant,
+        mock_get_client,
+        mock_calc_expires,
+        mock_get_expiry,
+        mock_require_enabled,
+    ):
+        from backend.services.user_management_service import signin_user
+
+        mock_require_enabled.side_effect = ValidationError(
+            "ASSET_OWNER feature is not enabled"
+        )
+        mock_get_user_tenant.return_value = {
+            "user_role": ASSET_OWNER_ROLE,
+            "tenant_id": "",
+        }
+        mock_client = MagicMock()
+        mock_user = MagicMock()
+        mock_user.id = "ao-user"
+        mock_user.user_metadata = {}
+        mock_session = MagicMock()
+        mock_session.access_token = "token"
+        mock_response = MagicMock()
+        mock_response.user = mock_user
+        mock_response.session = mock_session
+        mock_client.auth.sign_in_with_password.return_value = mock_response
+        mock_get_client.return_value = mock_client
+        mock_get_expiry.return_value = 3600
+        mock_calc_expires.return_value = 1234567890
+
+        with self.assertRaises(ValidationError):
+            await signin_user("owner@example.com", "Password123")
+
+        mock_client.auth.sign_out.assert_called_once()
+
+    @patch("backend.services.user_management_service.query_group_ids_by_user")
+    @patch("backend.services.user_management_service.get_user_tenant_by_user_id")
+    @patch("backend.services.user_management_service.get_db_session")
+    async def test_get_user_info_resolves_asset_owner_virtual_tenant(
+        self,
+        mock_get_db_session,
+        mock_get_user_tenant,
+        mock_query_groups,
+    ):
+        from backend.services.user_management_service import get_user_info
+
+        mock_get_user_tenant.return_value = {
+            "user_id": "ao-user",
+            "user_role": ASSET_OWNER_ROLE,
+            "user_email": "owner@example.com",
+            "tenant_id": "",
+        }
+        mock_query_groups.return_value = []
+
+        mock_session = MagicMock()
+        mock_session.query.return_value.filter.return_value.all.return_value = []
+        mock_get_db_session.return_value.__enter__.return_value = mock_session
+
+        result = await get_user_info("ao-user")
+
+        assert result is not None
+        assert result["user"]["tenant_id"] == ASSET_OWNER_TENANT_ID
 
 
 if __name__ == '__main__':

--- a/test/backend/utils/test_auth_utils.py
+++ b/test/backend/utils/test_auth_utils.py
@@ -628,3 +628,23 @@ class TestGetUserAndTenantByAccessKey:
 
         with pytest.raises(UnauthorizedError, match="No user associated with this access key"):
             au.get_user_and_tenant_by_access_key("nexent-abc123")
+
+
+class TestResolveTenantIdFromUserTenantRecord:
+    """Tests for resolve_tenant_id_from_user_tenant_record."""
+
+    def setup_method(self):
+        au.ASSET_OWNER_ROLE = "ASSET_OWNER"
+        au.ASSET_OWNER_TENANT_ID = "asset_owner_tenant_id"
+
+    def test_returns_explicit_tenant_id(self):
+        record = {"tenant_id": "tenant_explicit", "user_role": "USER"}
+        assert au.resolve_tenant_id_from_user_tenant_record(record) == "tenant_explicit"
+
+    def test_empty_tenant_asset_owner_role_maps_to_virtual_tenant(self):
+        record = {"tenant_id": "", "user_role": "ASSET_OWNER"}
+        assert au.resolve_tenant_id_from_user_tenant_record(record) == au.ASSET_OWNER_TENANT_ID
+
+    def test_empty_tenant_other_role_falls_back_to_default(self):
+        record = {"tenant_id": None, "user_role": "USER"}
+        assert au.resolve_tenant_id_from_user_tenant_record(record) == au.DEFAULT_TENANT_ID


### PR DESCRIPTION
- Block email/password registration for ASSET_OWNER invites; complete signup via OAuth
- Merge ASSET_OWNER-scoped agents into /agent/list and published-agent list for other tenants
- Add v2.2.0 migration for SU asset-owner invite permissions and ASSET_OWNER nav/CRUD RBAC
- Frontend: map virtual tenant_id for ASSET_OWNER sessions and show OAuth-only signup error