### PR TITLE
add_epub_dependency

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
     "ijson==3.5.0",
     "langchain-text-splitters==1.1.2",
     "ebooklib==0.20",
+    "pypandoc==1.17",
 ]
 
 [tool.uv]


### PR DESCRIPTION
1）修改内容：加上pypandoc依赖。
2）pypandoc 作用：用于被第三方工具unstructured内部调用，将.epub文件转换为html格式，供其进一步提取纯文本内容。
3）潜在问题：Docker镜像中未包含Pandoc，运行时也无优雅降级，仅提供pypandoc仍无法成功转换文件。

