### PR TITLE
🐛 Bugfix: Fixed an issue where the one-click rename function failed after importing an agent.

### DIFF
--- a/frontend/components/agent/AgentImportWizard.tsx
+++ b/frontend/components/agent/AgentImportWizard.tsx
@@ -393,7 +393,6 @@ export default function AgentImportWizard({
         items: agentsWithConflicts.map(([agentKey, conflict]) => {
           const agentInfo = initialData.agent_info[agentKey] as any;
           return {
-            agent_id: agentInfo?.agent_id,
             name: conflict.renamedName || agentInfo?.name || "",
             display_name: conflict.renamedDisplayName || agentInfo?.display_name || "",
             task_description: agentInfo?.business_description || agentInfo?.description || "",


### PR DESCRIPTION
🐛 Bugfix: Fixed an issue where the one-click rename function failed after importing an agent.
closed #3257 
[Specification Details]
1. The frontend does not pass `agent_id` when calling the `regenerate_name` API.
[Test Result]
<img width="845" height="671" alt="img_v3_0212p_ede29927-c0c8-4523-9ba4-44e84927e3eg" src="https://github.com/user-attachments/assets/7a5ee188-14d2-46ef-82fe-b26e5803d162" />
