### PR TITLE
fix: improve tool selection panel i18n and MCP grouping

### DIFF
--- a/frontend/app/[locale]/agents/components/AgentConfigComp.tsx
+++ b/frontend/app/[locale]/agents/components/AgentConfigComp.tsx
@@ -198,6 +198,7 @@ export default function AgentConfigComp({}: AgentConfigCompProps) {
                     size="small"
                     icon={<Wrench size={14} />}
                     onClick={() => setIsToolSelectOpen(true)}
+                    disabled={currentAgentId === null && !isCreatingMode}
                     className="h-7 gap-1 text-xs bg-white border border-gray-200 hover:!border-gray-300 hover:!bg-gray-50"
                   >
                     {t("toolPool.selectTools")}

--- a/frontend/app/[locale]/agents/components/agentConfig/ToolManagement.tsx
+++ b/frontend/app/[locale]/agents/components/agentConfig/ToolManagement.tsx
@@ -150,7 +150,7 @@ export default function ToolManagement({ isCreatingMode, currentAgentId }: ToolM
                     >
                       <ChevronRight className={`size-3.5 shrink-0 text-gray-400 transition-transform ${!isCollapsed ? "rotate-90" : ""}`} />
                       <span className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${accent}`}>
-                        {cat.category}
+                        {t(cat.category)}
                       </span>
                       <span className="text-[10px] text-gray-400">
                         {cat.tools.length}

--- a/frontend/app/[locale]/agents/components/agentConfig/tool/SelectToolsDialog.tsx
+++ b/frontend/app/[locale]/agents/components/agentConfig/tool/SelectToolsDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Modal, Tabs, Input, Checkbox, Button, Select } from "antd";
 import type { TabsProps } from "antd";
@@ -92,7 +92,11 @@ export default function SelectToolsDialog({
       );
       const catMap = new Map<string, any[]>();
       for (const tool of sourceTools) {
-        const cat = tool.category?.trim() || "toolPool.category.other";
+        // MCP tools are grouped by server name (usage); local/langchain by category
+        const cat =
+          tab.key === "mcp"
+            ? tool.usage?.trim() || "toolPool.category.other"
+            : tool.category?.trim() || "toolPool.category.other";
         if (!catMap.has(cat)) catMap.set(cat, []);
         catMap.get(cat)!.push(tool);
       }
@@ -258,10 +262,19 @@ export default function SelectToolsDialog({
     [prefetchKnowledgeBases, mergeInstanceParams, hasMissingRequired, confirm, updateTools, t]
   );
 
-  const tabItems: TabsProps["items"] = SOURCE_TABS.map((tab) => ({
-    key: tab.key,
-    label: t(tab.labelKey),
-  }));
+  const tabItems: TabsProps["items"] = SOURCE_TABS
+    .filter((tab) => (sourceGroups[tab.key] || []).length > 0)
+    .map((tab) => ({
+      key: tab.key,
+      label: t(tab.labelKey),
+    }));
+
+  // Auto-switch to first available tab when active tab becomes hidden
+  useEffect(() => {
+    if (tabItems.length > 0 && !tabItems.find((t) => t.key === activeTab)) {
+      setActiveTab(tabItems[0].key!);
+    }
+  }, [tabItems, activeTab]);
 
   const onCloseDialog = useCallback(() => {
     setSearch("");
@@ -346,7 +359,7 @@ export default function SelectToolsDialog({
                       : "border-transparent text-gray-500 hover:text-gray-700"
                   }`}
                 >
-                  {g.category}
+                  {t(g.category)}
                   <span className="ml-1 text-xs text-gray-400">
                     ({selCount > 0 ? `${selCount}/` : ""}{count})
                   </span>
@@ -365,7 +378,7 @@ export default function SelectToolsDialog({
               .map((g) => (
                 <div key={g.category}>
                   <div className="mb-1 px-1 text-xs font-medium text-gray-400">
-                    {g.category}
+                    {t(g.category)}
                   </div>
                   <ul className="space-y-1">
                     {g.tools.map((tool: any) => {

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -568,6 +568,7 @@
   "toolPool.tag.local": "Local Tool",
   "toolPool.tag.langchain": "LangChain Tool",
   "toolPool.group.local": "Local",
+  "toolPool.group.mcp": "MCP",
   "toolPool.group.langchain": "LangChain",
   "toolPool.group.other": "Other Tools",
   "toolPool.category.other": "other",

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -541,6 +541,7 @@
   "toolPool.tag.local": "本地工具",
   "toolPool.tag.langchain": "LangChain工具",
   "toolPool.group.local": "本地工具",
+  "toolPool.group.mcp": "MCP",
   "toolPool.group.langchain": "LangChain",
   "toolPool.group.other": "其他工具",
   "toolPool.category.other": "其他",


### PR DESCRIPTION
# What's chaned

## disable "select tools" button without an agent's selection

<img width="785" height="657" alt="image" src="https://github.com/user-attachments/assets/143ac2d2-3c1c-4579-90b8-0e0a2681b034" />

## fix i18n

<img width="848" height="546" alt="image" src="https://github.com/user-attachments/assets/78418adc-a8a1-4f86-ad0d-80ac9b69b6cb" />

## hide empty tool tabs(such as LangChain)

<img width="1081" height="446" alt="image" src="https://github.com/user-attachments/assets/228f75ca-0c0e-4cbb-8f70-171e97726829" />

<img width="1080" height="429" alt="image" src="https://github.com/user-attachments/assets/3e2e6b19-7929-4ebc-8511-c2278749f74d" />

