### PR TITLE
fix: ContextComponent.to_messages() returns smolagents-compatible list content

### DIFF
--- a/sdk/nexent/core/agents/agent_context.py
+++ b/sdk/nexent/core/agents/agent_context.py
@@ -1377,7 +1377,7 @@ class ContextManager:
         ]
 
         stable_text = "\n\n".join(
-            str(message.get("content", "")) for message in stable_messages
+            self._extract_message_text(message) for message in stable_messages
         )
         memory.system_prompt = SystemPromptStep(
             system_prompt=stable_text or fallback_system_prompt
@@ -1497,8 +1497,8 @@ class ContextManager:
             undefined=StrictUndefined,
         ).render(task=task or "")
         return (
-            [{"role": "system", "content": pre_messages}],
-            [{"role": "user", "content": post_messages}],
+            [{"role": "system", "content": [{"type": "text", "text": pre_messages}]}],
+            [{"role": "user", "content": [{"type": "text", "text": post_messages}]}],
         )
 
     @staticmethod
@@ -1543,6 +1543,22 @@ class ContextManager:
         return self._estimate_text_tokens(
             json.dumps(self._normalize_for_fingerprint(tools), ensure_ascii=False, sort_keys=True, default=str)
         )
+
+    @staticmethod
+    def _extract_message_text(message: Any) -> str:
+        """Extract plain text from a message dict or ChatMessage."""
+        content = (
+            message.get("content", "")
+            if isinstance(message, dict)
+            else getattr(message, "content", "")
+        )
+        if isinstance(content, list):
+            return "".join(
+                str(part.get("text", ""))
+                for part in content
+                if isinstance(part, dict)
+            )
+        return "" if content is None else str(content)
 
     @staticmethod
     def _message_role(message: Any) -> Optional[str]:

--- a/sdk/nexent/core/agents/agent_model.py
+++ b/sdk/nexent/core/agents/agent_model.py
@@ -395,13 +395,18 @@ class ContextComponent(BaseModel, ABC):
     metadata: Dict[str, Any] = Field(description="Additional metadata", default_factory=dict)
 
     @abstractmethod
-    def to_messages(self) -> List[Dict[str, str]]:
+    def to_messages(self) -> List[Dict[str, Any]]:
         """Convert component content to message format for LLM.
 
         Returns:
             List of message dicts with 'role' and 'content' keys.
         """
         pass
+
+    @staticmethod
+    def _text_message(role: str, text: str) -> Dict[str, Any]:
+        """Build smolagents-compatible text-part message content."""
+        return {"role": role, "content": [{"type": "text", "text": text}]}
 
     def estimate_tokens(self, chars_per_token: float = 1.5) -> int:
         """Estimate token count from content length.
@@ -412,7 +417,17 @@ class ContextComponent(BaseModel, ABC):
         Returns:
             Estimated token count.
         """
-        total_chars = sum(len(m.get("content", "")) for m in self.to_messages())
+        total_chars = 0
+        for m in self.to_messages():
+            content = m.get("content", "")
+            if isinstance(content, list):
+                total_chars += sum(
+                    len(part.get("text", ""))
+                    for part in content
+                    if isinstance(part, dict)
+                )
+            else:
+                total_chars += len(str(content))
         return int(total_chars / chars_per_token)
 
 
@@ -422,8 +437,8 @@ class SystemPromptComponent(ContextComponent):
     content: str = Field(description="Rendered system prompt content")
     template_name: Optional[str] = Field(description="Source template name", default=None)
 
-    def to_messages(self) -> List[Dict[str, str]]:
-        return [{"role": "system", "content": self.content}]
+    def to_messages(self) -> List[Dict[str, Any]]:
+        return [self._text_message("system", self.content)]
 
 
 class ToolsComponent(ContextComponent):
@@ -432,9 +447,9 @@ class ToolsComponent(ContextComponent):
     tools: List[Dict[str, Any]] = Field(description="List of tool definitions", default_factory=list)
     formatted_description: str = Field(description="Pre-formatted tool descriptions text", default="")
 
-    def to_messages(self) -> List[Dict[str, str]]:
+    def to_messages(self) -> List[Dict[str, Any]]:
         if self.formatted_description:
-            return [{"role": "system", "content": self.formatted_description}]
+            return [self._text_message("system", self.formatted_description)]
         return []
 
     def add_tool(self, name: str, description: str, inputs: str, output_type: str) -> None:
@@ -453,9 +468,9 @@ class SkillsComponent(ContextComponent):
     skills: List[Dict[str, Any]] = Field(description="List of skill definitions", default_factory=list)
     formatted_description: str = Field(description="Pre-formatted skill summaries text", default="")
 
-    def to_messages(self) -> List[Dict[str, str]]:
+    def to_messages(self) -> List[Dict[str, Any]]:
         if self.formatted_description:
-            return [{"role": "system", "content": self.formatted_description}]
+            return [self._text_message("system", self.formatted_description)]
         return []
 
     def add_skill(self, name: str, description: str) -> None:
@@ -473,12 +488,12 @@ class MemoryComponent(ContextComponent):
     formatted_content: str = Field(description="Pre-formatted memory context text", default="")
     search_query: Optional[str] = Field(description="Query used to search memory", default=None)
 
-    def to_messages(self) -> List[Dict[str, str]]:
+    def to_messages(self) -> List[Dict[str, Any]]:
         if self.formatted_content:
             # Memory is user/session-specific dynamic context.  Keeping it out
             # of the authoritative system prefix preserves cross-turn cache
             # reuse without changing its content or selection semantics.
-            return [{"role": "user", "content": self.formatted_content}]
+            return [self._text_message("user", self.formatted_content)]
         return []
 
     def add_memory(self, content: str, memory_type: str = "user", metadata: Dict[str, Any] = None) -> None:
@@ -496,12 +511,12 @@ class KnowledgeBaseComponent(ContextComponent):
     summary: str = Field(description="Knowledge base summary text", default="")
     kb_ids: List[str] = Field(description="Knowledge base IDs used", default_factory=list)
 
-    def to_messages(self) -> List[Dict[str, str]]:
+    def to_messages(self) -> List[Dict[str, Any]]:
         if self.summary:
             # Retrieved knowledge is request-dependent evidence, not
             # authoritative instruction.  Keeping it dynamic protects the
             # stable cache prefix when retrieval results change between turns.
-            return [{"role": "user", "content": self.summary}]
+            return [self._text_message("user", self.summary)]
         return []
 
 
@@ -511,9 +526,9 @@ class ManagedAgentsComponent(ContextComponent):
     agents: List[Dict[str, Any]] = Field(description="Managed agent definitions", default_factory=list)
     formatted_description: str = Field(description="Pre-formatted agent descriptions", default="")
 
-    def to_messages(self) -> List[Dict[str, str]]:
+    def to_messages(self) -> List[Dict[str, Any]]:
         if self.formatted_description:
-            return [{"role": "system", "content": self.formatted_description}]
+            return [self._text_message("system", self.formatted_description)]
         return []
 
     def add_agent(self, name: str, description: str, tools: List[str] = None) -> None:
@@ -531,9 +546,9 @@ class ExternalAgentsComponent(ContextComponent):
     agents: List[Dict[str, Any]] = Field(description="External A2A agent definitions", default_factory=list)
     formatted_description: str = Field(description="Pre-formatted agent descriptions", default="")
 
-    def to_messages(self) -> List[Dict[str, str]]:
+    def to_messages(self) -> List[Dict[str, Any]]:
         if self.formatted_description:
-            return [{"role": "system", "content": self.formatted_description}]
+            return [self._text_message("system", self.formatted_description)]
         return []
 
     def add_agent(self, agent_id: str, name: str, description: str, url: str) -> None:

--- a/test/backend/utils/test_context_component_types.py
+++ b/test/backend/utils/test_context_component_types.py
@@ -464,14 +464,14 @@ class TestComponentToMessages:
             formatted_description="test desc",
         )
         messages = comp.to_messages()
-        assert messages == [{"role": "system", "content": "test desc"}]
+        assert messages == [{"role": "system", "content": [{"type": "text", "text": "test desc"}]}]
 
     def test_knowledge_base_component_to_messages(self):
         from nexent.core.agents.agent_model import KnowledgeBaseComponent
 
         comp = KnowledgeBaseComponent(summary="KB summary")
         messages = comp.to_messages()
-        assert messages == [{"role": "user", "content": "KB summary"}]
+        assert messages == [{"role": "user", "content": [{"type": "text", "text": "KB summary"}]}]
 
     def test_knowledge_base_component_empty_summary_no_messages(self):
         from nexent.core.agents.agent_model import KnowledgeBaseComponent
@@ -485,14 +485,14 @@ class TestComponentToMessages:
 
         comp = MemoryComponent(formatted_content="memory text")
         messages = comp.to_messages()
-        assert messages == [{"role": "user", "content": "memory text"}]
+        assert messages == [{"role": "user", "content": [{"type": "text", "text": "memory text"}]}]
 
     def test_tools_component_to_messages(self):
         from nexent.core.agents.agent_model import ToolsComponent
 
         comp = ToolsComponent(formatted_description="tools text")
         messages = comp.to_messages()
-        assert messages == [{"role": "system", "content": "tools text"}]
+        assert messages == [{"role": "system", "content": [{"type": "text", "text": "tools text"}]}]
 
 
 class TestFullPromptAssembly:
@@ -519,7 +519,10 @@ class TestFullPromptAssembly:
         all_messages = []
         for comp in components:
             all_messages.extend(comp.to_messages())
-        combined = "\n".join(msg["content"] for msg in all_messages)
+        combined = "\n".join(
+            msg["content"][0]["text"] if isinstance(msg["content"], list) else msg["content"]
+            for msg in all_messages
+        )
         assert "\u57fa\u672c\u4fe1\u606f" in combined or "Basic Information" in combined
         assert "\u6838\u5fc3\u804c\u8d23" in combined or "Core Responsibilities" in combined
         assert "\u6267\u884c\u6d41\u7a0b" in combined or "Execution Process" in combined
@@ -537,7 +540,10 @@ class TestFullPromptAssembly:
         all_messages = []
         for comp in components:
             all_messages.extend(comp.to_messages())
-        combined = "\n".join(msg["content"] for msg in all_messages)
+        combined = "\n".join(
+            msg["content"][0]["text"] if isinstance(msg["content"], list) else msg["content"]
+            for msg in all_messages
+        )
         assert "Basic Information" in combined
         assert "Core Responsibilities" in combined
         assert "Execution Process" in combined

--- a/test/sdk/core/agents/test_agent_context/unit/test_component_management.py
+++ b/test/sdk/core/agents/test_agent_context/unit/test_component_management.py
@@ -20,7 +20,7 @@ for _path in (str(PROJECT_ROOT), str(TEST_ROOT)):
     if _path not in sys.path:
         sys.path.insert(0, _path)
 
-from loader import ContextManager, ContextManagerConfig
+from loader import ContextManager, ContextManagerConfig, ChatMessage, MessageRole
 from stubs import _SystemPromptStep
 
 
@@ -318,6 +318,38 @@ class TestComponentManagementWithConfig:
         cm.register_component(comp)
         registered = cm.get_registered_components()
         assert registered[0].token_estimate > 0
+
+
+class TestExtractMessageText:
+    """Tests for ContextManager._extract_message_text static method."""
+
+    def test_dict_with_list_content(self):
+        msg = {"role": "system", "content": [{"type": "text", "text": "hello"}]}
+        assert ContextManager._extract_message_text(msg) == "hello"
+
+    def test_dict_with_string_content(self):
+        msg = {"role": "system", "content": "plain text"}
+        assert ContextManager._extract_message_text(msg) == "plain text"
+
+    def test_dict_with_none_content(self):
+        msg = {"role": "system", "content": None}
+        assert ContextManager._extract_message_text(msg) == ""
+
+    def test_chatmessage_object_with_list_content(self):
+        msg = ChatMessage(role=MessageRole.SYSTEM, content=[{"type": "text", "text": "from object"}])
+        assert ContextManager._extract_message_text(msg) == "from object"
+
+    def test_chatmessage_object_with_string_content(self):
+        msg = ChatMessage(role=MessageRole.SYSTEM, content="string from object")
+        assert ContextManager._extract_message_text(msg) == "string from object"
+
+    def test_dict_missing_content_key(self):
+        msg = {"role": "system"}
+        assert ContextManager._extract_message_text(msg) == ""
+
+    def test_list_content_with_non_dict_parts(self):
+        msg = {"role": "system", "content": [{"type": "text", "text": "a"}, "raw_string"]}
+        assert ContextManager._extract_message_text(msg) == "a"
 
 
 if __name__ == "__main__":

--- a/test/sdk/core/agents/test_context_component.py
+++ b/test/sdk/core/agents/test_context_component.py
@@ -324,7 +324,7 @@ class TestSystemPromptComponent:
         messages = comp.to_messages()
         assert len(messages) == 1
         assert messages[0]["role"] == "system"
-        assert messages[0]["content"] == "Test prompt content"
+        assert messages[0]["content"] == [{"type": "text", "text": "Test prompt content"}]
 
     def test_with_template_name(self):
         comp = agent_model_module.SystemPromptComponent(

--- a/test/sdk/core/agents/test_context_component.py
+++ b/test/sdk/core/agents/test_context_component.py
@@ -23,7 +23,7 @@ import types
 import importlib.util
 from pathlib import Path
 from types import ModuleType
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -340,6 +340,14 @@ class TestSystemPromptComponent:
         tokens = comp.estimate_tokens(chars_per_token=1.5)
         assert tokens > 0
         assert tokens == int(len("This is a test prompt with some words.") / 1.5)
+
+    def test_estimate_tokens_with_string_content_fallback(self):
+        """estimate_tokens handles legacy string content via str() fallback."""
+        comp = agent_model_module.SystemPromptComponent(content="hello world")
+        with patch.object(agent_model_module.SystemPromptComponent, "to_messages",
+                          return_value=[{"role": "system", "content": "hello world"}]):
+            tokens = comp.estimate_tokens(chars_per_token=1.5)
+            assert tokens == int(len("hello world") / 1.5)
 
     def test_default_priority(self):
         comp = agent_model_module.SystemPromptComponent(content="test")

--- a/test/sdk/core/agents/test_context_manager_assembly.py
+++ b/test/sdk/core/agents/test_context_manager_assembly.py
@@ -10,6 +10,16 @@ from nexent.core.agents.agent_model import (
 from nexent.core.agents.summary_config import ContextManagerConfig
 
 
+def _message_text(message):
+    """Extract text from list-format or string-format message content."""
+    content = message["content"] if isinstance(message, dict) else message.content
+    if isinstance(content, list):
+        return "".join(
+            part.get("text", "") for part in content if isinstance(part, dict)
+        )
+    return content
+
+
 class _Memory:
     def __init__(self):
         self.system_prompt = None
@@ -22,7 +32,7 @@ class _Step:
         self.content = content
 
     def to_messages(self):
-        return [{"role": self.role, "content": self.content}]
+        return [{"role": self.role, "content": [{"type": "text", "text": self.content}]}]
 
 
 def test_context_manager_assembles_stable_dynamic_and_history_messages():
@@ -41,7 +51,7 @@ def test_context_manager_assembles_stable_dynamic_and_history_messages():
         tools=[{"name": "z"}, {"name": "a"}],
     )
 
-    assert [message["content"] for message in final.messages] == [
+    assert [_message_text(message) for message in final.messages] == [
         "stable policy",
         "memory fact",
         "kb fact",
@@ -82,7 +92,7 @@ def test_context_manager_owns_final_answer_assembly():
         "user",
         "assistant",
     ]
-    assert [message["content"] for message in final.messages[:4]] == [
+    assert [_message_text(message) for message in final.messages[:4]] == [
         "stable policy",
         "final instruction",
         "memory fact",


### PR DESCRIPTION
## Root Cause

Agent conversations fail with `Error: wrong content: <system prompt text>` when using non-modelengine model providers with `enable_context_manager` enabled.

**Error chain:**
```
core_agent.py → self.model(input_messages)
  → openai_llm.py → _prepare_completion_kwargs()
    → smolagents/models.py → get_clean_message_list()
      → assert isinstance(message.content, list), "Error: wrong content:" + str(message.content)
```

`ContextComponent.to_messages()` returned `{"content": "string"}` but smolagents v1.23 requires `{"content": [{"type": "text", "text": "..."}]}` when merging consecutive same-role messages.

The `prepare_messages_for_smolagents_text_flattening` mitigation in `openai_llm.py` only activated for `model_factory == "modelengine"`, leaving all other providers (OpenAI, Silicon, etc.) with string content that triggered the assertion.

## Changes

### Production code
- **`sdk/nexent/core/agents/agent_model.py`**: All 8 `to_messages()` methods now return list-format content via new `_text_message()` static helper. `estimate_tokens()` rewritten to handle list content.
- **`sdk/nexent/core/agents/agent_context.py`**: `prepare_run_context` uses new `_extract_message_text()` for stable_text assembly. `_purpose_messages` returns list-format content.

### Tests
- `test/sdk/core/agents/test_context_component.py`: 1 assertion updated
- `test/backend/utils/test_context_component_types.py`: 6 assertions updated
- `test/sdk/core/agents/test_context_manager_assembly.py`: `_message_text` helper + `_Step` stub + 2 assertions updated

## Verification

All 521 directly related and adjacent tests pass:
- `test_context_component.py`: 68/68
- `test_context_component_types.py`: 38/38
- `test_context_manager_assembly.py`: 4/4
- `test_agent_context/`: 126/126
- `test_agent_model.py`: 224/224
- `test_openai_llm.py`: 53/53
- `test_message_utils.py`: 8/8

<img width="1010" height="1207" alt="img_v3_02134_13b444fd-2bfd-4d3d-abe2-8efd9391230g" src="https://github.com/user-attachments/assets/a04d3e22-314d-4d0b-9f24-a185dee83de4" />