### PR TITLE
Fix: OpenAI LLM test memory exhaustion during collection

### DIFF
--- a/test/sdk/core/models/test_openai_llm.py
+++ b/test/sdk/core/models/test_openai_llm.py
@@ -103,16 +103,10 @@ def _setup_stubs():
     sys.modules["smolagents.models"] = sa_mod
 
 _setup_stubs()
-# Now that stubs are in place, attempt to execute the module so imports resolve to our stubs.
-# If this early import fails, clean up the partial module so the later, properly-patched import can run.
-try:
-    spec.loader.exec_module(openai_llm_module)
-    OpenAIModel = getattr(openai_llm_module, "OpenAIModel", None)
-except Exception:
-    # Remove any partially-imported module to avoid interfering with later imports
-    if MODULE_NAME in sys.modules:
-        del sys.modules[MODULE_NAME]
-    OpenAIModel = None
+# Do not execute the module here.  The import below runs after the full mock
+# graph is installed; importing it twice can initialise the real monitoring
+# stack during collection and exhaust local resources.
+OpenAIModel = None
 
 
 def make_chunk(content, reasoning=None, role=None):


### PR DESCRIPTION
## Problem

`test/sdk/core/models/test_openai_llm.py` was calling `spec.loader.exec_module()` at module level during test collection. This triggered a second import of `openai_llm` before the full mock graph was installed, which initialised the real monitoring stack and exhausted local resources (memory).

## Fix

Remove the premature `exec_module()` call and its try/except cleanup. Instead, defer the import to the test body where the mock graph is fully in place. `OpenAIModel` is set to `None` at module level and resolved lazily.

## Changes

- `test/sdk/core/models/test_openai_llm.py` — removed 10 lines of eager module execution, added explanatory comment (4 lines)