### PR TITLE
🐛 Bugfix: Fixed the issue of being unable to add MCP services via containerization.

### DIFF
--- a/backend/services/remote_mcp_service.py
+++ b/backend/services/remote_mcp_service.py
@@ -230,7 +230,7 @@ async def add_mcp_service(
     server_url: str,
     tags: list | None,
     authorization_token: str | None,
-    custom_headers: dict | None,
+    custom_headers: dict | None = None,
     container_config: dict | None,
     registry_json: dict | None,
     enabled: bool = False,

--- a/sdk/nexent/container/docker_client.py
+++ b/sdk/nexent/container/docker_client.py
@@ -57,7 +57,7 @@ class ContainerConnectionError(Exception):
 class DockerContainerClient(ContainerClient):
     """Docker container client implementation"""
 
-    DEFAULT_NETWORK_NAME = "nexent_nexent"
+    DEFAULT_NETWORK_NAME = "nexent_network"
 
     def __init__(self, config: DockerContainerConfig):
         """

--- a/test/sdk/container/test_docker_client.py
+++ b/test/sdk/container/test_docker_client.py
@@ -1627,10 +1627,10 @@ class TestEnsureNetwork:
         mock_network = MagicMock()
         docker_container_client.client.networks.get.return_value = mock_network
 
-        docker_container_client._ensure_network("nexent_nexent")
+        docker_container_client._ensure_network("nexent_network")
 
         docker_container_client.client.networks.get.assert_called_once_with(
-            "nexent_nexent")
+            "nexent_network")
         docker_container_client.client.networks.create.assert_not_called()
 
     def test_ensure_network_create_new(self, docker_container_client):
@@ -1640,12 +1640,12 @@ class TestEnsureNetwork:
         mock_network = MagicMock()
         docker_container_client.client.networks.create.return_value = mock_network
 
-        docker_container_client._ensure_network("nexent_nexent")
+        docker_container_client._ensure_network("nexent_network")
 
         docker_container_client.client.networks.get.assert_called_once_with(
-            "nexent_nexent")
+            "nexent_network")
         docker_container_client.client.networks.create.assert_called_once_with(
-            "nexent_nexent")
+            "nexent_network")
 
     def test_ensure_network_race_condition(self, docker_container_client):
         """Test ensuring network when race condition occurs (another process creates it)"""
@@ -1657,7 +1657,7 @@ class TestEnsureNetwork:
         docker_container_client.client.networks.create.side_effect = APIError(
             "Network already exists")
 
-        docker_container_client._ensure_network("nexent_nexent")
+        docker_container_client._ensure_network("nexent_network")
 
         assert docker_container_client.client.networks.get.call_count == 2
         docker_container_client.client.networks.create.assert_called_once()
@@ -1672,7 +1672,7 @@ class TestEnsureNetwork:
             "Create failed")
 
         with pytest.raises(ContainerError, match="Failed to create or get Docker network"):
-            docker_container_client._ensure_network("nexent_nexent")
+            docker_container_client._ensure_network("nexent_network")
 
     def test_ensure_network_get_api_error(self, docker_container_client):
         """Test ensuring network when get raises APIError"""
@@ -1680,7 +1680,7 @@ class TestEnsureNetwork:
             "API error")
 
         with pytest.raises(ContainerError, match="Failed to get Docker network"):
-            docker_container_client._ensure_network("nexent_nexent")
+            docker_container_client._ensure_network("nexent_network")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
🐛 Bugfix: Fixed the issue of being unable to add MCP services via containerization. fixed #3212 

[Specification Details]
1. Modify the DEFAULT_NETWORK_NAME when starting the MCP service in the container to match the name in docker-compose.
2. Modify the parameters passed to the add_mcp_service method; custom_headers defaults to None.

[Test Result]
<img width="1438" height="943" alt="img_v3_0212g_1213bf46-0ca0-4f49-af38-730ad69b217g" src="https://github.com/user-attachments/assets/61e3a237-7825-44bd-9ce8-e1aae3ae9740" />
<img width="969" height="747" alt="img_v3_0212g_16c18c29-5169-4219-a9bf-8f5dad15c69g" src="https://github.com/user-attachments/assets/c444dbd4-b6fd-4db4-a550-696dfc346663" />
