### PR TITLE
add selected count badges to tool/skill pool labels

### DIFF
--- a/frontend/app/[locale]/agents/components/AgentConfigComp.tsx
+++ b/frontend/app/[locale]/agents/components/AgentConfigComp.tsx
@@ -29,6 +29,8 @@ export default function AgentConfigComp({}: AgentConfigCompProps) {
   const currentAgentId = useAgentConfigStore((state) => state.currentAgentId);
   const isCreatingMode = useAgentConfigStore((state) => state.isCreatingMode);
   const isReadOnly = useAgentConfigStore((state) => state.isReadOnly());
+  const selectedTools = useAgentConfigStore((state) => state.editedAgent.tools);
+  const selectedSkills = useAgentConfigStore((state) => state.editedAgent.skills);
 
   const [isMcpModalOpen, setIsMcpModalOpen] = useState(false);
   const [isSkillModalOpen, setIsSkillModalOpen] = useState(false);
@@ -125,7 +127,12 @@ export default function AgentConfigComp({}: AgentConfigCompProps) {
       <Tabs defaultValue="tools" className="w-full flex-1 min-h-0 flex flex-col overflow-hidden">
         <TabsList className="grid w-full grid-cols-2 flex-shrink-0">
           <TabsTrigger value="tools">
-            {t("toolPool.title")}
+            <span className="inline-flex items-center gap-1">
+              {t("toolPool.title")}
+              {selectedTools.length > 0 && (
+                <Badge count={selectedTools.length} size="small" color="blue" />
+              )}
+            </span>
             <Tooltip
               title={<div style={{ whiteSpace: "pre-line" }}>{t("toolPool.tooltip.functionGuide")}</div>}
               color="#ffffff"
@@ -144,7 +151,14 @@ export default function AgentConfigComp({}: AgentConfigCompProps) {
               <Lightbulb className="mx-2 text-yellow-500" size={16} />
             </Tooltip>
           </TabsTrigger>
-          <TabsTrigger value="skills">{t("skillPool.title")}</TabsTrigger>
+          <TabsTrigger value="skills">
+            <span className="inline-flex items-center gap-1">
+              {t("skillPool.title")}
+              {selectedSkills && selectedSkills.length > 0 && (
+                <Badge count={selectedSkills.length} size="small" color="blue" />
+              )}
+            </span>
+          </TabsTrigger>
         </TabsList>
 
         <TabsContent value="tools" className="mt-4 flex-1 min-h-0 flex flex-col overflow-hidden">

--- a/frontend/app/[locale]/agents/components/agentConfig/SkillManagement.tsx
+++ b/frontend/app/[locale]/agents/components/agentConfig/SkillManagement.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { SkillGroup, Skill, SkillParam } from "@/types/agentConfig";
-import { Tabs, message, Tooltip } from "antd";
+import { Tabs, message, Tooltip, Badge } from "antd";
 import { useAgentConfigStore } from "@/stores/agentConfigStore";
 import { useSkillList } from "@/hooks/agent/useSkillList";
 import { Info, Trash2, Settings } from "lucide-react";
@@ -207,21 +207,27 @@ export default function SkillManagement({
   };
 
   const tabItems = skillGroups.map((group) => {
+    const selectedCount = group.skills.filter(s => originalSelectedSkillIdsSet.has(s.skill_id)).length;
+
     return {
       key: group.key,
       label: (
         <Tooltip title={group.label} placement="right">
-          <span
-            style={{
-              display: "block",
-              maxWidth: "100px",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-              textAlign: "left",
-            }}
-          >
-            {group.label}
+          <span className="inline-flex items-center gap-1">
+            <span
+              style={{
+                maxWidth: "100px",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                textAlign: "left",
+              }}
+            >
+              {group.label}
+            </span>
+            {selectedCount > 0 && (
+              <Badge count={selectedCount} size="small" color="blue" />
+            )}
           </span>
         </Tooltip>
       ),

--- a/frontend/app/[locale]/agents/components/agentConfig/ToolManagement.tsx
+++ b/frontend/app/[locale]/agents/components/agentConfig/ToolManagement.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import ToolConfigModal from "./tool/ToolConfigModal";
 import { ToolGroup, Tool, ToolParam } from "@/types/agentConfig";
-import { Tabs, Collapse, message, Tooltip } from "antd";
+import { Tabs, Collapse, message, Tooltip, Badge } from "antd";
 import { useAgentConfigStore } from "@/stores/agentConfigStore";
 import { useToolList } from "@/hooks/agent/useToolList";
 import { usePrefetchKnowledgeBases } from "@/hooks/useKnowledgeBaseSelector";
@@ -307,21 +307,29 @@ export default function ToolManagement({
   // Generate Tabs configuration
   const tabItems = toolGroups.map((group) => {
     const label = t(group.label);
+    const selectedCount = group.subGroups
+      ? group.subGroups.reduce(
+          (sum, sg) => sum + sg.tools.filter(t => originalSelectedToolIdsSet.has(t.id)).length, 0)
+      : group.tools.filter(t => originalSelectedToolIdsSet.has(t.id)).length;
 
     return {
       key: group.key,
       label: (
         <Tooltip title={label} placement="right">
-          <span
-            style={{
-              display: "block",
-              maxWidth: "100px",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-            }}
-          >
-            {label}
+          <span className="inline-flex items-center gap-1">
+            <span
+              style={{
+                maxWidth: "100px",
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {label}
+            </span>
+            {selectedCount > 0 && (
+              <Badge count={selectedCount} size="small" color="blue" />
+            )}
           </span>
         </Tooltip>
       ),
@@ -351,17 +359,25 @@ export default function ToolManagement({
                   items={group.subGroups.map((subGroup, index) => ({
                     key: subGroup.key,
                     label: (
-                      <span
-                        className="text-gray-700 font-medium"
-                        style={{
-                          paddingTop: "8px",
-                          paddingBottom: "8px",
-                          display: "block",
-                          minHeight: "36px",
-                          lineHeight: "20px",
-                        }}
-                      >
-                        {subGroup.label}
+                      <span className="inline-flex items-center gap-1">
+                        <span
+                          className="text-gray-700 font-medium"
+                          style={{
+                            paddingTop: "8px",
+                            paddingBottom: "8px",
+                            minHeight: "36px",
+                            lineHeight: "20px",
+                          }}
+                        >
+                          {subGroup.label}
+                        </span>
+                        {subGroup.tools.filter(t => originalSelectedToolIdsSet.has(t.id)).length > 0 && (
+                          <Badge
+                            count={subGroup.tools.filter(t => originalSelectedToolIdsSet.has(t.id)).length}
+                            size="small"
+                            color="blue"
+                          />
+                        )}
                       </span>
                     ),
                     className: `tool-category-panel ${


### PR DESCRIPTION
add selected count badges to tool/skill pool labels

for example:

<img width="938" height="830" alt="image" src="https://github.com/user-attachments/assets/ed79fee0-3267-4f1f-9a0c-ee0b0430566d" />

<img width="924" height="825" alt="image" src="https://github.com/user-attachments/assets/3b10ecf9-a5f6-46fd-afe7-91f48c1b6a18" />
