### PR TITLE
feat(model): optimize model type labels and max token input

### DIFF
--- a/frontend/app/[locale]/models/components/model/ModelAddDialog.tsx
+++ b/frontend/app/[locale]/models/components/model/ModelAddDialog.tsx
@@ -24,6 +24,11 @@ import {
   DEFAULT_EXPECTED_CHUNK_SIZE,
   DEFAULT_MAXIMUM_CHUNK_SIZE,
 } from "./ModelChunkSizeSilder";
+import {
+  isValidMaxTokens,
+  ModelMaxTokensInput,
+  parseMaxTokens,
+} from "./ModelMaxTokensInput";
 
 const { Option } = Select;
 
@@ -49,7 +54,7 @@ const DEFAULT_FORM_STATE = {
   displayName: "",
   url: "",
   apiKey: "",
-  maxTokens: "4096",
+  maxTokens: "",
   isMultimodal: false,
   isBatchImport: false,
   provider: "modelengine",
@@ -270,7 +275,7 @@ export const ModelAddDialog = ({
   const [settingsModalVisible, setSettingsModalVisible] = useState(false);
   const [selectedModelForSettings, setSelectedModelForSettings] =
     useState<any>(null);
-  const [modelMaxTokens, setModelMaxTokens] = useState("4096");
+  const [modelMaxTokens, setModelMaxTokens] = useState("");
 
   // Use the silicon model list hook
   const siliconHook  = useSiliconModelList({
@@ -432,7 +437,15 @@ export const ModelAddDialog = ({
 
   // Check if the form is valid
   const isFormValid = () => {
+    const needsMaxTokens =
+      form.type !== MODEL_TYPES.EMBEDDING &&
+      form.type !== MODEL_TYPES.MULTI_EMBEDDING &&
+      form.type !== MODEL_TYPES.STT;
+
     if (form.isBatchImport) {
+      if (needsMaxTokens && !isValidMaxTokens(form.maxTokens)) {
+        return false;
+      }
       // If provider is ModelEngine, require the ModelEngine URL as well.
       if (form.provider === "modelengine") {
         return (
@@ -442,6 +455,9 @@ export const ModelAddDialog = ({
         );
       }
       return form.provider.trim() !== "" && form.apiKey.trim() !== "";
+    }
+    if (needsMaxTokens && !isValidMaxTokens(form.maxTokens)) {
+      return false;
     }
     if (form.type === MODEL_TYPES.EMBEDDING) {
       return (
@@ -486,7 +502,7 @@ export const ModelAddDialog = ({
     return (
       form.name.trim() !== "" &&
       form.url.trim() !== "" &&
-      form.maxTokens.trim() !== ""
+      isValidMaxTokens(form.maxTokens)
     );
   };
 
@@ -569,7 +585,7 @@ export const ModelAddDialog = ({
               maxTokens:
                 form.type === MODEL_TYPES.EMBEDDING
                   ? parseInt(form.vectorDimension)
-                  : parseInt(form.maxTokens),
+                  : parseMaxTokens(form.maxTokens),
               embeddingDim:
                 form.type === MODEL_TYPES.EMBEDDING
                   ? parseInt(form.vectorDimension)
@@ -648,7 +664,7 @@ export const ModelAddDialog = ({
         } else {
           return {
             ...model,
-            max_tokens: model.max_tokens || parseInt(form.maxTokens) || 4096,
+            max_tokens: model.max_tokens ?? parseMaxTokens(form.maxTokens),
           };
         }
       });
@@ -720,18 +736,21 @@ export const ModelAddDialog = ({
   // Handle settings button click
   const handleSettingsClick = (model: any) => {
     setSelectedModelForSettings(model);
-    setModelMaxTokens(model.max_tokens?.toString() || "4096");
+    setModelMaxTokens(model.max_tokens?.toString() || "");
     setSettingsModalVisible(true);
   };
 
   // Handle settings save
   const handleSettingsSave = () => {
+    const nextMaxTokens = parseMaxTokens(modelMaxTokens);
+    if (!nextMaxTokens) return;
+
     if (selectedModelForSettings) {
       // Update the model in the list with new max_tokens
       setModelList((prev) =>
         prev.map((model) =>
           model.id === selectedModelForSettings.id
-            ? { ...model, max_tokens: parseInt(modelMaxTokens) || 4096 }
+            ? { ...model, max_tokens: nextMaxTokens }
             : model
         )
       );
@@ -761,7 +780,7 @@ export const ModelAddDialog = ({
           : form.type;
 
       // Determine the maximum tokens value
-      let maxTokensValue = parseInt(form.maxTokens);
+      let maxTokensValue = parseMaxTokens(form.maxTokens) || 0;
       if (
         form.type === MODEL_TYPES.EMBEDDING ||
         form.type === MODEL_TYPES.MULTI_EMBEDDING
@@ -1382,19 +1401,20 @@ export const ModelAddDialog = ({
         )}
 
         {/* Max Tokens */}
-        {!isEmbeddingModel && !form.isBatchImport && !isSTTModel && (
+        {!isEmbeddingModel && !isSTTModel && (
           <div>
             <label
               htmlFor="maxTokens"
               className="block mb-1 text-sm font-medium text-gray-700"
             >
-              {t("model.dialog.label.maxTokens")}
+              {t("model.dialog.label.maxTokens")}{" "}
+              <span className="text-red-500">*</span>
             </label>
-            <Input
+            <ModelMaxTokensInput
               id="maxTokens"
               placeholder={t("model.dialog.placeholder.maxTokens")}
               value={form.maxTokens}
-              onChange={(e) => handleFormChange("maxTokens", e.target.value)}
+              onChange={(value) => handleFormChange("maxTokens", value)}
             />
           </div>
         )}
@@ -1936,6 +1956,7 @@ export const ModelAddDialog = ({
         open={settingsModalVisible}
         onCancel={() => setSettingsModalVisible(false)}
         onOk={handleSettingsSave}
+        okButtonProps={{ disabled: !isValidMaxTokens(modelMaxTokens) }}
         cancelText={t("common.cancel")}
         okText={t("common.confirm")}
         destroyOnHidden
@@ -1943,12 +1964,12 @@ export const ModelAddDialog = ({
         <div className="space-y-3">
           <div>
             <label className="block mb-1 text-sm font-medium text-gray-700">
-              {t("model.dialog.settings.label.maxTokens")}
+              {t("model.dialog.settings.label.maxTokens")}{" "}
+              <span className="text-red-500">*</span>
             </label>
-            <Input
-              type="number"
+            <ModelMaxTokensInput
               value={modelMaxTokens}
-              onChange={(e) => setModelMaxTokens(e.target.value)}
+              onChange={setModelMaxTokens}
               placeholder={t("model.dialog.placeholder.maxTokens")}
             />
           </div>

--- a/frontend/app/[locale]/models/components/model/ModelDeleteDialog.tsx
+++ b/frontend/app/[locale]/models/components/model/ModelDeleteDialog.tsx
@@ -669,7 +669,7 @@ export const ModelDeleteDialog = ({
         setProviderModels((prev) =>
           prev.map((model) => ({
             ...model,
-            max_tokens: maxTokens || model.max_tokens || 4096,
+            max_tokens: maxTokens || model.max_tokens,
             timeout_seconds: timeoutSeconds || model.timeout_seconds,
             concurrency_limit: concurrencyLimit !== undefined ? concurrencyLimit : model.concurrency_limit,
           }))
@@ -844,7 +844,7 @@ export const ModelDeleteDialog = ({
                           } else {
                             return {
                               ...model,
-                              max_tokens: model.max_tokens || 4096,
+                              max_tokens: model.max_tokens,
                             };
                           }
                         }),
@@ -893,7 +893,7 @@ export const ModelDeleteDialog = ({
                             } else {
                               return {
                                 ...model,
-                                max_tokens: model.max_tokens || 4096,
+                                max_tokens: model.max_tokens,
                               };
                             }
                           }),
@@ -939,7 +939,7 @@ export const ModelDeleteDialog = ({
                             } else {
                               return {
                                 ...model,
-                                max_tokens: model.max_tokens || 4096,
+                                max_tokens: model.max_tokens,
                               };
                             }
                           }),
@@ -985,7 +985,7 @@ export const ModelDeleteDialog = ({
                             } else {
                               return {
                                 ...model,
-                                max_tokens: model.max_tokens || 4096,
+                                max_tokens: model.max_tokens,
                               };
                             }
                           }),
@@ -1523,13 +1523,15 @@ export const ModelDeleteDialog = ({
         isOpen={isProviderConfigOpen}
         onClose={() => setIsProviderConfigOpen(false)}
         initialApiKey={getApiKeyByType(deletingModelType, selectedSource || undefined)}
-        initialMaxTokens={(
-          models.find(
-            (m) =>
-              m.type === deletingModelType &&
-              m.source === (selectedSource || MODEL_SOURCES.SILICON)
-          )?.maxTokens || 4096
-        ).toString()}
+        initialMaxTokens={
+          models
+            .find(
+              (m) =>
+                m.type === deletingModelType &&
+                m.source === (selectedSource || MODEL_SOURCES.SILICON)
+            )
+            ?.maxTokens?.toString() || ""
+        }
         initialTimeoutSeconds={(
           models.find(
             (m) =>
@@ -1555,7 +1557,7 @@ export const ModelDeleteDialog = ({
           setIsSingleModelSettingsOpen(false);
           setSelectedSingleModel(null);
         }}
-        initialMaxTokens={selectedSingleModel?.max_tokens?.toString() || "4096"}
+        initialMaxTokens={selectedSingleModel?.max_tokens?.toString() || ""}
         initialTimeoutSeconds={selectedSingleModel?.timeout_seconds?.toString() || "120"}
         initialConcurrencyLimit={selectedSingleModel?.concurrency_limit?.toString() || ""}
         modelType={deletingModelType || undefined}

--- a/frontend/app/[locale]/models/components/model/ModelDeleteDialog.tsx
+++ b/frontend/app/[locale]/models/components/model/ModelDeleteDialog.tsx
@@ -168,11 +168,11 @@ export const ModelDeleteDialog = ({
       case MODEL_TYPES.TTS:
         return t("model.type.tts");
       case MODEL_TYPES.VLM:
-        return t("model.type.vlm");
+        return t("model.type.imageUnderstanding");
       case MODEL_TYPES.VLM2:
-        return `${t("model.type.vlm")}2`;
+        return t("model.type.imageGeneration");
       case MODEL_TYPES.VLM3:
-        return `${t("model.type.vlm")}3`;
+        return t("model.type.videoUnderstanding");
       default:
         return t("model.type.unknown");
     }

--- a/frontend/app/[locale]/models/components/model/ModelEditDialog.tsx
+++ b/frontend/app/[locale]/models/components/model/ModelEditDialog.tsx
@@ -13,6 +13,11 @@ import {
   DEFAULT_EXPECTED_CHUNK_SIZE,
   DEFAULT_MAXIMUM_CHUNK_SIZE,
 } from "./ModelChunkSizeSilder";
+import {
+  isValidMaxTokens,
+  ModelMaxTokensInput,
+  parseMaxTokens,
+} from "./ModelMaxTokensInput";
 
 const { Option } = Select;
 
@@ -40,7 +45,7 @@ export const ModelEditDialog = ({
     displayName: "",
     url: "",
     apiKey: "",
-    maxTokens: "4096",
+    maxTokens: "",
     timeoutSeconds: "120",
     concurrencyLimit: "",
     vectorDimension: "1024",
@@ -72,7 +77,7 @@ export const ModelEditDialog = ({
         displayName: model.displayName || model.name,
         url: model.apiUrl || "",
         apiKey: model.apiKey || "",
-        maxTokens: model.maxTokens?.toString() || "4096",
+        maxTokens: model.maxTokens?.toString() || "",
         timeoutSeconds: model.timeoutSeconds?.toString() || "120",
         concurrencyLimit: model.concurrencyLimit?.toString() || "",
         vectorDimension: model.maxTokens?.toString() || "1024",
@@ -118,7 +123,12 @@ export const ModelEditDialog = ({
     form.type === MODEL_TYPES.STT || form.type === MODEL_TYPES.TTS;
 
   const isFormValid = () => {
+    const needsMaxTokens = !isEmbeddingModel && !isRerankModel;
+
     if (isVoiceModel) {
+      if (needsMaxTokens && !isValidMaxTokens(form.maxTokens)) {
+        return false;
+      }
       if (form.modelFactory === "volcengine") {
         return (
           form.modelAppid.trim() !== "" &&
@@ -128,7 +138,11 @@ export const ModelEditDialog = ({
         return form.name.trim() !== "" && form.apiKey.trim() !== "";
       }
     }
-    return form.name.trim() !== "" && form.url.trim() !== "";
+    return (
+      form.name.trim() !== "" &&
+      form.url.trim() !== "" &&
+      (!needsMaxTokens || isValidMaxTokens(form.maxTokens))
+    );
   };
 
   // Verify model connectivity
@@ -155,7 +169,7 @@ export const ModelEditDialog = ({
             ? parseInt(form.vectorDimension)
             : form.type === MODEL_TYPES.RERANK
               ? 0
-              : parseInt(form.maxTokens),
+              : parseMaxTokens(form.maxTokens),
         embeddingDim:
           form.type === MODEL_TYPES.EMBEDDING
             ? parseInt(form.vectorDimension)
@@ -203,7 +217,7 @@ export const ModelEditDialog = ({
       // Use update interface instead of delete + add
       const modelType = form.type as ModelType;
       // Determine max tokens
-      let maxTokensValue = parseInt(form.maxTokens);
+      let maxTokensValue = parseMaxTokens(form.maxTokens) || 0;
       if (isEmbeddingModel || isRerankModel) maxTokensValue = 0;
 
       // Use original displayName for lookup, pass new displayName in body if changed
@@ -420,11 +434,13 @@ export const ModelEditDialog = ({
         {!isEmbeddingModel && !isRerankModel && (
           <div>
             <label className="block mb-1 text-sm font-medium text-gray-700">
-              {t("model.dialog.label.maxTokens")}
+              {t("model.dialog.label.maxTokens")}{" "}
+              <span className="text-red-500">*</span>
             </label>
-            <Input
+            <ModelMaxTokensInput
               value={form.maxTokens}
-              onChange={(e) => handleFormChange("maxTokens", e.target.value)}
+              placeholder={t("model.dialog.placeholder.maxTokens")}
+              onChange={(value) => handleFormChange("maxTokens", value)}
             />
           </div>
         )}
@@ -576,7 +592,7 @@ interface ProviderConfigEditDialogProps {
 export const ProviderConfigEditDialog = ({
   isOpen,
   initialApiKey = '',
-  initialMaxTokens = '4096',
+  initialMaxTokens = '',
   initialTimeoutSeconds = '120',
   initialConcurrencyLimit = '',
   modelType,
@@ -599,8 +615,8 @@ export const ProviderConfigEditDialog = ({
   }, [initialApiKey, initialMaxTokens, initialTimeoutSeconds, initialConcurrencyLimit])
 
   const valid = () => {
-    const parsed = parseInt(maxTokens)
-    return !Number.isNaN(parsed) && parsed >= 0
+    const isEmbeddingModel = modelType === MODEL_TYPES.EMBEDDING || modelType === MODEL_TYPES.MULTI_EMBEDDING
+    return isEmbeddingModel || isValidMaxTokens(maxTokens)
   }
 
   const handleSave = async () => {
@@ -611,7 +627,7 @@ export const ProviderConfigEditDialog = ({
       const isRerankModel = modelType === MODEL_TYPES.RERANK
       await onSave({
         ...(showApiKeyField ? { apiKey: apiKey.trim() === '' ? 'sk-no-api-key' : apiKey } : {}),
-        maxTokens: parseInt(maxTokens),
+        maxTokens: parseMaxTokens(maxTokens) || 0,
         ...(!isEmbeddingModel && !isRerankModel ? { timeoutSeconds: parseInt(timeoutSeconds) || 120 } : {}),
         ...(!isEmbeddingModel && !isRerankModel ? { concurrencyLimit: concurrencyLimit ? parseInt(concurrencyLimit) : undefined } : {}),
       })
@@ -644,9 +660,13 @@ export const ProviderConfigEditDialog = ({
         {!isEmbeddingModel && (
           <div>
             <label className="block mb-1 text-sm font-medium text-gray-700">
-              {t('model.dialog.label.maxTokens')}
+              {t('model.dialog.label.maxTokens')} <span className="text-red-500">*</span>
             </label>
-            <Input value={maxTokens} onChange={(e) => setMaxTokens(e.target.value)} />
+            <ModelMaxTokensInput
+              value={maxTokens}
+              placeholder={t("model.dialog.placeholder.maxTokens")}
+              onChange={setMaxTokens}
+            />
           </div>
         )}
         {!isEmbeddingModel && !isRerankModel && (

--- a/frontend/app/[locale]/models/components/model/ModelMaxTokensInput.tsx
+++ b/frontend/app/[locale]/models/components/model/ModelMaxTokensInput.tsx
@@ -7,8 +7,9 @@ const MAX_TOKEN_OPTIONS = [
   { value: "32768", label: "32K / 32,768" },
   { value: "65536", label: "64K / 65,536" },
   { value: "131072", label: "128K / 131,072" },
-  { value: "200000", label: "200K / 200,000" },
-  { value: "1000000", label: "1M / 1,000,000" },
+  { value: "204800", label: "200K / 204,800" },
+  { value: "262144", label: "256K / 262,144" },
+  { value: "1048576", label: "1M / 1,048,576" },
 ];
 
 interface ModelMaxTokensInputProps {

--- a/frontend/app/[locale]/models/components/model/ModelMaxTokensInput.tsx
+++ b/frontend/app/[locale]/models/components/model/ModelMaxTokensInput.tsx
@@ -1,0 +1,53 @@
+import { AutoComplete, Input } from "antd";
+
+const MAX_TOKEN_OPTIONS = [
+  { value: "4096", label: "4K / 4,096" },
+  { value: "8192", label: "8K / 8,192" },
+  { value: "16384", label: "16K / 16,384" },
+  { value: "32768", label: "32K / 32,768" },
+  { value: "65536", label: "64K / 65,536" },
+  { value: "131072", label: "128K / 131,072" },
+  { value: "200000", label: "200K / 200,000" },
+  { value: "1000000", label: "1M / 1,000,000" },
+];
+
+interface ModelMaxTokensInputProps {
+  id?: string;
+  value: string;
+  placeholder?: string;
+  onChange: (value: string) => void;
+}
+
+export const isValidMaxTokens = (value: string): boolean => {
+  const trimmed = value.trim();
+  return /^[1-9]\d*$/.test(trimmed);
+};
+
+export const parseMaxTokens = (value: string): number | undefined => {
+  return isValidMaxTokens(value) ? parseInt(value.trim(), 10) : undefined;
+};
+
+export const ModelMaxTokensInput = ({
+  id,
+  value,
+  placeholder,
+  onChange,
+}: ModelMaxTokensInputProps) => {
+  return (
+    <AutoComplete
+      className="w-full"
+      value={value}
+      options={MAX_TOKEN_OPTIONS}
+      placeholder={placeholder}
+      onChange={onChange}
+      filterOption={(inputValue, option) =>
+        String(option?.label ?? "")
+          .toLowerCase()
+          .includes(inputValue.toLowerCase()) ||
+        String(option?.value ?? "").includes(inputValue)
+      }
+    >
+      <Input id={id} inputMode="numeric" pattern="[0-9]*" />
+    </AutoComplete>
+  );
+};

--- a/frontend/services/modelService.ts
+++ b/frontend/services/modelService.ts
@@ -535,7 +535,7 @@ export const modelService = {
         model_type: config.modelType,
         api_key: config.apiKey || "sk-no-api-key",
         base_url: config.baseUrl || "",
-        max_tokens: config.maxTokens || 4096,
+        ...(config.maxTokens !== undefined ? { max_tokens: config.maxTokens } : {}),
         embedding_dim: config.embeddingDim || 1024,
       };
 
@@ -723,7 +723,7 @@ export const modelService = {
         model_type: params.type,
         base_url: params.url,
         api_key: params.apiKey,
-        max_tokens: params.maxTokens || 4096,
+        ...(params.maxTokens !== undefined ? { max_tokens: params.maxTokens } : {}),
         display_name: params.displayName || params.name,
         model_factory: params.modelFactory || "OpenAI-API-Compatible",
         expected_chunk_size: params.expectedChunkSize,


### PR DESCRIPTION
- Rename VLM display labels to image understanding/generation/video understanding
- Remove default max token values from model access forms
- Add required max token manual input with common quick-select options
- Reuse max token selector across add/edit/provider config flows
- Stop falling back to 4096 when max tokens are not explicitly provided
<img width="535" height="382" alt="image" src="https://github.com/user-attachments/assets/4dd4eb93-9682-4588-a991-c07213f8e5ba" />
<img width="542" height="616" alt="image" src="https://github.com/user-attachments/assets/9ddc76e9-7c12-4b62-9e09-b55603bdfaa1" />
