### PR TITLE
🐛 Bugfix: The backend setting for self-verification defaults to False.

### DIFF
--- a/sdk/nexent/core/agents/agent_model.py
+++ b/sdk/nexent/core/agents/agent_model.py
@@ -150,7 +150,7 @@ VerificationFailPolicy = Literal["repair_then_controlled_summary", "warn"]
 class AgentVerificationConfig(BaseModel):
     """Configuration for layered ReAct self-verification."""
 
-    enabled: bool = Field(description="Whether self-verification is enabled", default=True)
+    enabled: bool = Field(description="Whether self-verification is enabled", default=False)
     step_verification_enabled: bool = Field(
         description="Whether to verify critical ReAct step events",
         default=True,

--- a/test/sdk/core/agents/test_agent_model.py
+++ b/test/sdk/core/agents/test_agent_model.py
@@ -1262,10 +1262,10 @@ class TestAgentConfig:
 class TestAgentVerificationConfig:
     """Tests for layered ReAct verification configuration."""
 
-    def test_default_verification_config_is_enabled(self):
+    def test_default_verification_config_is_disabled_by_default(self):
         config = agent_model_module.AgentVerificationConfig()
 
-        assert config.enabled is True
+        assert config.enabled is False
         assert config.step_verification_enabled is True
         assert config.final_verification_enabled is True
         assert config.max_final_rounds == 2
@@ -1279,7 +1279,7 @@ class TestAgentVerificationConfig:
             model_name="test",
         )
 
-        assert config.verification_config.enabled is True
+        assert config.verification_config.enabled is False
         assert config.verification_config.strictness == "balanced"
 
     def test_verification_config_rejects_invalid_rounds(self):


### PR DESCRIPTION
🐛 Bugfix: The backend setting for self-verification defaults to False.
[Specification Details]
1. Self-verification is set to `False` by default in the SDK to ensure that existing agents do not have self-verification enabled by default.
[Test Results]
<img width="309" height="555" alt="image" src="https://github.com/user-attachments/assets/ca272c41-443a-404d-8454-7e45a3b0b18a" />
<img width="1019" height="389" alt="image" src="https://github.com/user-attachments/assets/dbdb4951-c71c-45e3-820d-8912cf3960ab" />
