### PR TITLE
🐛 Bugfix: Reset password strength indicator when re-entering registration modal

### DIFF
--- a/frontend/components/auth/registerModal.tsx
+++ b/frontend/components/auth/registerModal.tsx
@@ -73,6 +73,7 @@ export function RegisterModal() {
   const resetForm = () => {
     setEmailError("");
     setPasswordError({ target: "", message: "" });
+    setPasswordValue("");
     form.resetFields();
   };
 
@@ -144,6 +145,7 @@ export function RegisterModal() {
 
     setEmailError("");
     setPasswordError({ target: "", message: "" });
+    setPasswordValue("");
     form.resetFields();
     if (registerModalOptions?.email) {
       form.setFieldsValue({ email: registerModalOptions.email });


### PR DESCRIPTION
The passwordValue state was not being cleared when the registration modal re-opened, causing the password strength bar to persist from a previous registration attempt. Added setPasswordValue("") to both resetForm() and the modal-open useEffect.

Fixes #3204

<html>
<body>
<!--StartFragment--><!-- obsidian --><h2 data-heading="Description">Description</h2>
<h3 data-heading="Problem">Problem</h3>
<p>After registering, logging out, and re-entering the registration page, the password strength indicator bar does not reset to empty. It continues showing the strength level of the previously entered password.</p>
<h3 data-heading="Root Cause">Root Cause</h3>
<p>In <code>frontend/components/auth/registerModal.tsx</code>, the password strength indicator is conditionally rendered based on the <code>passwordValue</code> React state:</p>
<pre><code class="language-tsx">{passwordValue &#x26;&#x26; (() => { ... })()}
</code></pre>
<p>When the registration modal re-opens:</p>
<ul>
<li><code>form.resetFields()</code> was called, which clears the AntD form fields</li>
<li>However, the <code>passwordValue</code> state variable was <strong>never reset</strong> — it retained the old password value</li>
<li>Since <code>passwordValue</code> was still truthy, the old strength indicator persisted</li>
</ul>
<h3 data-heading="Fix">Fix</h3>
<p>Added <code>setPasswordValue("")</code> in two places:</p>
<ol>
<li><strong><code>resetForm()</code> function</strong> (line 76) — ensures password strength clears after successful registration or when switching to login modal</li>
<li><strong><code>useEffect</code> when modal opens</strong> (line 148) — ensures password strength clears when the registration modal re-opens after logout</li>
</ol>
<h3 data-heading="Files Changed">Files Changed</h3>

File | Change
-- | --
frontend/components/auth/registerModal.tsx | +2 lines: setPasswordValue("") in resetForm() and in the modal-open useEffect


<h3 data-heading="Testing">Testing</h3>
<ol>
<li>Open the registration modal</li>
<li>Type a password (e.g., <code>StrongP@ss1</code>) — observe the strength indicator appears</li>
<li>Register successfully, then logout</li>
<li>Re-open the registration modal</li>
<li><strong>Expected</strong>: Password field is empty and password strength indicator is hidden</li>
<li><strong>Before fix</strong>: Password strength indicator still showed the old strength level</li>
</ol><!--EndFragment-->
</body>
</html>