### PR TITLE
🐛 Bugfix: Guard memory_user_config against None in store/search memory tools

### DIFF
--- a/backend/agents/create_agent_info.py
+++ b/backend/agents/create_agent_info.py
@@ -762,6 +762,9 @@ async def create_agent_config(
                 "agent_id": memory_context.agent_id,
             }
 
+            memory_tool_names = {"store_memory", "search_memory"}
+            tool_list = [t for t in tool_list if t.name not in memory_tool_names]
+
             store_tool_config = ToolConfig(
                 class_name="StoreMemoryTool",
                 name="store_memory",

--- a/backend/consts/tool_labels.py
+++ b/backend/consts/tool_labels.py
@@ -52,3 +52,5 @@ BUILTIN_LABEL_MAP.update(_category_multimodal)
 BUILTIN_LABEL_MAP.update(_category_email)
 BUILTIN_LABEL_MAP.update(_category_memory)
 BUILTIN_LABEL_MAP.update(_category_terminal)
+
+SYSTEM_MANAGED_TOOL_NAMES = frozenset({"store_memory", "search_memory"})

--- a/backend/services/memory_config_service.py
+++ b/backend/services/memory_config_service.py
@@ -94,6 +94,17 @@ def _update_single_config(user_id: str, config_key: str, config_value: str) -> b
 				f"update_config_by_id failed, user_id={user_id}, key={config_key}, value={config_value}"
 			)
 			return False
+		
+		# Handle duplicate records: delete all except the first one
+		if len(record_list) > 1:
+			logger.warning(
+				f"Found {len(record_list)} duplicate records for user_id={user_id}, key={config_key}. Cleaning up..."
+			)
+			for duplicate in record_list[1:]:
+				dup_id = duplicate["config_id"]
+				delete_result = delete_config_by_config_id(dup_id, updated_by=user_id)
+				if not delete_result:
+					logger.error(f"Failed to delete duplicate config_id={dup_id}")
 	return True
 
 

--- a/backend/services/tool_configuration_service.py
+++ b/backend/services/tool_configuration_service.py
@@ -15,6 +15,7 @@ from pydantic_core import PydanticUndefined
 from consts.const import DATA_PROCESS_SERVICE, LOCAL_MCP_SERVER, MCP_MANAGEMENT_API
 from consts.exceptions import MCPConnectionError, NotFoundException, ToolExecutionException
 from consts.model import ToolInstanceInfoRequest, ToolInfo, ToolSourceEnum, ToolValidateRequest
+from consts.tool_labels import SYSTEM_MANAGED_TOOL_NAMES
 from database.outer_api_tool_db import (
     upsert_openapi_service,
     query_openapi_services_by_tenant,
@@ -505,6 +506,9 @@ async def list_all_tools(tenant_id: str, labels: Optional[List[str]] = None):
     formatted_tools = []
     for tool in tools_info:
         tool_name = tool.get("name")
+
+        if tool_name in SYSTEM_MANAGED_TOOL_NAMES:
+            continue
 
         # Always use SDK inputs for local tools to stay in sync with current tool code
         is_local = tool.get("source") == "local"

--- a/frontend/app/[locale]/memory/page.tsx
+++ b/frontend/app/[locale]/memory/page.tsx
@@ -297,32 +297,30 @@ export default function MemoryContent() {
       ),
       children: renderBaseSettings(),
     },
- [
-          {
-            key: MEMORY_TAB_KEYS.TENANT,
-            label: (
-              <span className="inline-flex items-center gap-2">
-                <UsersRound className="size-4" />
-                {t("memoryManageModal.tenantShareTab")}
-              </span>
-            ),
-            children: renderSingleList(memory.tenantSharedGroup),
-            disabled: !memory.memoryEnabled,
-          },
-          {
-            key: MEMORY_TAB_KEYS.AGENT_SHARED,
-            label: (
-              <span className="inline-flex items-center gap-2">
-                <Share2 className="size-4" />
-                {t("memoryManageModal.agentShareTab")}
-              </span>
-            ),
-            children: renderMemoryWithMenu(memory.agentSharedGroups, true),
-            disabled:
-              !memory.memoryEnabled ||
-              memory.shareOption === MEMORY_SHARE_STRATEGY.NEVER,
-          },
-        ],
+    ...(!isSpeedMode ? [{
+      key: MEMORY_TAB_KEYS.TENANT,
+      label: (
+        <span className="inline-flex items-center gap-2">
+          <UsersRound className="size-4" />
+          {t("memoryManageModal.tenantShareTab")}
+        </span>
+      ),
+      children: renderSingleList(memory.tenantSharedGroup),
+      disabled: !memory.memoryEnabled,
+    }] : []),
+    {
+      key: MEMORY_TAB_KEYS.AGENT_SHARED,
+      label: (
+        <span className="inline-flex items-center gap-2">
+          <Share2 className="size-4" />
+          {t("memoryManageModal.agentShareTab")}
+        </span>
+      ),
+      children: renderMemoryWithMenu(memory.agentSharedGroups, true),
+      disabled:
+        !memory.memoryEnabled ||
+        memory.shareOption === MEMORY_SHARE_STRATEGY.NEVER,
+    },
     {
       key: MEMORY_TAB_KEYS.USER_PERSONAL,
       label: (

--- a/sdk/nexent/core/tools/search_memory_tool.py
+++ b/sdk/nexent/core/tools/search_memory_tool.py
@@ -1,4 +1,5 @@
 import asyncio
+import concurrent.futures
 import logging
 from typing import Any
 
@@ -9,6 +10,15 @@ from ..utils.observer import MessageObserver, ProcessType
 from ..utils.tools_common_message import ToolSign, ToolCategory
 
 logger = logging.getLogger("search_memory_tool")
+
+
+def _run_coroutine(coro):
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(asyncio.run, coro).result()
 
 
 class SearchMemoryTool(Tool):
@@ -63,25 +73,34 @@ class SearchMemoryTool(Tool):
         self.running_prompt_en = "Searching memory..."
         self.running_prompt_zh = "搜索记忆中..."
 
+    def _resolve_memory_levels(self) -> list[str]:
+        """Determine which memory levels to search based on user preferences.
+
+        Conservative default: when config is unavailable, assume "never"
+        (no agent-level sharing) to protect user privacy.
+        """
+        levels = ["tenant", "user", "agent", "user_agent"]
+        if not self.memory_user_config or self.memory_user_config.agent_share_option == "never":
+            levels.remove("agent")
+        if self.memory_user_config and self.agent_id in getattr(self.memory_user_config, "disable_agent_ids", []):
+            if "agent" in levels:
+                levels.remove("agent")
+        if self.memory_user_config and self.agent_id in getattr(self.memory_user_config, "disable_user_agent_ids", []):
+            if "user_agent" in levels:
+                levels.remove("user_agent")
+        return levels
+
     def forward(self, query: str, top_k: int = 5) -> str:
         logger.info(f"[ACTIVE MEMORY] SearchMemoryTool invoked: query={query[:200]}, top_k={top_k}, user_id={self.user_id}, agent_id={self.agent_id}")
         if self.observer:
             running_prompt = self.running_prompt_zh if self.observer.lang == "zh" else self.running_prompt_en
             self.observer.add_message("", ProcessType.TOOL, running_prompt)
 
-        memory_levels = ["tenant", "user", "agent", "user_agent"]
-        if self.memory_user_config.agent_share_option == "never":
-            memory_levels.remove("agent")
-        if self.agent_id in getattr(self.memory_user_config, "disable_agent_ids", []):
-            if "agent" in memory_levels:
-                memory_levels.remove("agent")
-        if self.agent_id in getattr(self.memory_user_config, "disable_user_agent_ids", []):
-            if "user_agent" in memory_levels:
-                memory_levels.remove("user_agent")
+        memory_levels = self._resolve_memory_levels()
 
         try:
             from ...memory.memory_service import search_memory_in_levels
-            result = asyncio.run(search_memory_in_levels(
+            result = _run_coroutine(search_memory_in_levels(
                 query_text=query,
                 memory_config=self.memory_config,
                 tenant_id=self.tenant_id,

--- a/sdk/nexent/core/tools/store_memory_tool.py
+++ b/sdk/nexent/core/tools/store_memory_tool.py
@@ -1,4 +1,5 @@
 import asyncio
+import concurrent.futures
 import logging
 from typing import Any
 
@@ -9,6 +10,15 @@ from ..utils.observer import MessageObserver, ProcessType
 from ..utils.tools_common_message import ToolSign, ToolCategory
 
 logger = logging.getLogger("store_memory_tool")
+
+
+def _run_coroutine(coro):
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(asyncio.run, coro).result()
 
 
 class StoreMemoryTool(Tool):
@@ -58,6 +68,21 @@ class StoreMemoryTool(Tool):
         self.running_prompt_en = "Saving to memory..."
         self.running_prompt_zh = "保存到记忆中..."
 
+    def _resolve_memory_levels(self) -> list[str]:
+        """Determine which memory levels to write to based on user preferences.
+
+        Conservative default: when config is unavailable, assume "never"
+        (no agent-level sharing) to protect user privacy.
+        """
+        levels = ["user_agent", "agent"]
+        if not self.memory_user_config or self.memory_user_config.agent_share_option == "never":
+            levels.remove("agent")
+        if self.memory_user_config and self.agent_id in getattr(self.memory_user_config, "disable_user_agent_ids", []):
+            levels = [l for l in levels if l != "user_agent"]
+        if self.memory_user_config and self.agent_id in getattr(self.memory_user_config, "disable_agent_ids", []):
+            levels = [l for l in levels if l != "agent"]
+        return levels
+
     def forward(self, content: str) -> str:
         logger.info(f"[ACTIVE MEMORY] StoreMemoryTool invoked: content={content[:200]}, user_id={self.user_id}, agent_id={self.agent_id}, store_count={self.store_count}/{self.max_stores_per_run}")
         if self.observer:
@@ -67,19 +92,13 @@ class StoreMemoryTool(Tool):
         if self.store_count >= self.max_stores_per_run:
             return "Memory storage limit reached for this conversation. Information will be saved automatically at the end."
 
-        levels = ["user_agent", "agent"]
-        if self.memory_user_config.agent_share_option == "never":
-            levels.remove("agent")
-        if self.agent_id in getattr(self.memory_user_config, "disable_user_agent_ids", []):
-            levels = [l for l in levels if l != "user_agent"]
-        if self.agent_id in getattr(self.memory_user_config, "disable_agent_ids", []):
-            levels = [l for l in levels if l != "agent"]
+        levels = self._resolve_memory_levels()
         if not levels:
             return "No memory levels available (all disabled by user preferences)."
 
         try:
             from ...memory.memory_service import add_memory_in_levels
-            result = asyncio.run(add_memory_in_levels(
+            result = _run_coroutine(add_memory_in_levels(
                 messages=[{"role": "user", "content": content}],
                 memory_config=self.memory_config,
                 tenant_id=self.tenant_id,

--- a/test/backend/services/test_memory_config_service.py
+++ b/test/backend/services/test_memory_config_service.py
@@ -188,6 +188,38 @@ class TestMemoryConfigService(unittest.TestCase):
         ok = _update_single_config(self.user_id, "MEMORY_SWITCH", "Y")
         self.assertFalse(ok)
 
+    @patch("backend.services.memory_config_service.delete_config_by_config_id", return_value=True)
+    @patch("backend.services.memory_config_service.update_config_by_id", return_value=True)
+    @patch("backend.services.memory_config_service.get_memory_config_info")
+    def test_update_single_config_cleans_up_duplicates(self, m_get_info, m_update, m_del):
+        m_get_info.return_value = [
+            {"config_id": 10, "config_value": "N"},
+            {"config_id": 20, "config_value": "Y"},
+            {"config_id": 30, "config_value": "N"},
+        ]
+        from backend.services.memory_config_service import _update_single_config
+
+        ok = _update_single_config(self.user_id, "MEMORY_SWITCH", "Y")
+        self.assertTrue(ok)
+        m_update.assert_called_once()
+        self.assertEqual(m_del.call_count, 2)
+        m_del.assert_any_call(20, updated_by=self.user_id)
+        m_del.assert_any_call(30, updated_by=self.user_id)
+
+    @patch("backend.services.memory_config_service.delete_config_by_config_id", return_value=False)
+    @patch("backend.services.memory_config_service.update_config_by_id", return_value=True)
+    @patch("backend.services.memory_config_service.get_memory_config_info")
+    def test_update_single_config_duplicate_cleanup_failure_logged(self, m_get_info, m_update, m_del):
+        m_get_info.return_value = [
+            {"config_id": 10, "config_value": "N"},
+            {"config_id": 20, "config_value": "Y"},
+        ]
+        from backend.services.memory_config_service import _update_single_config
+
+        ok = _update_single_config(self.user_id, "MEMORY_SWITCH", "Y")
+        self.assertTrue(ok)
+        m_del.assert_called_once_with(20, updated_by=self.user_id)
+
     # ------------------------------ _add_multi_value ------------------------------
     @patch("backend.services.memory_config_service.insert_config", return_value=True)
     @patch("backend.services.memory_config_service.get_memory_config_info", return_value=[])

--- a/test/backend/services/test_tool_configuration_service.py
+++ b/test/backend/services/test_tool_configuration_service.py
@@ -1105,6 +1105,32 @@ class TestListAllToolsWithLabels:
         assert result[0]["tool_id"] == 2
         mock_query_by_labels.assert_called_once_with("tenant1", ["database", "file"])
 
+    @patch('backend.services.tool_configuration_service.get_local_tools_description_zh')
+    @patch('backend.services.tool_configuration_service.query_all_tools')
+    async def test_list_all_tools_filters_system_managed_tools(self, mock_query, mock_descriptions):
+        """list_all_tools filters out tools in SYSTEM_MANAGED_TOOL_NAMES."""
+        mock_query.return_value = [
+            {"tool_id": 1, "name": "tavily_search", "description": "d1", "source": "local",
+             "params": [], "inputs": "{}", "is_available": True, "create_time": "", "usage": ""},
+            {"tool_id": 2, "name": "store_memory", "description": "d2", "source": "local",
+             "params": [], "inputs": "{}", "is_available": True, "create_time": "", "usage": ""},
+            {"tool_id": 3, "name": "search_memory", "description": "d3", "source": "local",
+             "params": [], "inputs": "{}", "is_available": True, "create_time": "", "usage": ""},
+            {"tool_id": 4, "name": "postgres_database", "description": "d4", "source": "local",
+             "params": [], "inputs": "{}", "is_available": True, "create_time": "", "usage": ""},
+        ]
+        mock_descriptions.return_value = {}
+
+        from backend.services.tool_configuration_service import list_all_tools
+        result = await list_all_tools("tenant1")
+
+        result_names = [t["name"] for t in result]
+        assert "store_memory" not in result_names
+        assert "search_memory" not in result_names
+        assert "tavily_search" in result_names
+        assert "postgres_database" in result_names
+        assert len(result) == 2
+
 
 # test the fixture and helper function
 @pytest.fixture

--- a/test/sdk/core/tools/test_search_memory_tool.py
+++ b/test/sdk/core/tools/test_search_memory_tool.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
 
 from sdk.nexent.core.utils.observer import MessageObserver, ProcessType
-from sdk.nexent.core.tools.search_memory_tool import SearchMemoryTool
+from sdk.nexent.core.tools.search_memory_tool import SearchMemoryTool, _run_coroutine
 
 
 @pytest.fixture
@@ -207,3 +207,47 @@ def test_forward_exception_returns_friendly_error(search_memory_tool):
     assert "Memory search failed" in result
     assert "Elasticsearch timeout" in result
     assert "Continuing without memory results" in result
+
+
+def test_levels_none_config_conservative_default(mock_observer):
+    tool = SearchMemoryTool(
+        memory_config={"test": "config"},
+        tenant_id="tenant_1",
+        user_id="user_1",
+        agent_id="agent_1",
+        memory_user_config=None,
+        observer=mock_observer,
+    )
+
+    with patch(
+        "sdk.nexent.memory.memory_service.search_memory_in_levels",
+        new_callable=AsyncMock,
+        return_value={"results": []},
+    ) as mock_search:
+        tool.forward("query")
+
+    call_kwargs = mock_search.call_args[1]
+    assert "agent" not in call_kwargs["memory_levels"]
+    assert "tenant" in call_kwargs["memory_levels"]
+    assert "user" in call_kwargs["memory_levels"]
+    assert "user_agent" in call_kwargs["memory_levels"]
+
+
+def test_run_coroutine_no_running_loop():
+    async def sample_coro():
+        return "result"
+
+    result = _run_coroutine(sample_coro())
+    assert result == "result"
+
+
+def test_run_coroutine_with_running_loop():
+    async def sample_coro():
+        return "result"
+
+    async def run_with_loop():
+        return _run_coroutine(sample_coro())
+
+    import asyncio
+    result = asyncio.run(run_with_loop())
+    assert result == "result"

--- a/test/sdk/core/tools/test_store_memory_tool.py
+++ b/test/sdk/core/tools/test_store_memory_tool.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
 
 from sdk.nexent.core.utils.observer import MessageObserver, ProcessType
-from sdk.nexent.core.tools.store_memory_tool import StoreMemoryTool
+from sdk.nexent.core.tools.store_memory_tool import StoreMemoryTool, _run_coroutine
 
 
 @pytest.fixture
@@ -283,3 +283,46 @@ def test_forward_exception_does_not_increment_counter(store_memory_tool):
         store_memory_tool.forward("some content")
 
     assert store_memory_tool.store_count == 0
+
+
+def test_levels_none_config_conservative_default(mock_observer):
+    """When memory_user_config is None, apply conservative default (no agent-level sharing)."""
+    tool = StoreMemoryTool(
+        memory_config={"test": "config"},
+        tenant_id="tenant_1",
+        user_id="user_1",
+        agent_id="agent_1",
+        memory_user_config=None,
+        observer=mock_observer,
+    )
+
+    with patch(
+        "sdk.nexent.memory.memory_service.add_memory_in_levels",
+        new_callable=AsyncMock,
+        return_value={"results": [{"event": "ADD", "memory": "fact"}]},
+    ) as mock_add:
+        tool.forward("some content")
+
+    call_kwargs = mock_add.call_args[1]
+    assert call_kwargs["memory_levels"] == ["user_agent"]
+    assert "agent" not in call_kwargs["memory_levels"]
+
+
+def test_run_coroutine_no_running_loop():
+    async def sample_coro():
+        return "result"
+
+    result = _run_coroutine(sample_coro())
+    assert result == "result"
+
+
+def test_run_coroutine_with_running_loop():
+    async def sample_coro():
+        return "result"
+
+    async def run_with_loop():
+        return _run_coroutine(sample_coro())
+
+    import asyncio
+    result = asyncio.run(run_with_loop())
+    assert result == "result"


### PR DESCRIPTION
## Problem

This PR addresses multiple memory-related issues discovered during development and testing:

### 1. NoneType crash in memory tools
`StoreMemoryTool` and `SearchMemoryTool` crash with `AttributeError: 'NoneType' object has no attribute 'agent_share_option'` when `memory_user_config` is `None`.

This occurs in two scenarios:
- **Tool validation page** (`POST /api/tool/validate`): `_validate_local_tool` instantiates `StoreMemoryTool` via the generic `else` branch with default `memory_user_config=None`
- **Actual agent conversations**: `memory_user_config` can be `None` when metadata is not properly propagated to the tool instance

### 2. Duplicate tool names at runtime
`store_memory` and `search_memory` are system-managed tools that should be auto-injected when memory is enabled. They should not appear in the agent tool selection UI or be manually selectable by users. When present in both DB config and auto-injection, `smolagents` rejects with "Each tool or managed_agent should have a unique name".

### 3. Memory switch not persisting
The memory switch toggle in the UI would not persist after being enabled, because duplicate records in `memory_user_config_t` caused the aggregation logic to overwrite the latest value with stale data.

### 4. Hidden memory tabs in configuration page
The Tenant Shared and Agent Shared tabs in the memory configuration page were hidden due to a nested array syntax bug in `tabItems`. Additionally, the Tenant Shared tab should not be visible in speed mode (no tenant concept).

## Fix

### 1. None guard for memory_user_config

Add `None` checks before accessing `memory_user_config` attributes in both tools. When config is unavailable, apply a **conservative default** equivalent to `agent_share_option="never"` — disabling agent-level memory sharing to protect user privacy.

**Files changed:**
- `sdk/nexent/core/tools/store_memory_tool.py`
- `sdk/nexent/core/tools/search_memory_tool.py`

**Behavior when `memory_user_config` is `None`:**
- **store_memory**: Only writes to `user_agent` level (removes `agent` level)
- **search_memory**: Searches `["tenant", "user", "user_agent"]` (removes `agent` level)

### 2. System-managed tools hidden from UI

`store_memory` and `search_memory` are system-managed tools — they should not appear in the agent tool selection UI.

**Files changed:**
- `backend/consts/tool_labels.py` — Added `SYSTEM_MANAGED_TOOL_NAMES` constant
- `backend/services/tool_configuration_service.py` — Filter system-managed tools from `list_all_tools` response
- `backend/agents/create_agent_info.py` — Remove any existing memory tools from DB config before injecting the active memory versions (safety net for legacy data)

**Three-layer protection:**
1. **UI layer**: `list_all_tools` does not return `store_memory`/`search_memory`, preventing users from manually selecting them
2. **Runtime layer**: `create_agent_info.py` removes any DB-configured memory tools before appending the platform-injected versions
3. **Existing data**: Even if legacy agent configs contain memory tool instances in DB, they are safely replaced at runtime

### 3. Memory switch persistence fix

Clean up duplicate records in `memory_user_config_t` when updating single-type config entries. The `_update_single_config` function now detects and removes stale duplicates after updating the primary record.

**File changed:**
- `backend/services/memory_config_service.py`

**Root cause:** Multiple records existed for the same `(user_id, config_key)` pair with different values. The `_aggregate_records` function processes records in insertion order, so a stale `'N'` record inserted after the latest `'Y'` record would overwrite the correct value.

### 4. Memory configuration page tab fix

Fix nested array syntax bug that hid Tenant Shared and Agent Shared tabs. Conditionally hide Tenant Shared tab in speed mode.

**File changed:**
- `frontend/app/[locale]/memory/page.tsx`

**Changes:**
- Fix `[...]` nested array → proper spread with `...(!isSpeedMode ? [...] : [])` for Tenant Shared
- Fix Agent Shared tab from nested array to proper object in `tabItems`
- Speed mode: 4 tabs (Base Settings, Agent Shared, User Personal, User Agent)
- Non-speed mode: 5 tabs (Base Settings, Tenant Shared, Agent Shared, User Personal, User Agent)

## Testing

- Verified via Playwright: agent successfully calls `store_memory(content=...)` in an actual conversation without `AttributeError`
- Backend logs confirm `"Memory stored successfully."` with no `NoneType` errors
- Memory switch toggle now persists correctly after navigating between pages
- Agent tool selection UI no longer shows `store_memory`/`search_memory` options
- Agent with legacy `store_memory` DB config runs without "duplicate name" errors
- Memory configuration page shows all expected tabs (Tenant Shared hidden in speed mode)

<img width="1879" height="1290" alt="image" src="https://github.com/user-attachments/assets/ef958015-d33c-4059-80c3-a1481ba255c5" />
<img width="1879" height="1290" alt="image" src="https://github.com/user-attachments/assets/1c2d5f1e-d1f2-4e29-a6c2-339d00c6e961" />
<img width="1879" height="1290" alt="image" src="https://github.com/user-attachments/assets/eb75d64a-1e40-4cee-82cc-1c8677c1517f" />
<img width="1879" height="1290" alt="image" src="https://github.com/user-attachments/assets/650a7144-fc15-467a-8c1a-af7ba5f8e4d3" />
![Uploading image.png…]()
