### PR TITLE
[codex] Fix modelengine message flattening

### DIFF
--- a/sdk/nexent/core/models/message_utils.py
+++ b/sdk/nexent/core/models/message_utils.py
@@ -47,3 +47,18 @@ def prepare_messages_for_completion(normalized_messages: List[Any], model_factor
         return prepared
     return normalized_messages
 
+
+def prepare_messages_for_smolagents_text_flattening(normalized_messages: List[Any]) -> List[Any]:
+    """
+    Normalize message content for smolagents' flatten_messages_as_text path.
+
+    smolagents expects each message content to be a list whose first item is a
+    text dict when flatten_messages_as_text=True. Plain string content otherwise
+    fails with TypeError: string indices must be integers.
+    """
+    for msg in normalized_messages:
+        if isinstance(msg, dict):
+            msg["content"] = [{"type": "text", "text": _flatten_content(msg.get("content"))}]
+        else:
+            msg.content = [{"type": "text", "text": _flatten_content(getattr(msg, "content", None))}]
+    return normalized_messages

--- a/sdk/nexent/core/models/openai_llm.py
+++ b/sdk/nexent/core/models/openai_llm.py
@@ -32,6 +32,7 @@ from .prompt_cache import (
     extract_prompt_cache_usage,
     resolve_prompt_cache_profile,
 )
+from .message_utils import prepare_messages_for_smolagents_text_flattening
 
 logger = logging.getLogger("openai_llm")
 
@@ -216,12 +217,19 @@ ssl_verify=True, model_factory: Optional[str] = None,
                 **{f"llm.param.{k}": v for k, v in kwargs.items() if isinstance(v, (str, int, float, bool))}
             )
 
+        flatten_messages_as_text = self.model_factory == "modelengine"
+        messages_for_completion = (
+            prepare_messages_for_smolagents_text_flattening(normalized_messages)
+            if flatten_messages_as_text
+            else normalized_messages
+        )
+
         completion_kwargs = self._prepare_completion_kwargs(
-            messages=normalized_messages, stop_sequences=stop_sequences,
+            messages=messages_for_completion, stop_sequences=stop_sequences,
             response_format=response_format, tools_to_call_from=tools_to_call_from, model=self.model_id,
             custom_role_conversions=self.custom_role_conversions, convert_images_to_image_urls=True,
             temperature=self.temperature, top_p=self.top_p,
-            flatten_messages_as_text=self.model_factory == "modelengine", **kwargs,
+            flatten_messages_as_text=flatten_messages_as_text, **kwargs,
         )
 
         completion_kwargs["stream_options"] = {"include_usage": True}

--- a/test/sdk/core/models/test_message_utils.py
+++ b/test/sdk/core/models/test_message_utils.py
@@ -4,7 +4,11 @@ from pathlib import Path
 # Ensure sdk/ is on sys.path so package imports resolve in the test environment
 sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "sdk"))
 
-from nexent.core.models.message_utils import _flatten_content, prepare_messages_for_completion
+from nexent.core.models.message_utils import (
+    _flatten_content,
+    prepare_messages_for_completion,
+    prepare_messages_for_smolagents_text_flattening,
+)
 from types import SimpleNamespace
 
 
@@ -50,4 +54,13 @@ def test_prepare_messages_modelengine_with_objects_and_case_insensitive():
     assert prepared[0]["role"] == "system"
     assert "b" in prepared[1]["content"]
 
+
+def test_prepare_messages_for_smolagents_text_flattening_uses_text_part_shape():
+    obj1 = SimpleNamespace(role="system", content="SYS")
+    obj2 = SimpleNamespace(role="user", content=["a", {"text": "b"}])
+
+    prepared = prepare_messages_for_smolagents_text_flattening([obj1, obj2])
+
+    assert prepared[0].content == [{"type": "text", "text": "SYS"}]
+    assert prepared[1].content == [{"type": "text", "text": "ab"}]
 


### PR DESCRIPTION
## Summary

Fixes the ModelEngine chat path after the smolagents 2.14 upgrade by normalizing message content before using `flatten_messages_as_text=True`.

## Root Cause

`smolagents.get_clean_message_list(..., flatten_messages_as_text=True)` expects each message content to be a list with a first text part. The runtime agent path passed plain string content, so smolagents attempted `message.content[0]["text"]` on a string and raised `TypeError: string indices must be integers, not 'str'`.

## Changes

- Add a shared helper to normalize message content into smolagents expected text-part shape.
- Use that helper for the `model_factory == "modelengine"` path in `OpenAIModel` before preparing completion kwargs.
- Add coverage for string and structured content normalization.

## Validation

- `backend/.venv/bin/python -m pytest test/sdk/core/models/test_message_utils.py test/sdk/core/models/test_openai_llm.py -q`
- Manual runtime smoke check with a fake streaming client confirmed ModelEngine messages flatten to provider-safe plain text.
