### PR TITLE
🐛 Bugfix: Fixed an issue where calls to external tool interfaces returning a 401 status code would cause Nexent to log out.

### DIFF
--- a/backend/consts/error_code.py
+++ b/backend/consts/error_code.py
@@ -249,20 +249,23 @@ ERROR_CODE_HTTP_STATUS = {
     ErrorCode.SYSTEM_DATABASE_ERROR: 500,
     ErrorCode.SYSTEM_INTERNAL_ERROR: 500,
     # Dify (module 13)
+    # Auth failures against upstream services (Dify/iData/AIDP) are mapped to 502,
+    # not 401. 401 is reserved for this system's identity/session failures only,
+    # so the frontend can safely treat any 401 as a session-expired signal.
     ErrorCode.DIFY_CONFIG_INVALID: 400,
-    ErrorCode.DIFY_AUTH_ERROR: 401,
+    ErrorCode.DIFY_AUTH_ERROR: 502,
     ErrorCode.DIFY_CONNECTION_ERROR: 502,
     ErrorCode.DIFY_RESPONSE_ERROR: 502,
     ErrorCode.DIFY_RATE_LIMIT: 429,
     # iData (module 13)
     ErrorCode.IDATA_CONFIG_INVALID: 400,
-    ErrorCode.IDATA_AUTH_ERROR: 401,
+    ErrorCode.IDATA_AUTH_ERROR: 502,
     ErrorCode.IDATA_CONNECTION_ERROR: 502,
     ErrorCode.IDATA_RESPONSE_ERROR: 502,
     ErrorCode.IDATA_RATE_LIMIT: 429,
     # AIDP (module 13)
     ErrorCode.AIDP_CONFIG_INVALID: 400,
-    ErrorCode.AIDP_AUTH_ERROR: 401,
+    ErrorCode.AIDP_AUTH_ERROR: 502,
     ErrorCode.AIDP_CONNECTION_ERROR: 502,
     # OAuth (module 16)
     ErrorCode.OAUTH_PROVIDER_NOT_CONFIGURED: 400,

--- a/test/backend/consts/test_error_code.py
+++ b/test/backend/consts/test_error_code.py
@@ -169,9 +169,12 @@ class TestErrorCodeValues:
 class TestErrorCodeHttpStatusMapping:
     """Test class for ERROR_CODE_HTTP_STATUS mapping."""
 
-    def test_dify_auth_error_maps_to_401(self):
-        """Test DIFY_AUTH_ERROR maps to HTTP 401."""
-        assert ERROR_CODE_HTTP_STATUS[ErrorCode.DIFY_AUTH_ERROR] == 401
+    def test_dify_auth_error_maps_to_502(self):
+        """Upstream Dify auth failures are mapped to 502 (bad gateway), not 401.
+
+        401 is reserved for this system's identity/session failures only.
+        """
+        assert ERROR_CODE_HTTP_STATUS[ErrorCode.DIFY_AUTH_ERROR] == 502
 
     def test_dify_config_invalid_maps_to_400(self):
         """Test DIFY_CONFIG_INVALID maps to HTTP 400."""
@@ -249,9 +252,12 @@ class TestErrorCodeHttpStatusMapping:
         """Test SYSTEM_TIMEOUT maps to HTTP 504."""
         assert ERROR_CODE_HTTP_STATUS[ErrorCode.SYSTEM_TIMEOUT] == 504
 
-    def test_idata_auth_error_maps_to_401(self):
-        """Test IDATA_AUTH_ERROR maps to HTTP 401."""
-        assert ERROR_CODE_HTTP_STATUS[ErrorCode.IDATA_AUTH_ERROR] == 401
+    def test_idata_auth_error_maps_to_502(self):
+        """Upstream iData auth failures are mapped to 502 (bad gateway), not 401.
+
+        401 is reserved for this system's identity/session failures only.
+        """
+        assert ERROR_CODE_HTTP_STATUS[ErrorCode.IDATA_AUTH_ERROR] == 502
 
     def test_idata_config_invalid_maps_to_400(self):
         """Test IDATA_CONFIG_INVALID maps to HTTP 400."""

--- a/test/backend/consts/test_exceptions.py
+++ b/test/backend/consts/test_exceptions.py
@@ -57,14 +57,19 @@ class TestAppException:
         assert result["details"] is None
 
     def test_app_exception_http_status_property(self):
-        """Test AppException.http_status property."""
+        """Test AppException.http_status property.
+
+        Upstream auth failures (e.g. DIFY_AUTH_ERROR) map to 502, not 401,
+        so that 401 is reserved exclusively for this system's identity/session
+        failures.
+        """
         exc = AppException(ErrorCode.DIFY_AUTH_ERROR)
-        assert exc.http_status == 401
+        assert exc.http_status == 502
 
     def test_app_exception_http_status_for_different_codes(self):
         """Test http_status for different error codes."""
         test_cases = [
-            (ErrorCode.DIFY_AUTH_ERROR, 401),
+            (ErrorCode.DIFY_AUTH_ERROR, 502),
             (ErrorCode.DIFY_CONFIG_INVALID, 400),
             (ErrorCode.DIFY_RATE_LIMIT, 429),
             (ErrorCode.COMMON_VALIDATION_ERROR, 400),

--- a/test/backend/middleware/test_exception_handler.py
+++ b/test/backend/middleware/test_exception_handler.py
@@ -25,7 +25,7 @@ from backend.middleware.exception_handler import (
     create_success_response,
 )
 from consts.exceptions import AppException
-from consts.error_code import ErrorCode
+from consts.error_code import ErrorCode, ERROR_CODE_HTTP_STATUS
 from unittest.mock import patch, MagicMock, AsyncMock, Mock
 
 
@@ -153,7 +153,9 @@ class TestCreateErrorResponse:
         """Test creating error response with default values."""
         response = create_error_response(ErrorCode.DIFY_AUTH_ERROR)
 
-        assert response.status_code == 401
+        # Upstream auth failures map to 502 (see DIFY_AUTH_ERROR in ERROR_CODE_HTTP_STATUS);
+        # 401 is reserved for this system's identity/session failures.
+        assert response.status_code == ERROR_CODE_HTTP_STATUS[ErrorCode.DIFY_AUTH_ERROR]
         assert response.body is not None
 
     def test_create_error_response_custom_message(self):
@@ -164,7 +166,7 @@ class TestCreateErrorResponse:
             message=custom_message
         )
 
-        assert response.status_code == 401
+        assert response.status_code == ERROR_CODE_HTTP_STATUS[ErrorCode.DIFY_AUTH_ERROR]
 
     def test_create_error_response_with_trace_id(self):
         """Test creating error response with trace ID."""
@@ -174,7 +176,7 @@ class TestCreateErrorResponse:
             trace_id=trace_id
         )
 
-        assert response.status_code == 401
+        assert response.status_code == ERROR_CODE_HTTP_STATUS[ErrorCode.DIFY_AUTH_ERROR]  
 
     def test_create_error_response_with_details(self):
         """Test creating error response with additional details."""
@@ -196,10 +198,14 @@ class TestCreateErrorResponse:
         assert response.status_code == 502
 
     def test_create_error_response_dify_auth_error(self):
-        """Test creating error response for DIFY_AUTH_ERROR."""
+        """Test creating error response for DIFY_AUTH_ERROR.
+
+        Upstream Dify auth failures map to 502; 401 is reserved for this
+        system's identity/session failures only.
+        """
         response = create_error_response(ErrorCode.DIFY_AUTH_ERROR)
 
-        assert response.status_code == 401
+        assert response.status_code == ERROR_CODE_HTTP_STATUS[ErrorCode.DIFY_AUTH_ERROR]  
 
     def test_create_error_response_dify_config_invalid(self):
         """Test creating error response for DIFY_CONFIG_INVALID."""
@@ -305,7 +311,8 @@ class TestExceptionHandlerMiddleware:
 
         response = await middleware.dispatch(mock_request, mock_call_next)
 
-        assert response.status_code == 401
+        # Upstream auth failures are mapped to 502 in ERROR_CODE_HTTP_STATUS.
+        assert response.status_code == ERROR_CODE_HTTP_STATUS[ErrorCode.DIFY_AUTH_ERROR]  
 
     @pytest.mark.asyncio
     async def test_dispatch_http_exception(self):


### PR DESCRIPTION
🐛 Bugfix: Fixed an issue where calls to external tool interfaces returning a 401 status code would cause Nexent to log out.
closes #3263 

[Specification Details]
1. Map the 401 status code from the external interface to the 502 status code within Nexent.
[Test Result]
<img width="878" height="722" alt="e8072ceb-1f93-4637-80df-1f50283a5674" src="https://github.com/user-attachments/assets/0ccff438-e75c-4105-9f1a-d6e3e36e0eb1" />

<img width="524" height="153" alt="5f34d8aa-589f-4e5d-b50f-c29f77b905b6" src="https://github.com/user-attachments/assets/d03d4b3b-2119-41d4-871a-bea97901938c" />

