### PR TITLE
Add agent marketplace repository and version pinning for sub-agents

### DIFF
--- a/backend/agents/create_agent_info.py
+++ b/backend/agents/create_agent_info.py
@@ -22,7 +22,11 @@ from services.remote_mcp_service import get_remote_mcp_server_list
 from database.a2a_agent_db import PROTOCOL_JSONRPC
 from services.memory_config_service import build_memory_context
 from services.image_service import get_video_understanding_model, get_vlm_model
-from database.agent_db import search_agent_info_by_agent_id, query_sub_agents_id_list
+from database.agent_db import (
+    search_agent_info_by_agent_id,
+    query_sub_agent_relations,
+    resolve_sub_agent_version_no,
+)
 from database.agent_version_db import query_current_version_no
 from database.tool_db import search_tools_for_sub_agent
 from database.model_management_db import get_model_records, get_model_by_model_id
@@ -315,13 +319,16 @@ async def create_agent_config(
         agent_id=agent_id, tenant_id=tenant_id, version_no=version_no)
 
     # create sub agent
-    sub_agent_id_list = query_sub_agents_id_list(
+    sub_agent_relations = query_sub_agent_relations(
         main_agent_id=agent_id, tenant_id=tenant_id, version_no=version_no)
     managed_agents = []
-    for sub_agent_id in sub_agent_id_list:
-        # Get the current published version for this sub-agent (from draft version 0)
-        sub_agent_version_no = query_current_version_no(
-            agent_id=sub_agent_id, tenant_id=tenant_id) or 0
+    for rel in sub_agent_relations:
+        sub_agent_id = rel['selected_agent_id']
+        sub_agent_version_no = resolve_sub_agent_version_no(
+            selected_agent_id=sub_agent_id,
+            selected_agent_version_no=rel.get('selected_agent_version_no'),
+            tenant_id=tenant_id,
+        )
         sub_agent_config = await create_agent_config(
             agent_id=sub_agent_id,
             tenant_id=tenant_id,

--- a/backend/apps/agent_app.py
+++ b/backend/apps/agent_app.py
@@ -195,8 +195,6 @@ async def export_agent_api(request: AgentIDRequest, authorization: Optional[str]
                     "Content-Disposition": f"attachment; filename=\"{result.get('filename', 'agent_export.zip')}\""
                 }
             )
-        if isinstance(result, str):
-            result = json.loads(result)
         return ConversationResponse(code=0, message="success", data=result)
     except Exception as e:
         logger.error(f"Agent export error: {str(e)}")
@@ -621,3 +619,5 @@ async def list_published_agents_api(
         raise HTTPException(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Published agents list error."
         )
+
+

--- a/backend/apps/agent_repository_app.py
+++ b/backend/apps/agent_repository_app.py
@@ -1,0 +1,134 @@
+import logging
+from http import HTTPStatus
+from typing import Optional
+
+from fastapi import APIRouter, Body, Header, HTTPException, Query
+from starlette.responses import JSONResponse
+
+from consts.exceptions import SkillDuplicateError, UnauthorizedError
+from services.agent_repository_service import (
+    create_agent_repository_listing_impl,
+    import_agent_from_repository_impl,
+    list_agent_repository_listings_impl,
+    update_agent_repository_status_impl,
+)
+from utils.auth_utils import get_current_user_id
+
+agent_repository_router = APIRouter(prefix="/repository/agent")
+logger = logging.getLogger("agent_repository_app")
+
+
+@agent_repository_router.get("")
+async def list_agent_repository_listings_api(
+    status: Optional[str] = Query(None, description="Filter by listing status"),
+    authorization: str = Header(None),
+):
+    """List all marketplace repository listings with optional status filter."""
+    try:
+        get_current_user_id(authorization)
+        result = list_agent_repository_listings_impl(status=status)
+        return JSONResponse(status_code=HTTPStatus.OK, content=result)
+    except UnauthorizedError as e:
+        raise HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=str(e))
+    except Exception as e:
+        logger.error(f"List agent repository listings error: {str(e)}")
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail="List agent repository listings error.",
+        )
+
+
+@agent_repository_router.patch("/{agent_repository_id}/status")
+async def update_agent_repository_status_api(
+    agent_repository_id: int,
+    status: str = Body(
+        ...,
+        embed=True,
+        description=(
+            "New status: NOT_SHARED (未共享) / PENDING_REVIEW (待审核) / "
+            "REJECTED (审核驳回) / SHARED (已共享)"
+        ),
+    ),
+    authorization: str = Header(None),
+):
+    """Update marketplace repository listing status (share, unshare, approve, reject)."""
+    try:
+        user_id, _ = get_current_user_id(authorization)
+        result = update_agent_repository_status_impl(
+            agent_repository_id=agent_repository_id,
+            status=status,
+            user_id=user_id,
+        )
+        return JSONResponse(status_code=HTTPStatus.OK, content=result)
+    except UnauthorizedError as e:
+        raise HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=str(e))
+    except Exception as e:
+        logger.error(f"Update agent repository status error: {str(e)}")
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail="Update agent repository status error.",
+        )
+
+
+@agent_repository_router.post("/{agent_id}/versions/{version_no}")
+async def create_agent_repository_listing_api(
+    agent_id: int,
+    version_no: int,
+    authorization: str = Header(None),
+):
+    """Create or update a marketplace repository listing from an agent version snapshot."""
+    try:
+        user_id, tenant_id = get_current_user_id(authorization)
+        result = await create_agent_repository_listing_impl(
+            agent_id=agent_id,
+            tenant_id=tenant_id,
+            user_id=user_id,
+            version_no=version_no,
+        )
+        return JSONResponse(status_code=HTTPStatus.OK, content=result)
+    except UnauthorizedError as e:
+        raise HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=str(e))
+    except Exception as e:
+        logger.error(f"Create agent repository listing error: {str(e)}")
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail="Create agent repository listing error.",
+        )
+
+
+@agent_repository_router.post("/{agent_repository_id}/import")
+async def import_agent_from_repository_api(
+    agent_repository_id: int,
+    authorization: Optional[str] = Header(None),
+):
+    """Import an agent tree from a marketplace repository listing into the current tenant."""
+    try:
+        await import_agent_from_repository_impl(
+            agent_repository_id=agent_repository_id,
+            authorization=authorization,
+        )
+        return JSONResponse(status_code=HTTPStatus.OK, content={})
+    except UnauthorizedError as e:
+        raise HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail=str(e))
+    except SkillDuplicateError as exc:
+        raise HTTPException(
+            status_code=HTTPStatus.CONFLICT,
+            detail={
+                "type": "skill_duplicate",
+                "duplicate_skills": exc.duplicate_names,
+            },
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=str(e))
+    except Exception as e:
+        logger.error(f"Import agent from repository error: {str(e)}")
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail="Import agent from repository error.",
+        )

--- a/backend/apps/config_app.py
+++ b/backend/apps/config_app.py
@@ -2,6 +2,7 @@ import logging
 
 from apps.app_factory import create_app
 from apps.agent_app import agent_config_router as agent_router
+from apps.agent_repository_app import agent_repository_router
 from apps.config_sync_app import router as config_sync_router
 from apps.datamate_app import router as datamate_router
 from apps.vectordatabase_app import router as vectordatabase_router
@@ -55,6 +56,7 @@ async def sync_default_prompt_template_on_startup():
 app.include_router(model_manager_router)
 app.include_router(config_sync_router)
 app.include_router(agent_router)
+app.include_router(agent_repository_router)
 app.include_router(vectordatabase_router)
 app.include_router(datamate_router)
 app.include_router(voice_router)

--- a/backend/consts/model.py
+++ b/backend/consts/model.py
@@ -557,6 +557,7 @@ class MessageIdRequest(BaseModel):
 
 class ExportAndImportAgentInfo(BaseModel):
     agent_id: int
+    tenant_id: Optional[str] = None
     name: str
     display_name: Optional[str] = None
     description: str
@@ -591,6 +592,11 @@ class ExportAndImportDataFormat(BaseModel):
     agent_id: int
     agent_info: Dict[str, ExportAndImportAgentInfo]
     mcp_info: List[MCPInfo]
+
+
+class AgentRepositorySnapshot(ExportAndImportDataFormat):
+    """Frozen marketplace snapshot: export format plus optional skill ZIP payloads."""
+    skills: Optional[List["SkillZipEntry"]] = None
 
 
 class SkillZipEntry(BaseModel):

--- a/backend/database/agent_db.py
+++ b/backend/database/agent_db.py
@@ -1,9 +1,10 @@
 import logging
-from typing import List
+from typing import List, Optional
 from sqlalchemy import or_, update
 
 from database.client import get_db_session, as_dict, filter_property
 from database.db_models import AgentInfo, ToolInstance, AgentRelation
+from database.agent_version_db import query_current_version_no
 from consts.const import ASSET_OWNER_TENANT_ID
 from utils.str_utils import convert_list_to_string
 
@@ -100,6 +101,40 @@ def query_sub_agents_id_list(main_agent_id: int, tenant_id: str, version_no: int
             AgentRelation.delete_flag != 'Y')
         relations = query.all()
         return [relation.selected_agent_id for relation in relations]
+
+
+def query_sub_agent_relations(main_agent_id: int, tenant_id: str, version_no: int = 0) -> List[dict]:
+    """
+    Query sub-agent relations by main agent id, including pinned version info.
+    Default version_no=0 queries the draft version.
+
+    Args:
+        main_agent_id: Parent agent ID
+        tenant_id: Tenant ID
+        version_no: Version number to filter. Default 0 = draft/editing state
+    """
+    with get_db_session() as session:
+        query = session.query(AgentRelation).filter(
+            AgentRelation.parent_agent_id == main_agent_id,
+            AgentRelation.tenant_id == tenant_id,
+            AgentRelation.version_no == version_no,
+            AgentRelation.delete_flag != 'Y')
+        relations = query.all()
+        return [as_dict(relation) for relation in relations]
+
+
+def resolve_sub_agent_version_no(
+    selected_agent_id: int,
+    selected_agent_version_no: Optional[int],
+    tenant_id: str,
+) -> int:
+    """
+    Resolve the effective version number for a sub-agent relation.
+    Uses pinned version when set; otherwise falls back to child's current published version.
+    """
+    if selected_agent_version_no is not None:
+        return selected_agent_version_no
+    return query_current_version_no(agent_id=selected_agent_id, tenant_id=tenant_id) or 0
 
 
 def clear_agent_new_mark(agent_id: int, tenant_id: str, user_id: str, version_no: int = 0):

--- a/backend/database/agent_repository_db.py
+++ b/backend/database/agent_repository_db.py
@@ -1,0 +1,358 @@
+import logging
+import math
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy import func, or_, update
+
+from database.client import as_dict, filter_property, get_db_session
+from database.db_models import AgentRepository
+
+logger = logging.getLogger("agent_repository_db")
+
+# Listing status: NOT_SHARED (未共享), PENDING_REVIEW (待审核),
+# REJECTED (审核驳回), SHARED (已共享)
+STATUS_NOT_SHARED = "NOT_SHARED"
+STATUS_PENDING_REVIEW = "PENDING_REVIEW"
+STATUS_REJECTED = "REJECTED"
+STATUS_SHARED = "SHARED"
+
+VALID_REPOSITORY_STATUSES = frozenset({
+    STATUS_NOT_SHARED,
+    STATUS_PENDING_REVIEW,
+    STATUS_REJECTED,
+    STATUS_SHARED,
+})
+
+_UPSERT_IMMUTABLE_FIELDS = frozenset({
+    "agent_id",
+    "agent_repository_id",
+    "publisher_tenant_id",
+})
+
+_UPSERT_SNAPSHOT_FIELDS = frozenset({
+    "source_version_no",
+    "name",
+    "display_name",
+    "description",
+    "author",
+    "category_id",
+    "tags",
+    "tool_count",
+    "version_label",
+    "agent_info_json",
+})
+
+
+def insert_agent_repository_record(
+    repository_data: Dict[str, Any],
+    publisher_tenant_id: str,
+    publisher_user_id: str,
+) -> int:
+    """Insert a new agent repository listing record."""
+    with get_db_session() as session:
+        payload = {
+            **repository_data,
+            "publisher_tenant_id": publisher_tenant_id,
+            "publisher_user_id": publisher_user_id,
+            "created_by": publisher_user_id,
+            "updated_by": publisher_user_id,
+            "delete_flag": "N",
+        }
+        if payload.get("status") is None:
+            payload["status"] = STATUS_NOT_SHARED
+
+        new_record = AgentRepository(
+            **filter_property(payload, AgentRepository)
+        )
+        session.add(new_record)
+        session.flush()
+        return int(new_record.agent_repository_id)
+
+
+def get_agent_repository_by_id(repository_id: int) -> Optional[dict]:
+    """Fetch a repository listing by primary key."""
+    with get_db_session() as session:
+        record = session.query(AgentRepository).filter(
+            AgentRepository.agent_repository_id == repository_id,
+            AgentRepository.delete_flag != "Y",
+        ).first()
+        return as_dict(record) if record else None
+
+
+def get_agent_repository_by_id_and_publisher(
+    repository_id: int,
+    publisher_tenant_id: str,
+) -> Optional[dict]:
+    """Fetch a repository listing scoped to the publisher tenant."""
+    with get_db_session() as session:
+        record = session.query(AgentRepository).filter(
+            AgentRepository.agent_repository_id == repository_id,
+            AgentRepository.publisher_tenant_id == publisher_tenant_id,
+            AgentRepository.delete_flag != "Y",
+        ).first()
+        return as_dict(record) if record else None
+
+
+def get_agent_repository_by_agent_id(agent_id: int) -> Optional[dict]:
+    """Fetch an active repository listing by root agent_id."""
+    with get_db_session() as session:
+        record = session.query(AgentRepository).filter(
+            AgentRepository.agent_id == agent_id,
+            AgentRepository.delete_flag != "Y",
+        ).first()
+        return as_dict(record) if record else None
+
+
+def upsert_agent_repository_record(
+    repository_data: Dict[str, Any],
+    publisher_tenant_id: str,
+    publisher_user_id: str,
+) -> tuple[int, bool]:
+    """Insert or update a repository listing keyed by agent_id.
+
+    When no record exists, inserts a new listing. When a record exists:
+    - Same source_version_no: updates status (and updated_by) only.
+    - Different source_version_no: updates all snapshot fields, preserving
+      agent_id, agent_repository_id, and publisher_tenant_id.
+
+    Returns:
+        Tuple of (agent_repository_id, is_updated). is_updated is False on insert.
+    """
+    agent_id = repository_data.get("agent_id")
+    if agent_id is None:
+        raise ValueError("agent_id is required for repository upsert")
+
+    existing = get_agent_repository_by_agent_id(int(agent_id))
+    if not existing:
+        repository_id = insert_agent_repository_record(
+            repository_data=repository_data,
+            publisher_tenant_id=publisher_tenant_id,
+            publisher_user_id=publisher_user_id,
+        )
+        return repository_id, False
+
+    existing_version = existing.get("source_version_no")
+    incoming_version = repository_data.get("source_version_no")
+    repository_id = int(existing["agent_repository_id"])
+
+    if existing_version == incoming_version:
+        update_fields: Dict[str, Any] = {
+            "status": repository_data.get("status", STATUS_NOT_SHARED),
+            "updated_by": publisher_user_id,
+        }
+    else:
+        update_fields = {
+            key: repository_data[key]
+            for key in _UPSERT_SNAPSHOT_FIELDS
+            if key in repository_data
+        }
+        update_fields["publisher_user_id"] = publisher_user_id
+        update_fields["updated_by"] = publisher_user_id
+        update_fields["status"] = repository_data.get("status", STATUS_NOT_SHARED)
+
+    with get_db_session() as session:
+        session.execute(
+            update(AgentRepository)
+            .where(
+                AgentRepository.agent_repository_id == repository_id,
+                AgentRepository.publisher_tenant_id == publisher_tenant_id,
+                AgentRepository.delete_flag != "Y",
+            )
+            .values(**update_fields)
+        )
+    return repository_id, True
+
+
+def list_agent_repository_summaries(
+    *,
+    status: Optional[str] = None,
+) -> List[dict]:
+    """List all active repository summaries without heavy JSON blobs."""
+    with get_db_session() as session:
+        query = session.query(
+            AgentRepository.agent_repository_id,
+            AgentRepository.author,
+            AgentRepository.name,
+            AgentRepository.display_name,
+            AgentRepository.description,
+            AgentRepository.status,
+        ).filter(
+            AgentRepository.delete_flag != "Y",
+        )
+        if status:
+            query = query.filter(AgentRepository.status == status)
+        rows = query.order_by(AgentRepository.agent_repository_id.desc()).all()
+        return [
+            {
+                "agent_repository_id": row.agent_repository_id,
+                "author": row.author,
+                "name": row.name,
+                "display_name": row.display_name,
+                "description": row.description,
+                "status": row.status,
+            }
+            for row in rows
+        ]
+
+
+def query_agent_repository_list(
+    *,
+    page: int = 1,
+    page_size: int = 20,
+    search: Optional[str] = None,
+    tag: Optional[str] = None,
+    category_id: Optional[int] = None,
+    status: Optional[str] = STATUS_SHARED,
+    publisher_tenant_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Query repository listings with offset pagination."""
+    page = max(page, 1)
+    page_size = max(min(page_size, 100), 1)
+    offset = (page - 1) * page_size
+
+    with get_db_session() as session:
+        query = session.query(AgentRepository).filter(
+            AgentRepository.delete_flag != "Y",
+        )
+
+        if status:
+            query = query.filter(AgentRepository.status == status)
+        if publisher_tenant_id:
+            query = query.filter(
+                AgentRepository.publisher_tenant_id == publisher_tenant_id
+            )
+        if category_id is not None:
+            query = query.filter(AgentRepository.category_id == category_id)
+        if tag:
+            query = query.filter(AgentRepository.tags.any(tag))
+        if search:
+            keyword = f"%{search}%"
+            query = query.filter(
+                or_(
+                    AgentRepository.name.ilike(keyword),
+                    AgentRepository.display_name.ilike(keyword),
+                    AgentRepository.description.ilike(keyword),
+                    AgentRepository.author.ilike(keyword),
+                    func.array_to_string(AgentRepository.tags, ",").ilike(keyword),
+                )
+            )
+
+        total = query.count()
+        rows = (
+            query.order_by(AgentRepository.agent_repository_id.desc())
+            .offset(offset)
+            .limit(page_size)
+            .all()
+        )
+
+        total_pages = math.ceil(total / page_size) if total else 0
+        return {
+            "items": [as_dict(row) for row in rows],
+            "pagination": {
+                "page": page,
+                "page_size": page_size,
+                "total": total,
+                "total_pages": total_pages,
+            },
+        }
+
+
+def update_agent_repository_by_id(
+    *,
+    repository_id: int,
+    publisher_tenant_id: str,
+    user_id: str,
+    updates: Dict[str, Any],
+) -> int:
+    """Update a repository listing owned by the publisher tenant. Returns affected row count."""
+    allowed_fields = {
+        "display_name",
+        "description",
+        "author",
+        "category_id",
+        "tags",
+        "tool_count",
+        "version_label",
+        "source_version_no",
+        "agent_info_json",
+        "status",
+    }
+    update_fields = {
+        key: value
+        for key, value in updates.items()
+        if key in allowed_fields
+    }
+    if not update_fields:
+        return 0
+
+    update_fields["updated_by"] = user_id
+
+    with get_db_session() as session:
+        result = session.execute(
+            update(AgentRepository)
+            .where(
+                AgentRepository.agent_repository_id == repository_id,
+                AgentRepository.publisher_tenant_id == publisher_tenant_id,
+                AgentRepository.delete_flag != "Y",
+            )
+            .values(**update_fields)
+        )
+        return int(result.rowcount or 0)
+
+
+def update_agent_repository_status_by_id(
+    *,
+    repository_id: int,
+    status: str,
+    user_id: str,
+) -> int:
+    """Update repository listing status by primary key. Returns affected row count."""
+    with get_db_session() as session:
+        result = session.execute(
+            update(AgentRepository)
+            .where(
+                AgentRepository.agent_repository_id == repository_id,
+                AgentRepository.delete_flag != "Y",
+            )
+            .values(status=status, updated_by=user_id)
+        )
+        return int(result.rowcount or 0)
+
+
+def soft_delete_agent_repository_by_id(
+    *,
+    repository_id: int,
+    publisher_tenant_id: str,
+    user_id: str,
+) -> int:
+    """Soft-delete a repository listing owned by the publisher tenant."""
+    with get_db_session() as session:
+        result = session.execute(
+            update(AgentRepository)
+            .where(
+                AgentRepository.agent_repository_id == repository_id,
+                AgentRepository.publisher_tenant_id == publisher_tenant_id,
+                AgentRepository.delete_flag != "Y",
+            )
+            .values(delete_flag="Y", updated_by=user_id)
+        )
+        return int(result.rowcount or 0)
+
+
+def list_agent_repository_by_publisher(
+    publisher_tenant_id: str,
+    *,
+    publisher_user_id: Optional[str] = None,
+) -> List[dict]:
+    """List all repository listings published by a tenant."""
+    with get_db_session() as session:
+        query = session.query(AgentRepository).filter(
+            AgentRepository.publisher_tenant_id == publisher_tenant_id,
+            AgentRepository.delete_flag != "Y",
+        )
+        if publisher_user_id:
+            query = query.filter(
+                AgentRepository.publisher_user_id == publisher_user_id
+            )
+        rows = query.order_by(AgentRepository.agent_repository_id.desc()).all()
+        return [as_dict(row) for row in rows]

--- a/backend/database/db_models.py
+++ b/backend/database/db_models.py
@@ -570,6 +570,10 @@ class AgentRelation(TableBase):
     tenant_id = Column(String(100), doc="Tenant ID")
     version_no = Column(Integer, default=0, nullable=False,
                         doc="Version number. 0 = draft/editing state, >=1 = published snapshot")
+    selected_agent_version_no = Column(
+        Integer, nullable=True,
+        doc="Pinned version of selected_agent_id. NULL = runtime fallback to child current_version_no",
+    )
 
 
 class PartnerMappingId(TableBase):
@@ -698,6 +702,38 @@ class AgentVersion(TableBase):
                     doc="Version status: RELEASED / DISABLED / ARCHIVED")
     is_a2a = Column(Boolean, default=False,
                     doc="Whether this version is published as an A2A Server agent")
+
+
+class AgentRepository(TableBase):
+    """
+    Agent repository (marketplace) table. Frozen snapshot of a published agent tree for sharing.
+    """
+    __tablename__ = "ag_agent_repository_t"
+    __table_args__ = {"schema": SCHEMA}
+
+    agent_repository_id = Column(BigInteger, Sequence("ag_agent_repository_t_agent_repository_id_seq", schema=SCHEMA),
+                                 primary_key=True, nullable=False, doc="Agent repository listing ID, unique primary key")
+    publisher_tenant_id = Column(String(100), nullable=False, doc="Publisher tenant ID")
+    publisher_user_id = Column(String(100), nullable=False, doc="Publisher user ID")
+    agent_id = Column(Integer, nullable=False,
+                      doc="Root agent ID from ag_tenant_agent_t; upsert key")
+    source_version_no = Column(Integer, nullable=False,
+                               doc="Published version number frozen at share time")
+    name = Column(String(100), nullable=False,
+                  doc="Root agent programmatic name for display and search")
+    display_name = Column(String(100), doc="Root agent display name")
+    description = Column(Text, doc="Root agent description")
+    author = Column(String(100), doc="Agent author")
+    category_id = Column(Integer, doc="Optional marketplace category ID")
+    tags = Column(ARRAY(Text), doc="Marketplace tags")
+    tool_count = Column(Integer,
+                        doc="Total tool count across all agents in the bundle (display only)")
+    version_label = Column(String(100),
+                           doc="Repository entry version label for display (e.g. v1.0)")
+    agent_info_json = Column(JSONB, nullable=False,
+                             doc="Frozen ExportAndImportDataFormat snapshot with optional skills")
+    status = Column(String(30), default="NOT_SHARED",
+                    doc="Listing status: NOT_SHARED (未共享) / PENDING_REVIEW (待审核) / REJECTED (审核驳回) / SHARED (已共享)")
 
 
 class UserTokenInfo(TableBase):

--- a/backend/services/agent_repository_service.py
+++ b/backend/services/agent_repository_service.py
@@ -1,0 +1,306 @@
+import logging
+from typing import Any, Dict, Optional
+
+from consts.const import ASSET_OWNER_TENANT_ID
+from consts.model import AgentRepositorySnapshot
+from database.agent_db import search_agent_info_by_agent_id
+from database.agent_version_db import search_version_by_version_no
+from database.agent_repository_db import (
+    STATUS_PENDING_REVIEW,
+    VALID_REPOSITORY_STATUSES,
+    get_agent_repository_by_agent_id,
+    get_agent_repository_by_id,
+    insert_agent_repository_record,
+    list_agent_repository_summaries,
+    update_agent_repository_by_id,
+    update_agent_repository_status_by_id,
+)
+from services.agent_service import (
+    collect_skill_zip_entries,
+    export_agent_dict_for_repository_impl,
+    import_agent_impl,
+    import_agent_with_skills_impl,
+)
+
+logger = logging.getLogger("agent_repository_service")
+
+_UPDATE_SNAPSHOT_FIELDS = (
+    "display_name",
+    "description",
+    "author",
+    "category_id",
+    "tags",
+    "tool_count",
+    "version_label",
+    "source_version_no",
+    "agent_info_json",
+    "status",
+)
+
+
+def _to_summary_item(record: Dict[str, Any]) -> Dict[str, Any]:
+    """Map a DB record to a lightweight marketplace summary item."""
+    return {
+        "agent_repository_id": record.get("agent_repository_id"),
+        "author": record.get("author"),
+        "name": record.get("name"),
+        "display_name": record.get("display_name"),
+        "description": record.get("description"),
+        "status": record.get("status"),
+    }
+
+
+def list_agent_repository_listings_impl(
+    *,
+    status: Optional[str] = None,
+) -> Dict[str, Any]:
+    """List all repository listings with optional status filter."""
+    if status is not None and status not in VALID_REPOSITORY_STATUSES:
+        raise ValueError(
+            f"Invalid status '{status}'; must be one of: "
+            f"{', '.join(sorted(VALID_REPOSITORY_STATUSES))}"
+        )
+    records = list_agent_repository_summaries(status=status)
+    return {"items": [_to_summary_item(record) for record in records]}
+
+
+def update_agent_repository_status_impl(
+    *,
+    agent_repository_id: int,
+    status: str,
+    user_id: str,
+) -> Dict[str, Any]:
+    """Update a repository listing status by primary key."""
+    if status not in VALID_REPOSITORY_STATUSES:
+        raise ValueError(
+            f"Invalid status '{status}'; must be one of: "
+            f"{', '.join(sorted(VALID_REPOSITORY_STATUSES))}"
+        )
+
+    record = get_agent_repository_by_id(agent_repository_id)
+    if not record:
+        raise ValueError("Repository listing not found")
+
+    rows_affected = update_agent_repository_status_by_id(
+        repository_id=agent_repository_id,
+        status=status,
+        user_id=user_id,
+    )
+    if rows_affected == 0:
+        raise ValueError("Repository listing not found")
+
+    updated = get_agent_repository_by_id(agent_repository_id)
+    if not updated:
+        raise ValueError("Failed to load repository listing after update")
+    return _to_summary_item(updated)
+
+
+def _to_list_item(record: Dict[str, Any]) -> Dict[str, Any]:
+    """Map a DB record to a marketplace list item (without heavy JSON blobs)."""
+    return {
+        "id": record.get("agent_repository_id"),
+        "agent_repository_id": record.get("agent_repository_id"),
+        "agent_id": record.get("agent_id"),
+        "name": record.get("name"),
+        "display_name": record.get("display_name"),
+        "description": record.get("description"),
+        "author": record.get("author"),
+        "category_id": record.get("category_id"),
+        "tags": record.get("tags") or [],
+        "tool_count": record.get("tool_count"),
+        "version_label": record.get("version_label"),
+        "status": record.get("status"),
+        "source_version_no": record.get("source_version_no"),
+        "publisher_tenant_id": record.get("publisher_tenant_id"),
+        "created_at": record.get("create_time"),
+        "updated_at": record.get("update_time"),
+    }
+
+
+def _to_detail_item(
+    record: Dict[str, Any],
+    *,
+    include_bundles: bool = True,
+    is_updated: Optional[bool] = None,
+) -> Dict[str, Any]:
+    """Map a DB record to a marketplace detail payload."""
+    detail = _to_list_item(record)
+    if include_bundles:
+        detail["agent_info_json"] = record.get("agent_info_json")
+    if is_updated is not None:
+        detail["is_updated"] = is_updated
+    return detail
+
+
+def _validate_create_payload(repository_data: Dict[str, Any]) -> None:
+    """Validate required fields before inserting a repository listing."""
+    required_fields = (
+        "agent_id",
+        "source_version_no",
+        "name",
+        "agent_info_json",
+    )
+    missing = [
+        field for field in required_fields
+        if field not in repository_data or repository_data[field] is None
+    ]
+    if missing:
+        raise ValueError(f"Missing required repository fields: {', '.join(missing)}")
+    if not repository_data.get("name"):
+        raise ValueError("name must be a non-empty string")
+
+    agent_info_json = repository_data.get("agent_info_json")
+    if not isinstance(agent_info_json, dict):
+        raise ValueError("agent_info_json must be a JSON object")
+    for key in ("agent_id", "agent_info", "mcp_info"):
+        if key not in agent_info_json:
+            raise ValueError(f"agent_info_json must contain '{key}'")
+
+
+def _validate_agent_info_json_shareable(agent_info_json: dict) -> None:
+    """Reject marketplace share when any agent in the tree belongs to ASSET_OWNER tenant."""
+    agent_info_map = agent_info_json.get("agent_info")
+    if not isinstance(agent_info_map, dict):
+        return
+    for entry in agent_info_map.values():
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("tenant_id") == ASSET_OWNER_TENANT_ID:
+            raise ValueError("租户管理员智能体无法共享")
+
+
+async def _build_agent_info_json(
+    agent_id: int,
+    tenant_id: str,
+    user_id: str,
+    version_no: int,
+) -> dict:
+    """Build marketplace snapshot JSON via the agent export pipeline."""
+    export_dict = await export_agent_dict_for_repository_impl(
+        agent_id=agent_id,
+        tenant_id=tenant_id,
+        user_id=user_id,
+        version_no=version_no,
+    )
+    skills = collect_skill_zip_entries(
+        agent_id=agent_id,
+        tenant_id=tenant_id,
+        version_no=version_no,
+    )
+    snapshot = AgentRepositorySnapshot(
+        **export_dict,
+        skills=skills or None,
+    )
+    return snapshot.model_dump()
+
+
+async def _build_repository_data_from_agent(
+    agent_id: int,
+    tenant_id: str,
+    user_id: str,
+    version_no: int,
+) -> Dict[str, Any]:
+    """Build a repository upsert payload from a published agent version snapshot."""
+    agent_info = search_agent_info_by_agent_id(agent_id, tenant_id, version_no)
+    agent_info_json = await _build_agent_info_json(
+        agent_id=agent_id,
+        tenant_id=tenant_id,
+        user_id=user_id,
+        version_no=version_no,
+    )
+    _validate_agent_info_json_shareable(agent_info_json)
+
+    version_meta = search_version_by_version_no(agent_id, tenant_id, version_no)
+    version_label = (
+        version_meta.get("version_name")
+        if version_meta and version_meta.get("version_name")
+        else f"v{version_no}"
+    )
+
+    return {
+        "agent_id": agent_id,
+        "source_version_no": version_no,
+        "name": agent_info["name"],
+        "display_name": agent_info.get("display_name"),
+        "description": agent_info.get("description"),
+        "author": agent_info.get("author"),
+        "version_label": version_label,
+        "agent_info_json": agent_info_json,
+        "status": STATUS_PENDING_REVIEW,
+    }
+
+
+async def create_agent_repository_listing_impl(
+    agent_id: int,
+    tenant_id: str,
+    user_id: str,
+    version_no: int,
+) -> Dict[str, Any]:
+    """Create or update a repository listing from a published agent version.
+
+    Loads agent metadata and builds agent_info_json via the export pipeline,
+    then inserts or updates the marketplace table.
+
+    When a listing for the same agent_id already exists, snapshot fields are
+    updated via update_agent_repository_by_id.
+    """
+    if version_no < 0:
+        raise ValueError("version_no must be >= 0")
+
+    repository_data = await _build_repository_data_from_agent(
+        agent_id, tenant_id, user_id, version_no
+    )
+    _validate_create_payload(repository_data)
+
+    existing = get_agent_repository_by_agent_id(agent_id)
+    if not existing:
+        repository_id = insert_agent_repository_record(
+            repository_data=repository_data,
+            publisher_tenant_id=tenant_id,
+            publisher_user_id=user_id,
+        )
+        is_updated = False
+    else:
+        repository_id = int(existing["agent_repository_id"])
+        updates = {
+            key: repository_data[key]
+            for key in _UPDATE_SNAPSHOT_FIELDS
+            if key in repository_data
+        }
+        affected = update_agent_repository_by_id(
+            repository_id=repository_id,
+            publisher_tenant_id=tenant_id,
+            user_id=user_id,
+            updates=updates,
+        )
+        if affected == 0:
+            raise ValueError("Failed to update repository listing")
+        is_updated = True
+
+    record = get_agent_repository_by_id(repository_id)
+    if not record:
+        raise ValueError("Failed to load repository listing after write")
+    return _to_detail_item(record, is_updated=is_updated)
+
+
+async def import_agent_from_repository_impl(
+    agent_repository_id: int,
+    authorization: str,
+) -> Dict[int, int]:
+    """Import an agent tree from a marketplace repository listing into the current tenant."""
+    record = get_agent_repository_by_id(agent_repository_id)
+    if not record:
+        raise ValueError("Repository listing not found")
+
+    agent_info_json = record.get("agent_info_json")
+    if not isinstance(agent_info_json, dict):
+        raise ValueError("Repository listing has no agent snapshot")
+
+    snapshot = AgentRepositorySnapshot.model_validate(agent_info_json)
+    if snapshot.skills:
+        return await import_agent_with_skills_impl(
+            snapshot,
+            snapshot.skills,
+            authorization,
+        )
+    return await import_agent_impl(snapshot, authorization)

--- a/backend/services/agent_service.py
+++ b/backend/services/agent_service.py
@@ -46,7 +46,9 @@ from database.agent_db import (
     delete_related_agent,
     insert_related_agent,
     query_all_agent_info_by_tenant_id,
+    query_sub_agent_relations,
     query_sub_agents_id_list,
+    resolve_sub_agent_version_no,
     search_agent_id_by_agent_name,
     search_agent_info_by_agent_id,
     search_blank_sub_agent_by_main_agent_id,
@@ -984,14 +986,13 @@ async def get_agent_info_impl(agent_id: int, tenant_id: str, version_no: int = 0
             user_role = str(user_tenant_record.get("user_role") or "").upper()
             can_edit_all = user_role in CAN_EDIT_ALL_USER_ROLES
 
-            # Permission logic (same as agent list):
-            # - If creator or can_edit_all: PERMISSION_EDIT
-            # - Otherwise: use ingroup_permission, default to PERMISSION_READ if None
-            if can_edit_all or str(agent_info.get("created_by")) == str(user_id):
-                agent_info["permission"] = PERMISSION_EDIT
-            else:
-                ingroup_permission = agent_info.get("ingroup_permission")
-                agent_info["permission"] = ingroup_permission if ingroup_permission is not None else PERMISSION_READ
+            # Permission logic (same as agent list, including ASSET_OWNER read-only override)
+            agent_info["permission"] = resolve_agent_list_permission(
+                user_role=user_role,
+                agent=agent_info,
+                user_id=user_id,
+                can_edit_all=can_edit_all,
+            )
         except Exception as e:
             logger.warning(f"Failed to calculate agent permission: {str(e)}")
 
@@ -1413,76 +1414,216 @@ async def clear_agent_memory(agent_id: int, tenant_id: str, user_id: str):
         # Silently fail to maintain agent deletion process
 
 
-async def export_agent_impl(agent_id: int, authorization: str = Header(None)) -> str:
+async def _export_agent_dict_core(
+    root_agent_id: int,
+    tenant_id: str,
+    user_id: str,
+    version_no: int = 0,
+) -> dict:
+    """Build ExportAndImportDataFormat dict for an agent tree at the given version."""
+    export_agent_dict = {}
+    search_list: deque = deque([(root_agent_id, version_no)])
+    visited: set = set()
+
+    mcp_info_set = set()
+
+    while search_list:
+        current_agent_id, current_version_no = search_list.popleft()
+        visit_key = (current_agent_id, current_version_no)
+        if visit_key in visited:
+            continue
+        visited.add(visit_key)
+
+        agent_info = await export_agent_by_agent_id(
+            agent_id=current_agent_id,
+            tenant_id=tenant_id,
+            user_id=user_id,
+            version_no=current_version_no,
+        )
+
+        for tool in agent_info.tools:
+            if tool.source == "mcp" and tool.usage:
+                mcp_info_set.add(tool.usage)
+
+        relations = query_sub_agent_relations(
+            main_agent_id=current_agent_id,
+            tenant_id=tenant_id,
+            version_no=current_version_no,
+        )
+        for rel in relations:
+            child_id = rel["selected_agent_id"]
+            child_version = resolve_sub_agent_version_no(
+                child_id,
+                rel.get("selected_agent_version_no"),
+                tenant_id,
+            )
+            search_list.append((child_id, child_version))
+
+        export_agent_dict[str(agent_info.agent_id)] = agent_info
+
+    mcp_info_list = []
+    for mcp_server_name in mcp_info_set:
+        mcp_url = get_mcp_server_by_name_and_tenant(mcp_server_name, tenant_id)
+        mcp_info_list.append(
+            MCPInfo(mcp_server_name=mcp_server_name, mcp_url=mcp_url))
+
+    export_data = ExportAndImportDataFormat(
+        agent_id=root_agent_id,
+        agent_info=export_agent_dict,
+        mcp_info=mcp_info_list,
+    )
+    return export_data.model_dump()
+
+
+async def export_agent_dict_impl(
+    agent_id: int,
+    authorization: str = Header(None),
+    version_no: int = 0,
+) -> dict:
     """
     Export the configuration information of the specified agent and all its sub-agents.
 
     Args:
         agent_id (int): The ID of the agent to export.
         authorization (str): User authentication information, obtained from the Header.
+        version_no (int): Version to export. Default 0 = draft.
 
     Returns:
-        str: A formatted JSON string containing the configuration information of the agent and all its sub-agents.
-
-    Data Structure Example:
-        model.py  ExportAndImportDataFormat
-
-    Note:
-        This function recursively finds all managed sub-agents and exports the detailed configuration of each agent (including tools, prompts, etc.) as a dictionary, and finally returns it as a formatted JSON string for frontend download and backup.
+        dict: ExportAndImportDataFormat as a plain dict (via model_dump).
     """
-
     user_id, tenant_id, _ = get_current_user_info(authorization)
-
-    export_agent_dict = {}
-    search_list = deque([agent_id])
-    agent_id_set = set()
-
-    mcp_info_set = set()
-
-    while len(search_list):
-        left_ele = search_list.popleft()
-        if left_ele in agent_id_set:
-            continue
-
-        agent_id_set.add(left_ele)
-        agent_info = await export_agent_by_agent_id(agent_id=left_ele, tenant_id=tenant_id, user_id=user_id)
-
-        # collect mcp name
-        for tool in agent_info.tools:
-            if tool.source == "mcp" and tool.usage:
-                mcp_info_set.add(tool.usage)
-
-        search_list.extend(agent_info.managed_agents)
-        export_agent_dict[str(agent_info.agent_id)] = agent_info
-
-    # convert mcp info to MCPInfo list
-    mcp_info_list = []
-    for mcp_server_name in mcp_info_set:
-        # get mcp url by mcp_server_name and tenant_id
-        mcp_url = get_mcp_server_by_name_and_tenant(mcp_server_name, tenant_id)
-        mcp_info_list.append(
-            MCPInfo(mcp_server_name=mcp_server_name, mcp_url=mcp_url))
-
-    export_data = ExportAndImportDataFormat(
-        agent_id=agent_id, agent_info=export_agent_dict, mcp_info=mcp_info_list)
-    return json.dumps(export_data.model_dump())
+    return await _export_agent_dict_core(
+        root_agent_id=agent_id,
+        tenant_id=tenant_id,
+        user_id=user_id,
+        version_no=version_no,
+    )
 
 
-async def export_agent_by_agent_id(agent_id: int, tenant_id: str, user_id: str) -> ExportAndImportAgentInfo:
-    """
-    Export a single agent's information based on agent_id
-    """
+async def export_agent_dict_for_repository_impl(
+    agent_id: int,
+    tenant_id: str,
+    user_id: str,
+    version_no: int,
+) -> dict:
+    """Export agent tree for marketplace repository storage (no HTTP auth header)."""
+    return await _export_agent_dict_core(
+        root_agent_id=agent_id,
+        tenant_id=tenant_id,
+        user_id=user_id,
+        version_no=version_no,
+    )
+
+
+async def export_agent_impl(
+    agent_id: int,
+    authorization: str = Header(None),
+    version_no: int = 0,
+) -> str:
+    """Serialize export_agent_dict_impl output to a JSON string for download or ZIP embedding."""
+    agent_dict = await export_agent_dict_impl(
+        agent_id, authorization, version_no=version_no
+    )
+    return json.dumps(agent_dict)
+
+
+def _collect_skill_names_from_tree(
+    agent_id: int,
+    tenant_id: str,
+    version_no: int,
+    visited: Optional[set] = None,
+) -> List[str]:
+    """Collect unique skill names from an agent tree at the given version."""
+    if visited is None:
+        visited = set()
+
+    skill_names: List[str] = []
+    seen_names: set = set()
+
+    def _walk(current_agent_id: int, current_version_no: int) -> None:
+        visit_key = (current_agent_id, current_version_no)
+        if visit_key in visited:
+            return
+        visited.add(visit_key)
+
+        skill_instances = skill_db.query_skill_instances_by_agent_id(
+            agent_id=current_agent_id,
+            tenant_id=tenant_id,
+            version_no=current_version_no,
+        )
+        for inst in skill_instances:
+            skill_id = inst.get("skill_id")
+            skill = skill_db.get_skill_by_id(skill_id, tenant_id)
+            if skill:
+                name = skill.get("name")
+                if name and name not in seen_names:
+                    seen_names.add(name)
+                    skill_names.append(name)
+
+        relations = query_sub_agent_relations(
+            main_agent_id=current_agent_id,
+            tenant_id=tenant_id,
+            version_no=current_version_no,
+        )
+        for rel in relations:
+            child_id = rel["selected_agent_id"]
+            child_version = resolve_sub_agent_version_no(
+                child_id,
+                rel.get("selected_agent_version_no"),
+                tenant_id,
+            )
+            _walk(child_id, child_version)
+
+    _walk(agent_id, version_no)
+    return skill_names
+
+
+def collect_skill_zip_entries(
+    agent_id: int,
+    tenant_id: str,
+    version_no: int = 0,
+) -> List[SkillZipEntry]:
+    """Export skill ZIP payloads for all skills in an agent tree."""
+    skill_names = _collect_skill_names_from_tree(agent_id, tenant_id, version_no)
+    if not skill_names:
+        return []
+
+    skill_service = SkillService(tenant_id=tenant_id)
+    exported = skill_service.export_skills_by_names(skill_names, tenant_id)
+    return [
+        SkillZipEntry(
+            skill_name=entry["skill_name"],
+            skill_zip_base64=entry["skill_zip_base64"],
+        )
+        for entry in exported
+    ]
+
+
+async def export_agent_by_agent_id(
+    agent_id: int,
+    tenant_id: str,
+    user_id: str,
+    version_no: int = 0,
+) -> ExportAndImportAgentInfo:
+    """Export a single agent's information based on agent_id and version_no."""
     agent_info = search_agent_info_by_agent_id(
-        agent_id=agent_id, tenant_id=tenant_id)
+        agent_id=agent_id, tenant_id=tenant_id, version_no=version_no
+    )
     agent_relation_in_db = query_sub_agents_id_list(
-        main_agent_id=agent_id, tenant_id=tenant_id)
-    tool_list = await create_tool_config_list(agent_id=agent_id, tenant_id=tenant_id, user_id=user_id)
+        main_agent_id=agent_id, tenant_id=tenant_id, version_no=version_no
+    )
+    tool_list = await create_tool_config_list(
+        agent_id=agent_id,
+        tenant_id=tenant_id,
+        user_id=user_id,
+        version_no=version_no,
+    )
 
     # Collect skill names from skill instances
     skill_names: List[str] = []
     try:
         skill_instances = skill_db.query_skill_instances_by_agent_id(
-            agent_id=agent_id, tenant_id=tenant_id, version_no=0
+            agent_id=agent_id, tenant_id=tenant_id, version_no=version_no
         )
         for inst in skill_instances:
             skill_id = inst.get("skill_id")
@@ -1518,6 +1659,7 @@ async def export_agent_by_agent_id(agent_id: int, tenant_id: str, user_id: str) 
             "display_name") if business_logic_model_info is not None else None
 
     agent_info = ExportAndImportAgentInfo(agent_id=agent_id,
+                                          tenant_id=agent_info["tenant_id"],
                                           name=agent_info["name"],
                                           display_name=agent_info["display_name"],
                                           description=agent_info["description"],
@@ -2491,52 +2633,45 @@ def get_agent_call_relationship_impl(agent_id: int, tenant_id: str) -> dict:
         raise ValueError(f"Failed to get agent call relationship: {str(e)}")
 
 
-async def export_agent_with_skills_impl(agent_id: int, authorization: str) -> dict:
-    """Export an agent, returning a ZIP if it has skill instances, otherwise plain JSON.
+async def export_agent_with_skills_impl(
+    agent_id: int,
+    authorization: str,
+    version_no: int = 0,
+) -> dict:
+    """Export an agent, returning a ZIP if it has skill instances, otherwise a plain dict.
 
     The response is either:
       - A dict with {"_zip": True, "data": bytes, "filename": str} when the agent has skills
-      - A plain dict (JSON string) when the agent has no skills
+      - ExportAndImportDataFormat as a plain dict when the agent has no skills
     """
-    from services.skill_service import SkillService
-
     user_id, tenant_id, _ = get_current_user_info(authorization)
 
-    skill_instances = skill_db.query_skill_instances_by_agent_id(
-        agent_id=agent_id, tenant_id=tenant_id, version_no=0
+    skill_zip_entries = collect_skill_zip_entries(
+        agent_id=agent_id, tenant_id=tenant_id, version_no=version_no
     )
 
-    if not skill_instances:
-        return await export_agent_impl(agent_id, authorization)
+    if not skill_zip_entries:
+        return await export_agent_dict_impl(
+            agent_id, authorization, version_no=version_no
+        )
 
-    skill_names = []
-    for inst in skill_instances:
-        skill_id = inst.get("skill_id")
-        skill = skill_db.get_skill_by_id(skill_id, tenant_id)
-        if skill:
-            skill_names.append(skill.get("name"))
-
-    if not skill_names:
-        return await export_agent_impl(agent_id, authorization)
-
-    agent_json_str = await export_agent_impl(agent_id, authorization)
-
-    skill_service = SkillService(tenant_id=tenant_id)
-    skill_zip_entries = skill_service.export_skills_by_names(
-        skill_names, tenant_id)
+    agent_json_str = await export_agent_impl(
+        agent_id, authorization, version_no=version_no
+    )
 
     zip_buffer = io.BytesIO()
     with zipfile.ZipFile(zip_buffer, "w", zipfile.ZIP_DEFLATED) as zf:
         zf.writestr("agent.json", agent_json_str)
         for entry in skill_zip_entries:
-            skill_zip_bytes = base64.b64decode(entry["skill_zip_base64"])
-            zf.writestr(f"skills/{entry['skill_name']}.zip", skill_zip_bytes)
+            skill_zip_bytes = base64.b64decode(entry.skill_zip_base64)
+            zf.writestr(f"skills/{entry.skill_name}.zip", skill_zip_bytes)
 
     zip_buffer.seek(0)
     zip_data = zip_buffer.read()
 
     agent_info = search_agent_info_by_agent_id(
-        agent_id=agent_id, tenant_id=tenant_id)
+        agent_id=agent_id, tenant_id=tenant_id, version_no=version_no
+    )
     agent_name = agent_info.get(
         "name", "anonymous") if agent_info else "anonymous"
 

--- a/backend/services/agent_version_service.py
+++ b/backend/services/agent_version_service.py
@@ -49,6 +49,17 @@ def _remove_audit_fields_for_insert(data: dict) -> None:
     data.pop('delete_flag', None)
 
 
+def _build_sub_agent_relations(relations: List[dict]) -> List[dict]:
+    """Map relation snapshots to sub-agent relation payloads for API responses."""
+    return [
+        {
+            'agent_id': r['selected_agent_id'],
+            'version_no': r.get('selected_agent_version_no'),
+        }
+        for r in relations
+    ]
+
+
 def publish_version_impl(
     agent_id: int,
     tenant_id: str,
@@ -92,11 +103,18 @@ def publish_version_impl(
         _remove_audit_fields_for_insert(tool_snapshot)
         insert_tool_snapshot(tool_snapshot)
 
-    # Insert relation snapshots
+    # Insert relation snapshots with pinned child agent versions
     for rel in relations_draft:
+        child_id = rel['selected_agent_id']
+        child_version = query_current_version_no(child_id, tenant_id)
+        if child_version is None:
+            raise ValueError(
+                f"Sub-agent {child_id} has no published version; publish the sub-agent first."
+            )
         rel_snapshot = rel.copy()
         rel_snapshot.pop('version_no', None)
         rel_snapshot['version_no'] = new_version_no
+        rel_snapshot['selected_agent_version_no'] = child_version
         _remove_audit_fields_for_insert(rel_snapshot)
         insert_relation_snapshot(rel_snapshot)
 
@@ -271,6 +289,7 @@ def get_version_detail_impl(
 
     # Extract sub_agent_id_list from relations
     result['sub_agent_id_list'] = [r['selected_agent_id'] for r in relations_snapshot]
+    result['sub_agent_relations'] = _build_sub_agent_relations(relations_snapshot)
 
     # Get skill instances for this version (from ag_skill_instance_t with version_no)
     from database import skill_db as skill_db_module
@@ -710,6 +729,7 @@ def _get_version_detail_or_draft(
         # Add tools (only enabled tools)
         result['tools'] = [t for t in tools_draft if t.get('enabled', True)]
         result['sub_agent_id_list'] = [r['selected_agent_id'] for r in relations_draft]
+        result['sub_agent_relations'] = _build_sub_agent_relations(relations_draft)
 
         # Get draft skill instances (version_no=0)
         skills_draft = skill_db_module.query_skill_instances_by_agent_id(
@@ -783,12 +803,11 @@ async def list_published_agents_impl(
             CAN_EDIT_ALL_USER_ROLES,
             get_user_tenant_by_user_id,
             query_group_ids_by_user,
-            PERMISSION_EDIT,
-            PERMISSION_READ,
             get_model_by_model_id,
             check_agent_availability,
             _apply_duplicate_name_availability_rules,
         )
+        from services.asset_owner_visibility import resolve_agent_list_permission
         from database.agent_version_db import query_agent_snapshot
 
         # Get user role for permission check
@@ -858,6 +877,7 @@ async def list_published_agents_impl(
 
             # Extract sub_agent_id_list from relations
             agent_info['sub_agent_id_list'] = [r['selected_agent_id'] for r in relations_snapshot]
+            agent_info['sub_agent_relations'] = _build_sub_agent_relations(relations_snapshot)
 
             # Add published version info
             agent_info['published_version_no'] = current_version_no
@@ -893,7 +913,12 @@ async def list_published_agents_impl(
                     model_cache[model_id] = get_model_by_model_id(model_id, tenant_id)
                 model_info = model_cache.get(model_id)
 
-            permission = PERMISSION_EDIT if can_edit_all or str(agent.get("created_by")) == str(user_id) else PERMISSION_READ
+            permission = resolve_agent_list_permission(
+                user_role=user_role,
+                agent=agent,
+                user_id=user_id,
+                can_edit_all=can_edit_all,
+            )
 
             simple_agent_list.append({
                 "agent_id": agent.get("agent_id"),

--- a/backend/services/vectordatabase_service.py
+++ b/backend/services/vectordatabase_service.py
@@ -354,15 +354,18 @@ def get_embedding_model(
         tenant_id: Tenant ID
         model_name: Optional display name of the embedding model to use.
                    If provided, will find the model by display_name in the tenant's model list.
+        model_type: Optional model type filter. When model_name is omitted, queries tenant
+                   model records by this type; when model_type is also omitted, prefers
+                   embedding models, then multi_embedding models.
 
     Returns:
         Tuple of (embedding model instance or None, model_id or None)
     """
     if model_name:
         try:
-            normalized_model_type = _normalize_model_type(model_type)
-            if normalized_model_type:
-                model = get_model_by_display_name(model_name, tenant_id, normalized_model_type)
+            model_type = _normalize_model_type(model_type)
+            if model_type:
+                model = get_model_by_display_name(model_name, tenant_id, model_type)
             else:
                 model = get_model_by_display_name(model_name, tenant_id)
 
@@ -373,8 +376,25 @@ def get_embedding_model(
             return _create_embedding_model(model), model.get("model_id")
         except Exception as e:
             logger.warning(f"Failed to get embedding model by name {model_name}: {e}")
+    else:
+        try:
+            if model_type:
+                records = get_model_records({"model_type": model_type}, tenant_id)
+            else:
+                records = get_model_records({"model_type": "embedding"}, tenant_id)
+                if not records:
+                    records = get_model_records({"model_type": "multi_embedding"}, tenant_id)
 
-    # No default fallback - return None, None when no model is specified or found
+            if records:
+                model = records[0]
+                if model.get("model_type") in ["embedding", "multi_embedding"]:
+                    return _create_embedding_model(model), model.get("model_id")
+                logger.warning(
+                    f"Resolved model is not an embedding model: {model.get('model_type')}"
+                )
+        except Exception as e:
+            logger.warning(f"Failed to get default embedding model for tenant {tenant_id}: {e}")
+
     return None, None
 
 

--- a/docker/init.sql
+++ b/docker/init.sql
@@ -721,6 +721,7 @@ CREATE TABLE IF NOT EXISTS nexent.ag_agent_relation_t (
     parent_agent_id INTEGER,
     tenant_id VARCHAR(100),
     version_no INTEGER DEFAULT 0 NOT NULL,
+    selected_agent_version_no INTEGER,
     create_time TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     update_time TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     created_by VARCHAR(100),
@@ -753,6 +754,7 @@ COMMENT ON COLUMN nexent.ag_agent_relation_t.selected_agent_id IS 'Selected agen
 COMMENT ON COLUMN nexent.ag_agent_relation_t.parent_agent_id IS 'Parent agent ID';
 COMMENT ON COLUMN nexent.ag_agent_relation_t.tenant_id IS 'Tenant ID';
 COMMENT ON COLUMN nexent.ag_agent_relation_t.version_no IS 'Version number. 0 = draft/editing state, >=1 = published snapshot';
+COMMENT ON COLUMN nexent.ag_agent_relation_t.selected_agent_version_no IS 'Pinned version of selected_agent_id. NULL = use child current published version at runtime (legacy/draft).';
 COMMENT ON COLUMN nexent.ag_agent_relation_t.create_time IS 'Creation time, audit field';
 COMMENT ON COLUMN nexent.ag_agent_relation_t.update_time IS 'Update time, audit field';
 COMMENT ON COLUMN nexent.ag_agent_relation_t.created_by IS 'Creator ID, audit field';
@@ -1266,7 +1268,6 @@ CREATE TABLE IF NOT EXISTS nexent.ag_skill_info_t (
     config_schemas JSON,
     config_values JSON,
     source VARCHAR(30) DEFAULT 'official',
-    tenant_id VARCHAR(100),
     created_by VARCHAR(100),
     create_time TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_by VARCHAR(100),

--- a/docker/sql/v2.2.0_0605_add_ag_agent_repository_t.sql
+++ b/docker/sql/v2.2.0_0605_add_ag_agent_repository_t.sql
@@ -1,0 +1,96 @@
+-- Migration: Add ag_agent_repository_t table
+-- Date: 2026-06-05
+-- Description: Agent marketplace repository for frozen shareable agent snapshots.
+
+SET search_path TO nexent;
+
+BEGIN;
+
+CREATE SEQUENCE IF NOT EXISTS nexent.ag_agent_repository_t_agent_repository_id_seq;
+
+CREATE TABLE IF NOT EXISTS nexent.ag_agent_repository_t (
+    agent_repository_id BIGINT NOT NULL DEFAULT nextval('nexent.ag_agent_repository_t_agent_repository_id_seq'),
+    publisher_tenant_id VARCHAR(100) NOT NULL,
+    publisher_user_id VARCHAR(100) NOT NULL,
+    agent_id INTEGER NOT NULL,
+    source_version_no INTEGER NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    display_name VARCHAR(100),
+    description TEXT,
+    author VARCHAR(100),
+    category_id INTEGER,
+    tags TEXT[],
+    tool_count INTEGER,
+    version_label VARCHAR(100),
+    agent_info_json JSONB NOT NULL,
+    status VARCHAR(30) DEFAULT 'NOT_SHARED',
+    create_time TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    update_time TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    created_by VARCHAR(100),
+    updated_by VARCHAR(100),
+    delete_flag VARCHAR(1) DEFAULT 'N',
+    CONSTRAINT ag_agent_repository_t_pkey PRIMARY KEY (agent_repository_id)
+);
+
+ALTER SEQUENCE nexent.ag_agent_repository_t_agent_repository_id_seq
+    OWNED BY nexent.ag_agent_repository_t.agent_repository_id;
+
+ALTER TABLE nexent.ag_agent_repository_t OWNER TO root;
+
+COMMENT ON TABLE nexent.ag_agent_repository_t IS 'Agent marketplace repository for frozen shareable agent snapshots';
+COMMENT ON COLUMN nexent.ag_agent_repository_t.agent_repository_id IS 'Agent repository listing ID, unique primary key';
+COMMENT ON COLUMN nexent.ag_agent_repository_t.publisher_tenant_id IS 'Publisher tenant ID';
+COMMENT ON COLUMN nexent.ag_agent_repository_t.publisher_user_id IS 'Publisher user ID';
+COMMENT ON COLUMN nexent.ag_agent_repository_t.agent_id IS 'Root agent ID from ag_tenant_agent_t; upsert key with publisher_tenant_id';
+COMMENT ON COLUMN nexent.ag_agent_repository_t.source_version_no IS 'Published version number frozen at share time';
+COMMENT ON COLUMN nexent.ag_agent_repository_t.name IS 'Root agent programmatic name for display and search';
+COMMENT ON COLUMN nexent.ag_agent_repository_t.display_name IS 'Root agent display name';
+COMMENT ON COLUMN nexent.ag_agent_repository_t.description IS 'Root agent description';
+COMMENT ON COLUMN nexent.ag_agent_repository_t.author IS 'Agent author';
+COMMENT ON COLUMN nexent.ag_agent_repository_t.category_id IS 'Optional marketplace category ID';
+COMMENT ON COLUMN nexent.ag_agent_repository_t.tags IS 'Marketplace tags';
+COMMENT ON COLUMN nexent.ag_agent_repository_t.tool_count IS 'Total tool count across all agents in the bundle (display only)';
+COMMENT ON COLUMN nexent.ag_agent_repository_t.version_label IS 'Repository entry version label for display (e.g. v1.0)';
+COMMENT ON COLUMN nexent.ag_agent_repository_t.agent_info_json IS 'Frozen ExportAndImportDataFormat snapshot with optional skills';
+COMMENT ON COLUMN nexent.ag_agent_repository_t.status IS 'Listing status: NOT_SHARED (未共享) / PENDING_REVIEW (待审核) / REJECTED (审核驳回) / SHARED (已共享)';
+COMMENT ON COLUMN nexent.ag_agent_repository_t.create_time IS 'Creation time';
+COMMENT ON COLUMN nexent.ag_agent_repository_t.update_time IS 'Update time';
+COMMENT ON COLUMN nexent.ag_agent_repository_t.created_by IS 'Creator ID';
+COMMENT ON COLUMN nexent.ag_agent_repository_t.updated_by IS 'Updater ID';
+COMMENT ON COLUMN nexent.ag_agent_repository_t.delete_flag IS 'Soft delete flag: Y/N';
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_agent_repository_tenant_agent_active
+    ON nexent.ag_agent_repository_t (publisher_tenant_id, agent_id)
+    WHERE delete_flag = 'N';
+
+CREATE INDEX IF NOT EXISTS idx_agent_repository_publisher_delete
+    ON nexent.ag_agent_repository_t (publisher_tenant_id, delete_flag);
+
+CREATE INDEX IF NOT EXISTS idx_agent_repository_status_delete
+    ON nexent.ag_agent_repository_t (status, delete_flag);
+
+CREATE INDEX IF NOT EXISTS idx_agent_repository_name_delete
+    ON nexent.ag_agent_repository_t (name, delete_flag);
+
+CREATE INDEX IF NOT EXISTS idx_agent_repository_tags_gin
+    ON nexent.ag_agent_repository_t USING GIN (tags);
+
+CREATE OR REPLACE FUNCTION update_ag_agent_repository_update_time()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.update_time = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION update_ag_agent_repository_update_time() IS 'Auto-update update_time for ag_agent_repository_t';
+
+DROP TRIGGER IF EXISTS update_ag_agent_repository_update_time_trigger ON nexent.ag_agent_repository_t;
+CREATE TRIGGER update_ag_agent_repository_update_time_trigger
+BEFORE UPDATE ON nexent.ag_agent_repository_t
+FOR EACH ROW
+EXECUTE FUNCTION update_ag_agent_repository_update_time();
+
+COMMENT ON TRIGGER update_ag_agent_repository_update_time_trigger ON nexent.ag_agent_repository_t IS 'Trigger to maintain update_time';
+
+COMMIT;

--- a/docker/sql/v2.2.0_0609_add_selected_agent_version_no_to_agent_relation_t.sql
+++ b/docker/sql/v2.2.0_0609_add_selected_agent_version_no_to_agent_relation_t.sql
@@ -1,0 +1,15 @@
+-- Migration: Add selected_agent_version_no to ag_agent_relation_t
+-- Date: 2026-06-09
+-- Description: Pin child agent version on parent-child relations at publish time.
+
+SET search_path TO nexent;
+
+BEGIN;
+
+ALTER TABLE nexent.ag_agent_relation_t
+    ADD COLUMN IF NOT EXISTS selected_agent_version_no INTEGER;
+
+COMMENT ON COLUMN nexent.ag_agent_relation_t.selected_agent_version_no IS
+    'Pinned version of selected_agent_id. NULL = use child current published version at runtime (legacy/draft).';
+
+COMMIT;

--- a/test/backend/agents/test_create_agent_info.py
+++ b/test/backend/agents/test_create_agent_info.py
@@ -1487,7 +1487,7 @@ class TestCreateAgentConfig:
     async def test_create_agent_config_basic(self):
         """Test case for basic agent configuration creation"""
         with patch('backend.agents.create_agent_info.search_agent_info_by_agent_id') as mock_search_agent, \
-                patch('backend.agents.create_agent_info.query_sub_agents_id_list') as mock_query_sub, \
+                patch('backend.agents.create_agent_info.query_sub_agent_relations') as mock_query_sub, \
                 patch('backend.agents.create_agent_info.create_tool_config_list') as mock_create_tools, \
                 patch('backend.agents.create_agent_info.get_agent_prompt_template') as mock_get_template, \
                 patch('backend.agents.create_agent_info.tenant_config_manager') as mock_tenant_config, \
@@ -1545,7 +1545,7 @@ class TestCreateAgentConfig:
     async def test_create_agent_config_with_sub_agents(self):
         """Test case for creating agent configuration with sub-agents"""
         with patch('backend.agents.create_agent_info.search_agent_info_by_agent_id') as mock_search_agent, \
-                patch('backend.agents.create_agent_info.query_sub_agents_id_list') as mock_query_sub, \
+                patch('backend.agents.create_agent_info.query_sub_agent_relations') as mock_query_sub, \
                 patch('backend.agents.create_agent_info.create_tool_config_list') as mock_create_tools, \
                 patch('backend.agents.create_agent_info.get_agent_prompt_template') as mock_get_template, \
                 patch('backend.agents.create_agent_info.tenant_config_manager') as mock_tenant_config, \
@@ -1566,7 +1566,9 @@ class TestCreateAgentConfig:
                 "model_id": 123,
                 "provide_run_summary": True
             }
-            mock_query_sub.return_value = ["sub_agent_1"]
+            mock_query_sub.return_value = [
+                {"selected_agent_id": "sub_agent_1", "selected_agent_version_no": None}
+            ]
             mock_create_tools.return_value = []
             mock_get_template.return_value = {
                 "system_prompt": "{{duty}} {{constraint}} {{few_shots}}"}
@@ -1611,10 +1613,69 @@ class TestCreateAgentConfig:
                 )
 
     @pytest.mark.asyncio
+    async def test_create_agent_config_with_pinned_sub_agent_version(self):
+        """Test sub-agent config uses pinned selected_agent_version_no from relation"""
+        with patch('backend.agents.create_agent_info.search_agent_info_by_agent_id') as mock_search_agent, \
+                patch('backend.agents.create_agent_info.query_sub_agent_relations') as mock_query_sub, \
+                patch('backend.agents.create_agent_info.resolve_sub_agent_version_no', return_value=3) as mock_resolve, \
+                patch('backend.agents.create_agent_info.create_tool_config_list', new_callable=AsyncMock) as mock_create_tools, \
+                patch('backend.agents.create_agent_info.get_agent_prompt_template') as mock_get_template, \
+                patch('backend.agents.create_agent_info.tenant_config_manager') as mock_tenant_config, \
+                patch('backend.agents.create_agent_info.build_memory_context') as mock_build_memory, \
+                patch('backend.agents.create_agent_info.AgentConfig') as mock_agent_config, \
+                patch('backend.agents.create_agent_info.prepare_prompt_templates') as mock_prepare_templates, \
+                patch('backend.agents.create_agent_info.get_model_by_model_id') as mock_get_model_by_id:
+
+            mock_search_agent.return_value = {
+                "name": "test_agent",
+                "description": "test description",
+                "duty_prompt": "test duty",
+                "constraint_prompt": "test constraint",
+                "few_shots_prompt": "test few shots",
+                "max_steps": 5,
+                "model_id": 123,
+                "provide_run_summary": True,
+            }
+            mock_query_sub.return_value = [
+                {"selected_agent_id": 42, "selected_agent_version_no": 3}
+            ]
+            mock_create_tools.return_value = []
+            mock_get_template.return_value = {"system_prompt": "{{duty}}"}
+            mock_tenant_config.get_app_config.side_effect = ["TestApp", "Test Description"]
+            mock_build_memory.return_value = Mock(
+                user_config=Mock(memory_switch=False),
+                memory_config={},
+                tenant_id="tenant_1",
+                user_id="user_1",
+                agent_id="agent_1",
+            )
+            mock_prepare_templates.return_value = {"system_prompt": "populated_system_prompt"}
+            mock_get_model_by_id.return_value = {"display_name": "test_model"}
+
+            mock_sub_agent_config = Mock()
+            mock_sub_agent_config.name = "sub_agent"
+
+            with patch(
+                'backend.agents.create_agent_info.create_agent_config',
+                new_callable=AsyncMock,
+                return_value=mock_sub_agent_config,
+            ) as mock_recursive_create:
+                mock_agent_config.reset_mock()
+                await create_agent_config("agent_1", "tenant_1", "user_1", "zh", "test query", version_no=2)
+
+                mock_resolve.assert_called_once_with(
+                    selected_agent_id=42,
+                    selected_agent_version_no=3,
+                    tenant_id="tenant_1",
+                )
+                mock_recursive_create.assert_called_once()
+                assert mock_recursive_create.call_args.kwargs["version_no"] == 3
+
+    @pytest.mark.asyncio
     async def test_create_agent_config_with_memory(self):
         """Test case for creating agent configuration with memory"""
         with patch('backend.agents.create_agent_info.search_agent_info_by_agent_id') as mock_search_agent, \
-                patch('backend.agents.create_agent_info.query_sub_agents_id_list') as mock_query_sub, \
+                patch('backend.agents.create_agent_info.query_sub_agent_relations') as mock_query_sub, \
                 patch('backend.agents.create_agent_info.create_tool_config_list') as mock_create_tools, \
                 patch('backend.agents.create_agent_info.get_agent_prompt_template') as mock_get_template, \
                 patch('backend.agents.create_agent_info.tenant_config_manager') as mock_tenant_config, \
@@ -1678,7 +1739,7 @@ class TestCreateAgentConfig:
             "backend.agents.create_agent_info.search_agent_info_by_agent_id"
         ) as mock_search_agent, \
             patch(
-                "backend.agents.create_agent_info.query_sub_agents_id_list"
+                "backend.agents.create_agent_info.query_sub_agent_relations"
             ) as mock_query_sub, \
             patch(
                 "backend.agents.create_agent_info.create_tool_config_list"
@@ -1756,7 +1817,7 @@ class TestCreateAgentConfig:
     async def test_create_agent_config_model_id_none(self):
         """Test case for creating agent configuration when model_id is None"""
         with patch('backend.agents.create_agent_info.search_agent_info_by_agent_id') as mock_search_agent, \
-                patch('backend.agents.create_agent_info.query_sub_agents_id_list') as mock_query_sub, \
+                patch('backend.agents.create_agent_info.query_sub_agent_relations') as mock_query_sub, \
                 patch('backend.agents.create_agent_info.create_tool_config_list') as mock_create_tools, \
                 patch('backend.agents.create_agent_info.get_agent_prompt_template') as mock_get_template, \
                 patch('backend.agents.create_agent_info.tenant_config_manager') as mock_tenant_config, \
@@ -1817,7 +1878,7 @@ class TestCreateAgentConfig:
                 "backend.agents.create_agent_info.search_agent_info_by_agent_id"
             ) as mock_search_agent,
             patch(
-                "backend.agents.create_agent_info.query_sub_agents_id_list"
+                "backend.agents.create_agent_info.query_sub_agent_relations"
             ) as mock_query_sub,
             patch(
                 "backend.agents.create_agent_info.create_tool_config_list"
@@ -1897,7 +1958,7 @@ class TestCreateAgentConfig:
                 "backend.agents.create_agent_info.search_agent_info_by_agent_id"
             ) as mock_search_agent,
             patch(
-                "backend.agents.create_agent_info.query_sub_agents_id_list"
+                "backend.agents.create_agent_info.query_sub_agent_relations"
             ) as mock_query_sub,
             patch(
                 "backend.agents.create_agent_info.create_tool_config_list"
@@ -1992,7 +2053,7 @@ class TestCreateAgentConfig:
                 "backend.agents.create_agent_info.search_agent_info_by_agent_id"
             ) as mock_search_agent,
             patch(
-                "backend.agents.create_agent_info.query_sub_agents_id_list"
+                "backend.agents.create_agent_info.query_sub_agent_relations"
             ) as mock_query_sub,
             patch(
                 "backend.agents.create_agent_info.create_tool_config_list"
@@ -2087,7 +2148,7 @@ class TestCreateAgentConfig:
                 "backend.agents.create_agent_info.search_agent_info_by_agent_id"
             ) as mock_search_agent,
             patch(
-                "backend.agents.create_agent_info.query_sub_agents_id_list"
+                "backend.agents.create_agent_info.query_sub_agent_relations"
             ) as mock_query_sub,
             patch(
                 "backend.agents.create_agent_info.create_tool_config_list"
@@ -2181,7 +2242,7 @@ class TestCreateAgentConfig:
                 "backend.agents.create_agent_info.search_agent_info_by_agent_id"
             ) as mock_search_agent,
             patch(
-                "backend.agents.create_agent_info.query_sub_agents_id_list"
+                "backend.agents.create_agent_info.query_sub_agent_relations"
             ) as mock_query_sub,
             patch(
                 "backend.agents.create_agent_info.create_tool_config_list"
@@ -2302,7 +2363,7 @@ class TestCreateAgentConfig:
                 "backend.agents.create_agent_info.search_agent_info_by_agent_id"
             ) as mock_search_agent,
             patch(
-                "backend.agents.create_agent_info.query_sub_agents_id_list"
+                "backend.agents.create_agent_info.query_sub_agent_relations"
             ) as mock_query_sub,
             patch(
                 "backend.agents.create_agent_info.create_tool_config_list"
@@ -2413,7 +2474,7 @@ class TestCreateAgentConfig:
                 "backend.agents.create_agent_info.search_agent_info_by_agent_id"
             ) as mock_search_agent,
             patch(
-                "backend.agents.create_agent_info.query_sub_agents_id_list"
+                "backend.agents.create_agent_info.query_sub_agent_relations"
             ) as mock_query_sub,
             patch(
                 "backend.agents.create_agent_info.create_tool_config_list"
@@ -2513,7 +2574,7 @@ class TestCreateAgentConfig:
                 "backend.agents.create_agent_info.search_agent_info_by_agent_id"
             ) as mock_search_agent,
             patch(
-                "backend.agents.create_agent_info.query_sub_agents_id_list"
+                "backend.agents.create_agent_info.query_sub_agent_relations"
             ) as mock_query_sub,
             patch(
                 "backend.agents.create_agent_info.create_tool_config_list"
@@ -2578,7 +2639,7 @@ class TestCreateAgentConfig:
     async def test_create_agent_config_knowledge_base_summary_error(self):
         """Test case for error handling during knowledge base summary build"""
         with patch('backend.agents.create_agent_info.search_agent_info_by_agent_id') as mock_search_agent, \
-                patch('backend.agents.create_agent_info.query_sub_agents_id_list') as mock_query_sub, \
+                patch('backend.agents.create_agent_info.query_sub_agent_relations') as mock_query_sub, \
                 patch('backend.agents.create_agent_info.create_tool_config_list') as mock_create_tools, \
                 patch('backend.agents.create_agent_info.get_agent_prompt_template') as mock_get_template, \
                 patch('backend.agents.create_agent_info.tenant_config_manager') as mock_tenant_config, \

--- a/test/backend/app/test_agent_app.py
+++ b/test/backend/app/test_agent_app.py
@@ -720,7 +720,7 @@ def test_export_agent_api_success(mocker, mock_auth_header):
     """Test export_agent_api success case returning JSON."""
     mock_export_agent = mocker.patch(
         "apps.agent_app.export_agent_with_skills_impl", new_callable=AsyncMock)
-    mock_export_agent.return_value = '{"agent_id": 123, "name": "Test Agent"}'
+    mock_export_agent.return_value = {"agent_id": 123, "name": "Test Agent"}
 
     response = config_client.post(
         "/agent/export",

--- a/test/backend/app/test_agent_repository_app.py
+++ b/test/backend/app/test_agent_repository_app.py
@@ -46,7 +46,7 @@ def test_create_agent_repository_listing_api_success(mocker, mock_auth_header):
     }
 
     response = client.post(
-        "/repository/123/versions/1",
+        "/repository/agent/123/versions/1",
         headers=mock_auth_header,
     )
 
@@ -81,7 +81,7 @@ def test_create_agent_repository_listing_api_draft_version(mocker, mock_auth_hea
     }
 
     response = client.post(
-        "/repository/123/versions/0",
+        "/repository/agent/123/versions/0",
         headers=mock_auth_header,
     )
 
@@ -109,7 +109,7 @@ def test_create_agent_repository_listing_api_bad_request(mocker, mock_auth_heade
     mock_create_listing.side_effect = ValueError("version_no must be >= 0")
 
     response = client.post(
-        "/repository/123/versions/-1",
+        "/repository/agent/123/versions/-1",
         headers=mock_auth_header,
     )
 
@@ -131,7 +131,7 @@ def test_create_agent_repository_listing_api_rejects_asset_owner(mocker, mock_au
     mock_create_listing.side_effect = ValueError("租户管理员智能体无法共享")
 
     response = client.post(
-        "/repository/123/versions/1",
+        "/repository/agent/123/versions/1",
         headers=mock_auth_header,
     )
 
@@ -153,7 +153,7 @@ def test_create_agent_repository_listing_api_exception(mocker, mock_auth_header)
     mock_create_listing.side_effect = Exception("Database error")
 
     response = client.post(
-        "/repository/123/versions/1",
+        "/repository/agent/123/versions/1",
         headers=mock_auth_header,
     )
 

--- a/test/backend/app/test_agent_repository_app.py
+++ b/test/backend/app/test_agent_repository_app.py
@@ -1,0 +1,161 @@
+"""Unit tests for backend.apps.agent_repository_app module."""
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+backend_dir = os.path.abspath(os.path.join(current_dir, "../../../backend"))
+sys.path.insert(0, backend_dir)
+
+sys.modules.setdefault("services.agent_repository_service", MagicMock())
+sys.modules.setdefault("utils.auth_utils", MagicMock())
+
+from apps.agent_repository_app import agent_repository_router
+
+app = FastAPI()
+app.include_router(agent_repository_router)
+client = TestClient(app)
+
+
+@pytest.fixture
+def mock_auth_header():
+    return {"Authorization": "Bearer test_token"}
+
+
+def test_create_agent_repository_listing_api_success(mocker, mock_auth_header):
+    """Test create_agent_repository_listing_api success case."""
+    mock_get_user_id = mocker.patch(
+        "apps.agent_repository_app.get_current_user_id"
+    )
+    mock_create_listing = mocker.patch(
+        "apps.agent_repository_app.create_agent_repository_listing_impl",
+        new_callable=AsyncMock,
+    )
+
+    mock_get_user_id.return_value = ("test_user_id", "test_tenant_id")
+    mock_create_listing.return_value = {
+        "agent_repository_id": 42,
+        "agent_id": 123,
+        "source_version_no": 1,
+        "is_updated": False,
+    }
+
+    response = client.post(
+        "/repository/123/versions/1",
+        headers=mock_auth_header,
+    )
+
+    assert response.status_code == 200
+    mock_get_user_id.assert_called_once_with(mock_auth_header["Authorization"])
+    mock_create_listing.assert_awaited_once_with(
+        agent_id=123,
+        tenant_id="test_tenant_id",
+        user_id="test_user_id",
+        version_no=1,
+    )
+    assert response.json()["agent_repository_id"] == 42
+    assert response.json()["is_updated"] is False
+
+
+def test_create_agent_repository_listing_api_draft_version(mocker, mock_auth_header):
+    """Test create_agent_repository_listing_api with draft version (version_no=0)."""
+    mock_get_user_id = mocker.patch(
+        "apps.agent_repository_app.get_current_user_id"
+    )
+    mock_create_listing = mocker.patch(
+        "apps.agent_repository_app.create_agent_repository_listing_impl",
+        new_callable=AsyncMock,
+    )
+
+    mock_get_user_id.return_value = ("test_user_id", "test_tenant_id")
+    mock_create_listing.return_value = {
+        "agent_repository_id": 42,
+        "agent_id": 123,
+        "source_version_no": 0,
+        "is_updated": True,
+    }
+
+    response = client.post(
+        "/repository/123/versions/0",
+        headers=mock_auth_header,
+    )
+
+    assert response.status_code == 200
+    mock_create_listing.assert_awaited_once_with(
+        agent_id=123,
+        tenant_id="test_tenant_id",
+        user_id="test_user_id",
+        version_no=0,
+    )
+    assert response.json()["source_version_no"] == 0
+
+
+def test_create_agent_repository_listing_api_bad_request(mocker, mock_auth_header):
+    """Test create_agent_repository_listing_api with ValueError."""
+    mock_get_user_id = mocker.patch(
+        "apps.agent_repository_app.get_current_user_id"
+    )
+    mock_create_listing = mocker.patch(
+        "apps.agent_repository_app.create_agent_repository_listing_impl",
+        new_callable=AsyncMock,
+    )
+
+    mock_get_user_id.return_value = ("test_user_id", "test_tenant_id")
+    mock_create_listing.side_effect = ValueError("version_no must be >= 0")
+
+    response = client.post(
+        "/repository/123/versions/-1",
+        headers=mock_auth_header,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "version_no must be >= 0"
+
+
+def test_create_agent_repository_listing_api_rejects_asset_owner(mocker, mock_auth_header):
+    """Test create_agent_repository_listing_api rejects ASSET_OWNER agents with 400."""
+    mock_get_user_id = mocker.patch(
+        "apps.agent_repository_app.get_current_user_id"
+    )
+    mock_create_listing = mocker.patch(
+        "apps.agent_repository_app.create_agent_repository_listing_impl",
+        new_callable=AsyncMock,
+    )
+
+    mock_get_user_id.return_value = ("test_user_id", "test_tenant_id")
+    mock_create_listing.side_effect = ValueError("租户管理员智能体无法共享")
+
+    response = client.post(
+        "/repository/123/versions/1",
+        headers=mock_auth_header,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "租户管理员智能体无法共享"
+
+
+def test_create_agent_repository_listing_api_exception(mocker, mock_auth_header):
+    """Test create_agent_repository_listing_api with general exception."""
+    mock_get_user_id = mocker.patch(
+        "apps.agent_repository_app.get_current_user_id"
+    )
+    mock_create_listing = mocker.patch(
+        "apps.agent_repository_app.create_agent_repository_listing_impl",
+        new_callable=AsyncMock,
+    )
+
+    mock_get_user_id.return_value = ("test_user_id", "test_tenant_id")
+    mock_create_listing.side_effect = Exception("Database error")
+
+    response = client.post(
+        "/repository/123/versions/1",
+        headers=mock_auth_header,
+    )
+
+    assert response.status_code == 500
+    assert "Create agent repository listing error." in response.json()["detail"]

--- a/test/backend/app/test_idata_app.py
+++ b/test/backend/app/test_idata_app.py
@@ -525,21 +525,9 @@ class TestIdataAppRouter:
     def test_router_methods(self):
         """Test that routes have correct HTTP methods."""
         app = _build_app()
+        paths = app.openapi()["paths"]
 
-        # Find routes by path
-        knowledge_space_route = None
-        datasets_route = None
-
-        for route in app.routes:
-            if hasattr(route, 'path'):
-                if route.path == "/idata/knowledge-space":
-                    knowledge_space_route = route
-                elif route.path == "/idata/datasets":
-                    datasets_route = route
-
-        assert knowledge_space_route is not None
-        assert datasets_route is not None
-
-        # Check HTTP methods
-        assert "GET" in [method for method in knowledge_space_route.methods]
-        assert "GET" in [method for method in datasets_route.methods]
+        assert "/idata/knowledge-space" in paths
+        assert "/idata/datasets" in paths
+        assert "get" in paths["/idata/knowledge-space"]
+        assert "get" in paths["/idata/datasets"]

--- a/test/backend/app/test_idata_app.py
+++ b/test/backend/app/test_idata_app.py
@@ -517,10 +517,10 @@ class TestIdataAppRouter:
     def test_routes_registered(self):
         """Test that all routes are registered."""
         app = _build_app()
-        routes = [route.path for route in app.routes]
+        paths = app.openapi()["paths"]
 
-        assert "/idata/knowledge-space" in routes
-        assert "/idata/datasets" in routes
+        assert "/idata/knowledge-space" in paths
+        assert "/idata/datasets" in paths
 
     def test_router_methods(self):
         """Test that routes have correct HTTP methods."""

--- a/test/backend/app/test_northbound_base_app.py
+++ b/test/backend/app/test_northbound_base_app.py
@@ -279,12 +279,12 @@ class TestNorthboundBaseApp(unittest.TestCase):
 
     def test_a2a_router_inclusion(self):
         """A2A router should be registered under /nb/a2a."""
-        routes = [route.path for route in app.routes]
-        self.assertIn("/nb/a2a/{endpoint_id}/.well-known/agent-card.json", routes)
-        self.assertIn("/nb/a2a/{endpoint_id}/v1", routes)
-        self.assertIn("/nb/a2a/{endpoint_id}/message:send", routes)
-        self.assertIn("/nb/a2a/{endpoint_id}/message:stream", routes)
-        self.assertIn("/nb/a2a/{endpoint_id}/tasks/{task_id}", routes)
+        paths = app.openapi()["paths"]
+        self.assertIn("/nb/a2a/{endpoint_id}/.well-known/agent-card.json", paths)
+        self.assertIn("/nb/a2a/{endpoint_id}/v1", paths)
+        self.assertIn("/nb/a2a/{endpoint_id}/message:send", paths)
+        self.assertIn("/nb/a2a/{endpoint_id}/message:stream", paths)
+        self.assertIn("/nb/a2a/{endpoint_id}/tasks/{task_id}", paths)
 
     # -------------------------------------------------------------------
     # Exception handlers - delegated to app_factory which calls register_exception_handlers

--- a/test/backend/app/test_northbound_base_app.py
+++ b/test/backend/app/test_northbound_base_app.py
@@ -274,8 +274,8 @@ class TestNorthboundBaseApp(unittest.TestCase):
 
     def test_router_inclusion(self):
         """The main northbound router should be included."""
-        routes = [route.path for route in app.routes]
-        self.assertIn("/dummy", routes)
+        paths = app.openapi()["paths"]
+        self.assertIn("/dummy", paths)
 
     def test_a2a_router_inclusion(self):
         """A2A router should be registered under /nb/a2a."""

--- a/test/backend/database/test_agent_db.py
+++ b/test/backend/database/test_agent_db.py
@@ -77,6 +77,12 @@ db_models_mock.AgentInfo = MagicMock()
 db_models_mock.ToolInstance = MagicMock()
 db_models_mock.AgentRelation = MagicMock()
 
+# Mock database.agent_version_db before agent_db imports it
+agent_version_db_mock = MagicMock()
+agent_version_db_mock.query_current_version_no = MagicMock(return_value=3)
+sys.modules['database.agent_version_db'] = agent_version_db_mock
+sys.modules['backend.database.agent_version_db'] = agent_version_db_mock
+
 # 将模拟的db_models模块添加到sys.modules中
 sys.modules['database.db_models'] = db_models_mock
 sys.modules['backend.database.db_models'] = db_models_mock
@@ -87,6 +93,8 @@ from backend.database.agent_db import (
     search_agent_id_by_agent_name,
     search_blank_sub_agent_by_main_agent_id,
     query_sub_agents_id_list,
+    query_sub_agent_relations,
+    resolve_sub_agent_version_no,
     create_agent,
     update_agent,
     delete_agent_by_id,
@@ -131,8 +139,9 @@ class MockAgent:
         self.created_by = None
 
 class MockAgentRelation:
-    def __init__(self):
+    def __init__(self, selected_agent_version_no=None):
         self.selected_agent_id = 2
+        self.selected_agent_version_no = selected_agent_version_no
 
 @pytest.fixture
 def mock_session():
@@ -277,6 +286,69 @@ def test_query_sub_agents_id_list(monkeypatch, mock_session):
     result = query_sub_agents_id_list(1, "tenant1")
 
     assert result == [2]
+
+
+def test_query_sub_agent_relations(monkeypatch, mock_session):
+    """Test querying sub-agent relations including pinned version"""
+    session, query = mock_session
+    mock_relation = MockAgentRelation(selected_agent_version_no=2)
+
+    mock_all = MagicMock()
+    mock_all.return_value = [mock_relation]
+    mock_filter = MagicMock()
+    mock_filter.all = mock_all
+    query.filter.return_value = mock_filter
+
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__.return_value = session
+    mock_ctx.__exit__.return_value = None
+    monkeypatch.setattr("backend.database.agent_db.get_db_session", lambda: mock_ctx)
+    monkeypatch.setattr("backend.database.agent_db.as_dict", lambda obj: obj.__dict__)
+
+    result = query_sub_agent_relations(1, "tenant1", version_no=1)
+
+    assert len(result) == 1
+    assert result[0]["selected_agent_id"] == 2
+    assert result[0]["selected_agent_version_no"] == 2
+
+
+def test_resolve_sub_agent_version_no_pinned(monkeypatch):
+    """Test resolve uses pinned version when set"""
+    result = resolve_sub_agent_version_no(
+        selected_agent_id=2,
+        selected_agent_version_no=5,
+        tenant_id="tenant1",
+    )
+    assert result == 5
+
+
+def test_resolve_sub_agent_version_no_fallback(monkeypatch):
+    """Test resolve falls back to child current_version_no when pin is NULL"""
+    monkeypatch.setattr(
+        "backend.database.agent_db.query_current_version_no",
+        MagicMock(return_value=3),
+    )
+    result = resolve_sub_agent_version_no(
+        selected_agent_id=2,
+        selected_agent_version_no=None,
+        tenant_id="tenant1",
+    )
+    assert result == 3
+
+
+def test_resolve_sub_agent_version_no_fallback_to_draft(monkeypatch):
+    """Test resolve falls back to draft when child has no published version"""
+    monkeypatch.setattr(
+        "backend.database.agent_db.query_current_version_no",
+        MagicMock(return_value=None),
+    )
+    result = resolve_sub_agent_version_no(
+        selected_agent_id=2,
+        selected_agent_version_no=None,
+        tenant_id="tenant1",
+    )
+    assert result == 0
+
 
 def test_create_agent_success(monkeypatch, mock_session):
     """测试成功创建agent"""

--- a/test/backend/database/test_agent_version_db.py
+++ b/test/backend/database/test_agent_version_db.py
@@ -171,6 +171,7 @@ class MockAgentRelation:
         self.id = 1
         self.parent_agent_id = 1
         self.selected_agent_id = 2
+        self.selected_agent_version_no = 3
         self.tenant_id = "tenant1"
         self.version_no = 1
         self.delete_flag = "N"
@@ -178,6 +179,7 @@ class MockAgentRelation:
             "id": 1,
             "parent_agent_id": 1,
             "selected_agent_id": 2,
+            "selected_agent_version_no": 3,
             "tenant_id": "tenant1",
             "version_no": 1,
             "delete_flag": "N",
@@ -542,6 +544,25 @@ def test_query_agent_snapshot_success(monkeypatch, mock_session):
     assert tools_list[0]["tool_id"] == 1
     assert len(relations_list) == 1
     assert relations_list[0]["selected_agent_id"] == 2
+    assert relations_list[0]["selected_agent_version_no"] == 3
+
+
+def test_restore_agent_draft_relation_copy_preserves_selected_agent_version_no():
+    """Verify restore draft relation copy keeps selected_agent_version_no unchanged."""
+    rel = {
+        "relation_id": 10,
+        "parent_agent_id": 1,
+        "selected_agent_id": 2,
+        "selected_agent_version_no": 3,
+        "tenant_id": "tenant1",
+        "version_no": 2,
+    }
+    rel_copy = {k: v for k, v in rel.items() if k not in ("version_no",)}
+    rel_copy["version_no"] = 0
+
+    assert rel_copy["selected_agent_version_no"] == 3
+    assert rel_copy["version_no"] == 0
+    assert rel_copy["selected_agent_id"] == 2
 
 
 def test_query_agent_snapshot_no_agent(monkeypatch, mock_session):

--- a/test/backend/services/test_agent_repository_service.py
+++ b/test/backend/services/test_agent_repository_service.py
@@ -1,0 +1,398 @@
+"""Unit tests for agent marketplace repository service."""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+# Mock DB layer before importing the service under test
+sys.modules.setdefault("sqlalchemy", MagicMock())
+sys.modules.setdefault("sqlalchemy.dialects", MagicMock())
+sys.modules.setdefault("sqlalchemy.dialects.postgresql", MagicMock())
+
+_agent_repo_db_mock = MagicMock()
+_agent_repo_db_mock.STATUS_PENDING_REVIEW = "PENDING_REVIEW"
+_agent_repo_db_mock.VALID_REPOSITORY_STATUSES = frozenset({
+    "NOT_SHARED",
+    "PENDING_REVIEW",
+    "REJECTED",
+    "SHARED",
+})
+_agent_repo_db_mock.get_agent_repository_by_id = MagicMock()
+_agent_repo_db_mock.get_agent_repository_by_agent_id = MagicMock()
+_agent_repo_db_mock.insert_agent_repository_record = MagicMock()
+_agent_repo_db_mock.update_agent_repository_by_id = MagicMock()
+sys.modules["database.agent_repository_db"] = _agent_repo_db_mock
+
+_agent_db_mock = MagicMock()
+_agent_db_mock.search_agent_info_by_agent_id = MagicMock()
+sys.modules["database.agent_db"] = _agent_db_mock
+
+_agent_version_db_mock = MagicMock()
+_agent_version_db_mock.search_version_by_version_no = MagicMock()
+sys.modules["database.agent_version_db"] = _agent_version_db_mock
+
+class _SkillZipEntryMock:
+    def __init__(self, skill_name: str, skill_zip_base64: str):
+        self.skill_name = skill_name
+        self.skill_zip_base64 = skill_zip_base64
+
+
+class _AgentRepositorySnapshotMock:
+    def __init__(self, **kwargs):
+        self._data = kwargs
+
+    def model_dump(self):
+        data = dict(self._data)
+        skills = data.get("skills")
+        if skills:
+            data["skills"] = [
+                {
+                    "skill_name": entry.skill_name,
+                    "skill_zip_base64": entry.skill_zip_base64,
+                }
+                for entry in skills
+            ]
+        return data
+
+
+_consts_model_mock = MagicMock()
+_consts_model_mock.AgentRepositorySnapshot = _AgentRepositorySnapshotMock
+_consts_model_mock.SkillZipEntry = _SkillZipEntryMock
+sys.modules["consts.model"] = _consts_model_mock
+
+_agent_service_mock = MagicMock()
+_agent_service_mock.collect_skill_zip_entries = MagicMock(return_value=[])
+_agent_service_mock.export_agent_dict_for_repository_impl = AsyncMock(return_value={
+    "agent_id": 1,
+    "agent_info": {
+        "1": {
+            "agent_id": 1,
+            "name": "agent_one",
+            "description": "desc",
+            "business_description": "biz",
+            "max_steps": 5,
+            "provide_run_summary": False,
+            "enabled": True,
+            "tools": [],
+            "managed_agents": [],
+        }
+    },
+    "mcp_info": [],
+})
+sys.modules["services.agent_service"] = _agent_service_mock
+
+from consts.const import ASSET_OWNER_TENANT_ID
+
+from backend.services import agent_repository_service as ars
+
+
+@pytest.mark.asyncio
+async def test_create_agent_repository_listing_impl_success():
+    agent_info_json = {
+        "agent_id": 1,
+        "agent_info": {"1": {"agent_id": 1, "name": "agent_one"}},
+        "mcp_info": [],
+        "skills": None,
+    }
+    with patch.object(
+        ars, "_build_repository_data_from_agent", new_callable=AsyncMock
+    ) as mock_build_data, patch.object(
+        ars, "get_agent_repository_by_agent_id"
+    ) as mock_get_by_agent_id, patch.object(
+        ars, "insert_agent_repository_record"
+    ) as mock_insert, patch.object(
+        ars, "get_agent_repository_by_id"
+    ) as mock_get_by_id:
+        mock_build_data.return_value = {
+            "agent_id": 1,
+            "source_version_no": 1,
+            "name": "agent_one",
+            "agent_info_json": agent_info_json,
+            "status": "PENDING_REVIEW",
+        }
+        mock_get_by_agent_id.return_value = None
+        mock_insert.return_value = 42
+        mock_get_by_id.return_value = {
+            "agent_repository_id": 42,
+            "agent_id": 1,
+            "name": "agent_one",
+            "agent_info_json": agent_info_json,
+            "source_version_no": 1,
+            "status": "PENDING_REVIEW",
+            "tags": [],
+        }
+
+        result = await ars.create_agent_repository_listing_impl(
+            agent_id=1,
+            tenant_id="tenant_a",
+            user_id="user_a",
+            version_no=1,
+        )
+
+    assert result["agent_repository_id"] == 42
+    assert result["agent_info_json"] == agent_info_json
+    assert result["is_updated"] is False
+    mock_insert.assert_called_once()
+    mock_get_by_agent_id.assert_called_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_create_agent_repository_listing_impl_updates_existing():
+    agent_info_json = {
+        "agent_id": 1,
+        "agent_info": {"1": {"agent_id": 1, "name": "agent_one"}},
+        "mcp_info": [],
+        "skills": None,
+    }
+    with patch.object(
+        ars, "_build_repository_data_from_agent", new_callable=AsyncMock
+    ) as mock_build_data, patch.object(
+        ars, "get_agent_repository_by_agent_id"
+    ) as mock_get_by_agent_id, patch.object(
+        ars, "update_agent_repository_by_id"
+    ) as mock_update, patch.object(
+        ars, "get_agent_repository_by_id"
+    ) as mock_get_by_id:
+        mock_build_data.return_value = {
+            "agent_id": 1,
+            "source_version_no": 2,
+            "name": "agent_one",
+            "agent_info_json": agent_info_json,
+            "status": "PENDING_REVIEW",
+        }
+        mock_get_by_agent_id.return_value = {"agent_repository_id": 42}
+        mock_update.return_value = 1
+        mock_get_by_id.return_value = {
+            "agent_repository_id": 42,
+            "agent_id": 1,
+            "name": "agent_one",
+            "agent_info_json": agent_info_json,
+            "source_version_no": 2,
+            "status": "PENDING_REVIEW",
+            "tags": [],
+        }
+
+        result = await ars.create_agent_repository_listing_impl(
+            agent_id=1,
+            tenant_id="tenant_a",
+            user_id="user_a",
+            version_no=2,
+        )
+
+    assert result["agent_repository_id"] == 42
+    assert result["is_updated"] is True
+    mock_update.assert_called_once()
+    mock_update.assert_called_with(
+        repository_id=42,
+        publisher_tenant_id="tenant_a",
+        user_id="user_a",
+        updates={
+            "source_version_no": 2,
+            "agent_info_json": agent_info_json,
+            "status": "PENDING_REVIEW",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_agent_repository_listing_impl_accepts_draft_version():
+    agent_info_json = {
+        "agent_id": 1,
+        "agent_info": {"1": {"agent_id": 1, "name": "agent_one"}},
+        "mcp_info": [],
+        "skills": None,
+    }
+    with patch.object(
+        ars, "_build_repository_data_from_agent", new_callable=AsyncMock
+    ) as mock_build_data, patch.object(
+        ars, "get_agent_repository_by_agent_id"
+    ) as mock_get_by_agent_id, patch.object(
+        ars, "insert_agent_repository_record"
+    ) as mock_insert, patch.object(
+        ars, "get_agent_repository_by_id"
+    ) as mock_get_by_id:
+        mock_build_data.return_value = {
+            "agent_id": 1,
+            "source_version_no": 0,
+            "name": "agent_one",
+            "agent_info_json": agent_info_json,
+            "status": "PENDING_REVIEW",
+        }
+        mock_get_by_agent_id.return_value = None
+        mock_insert.return_value = 42
+        mock_get_by_id.return_value = {
+            "agent_repository_id": 42,
+            "agent_id": 1,
+            "name": "agent_one",
+            "agent_info_json": agent_info_json,
+            "source_version_no": 0,
+            "status": "PENDING_REVIEW",
+            "tags": [],
+        }
+
+        result = await ars.create_agent_repository_listing_impl(
+            agent_id=1,
+            tenant_id="tenant_a",
+            user_id="user_a",
+            version_no=0,
+        )
+
+    assert result["agent_repository_id"] == 42
+    assert result["source_version_no"] == 0
+    mock_build_data.assert_awaited_once_with(1, "tenant_a", "user_a", 0)
+
+
+@pytest.mark.asyncio
+async def test_create_agent_repository_listing_impl_rejects_negative_version():
+    with pytest.raises(ValueError, match="version_no must be >= 0"):
+        await ars.create_agent_repository_listing_impl(
+            agent_id=1,
+            tenant_id="tenant_a",
+            user_id="user_a",
+            version_no=-1,
+        )
+
+
+def test_validate_create_payload_requires_agent_info_json():
+    with pytest.raises(ValueError, match="agent_info_json"):
+        ars._validate_create_payload({
+            "agent_id": 1,
+            "source_version_no": 1,
+            "name": "agent_one",
+        })
+
+    with pytest.raises(ValueError, match="agent_info_json must contain"):
+        ars._validate_create_payload({
+            "agent_id": 1,
+            "source_version_no": 1,
+            "name": "agent_one",
+            "agent_info_json": {"agent_id": 1},
+        })
+
+
+@pytest.mark.asyncio
+async def test_build_repository_data_from_agent_includes_skills():
+    SkillZipEntry = _consts_model_mock.SkillZipEntry
+
+    _agent_db_mock.search_agent_info_by_agent_id.return_value = {
+        "name": "agent_one",
+        "display_name": "Agent One",
+        "description": "desc",
+        "author": "author",
+    }
+    _agent_service_mock.export_agent_dict_for_repository_impl.return_value = {
+        "agent_id": 1,
+        "agent_info": {
+            "1": {
+                "agent_id": 1,
+                "name": "agent_one",
+                "description": "desc",
+                "business_description": "biz",
+                "max_steps": 5,
+                "provide_run_summary": False,
+                "enabled": True,
+                "tools": [],
+                "managed_agents": [],
+            }
+        },
+        "mcp_info": [],
+    }
+    _agent_service_mock.collect_skill_zip_entries.return_value = [
+        SkillZipEntry(skill_name="SkillA", skill_zip_base64="abc=")
+    ]
+    _agent_version_db_mock.search_version_by_version_no.return_value = {
+        "version_name": "v1.0"
+    }
+
+    result = await ars._build_repository_data_from_agent(
+        agent_id=1,
+        tenant_id="tenant_a",
+        user_id="user_a",
+        version_no=1,
+    )
+
+    assert result["agent_info_json"]["agent_id"] == 1
+    assert result["agent_info_json"]["skills"][0]["skill_name"] == "SkillA"
+    assert result["version_label"] == "v1.0"
+
+
+def test_validate_agent_info_json_rejects_asset_owner_agent():
+    agent_info_json = {
+        "agent_id": 1,
+        "agent_info": {
+            "1": {"agent_id": 1, "tenant_id": ASSET_OWNER_TENANT_ID, "name": "owner_agent"},
+        },
+        "mcp_info": [],
+    }
+    with pytest.raises(ValueError, match="租户管理员智能体无法共享"):
+        ars._validate_agent_info_json_shareable(agent_info_json)
+
+
+def test_validate_agent_info_json_allows_normal_tenant():
+    agent_info_json = {
+        "agent_id": 1,
+        "agent_info": {
+            "1": {"agent_id": 1, "tenant_id": "tenant_a", "name": "agent_one"},
+            "2": {"agent_id": 2, "tenant_id": "tenant_b", "name": "sub_agent"},
+        },
+        "mcp_info": [],
+    }
+    ars._validate_agent_info_json_shareable(agent_info_json)
+
+
+@pytest.mark.asyncio
+async def test_build_repository_data_from_agent_rejects_asset_owner():
+    _agent_db_mock.search_agent_info_by_agent_id.return_value = {
+        "name": "agent_one",
+        "display_name": "Agent One",
+        "description": "desc",
+        "author": "author",
+    }
+    _agent_service_mock.export_agent_dict_for_repository_impl.return_value = {
+        "agent_id": 1,
+        "agent_info": {
+            "1": {
+                "agent_id": 1,
+                "tenant_id": "tenant_a",
+                "name": "agent_one",
+                "description": "desc",
+                "business_description": "biz",
+                "max_steps": 5,
+                "provide_run_summary": False,
+                "enabled": True,
+                "tools": [],
+                "managed_agents": [],
+            },
+            "2": {
+                "agent_id": 2,
+                "tenant_id": ASSET_OWNER_TENANT_ID,
+                "name": "sub_owner_agent",
+                "description": "desc",
+                "business_description": "biz",
+                "max_steps": 5,
+                "provide_run_summary": False,
+                "enabled": True,
+                "tools": [],
+                "managed_agents": [],
+            },
+        },
+        "mcp_info": [],
+    }
+    _agent_service_mock.collect_skill_zip_entries.return_value = []
+    _agent_version_db_mock.search_version_by_version_no.return_value = {
+        "version_name": "v1.0"
+    }
+
+    with pytest.raises(ValueError, match="租户管理员智能体无法共享"):
+        await ars._build_repository_data_from_agent(
+            agent_id=1,
+            tenant_id="tenant_a",
+            user_id="user_a",
+            version_no=1,
+        )

--- a/test/backend/services/test_agent_service.py
+++ b/test/backend/services/test_agent_service.py
@@ -1436,7 +1436,7 @@ async def test_export_agent_impl_success(mock_get_current_user_info, mock_export
     # Verify function calls
     mock_get_current_user_info.assert_called_once_with("Bearer token")
     mock_export_agent_by_id.assert_called_once_with(
-        agent_id=123, tenant_id="test_tenant", user_id="test_user")
+        agent_id=123, tenant_id="test_tenant", user_id="test_user", version_no=0)
     mock_get_mcp_server.assert_called_once_with(
         "test_mcp_server", "test_tenant")
     mock_export_data_format.assert_called_once()
@@ -1516,7 +1516,7 @@ async def test_export_agent_impl_no_mcp_tools(mock_get_current_user_info, mock_e
     # Verify function calls
     mock_get_current_user_info.assert_called_once_with("Bearer token")
     mock_export_agent_by_id.assert_called_once_with(
-        agent_id=123, tenant_id="test_tenant", user_id="test_user")
+        agent_id=123, tenant_id="test_tenant", user_id="test_user", version_no=0)
     # Should not be called when no MCP tools
     mock_get_mcp_server.assert_not_called()
     mock_export_data_format.assert_called_once()
@@ -3064,6 +3064,7 @@ async def test_export_agent_by_agent_id_success(mock_search_agent_info, mock_cre
 
     # Assert
     assert result.agent_id == 123
+    assert result.tenant_id == "test_tenant"
     assert result.name == "Test Agent"
     assert result.business_description == "For testing purposes"
     assert len(result.tools) == 5
@@ -3089,11 +3090,11 @@ async def test_export_agent_by_agent_id_success(mock_search_agent_info, mock_cre
 
     # Verify function calls
     mock_search_agent_info.assert_called_once_with(
-        agent_id=123, tenant_id="test_tenant")
+        agent_id=123, tenant_id="test_tenant", version_no=0)
     mock_create_tool_config.assert_called_once_with(
-        agent_id=123, tenant_id="test_tenant", user_id="test_user")
+        agent_id=123, tenant_id="test_tenant", user_id="test_user", version_no=0)
     mock_query_sub_agents_id.assert_called_once_with(
-        main_agent_id=123, tenant_id="test_tenant")
+        main_agent_id=123, tenant_id="test_tenant", version_no=0)
 
 
 @patch('backend.services.agent_service.create_or_update_tool_by_tool_info')
@@ -8738,6 +8739,175 @@ async def test_list_all_agent_info_impl_asset_owner_agent_read_only_for_admin(
     assert result[0]["permission"] == PERMISSION_READ
 
 
+def _mock_get_agent_info_impl_dependencies(
+    mock_search_agent_info,
+    mock_search_tools,
+    mock_query_sub_agents_id,
+    mock_get_model_by_model_id,
+    mock_check_availability,
+    mock_query_external_sub_agents,
+    mock_skill_service,
+    agent_info,
+):
+    """Configure common mocks for get_agent_info_impl permission tests."""
+    mock_search_agent_info.return_value = agent_info
+    mock_search_tools.return_value = []
+    mock_query_sub_agents_id.return_value = []
+    mock_query_external_sub_agents.return_value = []
+    mock_get_model_by_model_id.return_value = None
+    mock_check_availability.return_value = (True, [])
+    mock_skill_service_instance = MagicMock()
+    mock_skill_service_instance.list_skill_instances.return_value = []
+    mock_skill_service.return_value = mock_skill_service_instance
+
+
+@patch("backend.services.agent_service.SkillService")
+@patch("backend.services.agent_service.query_external_sub_agents")
+@patch("backend.services.agent_service.check_agent_availability")
+@patch("backend.services.agent_service.get_model_by_model_id")
+@patch("backend.services.agent_service.query_sub_agents_id_list")
+@patch("backend.services.agent_service.search_tools_for_sub_agent")
+@patch("backend.services.agent_service.search_agent_info_by_agent_id")
+@patch("backend.services.agent_service.get_user_tenant_by_user_id")
+@pytest.mark.asyncio
+async def test_get_agent_info_impl_asset_owner_agent_read_only_for_admin(
+    mock_get_user_tenant,
+    mock_search_agent_info,
+    mock_search_tools,
+    mock_query_sub_agents_id,
+    mock_get_model_by_model_id,
+    mock_check_availability,
+    mock_query_external_sub_agents,
+    mock_skill_service,
+):
+    """ASSET_OWNER-scoped agent detail is READ_ONLY for ADMIN viewers."""
+    from consts.const import ASSET_OWNER_TENANT_ID, PERMISSION_EDIT, PERMISSION_READ
+
+    agent_info = {
+        "agent_id": 99,
+        "tenant_id": ASSET_OWNER_TENANT_ID,
+        "created_by": "admin_user",
+        "ingroup_permission": PERMISSION_EDIT,
+    }
+    _mock_get_agent_info_impl_dependencies(
+        mock_search_agent_info,
+        mock_search_tools,
+        mock_query_sub_agents_id,
+        mock_get_model_by_model_id,
+        mock_check_availability,
+        mock_query_external_sub_agents,
+        mock_skill_service,
+        agent_info,
+    )
+    mock_get_user_tenant.return_value = {"user_role": "ADMIN"}
+
+    result = await get_agent_info_impl(
+        agent_id=99,
+        tenant_id="regular_tenant",
+        user_id="admin_user",
+    )
+
+    assert result["permission"] == PERMISSION_READ
+
+
+@patch("backend.services.agent_service.SkillService")
+@patch("backend.services.agent_service.query_external_sub_agents")
+@patch("backend.services.agent_service.check_agent_availability")
+@patch("backend.services.agent_service.get_model_by_model_id")
+@patch("backend.services.agent_service.query_sub_agents_id_list")
+@patch("backend.services.agent_service.search_tools_for_sub_agent")
+@patch("backend.services.agent_service.search_agent_info_by_agent_id")
+@patch("backend.services.agent_service.get_user_tenant_by_user_id")
+@pytest.mark.asyncio
+async def test_get_agent_info_impl_asset_owner_agent_read_only_for_dev(
+    mock_get_user_tenant,
+    mock_search_agent_info,
+    mock_search_tools,
+    mock_query_sub_agents_id,
+    mock_get_model_by_model_id,
+    mock_check_availability,
+    mock_query_external_sub_agents,
+    mock_skill_service,
+):
+    """ASSET_OWNER-scoped agent detail is READ_ONLY for DEV even with ingroup EDIT."""
+    from consts.const import ASSET_OWNER_TENANT_ID, PERMISSION_EDIT, PERMISSION_READ
+
+    agent_info = {
+        "agent_id": 99,
+        "tenant_id": ASSET_OWNER_TENANT_ID,
+        "created_by": "asset_owner_user",
+        "ingroup_permission": PERMISSION_EDIT,
+    }
+    _mock_get_agent_info_impl_dependencies(
+        mock_search_agent_info,
+        mock_search_tools,
+        mock_query_sub_agents_id,
+        mock_get_model_by_model_id,
+        mock_check_availability,
+        mock_query_external_sub_agents,
+        mock_skill_service,
+        agent_info,
+    )
+    mock_get_user_tenant.return_value = {"user_role": "DEV"}
+
+    result = await get_agent_info_impl(
+        agent_id=99,
+        tenant_id="regular_tenant",
+        user_id="dev_user",
+    )
+
+    assert result["permission"] == PERMISSION_READ
+
+
+@patch("backend.services.agent_service.SkillService")
+@patch("backend.services.agent_service.query_external_sub_agents")
+@patch("backend.services.agent_service.check_agent_availability")
+@patch("backend.services.agent_service.get_model_by_model_id")
+@patch("backend.services.agent_service.query_sub_agents_id_list")
+@patch("backend.services.agent_service.search_tools_for_sub_agent")
+@patch("backend.services.agent_service.search_agent_info_by_agent_id")
+@patch("backend.services.agent_service.get_user_tenant_by_user_id")
+@pytest.mark.asyncio
+async def test_get_agent_info_impl_asset_owner_role_gets_edit(
+    mock_get_user_tenant,
+    mock_search_agent_info,
+    mock_search_tools,
+    mock_query_sub_agents_id,
+    mock_get_model_by_model_id,
+    mock_check_availability,
+    mock_query_external_sub_agents,
+    mock_skill_service,
+):
+    """ASSET_OWNER role creator retains EDIT on ASSET_OWNER-scoped agent detail."""
+    from consts.const import ASSET_OWNER_ROLE, ASSET_OWNER_TENANT_ID, PERMISSION_EDIT, PERMISSION_READ
+
+    agent_info = {
+        "agent_id": 99,
+        "tenant_id": ASSET_OWNER_TENANT_ID,
+        "created_by": "asset_owner_user",
+        "ingroup_permission": PERMISSION_READ,
+    }
+    _mock_get_agent_info_impl_dependencies(
+        mock_search_agent_info,
+        mock_search_tools,
+        mock_query_sub_agents_id,
+        mock_get_model_by_model_id,
+        mock_check_availability,
+        mock_query_external_sub_agents,
+        mock_skill_service,
+        agent_info,
+    )
+    mock_get_user_tenant.return_value = {"user_role": ASSET_OWNER_ROLE}
+
+    result = await get_agent_info_impl(
+        agent_id=99,
+        tenant_id=ASSET_OWNER_TENANT_ID,
+        user_id="asset_owner_user",
+    )
+
+    assert result["permission"] == PERMISSION_EDIT
+
+
 @pytest.mark.asyncio
 @patch("backend.services.agent_service.get_model_by_model_id")
 @patch("backend.services.agent_service.check_agent_availability")
@@ -9122,79 +9292,73 @@ def test_generate_stream_with_memory_decorated():
 # =============================================================================
 
 @pytest.mark.asyncio
-@patch('backend.services.agent_service.search_agent_info_by_agent_id')
-@patch('backend.services.agent_service.export_agent_impl')
+@patch('backend.services.agent_service.collect_skill_zip_entries')
+@patch('backend.services.agent_service.export_agent_dict_impl')
 @patch('backend.services.agent_service.get_current_user_info')
-async def test_export_agent_with_skills_impl_no_skills(mock_get_user_info, mock_export_impl, mock_search_info):
-    """Test export_agent_with_skills_impl returns JSON when agent has no skill instances."""
+async def test_export_agent_with_skills_impl_no_skills(
+    mock_get_user_info, mock_export_dict_impl, mock_collect_skills
+):
+    """Test export_agent_with_skills_impl returns dict when agent has no skill instances."""
     from backend.services.agent_service import export_agent_with_skills_impl
-    from backend.services import agent_service as ag_svc
 
     mock_get_user_info.return_value = ("user_123", "tenant_abc", "en")
-    mock_export_impl.return_value = '{"agent_id": 1, "agent_info": {}}'
-    mock_search_info.return_value = {"name": "test_agent"}
+    mock_export_dict_impl.return_value = {"agent_id": 1, "agent_info": {}}
+    mock_collect_skills.return_value = []
 
-    # Mock skill_db.query_skill_instances_by_agent_id to return empty list
-    with patch.object(ag_svc.skill_db, 'query_skill_instances_by_agent_id', return_value=[]):
-        result = await export_agent_with_skills_impl(agent_id=1, authorization="Bearer token")
+    result = await export_agent_with_skills_impl(agent_id=1, authorization="Bearer token")
 
-    assert result == '{"agent_id": 1, "agent_info": {}}'
-    mock_export_impl.assert_called_once_with(1, "Bearer token")
+    assert result == {"agent_id": 1, "agent_info": {}}
+    mock_export_dict_impl.assert_called_once_with(
+        1, "Bearer token", version_no=0
+    )
+
+
+@pytest.mark.asyncio
+@patch('backend.services.agent_service.collect_skill_zip_entries')
+@patch('backend.services.agent_service.export_agent_dict_impl')
+@patch('backend.services.agent_service.get_current_user_info')
+async def test_export_agent_with_skills_impl_skills_but_no_names(
+    mock_get_user_info, mock_export_dict_impl, mock_collect_skills
+):
+    """Test export_agent_with_skills_impl returns dict when skill export yields nothing."""
+    from backend.services.agent_service import export_agent_with_skills_impl
+
+    mock_get_user_info.return_value = ("user_123", "tenant_abc", "en")
+    mock_export_dict_impl.return_value = {"agent_id": 1, "agent_info": {}}
+    mock_collect_skills.return_value = []
+
+    result = await export_agent_with_skills_impl(agent_id=1, authorization="Bearer token")
+
+    assert result == {"agent_id": 1, "agent_info": {}}
+    mock_export_dict_impl.assert_called_once()
 
 
 @pytest.mark.asyncio
 @patch('backend.services.agent_service.search_agent_info_by_agent_id')
-@patch('backend.services.agent_service.export_agent_impl')
+@patch('backend.services.agent_service.collect_skill_zip_entries')
 @patch('backend.services.agent_service.get_current_user_info')
-async def test_export_agent_with_skills_impl_skills_but_no_names(mock_get_user_info, mock_export_impl, mock_search_info):
-    """Test export_agent_with_skills_impl returns JSON when skill instances have no names."""
-    from backend.services.agent_service import export_agent_with_skills_impl
-    from backend.services import agent_service as ag_svc
-
-    mock_get_user_info.return_value = ("user_123", "tenant_abc", "en")
-    mock_export_impl.return_value = '{"agent_id": 1, "agent_info": {}}'
-    mock_search_info.return_value = {"name": "test_agent"}
-
-    # Mock skill_db to return skill instances without names
-    with patch.object(ag_svc.skill_db, 'query_skill_instances_by_agent_id', return_value=[{"skill_id": 1}]):
-        with patch.object(ag_svc.skill_db, 'get_skill_by_id', return_value=None):
-            result = await export_agent_with_skills_impl(agent_id=1, authorization="Bearer token")
-
-    assert result == '{"agent_id": 1, "agent_info": {}}'
-    mock_export_impl.assert_called_once()
-
-
-@pytest.mark.asyncio
-@patch('backend.services.agent_service.search_agent_info_by_agent_id')
-@patch('backend.services.agent_service.get_current_user_info')
-async def test_export_agent_with_skills_impl_with_zip(mock_get_user_info, mock_search_info):
+async def test_export_agent_with_skills_impl_with_zip(
+    mock_get_user_info, mock_collect_skills, mock_search_info
+):
     """Test export_agent_with_skills_impl returns ZIP when agent has skills."""
     from backend.services.agent_service import export_agent_with_skills_impl
     from backend.services import agent_service as ag_svc
+    from consts.model import SkillZipEntry
     import io
     import zipfile
 
     mock_get_user_info.return_value = ("user_123", "tenant_abc", "en")
     mock_search_info.return_value = {"name": "my_agent"}
-
-    skill_instance = {"skill_id": 100}
-    skill_info = {"name": "TestSkill", "skill_id": 100}
-
-    mock_skill_service = MagicMock()
-    mock_skill_service.export_skills_by_names.return_value = [
-        {"skill_name": "TestSkill", "skill_zip_base64": "SGVsbG8gV29ybGQ="}  # "Hello World" in base64
+    mock_collect_skills.return_value = [
+        SkillZipEntry(skill_name="TestSkill", skill_zip_base64="SGVsbG8gV29ybGQ=")
     ]
 
-    with patch.object(ag_svc.skill_db, 'query_skill_instances_by_agent_id', return_value=[skill_instance]):
-        with patch.object(ag_svc.skill_db, 'get_skill_by_id', return_value=skill_info):
-            with patch.object(ag_svc, 'export_agent_impl', return_value='{"agent_id": 1}'):
-                with patch('services.skill_service.SkillService', return_value=mock_skill_service):
-                    result = await export_agent_with_skills_impl(agent_id=1, authorization="Bearer token")
+    with patch.object(ag_svc, 'export_agent_impl', return_value='{"agent_id": 1}'):
+        result = await export_agent_with_skills_impl(agent_id=1, authorization="Bearer token")
 
     assert result["_zip"] is True
     assert "data" in result
     assert result["filename"] == "my_agent.zip"
-    # Verify it's a valid ZIP
     zip_data = io.BytesIO(result["data"])
     with zipfile.ZipFile(zip_data, 'r') as zf:
         assert "agent.json" in zf.namelist()
@@ -9980,3 +10144,96 @@ async def test_update_agent_info_impl_example_questions_exceed_limit(mock_get_cu
         await update_agent_info_impl(request, authorization="Bearer token")
 
     assert exc_info.value.error_code == ErrorCode.COMMON_PARAMETER_INVALID
+
+
+# =============================================================================
+# Tests for version_no export and repository export helpers
+# =============================================================================
+
+@pytest.mark.asyncio
+@patch('backend.services.agent_service.resolve_sub_agent_version_no')
+@patch('backend.services.agent_service.query_sub_agent_relations')
+@patch('backend.services.agent_service.export_agent_by_agent_id')
+async def test_export_agent_dict_impl_uses_pinned_sub_agent_versions(
+    mock_export_agent_by_id,
+    mock_query_relations,
+    mock_resolve_version,
+):
+    """BFS export should enqueue sub-agents with their pinned version numbers."""
+    from backend.services.agent_service import export_agent_dict_impl
+    from consts.model import ExportAndImportAgentInfo
+
+    root_agent = ExportAndImportAgentInfo(
+        agent_id=1,
+        name="root",
+        display_name="Root",
+        description="desc",
+        business_description="biz",
+        max_steps=5,
+        provide_run_summary=False,
+        enabled=True,
+        tools=[],
+        managed_agents=[2],
+    )
+    child_agent = ExportAndImportAgentInfo(
+        agent_id=2,
+        name="child",
+        display_name="Child",
+        description="desc",
+        business_description="biz",
+        max_steps=5,
+        provide_run_summary=False,
+        enabled=True,
+        tools=[],
+        managed_agents=[],
+    )
+
+    async def _export_side_effect(agent_id, tenant_id, user_id, version_no=0):
+        if agent_id == 1:
+            return root_agent
+        return child_agent
+
+    mock_export_agent_by_id.side_effect = _export_side_effect
+    mock_query_relations.side_effect = [
+        [{"selected_agent_id": 2, "selected_agent_version_no": 3}],
+        [],
+    ]
+    mock_resolve_version.return_value = 3
+
+    with patch('backend.services.agent_service.get_current_user_info', return_value=("u", "t", "en")):
+        result = await export_agent_dict_impl(agent_id=1, authorization="Bearer token", version_no=2)
+
+    assert result["agent_id"] == 1
+    assert "1" in result["agent_info"]
+    assert "2" in result["agent_info"]
+    mock_export_agent_by_id.assert_any_call(
+        agent_id=1, tenant_id="t", user_id="u", version_no=2
+    )
+    mock_export_agent_by_id.assert_any_call(
+        agent_id=2, tenant_id="t", user_id="u", version_no=3
+    )
+
+
+@pytest.mark.asyncio
+@patch('backend.services.agent_service._export_agent_dict_core')
+async def test_export_agent_dict_for_repository_impl(mock_export_core):
+    """Repository export helper should delegate to core export without auth header."""
+    from backend.services.agent_service import export_agent_dict_for_repository_impl
+
+    mock_export_core.return_value = {
+        "agent_id": 10,
+        "agent_info": {},
+        "mcp_info": [],
+    }
+
+    result = await export_agent_dict_for_repository_impl(
+        agent_id=10, tenant_id="tenant_a", user_id="user_a", version_no=1
+    )
+
+    assert result["agent_id"] == 10
+    mock_export_core.assert_called_once_with(
+        root_agent_id=10,
+        tenant_id="tenant_a",
+        user_id="user_a",
+        version_no=1,
+    )

--- a/test/backend/services/test_agent_service.py
+++ b/test/backend/services/test_agent_service.py
@@ -2988,7 +2988,8 @@ async def test_export_agent_by_agent_id_success(mock_search_agent_info, mock_cre
         "duty_prompt": "Test duty prompt",
         "constraint_prompt": "Test constraint prompt",
         "few_shots_prompt": "Test few shots prompt",
-        "enabled": True
+        "enabled": True,
+        "tenant_id": "test_tenant",
     }
     mock_search_agent_info.return_value = mock_agent_info
 
@@ -5164,6 +5165,7 @@ async def test_export_agent_includes_model_names(
         "constraint_prompt": "Test constraints",
         "few_shots_prompt": "Test examples",
         "enabled": True,
+        "tenant_id": "test_tenant",
         "model_id": 5,
         "business_logic_model_id": 4
     }
@@ -5229,6 +5231,7 @@ async def test_export_agent_with_null_model_id(
         "constraint_prompt": "Test constraints",
         "few_shots_prompt": "Test examples",
         "enabled": True,
+        "tenant_id": "test_tenant",
         "model_id": None,  # NULL in database
         "business_logic_model_id": None  # NULL in database
     }
@@ -5291,6 +5294,7 @@ async def test_export_then_import_preserves_model_names(
         "constraint_prompt": "Follow safety rules",
         "few_shots_prompt": "Example tasks",
         "enabled": True,
+        "tenant_id": "source_tenant",
         "model_id": 10,  # Model ID in source tenant
         "business_logic_model_id": 9  # Business logic model ID in source tenant
     }
@@ -5406,6 +5410,7 @@ async def test_export_agent_model_not_found(
         "constraint_prompt": "Test",
         "few_shots_prompt": "Test",
         "enabled": True,
+        "tenant_id": "test_tenant",
         "model_id": 999,  # This model doesn't exist
         "business_logic_model_id": 998  # This model doesn't exist
     }
@@ -8750,7 +8755,8 @@ def _mock_get_agent_info_impl_dependencies(
     agent_info,
 ):
     """Configure common mocks for get_agent_info_impl permission tests."""
-    mock_search_agent_info.return_value = agent_info
+    defaults = {"model_id": None}
+    mock_search_agent_info.return_value = {**defaults, **agent_info}
     mock_search_tools.return_value = []
     mock_query_sub_agents_id.return_value = []
     mock_query_external_sub_agents.return_value = []

--- a/test/backend/services/test_agent_version_service.py
+++ b/test/backend/services/test_agent_version_service.py
@@ -206,8 +206,13 @@ def mock_tools_draft():
 
 
 @pytest.fixture
-def mock_relations_draft():
+def mock_relations_draft(monkeypatch):
     """Mock relations draft data"""
+    monkeypatch.setattr(
+        agent_version_service_module,
+        "query_current_version_no",
+        MagicMock(return_value=1),
+    )
     return [
         {
             "id": 1,
@@ -279,7 +284,32 @@ def test_publish_version_impl_success(monkeypatch, mock_agent_draft, mock_tools_
     mock_insert_agent.assert_called_once()
     assert mock_insert_tool.call_count == 2
     assert mock_insert_relation.call_count == 1
+    relation_snapshot = mock_insert_relation.call_args[0][0]
+    assert relation_snapshot["selected_agent_version_no"] == 1
     assert mock_insert_skill.call_count == 1
+
+
+def test_publish_version_impl_unpublished_sub_agent(
+    monkeypatch, mock_agent_draft, mock_tools_draft, mock_relations_draft, mock_skills_draft
+):
+    """Test publishing fails when a sub-agent has no published version"""
+    mock_query_draft = MagicMock(
+        return_value=(mock_agent_draft, mock_tools_draft, mock_relations_draft)
+    )
+    monkeypatch.setattr(agent_version_service_module, "query_agent_draft", mock_query_draft)
+    monkeypatch.setattr(
+        agent_version_service_module,
+        "query_current_version_no",
+        MagicMock(return_value=None),
+    )
+    monkeypatch.setattr(agent_version_service_module, "get_next_version_no", MagicMock(return_value=1))
+
+    with pytest.raises(ValueError, match="Sub-agent 2 has no published version"):
+        publish_version_impl(
+            agent_id=1,
+            tenant_id="tenant1",
+            user_id="user1",
+        )
 
 
 def test_publish_version_impl_no_draft(monkeypatch):
@@ -1284,6 +1314,7 @@ def test_get_version_detail_or_draft_draft_version(monkeypatch):
     assert result["version"]["version_status"] == "DRAFT"
     assert len(result["tools"]) == 1
     assert result["sub_agent_id_list"] == [2]
+    assert result["sub_agent_relations"] == [{"agent_id": 2, "version_no": None}]
     assert len(result["skills"]) == 1
 
 

--- a/test/backend/services/test_agent_version_service.py
+++ b/test/backend/services/test_agent_version_service.py
@@ -1,5 +1,6 @@
 import asyncio
 import sys
+import types
 import pytest
 from unittest.mock import patch, MagicMock
 from contextlib import contextmanager
@@ -18,9 +19,25 @@ consts_mock.const.NEXENT_POSTGRES_PASSWORD = "test_password"
 consts_mock.const.POSTGRES_DB = "test_db"
 consts_mock.const.POSTGRES_PORT = 5432
 consts_mock.const.DEFAULT_TENANT_ID = "default_tenant"
+consts_mock.const.AGENT_PROMPTS_HIDDEN_FLAG = "prompts_hidden"
+consts_mock.const.ASSET_OWNER_ROLE = "ASSET_OWNER"
+consts_mock.const.ASSET_OWNER_TENANT_ID = "asset_owner_tenant_id"
+consts_mock.const.ENABLE_ASSET_OWNER_ROLE = False
+consts_mock.const.PERMISSION_EDIT = "EDIT"
+consts_mock.const.PERMISSION_READ = "READ_ONLY"
 
 sys.modules['consts'] = consts_mock
 sys.modules['consts.const'] = consts_mock.const
+
+consts_exceptions_mod = types.ModuleType("consts.exceptions")
+
+
+class ValidationError(Exception):
+    pass
+
+
+consts_exceptions_mod.ValidationError = ValidationError
+sys.modules['consts.exceptions'] = consts_exceptions_mod
 
 # Mock consts.agent_unavailable_reasons
 agent_unavailable_reasons_mock = MagicMock()
@@ -1518,7 +1535,7 @@ def test_list_published_agents_impl_success(monkeypatch):
         return_value=(True, [])
     )
     agent_service_mock._apply_duplicate_name_availability_rules = MagicMock()
-    model_management_db_mock.get_model_by_model_id = MagicMock(
+    agent_service_mock.get_model_by_model_id = MagicMock(
         return_value={"display_name": "Test Model", "model_name": "test_model"}
     )
 
@@ -1671,15 +1688,15 @@ def test_list_published_agents_impl_user_with_groups(monkeypatch):
         return_value=(True, [])
     )
     agent_service_mock._apply_duplicate_name_availability_rules = MagicMock()
-    model_management_db_mock.get_model_by_model_id = MagicMock(
+    agent_service_mock.get_model_by_model_id = MagicMock(
         return_value={"display_name": "Test Model", "model_name": "test_model"}
     )
 
     result = asyncio.run(list_published_agents_impl(tenant_id="tenant1", user_id="user1"))
 
     assert len(result) == 1
-    # User should have READ permission (not EDIT)
-    assert result[0]["permission"] == "READ"
+    # User should have READ_ONLY permission (not EDIT)
+    assert result[0]["permission"] == "READ_ONLY"
 
 
 def test_list_published_agents_impl_model_cache(monkeypatch):
@@ -1721,7 +1738,7 @@ def test_list_published_agents_impl_model_cache(monkeypatch):
         return_value=(True, [])
     )
     agent_service_mock._apply_duplicate_name_availability_rules = MagicMock()
-    model_management_db_mock.get_model_by_model_id = MagicMock(
+    agent_service_mock.get_model_by_model_id = MagicMock(
         return_value={"display_name": "Test Model", "model_name": "test_model"}
     )
 
@@ -1802,7 +1819,7 @@ def test_list_published_agents_impl_is_available_false(monkeypatch):
         return_value=(False, ["model_not_configured"])
     )
     agent_service_mock._apply_duplicate_name_availability_rules = MagicMock()
-    model_management_db_mock.get_model_by_model_id = MagicMock(return_value=None)
+    agent_service_mock.get_model_by_model_id = MagicMock(return_value=None)
 
     result = asyncio.run(list_published_agents_impl(tenant_id="tenant1", user_id="user1"))
 
@@ -1811,8 +1828,7 @@ def test_list_published_agents_impl_is_available_false(monkeypatch):
     assert "model_not_configured" in result[0]["unavailable_reasons"]
 
 
-@pytest.mark.asyncio
-async def test_list_published_agents_impl_exception_handling(monkeypatch):
+def test_list_published_agents_impl_exception_handling(monkeypatch):
     """Test exception handling in list_published_agents_impl"""
     # Mock query_all_agent_info_by_tenant_id to raise an exception
     test_exception = RuntimeError("Database connection failed")
@@ -1827,7 +1843,7 @@ async def test_list_published_agents_impl_exception_handling(monkeypatch):
 
     # Verify that the exception is caught and re-raised as ValueError
     with pytest.raises(ValueError, match="Failed to list published agents: Database connection failed"):
-        await list_published_agents_impl(tenant_id="tenant1", user_id="user1")
+        asyncio.run(list_published_agents_impl(tenant_id="tenant1", user_id="user1"))
 
 
 def test_publish_version_impl_with_a2a_new_agent(monkeypatch, mock_agent_draft, mock_tools_draft, mock_relations_draft, mock_skills_draft):

--- a/test/backend/services/test_mcp_service.py
+++ b/test/backend/services/test_mcp_service.py
@@ -954,14 +954,13 @@ class TestGetMcpManagementApp:
     def test_app_has_routes(self):
         """Test that app has expected routes"""
         app = mcp_service.get_mcp_management_app()
+        paths = app.openapi()["paths"]
 
-        routes = [route.path for route in app.routes]
-
-        assert "/tools/outer_api/refresh" in routes
-        assert "/tools/openapi_service/refresh" in routes
-        assert "/tools/openapi_service" in routes
-        assert "/tools/openapi_service/{service_name}/refresh" in routes
-        assert "/tools/outer_api" in routes
+        assert "/tools/outer_api/refresh" in paths
+        assert "/tools/openapi_service/refresh" in paths
+        assert "/tools/openapi_service" in paths
+        assert "/tools/openapi_service/{service_name}/refresh" in paths
+        assert "/tools/outer_api" in paths
 
 
 # ---------------------------------------------------------------------------

--- a/test/backend/services/test_vectordatabase_service.py
+++ b/test/backend/services/test_vectordatabase_service.py
@@ -4253,73 +4253,172 @@ class TestElasticSearchService(unittest.TestCase):
             # Restart the mock for other tests
             self.get_embedding_model_patcher.start()
 
-    def test_get_embedding_model_unknown_type(self):
+    @patch('backend.services.vectordatabase_service.get_model_records')
+    def test_get_embedding_model_no_model_name_no_records(self, mock_get_model_records):
         """
-        Test get_embedding_model when no model_name is provided.
+        Test get_embedding_model when no model_name is provided and no records exist.
 
         This test verifies that:
-        1. When no model_name is provided, the function returns (None, None)
-        2. The function handles missing model_name gracefully
+        1. When no model_name is provided and no model records exist, returns (None, None)
+        2. Embedding models are queried before multi_embedding models
         """
-        # Stop the mock from setUp to test the real function
+        mock_get_model_records.side_effect = [
+            [],
+            [],
+        ]
+
         self.get_embedding_model_patcher.stop()
 
         try:
-            # Execute - now we can call the real function
             from backend.services.vectordatabase_service import get_embedding_model
             result, model_id = get_embedding_model("test_tenant")
 
-            # Assert
             self.assertIsNone(result)
             self.assertIsNone(model_id)
+            mock_get_model_records.assert_any_call({"model_type": "embedding"}, "test_tenant")
+            mock_get_model_records.assert_any_call({"model_type": "multi_embedding"}, "test_tenant")
         finally:
-            # Restart the mock for other tests
             self.get_embedding_model_patcher.start()
 
-    def test_get_embedding_model_empty_type(self):
+    @patch('backend.services.vectordatabase_service.get_model_records')
+    def test_get_embedding_model_default_embedding_record(self, mock_get_model_records):
         """
-        Test get_embedding_model when no model_name is provided.
+        Test get_embedding_model falls back to the newest embedding model when model_name is omitted.
+        """
+        mock_get_model_records.return_value = [{
+            "model_id": 101,
+            "model_type": "embedding",
+            "model_name": "default-embedding",
+            "model_repo": "openai",
+            "api_key": "test_api_key",
+            "base_url": "https://test.api.com",
+            "max_tokens": 1024,
+            "ssl_verify": True,
+        }]
 
-        This test verifies that:
-        1. When no model_name is provided, the function returns (None, None)
-        2. The function handles missing model_name gracefully
-        """
-        # Stop the mock from setUp to test the real function
         self.get_embedding_model_patcher.stop()
 
         try:
-            # Execute - now we can call the real function
-            from backend.services.vectordatabase_service import get_embedding_model
-            result, model_id = get_embedding_model("test_tenant")
+            with patch('backend.services.vectordatabase_service.OpenAICompatibleEmbedding') as mock_embedding_class, \
+                    patch('backend.services.vectordatabase_service.get_model_name_from_config') as mock_get_model_name:
+                mock_embedding_instance = MagicMock()
+                mock_embedding_class.return_value = mock_embedding_instance
+                mock_get_model_name.return_value = "default-embedding"
 
-            # Assert
-            self.assertIsNone(result)
-            self.assertIsNone(model_id)
+                from backend.services.vectordatabase_service import get_embedding_model
+                result, model_id = get_embedding_model("test_tenant")
+
+                self.assertEqual(result, mock_embedding_instance)
+                self.assertEqual(model_id, 101)
+                mock_get_model_records.assert_called_once_with({"model_type": "embedding"}, "test_tenant")
         finally:
-            # Restart the mock for other tests
             self.get_embedding_model_patcher.start()
 
-    def test_get_embedding_model_missing_type(self):
+    @patch('backend.services.vectordatabase_service.get_model_records')
+    def test_get_embedding_model_fallback_to_multi_embedding(self, mock_get_model_records):
         """
-        Test get_embedding_model when no model_name is provided.
+        Test get_embedding_model falls back to multi_embedding when no embedding model exists.
+        """
+        mock_get_model_records.side_effect = [
+            [],
+            [{
+                "model_id": 202,
+                "model_type": "multi_embedding",
+                "model_name": "default-multi-embedding",
+                "model_repo": "jina",
+                "api_key": "test_api_key",
+                "base_url": "https://test.api.com",
+                "max_tokens": 2048,
+                "ssl_verify": True,
+            }],
+        ]
 
-        This test verifies that:
-        1. When no model_name is provided, the function returns (None, None)
-        2. The function handles missing model_name gracefully
-        """
-        # Stop the mock from setUp to test the real function
         self.get_embedding_model_patcher.stop()
 
         try:
-            # Execute - now we can call the real function
-            from backend.services.vectordatabase_service import get_embedding_model
-            result, model_id = get_embedding_model("test_tenant")
+            with patch('backend.services.vectordatabase_service.JinaEmbedding') as mock_embedding_class, \
+                    patch('backend.services.vectordatabase_service.get_model_name_from_config') as mock_get_model_name:
+                mock_embedding_instance = MagicMock()
+                mock_embedding_class.return_value = mock_embedding_instance
+                mock_get_model_name.return_value = "default-multi-embedding"
 
-            # Assert
-            self.assertIsNone(result)
-            self.assertIsNone(model_id)
+                from backend.services.vectordatabase_service import get_embedding_model
+                result, model_id = get_embedding_model("test_tenant")
+
+                self.assertEqual(result, mock_embedding_instance)
+                self.assertEqual(model_id, 202)
+                self.assertEqual(mock_get_model_records.call_count, 2)
         finally:
-            # Restart the mock for other tests
+            self.get_embedding_model_patcher.start()
+
+    @patch('backend.services.vectordatabase_service.get_model_records')
+    def test_get_embedding_model_default_with_model_type_embedding(self, mock_get_model_records):
+        """
+        Test get_embedding_model queries by the provided model_type when model_name is omitted.
+        """
+        mock_get_model_records.return_value = [{
+            "model_id": 303,
+            "model_type": "embedding",
+            "model_name": "typed-embedding",
+            "model_repo": "openai",
+            "api_key": "test_api_key",
+            "base_url": "https://test.api.com",
+            "max_tokens": 1024,
+            "ssl_verify": True,
+        }]
+
+        self.get_embedding_model_patcher.stop()
+
+        try:
+            with patch('backend.services.vectordatabase_service.OpenAICompatibleEmbedding') as mock_embedding_class, \
+                    patch('backend.services.vectordatabase_service.get_model_name_from_config') as mock_get_model_name:
+                mock_embedding_instance = MagicMock()
+                mock_embedding_class.return_value = mock_embedding_instance
+                mock_get_model_name.return_value = "typed-embedding"
+
+                from backend.services.vectordatabase_service import get_embedding_model
+                result, model_id = get_embedding_model("test_tenant", model_type="embedding")
+
+                self.assertEqual(result, mock_embedding_instance)
+                self.assertEqual(model_id, 303)
+                mock_get_model_records.assert_called_once_with({"model_type": "embedding"}, "test_tenant")
+        finally:
+            self.get_embedding_model_patcher.start()
+
+    @patch('backend.services.vectordatabase_service.get_model_records')
+    def test_get_embedding_model_default_with_model_type_multi_embedding(self, mock_get_model_records):
+        """
+        Test get_embedding_model queries multi_embedding records when model_type is specified.
+        """
+        mock_get_model_records.return_value = [{
+            "model_id": 404,
+            "model_type": "multi_embedding",
+            "model_name": "typed-multi-embedding",
+            "model_repo": "jina",
+            "api_key": "test_api_key",
+            "base_url": "https://test.api.com",
+            "max_tokens": 2048,
+            "ssl_verify": True,
+        }]
+
+        self.get_embedding_model_patcher.stop()
+
+        try:
+            with patch('backend.services.vectordatabase_service.JinaEmbedding') as mock_embedding_class, \
+                    patch('backend.services.vectordatabase_service.get_model_name_from_config') as mock_get_model_name:
+                mock_embedding_instance = MagicMock()
+                mock_embedding_class.return_value = mock_embedding_instance
+                mock_get_model_name.return_value = "typed-multi-embedding"
+
+                from backend.services.vectordatabase_service import get_embedding_model
+                result, model_id = get_embedding_model("test_tenant", model_type="multi_embedding")
+
+                self.assertEqual(result, mock_embedding_instance)
+                self.assertEqual(model_id, 404)
+                mock_get_model_records.assert_called_once_with(
+                    {"model_type": "multi_embedding"}, "test_tenant"
+                )
+        finally:
             self.get_embedding_model_patcher.start()
 
     @patch('backend.services.vectordatabase_service.get_model_by_display_name')


### PR DESCRIPTION
…publish

Introduce ag_agent_repository_t with list/status/publish/import APIs for frozen agent snapshots. Pin selected_agent_version_no on agent relations when publishing so sub-agents resolve to a fixed version at runtime. Extend agent export/import to bundle skills in ZIP payloads and add embedding model fallback when no model name is provided.