### PR TITLE
🐛 Bugfix: Fixed an issue where the MCP service failed to start in a Kubernetes pod.

### DIFF
--- a/sdk/nexent/container/k8s_client.py
+++ b/sdk/nexent/container/k8s_client.py
@@ -8,6 +8,7 @@ for network access.
 import asyncio
 import logging
 import socket
+import re
 import uuid
 
 import kubernetes
@@ -22,6 +23,47 @@ from .container_client_base import ContainerClient
 from .k8s_config import KubernetesContainerConfig
 
 logger = logging.getLogger("nexent.container.kubernetes")
+
+# Kubernetes naming constraints: lowercase alphanumeric or dash, cannot start/end with dash,
+# cannot have consecutive dashes, max 253 characters
+K8S_NAME_PATTERN = re.compile(r"[^a-z0-9-]+")
+K8S_CONSECUTIVE_DASHES = re.compile(r"-+")
+
+
+def _sanitize_k8s_name(name: str) -> str:
+    """Convert arbitrary string to valid Kubernetes resource name.
+
+    Rules:
+    - Convert to lowercase
+    - Replace invalid characters with dash
+    - Collapse consecutive dashes
+    - Remove leading/trailing dashes
+    - Must start with alphanumeric
+
+    Args:
+        name: Input string to sanitize
+
+    Returns:
+        Valid Kubernetes name (lowercase alphanumeric and dashes only)
+    """
+    if not name:
+        return "unknown"
+
+    # Lowercase and replace invalid chars with dash
+    sanitized = K8S_NAME_PATTERN.sub("-", name.lower())
+
+    # Collapse consecutive dashes
+    sanitized = K8S_CONSECUTIVE_DASHES.sub("-", sanitized)
+
+    # Remove leading/trailing dashes
+    sanitized = sanitized.strip("-")
+
+    # Ensure it starts with alphanumeric
+    if sanitized and not sanitized[0].isalnum():
+        sanitized = "x" + sanitized
+
+    # Fallback if empty
+    return sanitized if sanitized else "unknown"
 
 
 class ContainerError(Exception):
@@ -77,9 +119,9 @@ class KubernetesContainerClient(ContainerClient):
 
     def _generate_pod_name(self, service_name: str, tenant_id: str, user_id: str) -> str:
         """Generate unique pod name with service, tenant, and user segments."""
-        safe_name = "".join(c if c.isalnum() or c == "-" else "-" for c in service_name)
-        tenant_part = (tenant_id or "")[:8]
-        user_part = (user_id or "")[:8]
+        safe_name = _sanitize_k8s_name(service_name)
+        tenant_part = _sanitize_k8s_name(tenant_id)[:8]
+        user_part = _sanitize_k8s_name(user_id)[:8]
         uuid_part = uuid.uuid4().hex[:8]
         return f"mcp-{safe_name}-{tenant_part}-{user_part}-{uuid_part}"
 
@@ -486,7 +528,7 @@ class KubernetesContainerClient(ContainerClient):
 
                 # Filter by service_name if provided
                 if service_name:
-                    safe_name = "".join(c if c.isalnum() or c == "-" else "-" for c in service_name)
+                    safe_name = _sanitize_k8s_name(service_name)
                     pod_component = labels.get(self.LABEL_COMPONENT, "")
                     if safe_name not in pod_component:
                         continue

--- a/test/sdk/container/test_k8s_client.py
+++ b/test/sdk/container/test_k8s_client.py
@@ -11,6 +11,7 @@ from nexent.container.k8s_client import (
     KubernetesContainerClient,
     ContainerError,
     ContainerConnectionError,
+    _sanitize_k8s_name,
 )
 from nexent.container.k8s_config import KubernetesContainerConfig
 
@@ -88,6 +89,79 @@ def mock_pod():
     ]
     pod.spec.containers = [container]
     return pod
+
+
+# ---------------------------------------------------------------------------
+# Test _sanitize_k8s_name
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeK8sName:
+    """Test _sanitize_k8s_name helper function"""
+
+    def test_sanitize_basic_alphanumeric(self):
+        """Test basic alphanumeric string passes through"""
+        assert _sanitize_k8s_name("test-service") == "test-service"
+        assert _sanitize_k8s_name("abc123") == "abc123"
+
+    def test_sanitize_lowercase_conversion(self):
+        """Test uppercase letters are converted to lowercase"""
+        assert _sanitize_k8s_name("TestService") == "testservice"
+        assert _sanitize_k8s_name("UPPERCASE") == "uppercase"
+
+    def test_sanitize_special_characters_replaced(self):
+        """Test special characters are replaced with dash"""
+        assert _sanitize_k8s_name("test@service") == "test-service"
+        assert _sanitize_k8s_name("foo#bar") == "foo-bar"
+        assert _sanitize_k8s_name("test$123") == "test-123"
+
+    def test_sanitize_consecutive_special_chars(self):
+        """Test consecutive special characters are collapsed to single dash"""
+        assert _sanitize_k8s_name("foo@@bar") == "foo-bar"
+        assert _sanitize_k8s_name("test@#$service") == "test-service"
+        assert _sanitize_k8s_name("a!!b") == "a-b"
+
+    def test_sanitize_leading_special_chars(self):
+        """Test leading special characters are removed"""
+        assert _sanitize_k8s_name("@test") == "test"
+        assert _sanitize_k8s_name("#foo") == "foo"
+        assert _sanitize_k8s_name("!test@service") == "test-service"
+
+    def test_sanitize_trailing_special_chars(self):
+        """Test trailing special characters are removed"""
+        assert _sanitize_k8s_name("test@") == "test"
+        assert _sanitize_k8s_name("test-service!") == "test-service"
+
+    def test_sanitize_mixed_case_with_specials(self):
+        """Test mixed case with special characters"""
+        assert _sanitize_k8s_name("Foo@Bar!Test") == "foo-bar-test"
+
+    def test_sanitize_empty_string(self):
+        """Test empty string returns 'unknown'"""
+        assert _sanitize_k8s_name("") == "unknown"
+
+    def test_sanitize_only_special_chars(self):
+        """Test string with only special characters returns 'unknown'"""
+        assert _sanitize_k8s_name("@@@") == "unknown"
+        assert _sanitize_k8s_name("!@#") == "unknown"
+
+    def test_sanitize_none(self):
+        """Test None returns 'unknown'"""
+        assert _sanitize_k8s_name(None) == "unknown"
+
+    def test_sanitize_with_dots(self):
+        """Test dots are converted to dashes"""
+        assert _sanitize_k8s_name("foo.bar") == "foo-bar"
+        assert _sanitize_k8s_name("foo...bar") == "foo-bar"
+
+    def test_sanitize_underscore_replaced(self):
+        """Test underscores are replaced with dash"""
+        assert _sanitize_k8s_name("foo_bar") == "foo-bar"
+
+    def test_sanitize_spaces_replaced(self):
+        """Test spaces are replaced with dash"""
+        assert _sanitize_k8s_name("foo bar") == "foo-bar"
+        assert _sanitize_k8s_name("foo  bar") == "foo-bar"
 
 
 # ---------------------------------------------------------------------------
@@ -192,6 +266,72 @@ class TestGeneratePodName:
             assert "@" not in name
             assert "#" not in name
 
+    def test_generate_pod_name_consecutive_special_chars(self, k8s_container_client):
+        """Test pod name generation with consecutive special characters"""
+        with patch("nexent.container.k8s_client.uuid.uuid4") as mock_uuid:
+            mock_uuid.return_value.hex = "a1b2c3d4"
+            name = k8s_container_client._generate_pod_name(
+                "foo@@bar", "tenant123", "user12345")
+            assert name == "mcp-foo-bar-tenant12-user1234-a1b2c3d4"
+            assert "--" not in name
+
+    def test_generate_pod_name_leading_special_chars(self, k8s_container_client):
+        """Test pod name generation with leading special characters"""
+        with patch("nexent.container.k8s_client.uuid.uuid4") as mock_uuid:
+            mock_uuid.return_value.hex = "a1b2c3d4"
+            name = k8s_container_client._generate_pod_name(
+                "@test-service", "tenant123", "user12345")
+            # "@test-service" -> "test-service" (leading @ stripped)
+            assert name.startswith("mcp-test")
+            assert not name.startswith("mcp-@")
+
+    def test_generate_pod_name_trailing_special_chars(self, k8s_container_client):
+        """Test pod name generation with trailing special characters"""
+        with patch("nexent.container.k8s_client.uuid.uuid4") as mock_uuid:
+            mock_uuid.return_value.hex = "a1b2c3d4"
+            name = k8s_container_client._generate_pod_name(
+                "test-service@", "tenant123", "user12345")
+            assert name == "mcp-test-service-tenant12-user1234-a1b2c3d4"
+            assert name.endswith("-a1b2c3d4")
+
+    def test_generate_pod_name_uppercase(self, k8s_container_client):
+        """Test pod name generation with uppercase letters"""
+        with patch("nexent.container.k8s_client.uuid.uuid4") as mock_uuid:
+            mock_uuid.return_value.hex = "a1b2c3d4"
+            name = k8s_container_client._generate_pod_name(
+                "TestService", "tenant123", "user12345")
+            assert name == "mcp-testservice-tenant12-user1234-a1b2c3d4"
+
+    def test_generate_pod_name_underscores(self, k8s_container_client):
+        """Test pod name generation with underscores"""
+        with patch("nexent.container.k8s_client.uuid.uuid4") as mock_uuid:
+            mock_uuid.return_value.hex = "a1b2c3d4"
+            name = k8s_container_client._generate_pod_name(
+                "test_service", "tenant_123", "user_12345")
+            # tenant_123 -> tenant-123 (9 chars), truncated to 8 -> tenant-1
+            # user_12345 -> user-12345 (10 chars), truncated to 8 -> user-123
+            assert name == "mcp-test-service-tenant-1-user-123-a1b2c3d4"
+
+    def test_generate_pod_name_dots(self, k8s_container_client):
+        """Test pod name generation with dots"""
+        with patch("nexent.container.k8s_client.uuid.uuid4") as mock_uuid:
+            mock_uuid.return_value.hex = "a1b2c3d4"
+            name = k8s_container_client._generate_pod_name(
+                "test.service", "tenant.123", "user.12345")
+            # tenant.123 -> tenant.123 (9 chars), truncated to 8 -> tenant.1
+            # user.12345 -> user.12345 (10 chars), truncated to 8 -> user.123
+            assert name == "mcp-test-service-tenant-1-user-123-a1b2c3d4"
+
+    def test_generate_pod_name_spaces(self, k8s_container_client):
+        """Test pod name generation with spaces"""
+        with patch("nexent.container.k8s_client.uuid.uuid4") as mock_uuid:
+            mock_uuid.return_value.hex = "a1b2c3d4"
+            name = k8s_container_client._generate_pod_name(
+                "test service", "tenant 123", "user 12345")
+            # tenant 123 -> tenant 123 (9 chars), truncated to 8 -> tenant 1
+            # user 12345 -> user 12345 (10 chars), truncated to 8 -> user 123
+            assert name == "mcp-test-service-tenant-1-user-123-a1b2c3d4"
+
     def test_generate_pod_name_long_user_id(self, k8s_container_client):
         """Test pod name generation with long user ID"""
         long_user_id = "a" * 20
@@ -216,7 +356,7 @@ class TestGeneratePodName:
             mock_uuid.return_value.hex = "a1b2c3d4"
             name = k8s_container_client._generate_pod_name(
                 "test-service", "", "user12345")
-            assert name == "mcp-test-service--user1234-a1b2c3d4"
+            assert name == "mcp-test-service-unknown-user1234-a1b2c3d4"
 
     def test_generate_pod_name_empty_user(self, k8s_container_client):
         """Test pod name generation with empty user_id"""
@@ -224,7 +364,7 @@ class TestGeneratePodName:
             mock_uuid.return_value.hex = "a1b2c3d4"
             name = k8s_container_client._generate_pod_name(
                 "test-service", "tenant123", "")
-            assert name == "mcp-test-service-tenant12--a1b2c3d4"
+            assert name == "mcp-test-service-tenant12-unknown-a1b2c3d4"
 
     def test_generate_pod_name_none_tenant(self, k8s_container_client):
         """Test pod name generation with None tenant_id"""
@@ -232,7 +372,7 @@ class TestGeneratePodName:
             mock_uuid.return_value.hex = "a1b2c3d4"
             name = k8s_container_client._generate_pod_name(
                 "test-service", None, "user12345")
-            assert name == "mcp-test-service--user1234-a1b2c3d4"
+            assert name == "mcp-test-service-unknown-user1234-a1b2c3d4"
 
     def test_generate_pod_name_none_user(self, k8s_container_client):
         """Test pod name generation with None user_id"""
@@ -240,7 +380,7 @@ class TestGeneratePodName:
             mock_uuid.return_value.hex = "a1b2c3d4"
             name = k8s_container_client._generate_pod_name(
                 "test-service", "tenant123", None)
-            assert name == "mcp-test-service-tenant12--a1b2c3d4"
+            assert name == "mcp-test-service-tenant12-unknown-a1b2c3d4"
 
 
 # ---------------------------------------------------------------------------
@@ -1264,6 +1404,26 @@ class TestListContainers:
         result = k8s_container_client.list_containers(service_name="test@service#123")
 
         assert len(result) == 0
+
+    def test_list_containers_service_filter_consecutive_special_chars(self, k8s_container_client, mock_pod):
+        """Test listing containers with service filter containing consecutive special characters"""
+        k8s_container_client.core_v1.list_namespaced_pod.return_value = MagicMock(items=[mock_pod])
+
+        # The sanitized version of "test@@service" is "test-service"
+        # Since mock_pod's component is "test-service", it should match
+        result = k8s_container_client.list_containers(service_name="test@@service")
+
+        assert len(result) == 1
+
+    def test_list_containers_service_filter_leading_special_chars(self, k8s_container_client, mock_pod):
+        """Test listing containers with service filter containing leading special characters"""
+        k8s_container_client.core_v1.list_namespaced_pod.return_value = MagicMock(items=[mock_pod])
+
+        # The sanitized version of "@test-service" is "test-service" (leading @ stripped)
+        # Since mock_pod's component is "test-service", it should match
+        result = k8s_container_client.list_containers(service_name="@test-service")
+
+        assert len(result) == 1
 
     def test_list_containers_pod_no_ports(self, k8s_container_client):
         """Test listing containers when pod has no ports configured"""


### PR DESCRIPTION
🐛 Bugfix: Fixed an issue where the MCP service failed to start in a Kubernetes pod.
fixes #3253 
[Specification Details]
1. Modify the pod naming logic to convert all non-compliant characters to -.
2. Modify test cases.