### PR TITLE
🐛Bugfix: Fix responsive layout issues on knowledge base page

### DIFF
--- a/frontend/app/[locale]/knowledges/KnowledgeBaseConfiguration.tsx
+++ b/frontend/app/[locale]/knowledges/KnowledgeBaseConfiguration.tsx
@@ -1013,7 +1013,8 @@ function DataConfig({ isActive }: DataConfigProps) {
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
       >
-        <Row className="h-full w-full" gutter={TWO_COLUMN_LAYOUT.GUTTER}>
+        <div className="w-full h-full">
+          <Row className="h-full w-full" gutter={TWO_COLUMN_LAYOUT.GUTTER}>
           <Col
             className="h-full"
             xs={TWO_COLUMN_LAYOUT.LEFT_COLUMN.xs}
@@ -1188,6 +1189,7 @@ function DataConfig({ isActive }: DataConfigProps) {
             )}
           </Col>
         </Row>
+          </div>
       </div>
 
       <Modal

--- a/frontend/app/[locale]/knowledges/components/document/DocumentList.tsx
+++ b/frontend/app/[locale]/knowledges/components/document/DocumentList.tsx
@@ -17,7 +17,9 @@ import {
   Eye,
   Glasses,
   CircleOff,
+  AlertCircle,
 } from "lucide-react";
+import { NAME_CHECK_STATUS } from "@/const/agentConfig";
 import { MarkdownRenderer } from "@/components/common/markdownRenderer";
 import { FilePreviewDrawer } from "@/components/common/filePreviewDrawer";
 
@@ -58,7 +60,7 @@ const CONTAINER_HEIGHT_CLASS_MAP: Record<string, string> = {
 };
 
 const TITLE_BAR_HEIGHT_CLASS_MAP: Record<string, string> = {
-  "56.8px": "h-[56.8px]",
+  "56.8px": "min-h-[56.8px]",
 };
 
 interface DocumentListProps {
@@ -253,6 +255,7 @@ const DocumentListContainer = forwardRef<DocumentListRef, DocumentListProps>(
     }));
     const [showDetail, setShowDetail] = React.useState(false);
     const [showChunk, setShowChunk] = React.useState(false);
+    const [nameStatus, setNameStatus] = useState<string>("available");
     const [summary, setSummary] = useState("");
     const [isSummarizing, setIsSummarizing] = useState(false);
     const [isEditing, setIsEditing] = useState(false);
@@ -545,7 +548,7 @@ const DocumentListContainer = forwardRef<DocumentListRef, DocumentListProps>(
     const containerHeightClass =
       CONTAINER_HEIGHT_CLASS_MAP[containerHeight] ?? "h-full";
     const titleBarHeightClass =
-      TITLE_BAR_HEIGHT_CLASS_MAP[titleBarHeight] ?? "h-14";
+      TITLE_BAR_HEIGHT_CLASS_MAP[titleBarHeight] ?? "min-h-[56px]";
 
     return (
       <div
@@ -553,39 +556,58 @@ const DocumentListContainer = forwardRef<DocumentListRef, DocumentListProps>(
       >
         {/* Title bar */}
         <div
-          className={`${LAYOUT.KB_HEADER_PADDING} border-b border-gray-200 flex-shrink-0 flex items-center ${titleBarHeightClass}`}
+          className={`${LAYOUT.KB_HEADER_PADDING} border-b border-gray-200 flex-shrink-0 flex items-start ${titleBarHeightClass}`}
         >
           <div
-            className="flex items-center justify-between w-full"
+            className="flex items-start justify-between w-full"
             style={{ width: "100%" }}
           >
-            <div className="flex items-center" style={{ width: "100%" }}>
+            <div className="flex items-start" style={{ width: "100%" }}>
               {isCreatingMode ? (
                 <div
-                  className="flex items-center flex-1"
+                  className="flex items-start flex-1"
                   style={{ width: "100%" }}
                 >
-                  <Input
-                    value={knowledgeBaseName}
-                    onChange={(e) =>
-                      onNameChange && onNameChange(e.target.value)
-                    }
-                    placeholder={t("document.input.knowledgeBaseName")}
-                    className={`${LAYOUT.KB_TITLE_MARGIN} w-[240px] font-medium my-[2px]`}
-                    size="large"
-                    prefix={<span className="text-blue-600">📚</span>}
-                    autoFocus
-                    disabled={
-                      hasDocuments || isUploading || docState.isLoadingDocuments
-                    }
-                  />
+                  <div className="flex flex-col">
+                    <Input
+                      value={knowledgeBaseName}
+                      onChange={(e) =>
+                        onNameChange && onNameChange(e.target.value)
+                      }
+                      placeholder={t("document.input.knowledgeBaseName")}
+                      className={`${LAYOUT.KB_TITLE_MARGIN} w-[240px] font-medium`}
+                      size="large"
+                      prefix={<span className="text-blue-600">📚</span>}
+                      status={
+                        isCreatingMode &&
+                        (nameStatus === NAME_CHECK_STATUS.EXISTS_IN_TENANT ||
+                          nameStatus === NAME_CHECK_STATUS.EXISTS_IN_OTHER_TENANT)
+                          ? "error"
+                          : undefined
+                      }
+                      autoFocus
+                      disabled={
+                        hasDocuments || isUploading || docState.isLoadingDocuments
+                      }
+                    />
+                    {isCreatingMode &&
+                      (nameStatus === NAME_CHECK_STATUS.EXISTS_IN_TENANT ||
+                        nameStatus === NAME_CHECK_STATUS.EXISTS_IN_OTHER_TENANT) && (
+                        <div className="flex items-center gap-1 text-red-500 text-s whitespace-nowrap mt-0.5 ml-3">
+                          <AlertCircle size={14} />
+                          <span>
+                            {t("tenantResources.knowledgeBase.nameExists")}
+                          </span>
+                        </div>
+                      )}
+                  </div>
                   {/* Right-aligned container for dropdowns */}
                   <div
-                    className="flex items-center ml-auto justify-end"
+                    className="flex items-start ml-auto justify-end"
                     style={{
                       gap: "12px",
                       justifyContent: "flex-end",
-                      alignItems: "flex-end",
+                      alignItems: "flex-start",
                       width: "100%",
                     }}
                   >
@@ -1107,6 +1129,7 @@ const DocumentListContainer = forwardRef<DocumentListRef, DocumentListProps>(
               indexName={knowledgeBaseId || knowledgeBaseName}
               newKnowledgeBaseName={isCreatingMode ? knowledgeBaseName : ""}
               modelMismatch={modelMismatch}
+              onNameStatusChange={setNameStatus}
             />
           ))}
 

--- a/frontend/app/[locale]/knowledges/components/document/DocumentList.tsx
+++ b/frontend/app/[locale]/knowledges/components/document/DocumentList.tsx
@@ -552,7 +552,7 @@ const DocumentListContainer = forwardRef<DocumentListRef, DocumentListProps>(
 
     return (
       <div
-        className={`flex flex-col w-full h-full bg-white border border-gray-200 rounded-md shadow-sm `}
+        className={`flex flex-col w-full h-full bg-white border border-gray-200 rounded-md shadow-sm overflow-hidden`}
       >
         {/* Title bar */}
         <div
@@ -562,20 +562,17 @@ const DocumentListContainer = forwardRef<DocumentListRef, DocumentListProps>(
             className="flex items-start justify-between w-full"
             style={{ width: "100%" }}
           >
-            <div className="flex items-start" style={{ width: "100%" }}>
+            <div className="flex items-start flex-1 min-w-0">
               {isCreatingMode ? (
-                <div
-                  className="flex items-start flex-1"
-                  style={{ width: "100%" }}
-                >
-                  <div className="flex flex-col">
+                <div className="flex flex-wrap items-start gap-3 w-full">
+                  <div className="flex flex-col flex-1" style={{ minWidth: 120 }}>
                     <Input
                       value={knowledgeBaseName}
                       onChange={(e) =>
                         onNameChange && onNameChange(e.target.value)
                       }
                       placeholder={t("document.input.knowledgeBaseName")}
-                      className={`${LAYOUT.KB_TITLE_MARGIN} w-[240px] font-medium`}
+                      className={`${LAYOUT.KB_TITLE_MARGIN} max-w-[240px] font-medium`}
                       size="large"
                       prefix={<span className="text-blue-600">📚</span>}
                       status={
@@ -601,26 +598,17 @@ const DocumentListContainer = forwardRef<DocumentListRef, DocumentListProps>(
                         </div>
                       )}
                   </div>
-                  {/* Right-aligned container for dropdowns */}
+                  {/* Right dropdowns for create mode */}
                   <div
-                    className="flex items-start ml-auto justify-end"
-                    style={{
-                      gap: "12px",
-                      justifyContent: "flex-end",
-                      alignItems: "flex-start",
-                      width: "100%",
-                    }}
+                    className="flex items-center justify-end flex-wrap"
+                    style={{ gap: "12px" }}
                   >
                     {/* Embedding model selection - first position in create mode */}
                     {isCreatingMode && onEmbeddingModelChange && (
                       <Select
                         value={selectedEmbeddingModel}
                         onChange={onEmbeddingModelChange}
-                        style={{
-                          minWidth: 200,
-                          justifyContent: "center",
-                          alignItems: "flex-end",
-                        }}
+                        style={{ flex: "1 1 200px", minWidth: 200, justifyContent: "center", alignItems: "flex-end" }}
                         placeholder={
                           t("knowledgeBase.create.embeddingModelPlaceholder") ||
                           "Select embedding model"
@@ -658,11 +646,7 @@ const DocumentListContainer = forwardRef<DocumentListRef, DocumentListProps>(
                         mode="multiple"
                         value={isGroupSelectDisabled ? [] : selectedGroupIds}
                         onChange={onSelectedGroupIdsChange}
-                        style={{
-                          minWidth: 200,
-                          justifyContent: "center",
-                          alignItems: "flex-end",
-                        }}
+                        style={{ flex: "1 1 200px", minWidth: 200, justifyContent: "center", alignItems: "flex-end" }}
                         placeholder={t(
                           "knowledgeBase.create.permission.groupPlaceholder"
                         )}
@@ -677,11 +661,7 @@ const DocumentListContainer = forwardRef<DocumentListRef, DocumentListProps>(
                       <Select
                         value={ingroupPermission}
                         onChange={onIngroupPermissionChange}
-                        style={{
-                          width: 160,
-                          justifyContent: "center",
-                          alignItems: "flex-end",
-                        }}
+                        style={{ flex: "1 1 160px", minWidth: 160, justifyContent: "center", alignItems: "flex-end" }}
                         placeholder={t(
                           "knowledgeBase.ingroup.permission.DEFAULT"
                         )}
@@ -693,7 +673,8 @@ const DocumentListContainer = forwardRef<DocumentListRef, DocumentListProps>(
                         value={preserveSourceFile}
                         onChange={onPreserveSourceFileChange}
                         style={{
-                          width: 200,
+                          flex: "1 1 200px",
+                          minWidth: 200,
                           justifyContent: "center",
                           alignItems: "flex-end",
                         }}

--- a/frontend/app/[locale]/knowledges/components/document/DocumentList.tsx
+++ b/frontend/app/[locale]/knowledges/components/document/DocumentList.tsx
@@ -562,9 +562,9 @@ const DocumentListContainer = forwardRef<DocumentListRef, DocumentListProps>(
             className="flex items-start justify-between w-full"
             style={{ width: "100%" }}
           >
-            <div className="flex items-start flex-1 min-w-0">
+            <div className="flex items-start flex-1 min-w-0 overflow-hidden">
               {isCreatingMode ? (
-                <div className="flex flex-wrap items-start gap-3 w-full">
+                <div className="flex flex-wrap items-start gap-3 w-full overflow-hidden">
                   <div className="flex flex-col flex-1" style={{ minWidth: 120 }}>
                     <Input
                       value={knowledgeBaseName}
@@ -695,7 +695,7 @@ const DocumentListContainer = forwardRef<DocumentListRef, DocumentListProps>(
                 </div>
               ) : (
                 <h3
-                  className={`${LAYOUT.KB_TITLE_MARGIN} ${LAYOUT.KB_TITLE_SIZE} font-semibold text-blue-500 flex items-center`}
+                  className={`${LAYOUT.KB_TITLE_MARGIN} ${LAYOUT.KB_TITLE_SIZE} font-semibold text-blue-500 flex items-center truncate`}
                 >
                   {knowledgeBaseName}
                 </h3>
@@ -708,7 +708,7 @@ const DocumentListContainer = forwardRef<DocumentListRef, DocumentListProps>(
             </div>
             {/* Right: overview and detail buttons */}
             {!isCreatingMode && !isDataMate && (
-              <div className="flex gap-2">
+              <div className="flex gap-2 flex-shrink-0 ml-3">
                 <Button
                   type="primary"
                   icon={<BookText size={16} />}

--- a/frontend/app/[locale]/knowledges/components/knowledge/KnowledgeBaseList.tsx
+++ b/frontend/app/[locale]/knowledges/components/knowledge/KnowledgeBaseList.tsx
@@ -319,7 +319,7 @@ const KnowledgeBaseList: React.FC<KnowledgeBaseListProps> = ({
   ]);
 
   return (
-    <div className="w-full h-full bg-white border border-gray-200 rounded-md flex flex-col">
+    <div className="w-full h-full bg-white border border-gray-200 rounded-md flex flex-col overflow-hidden">
       {/* Fixed header area */}
       <div
         className={`${KB_LAYOUT.HEADER_PADDING} border-b border-gray-200 shrink-0`}
@@ -409,13 +409,13 @@ const KnowledgeBaseList: React.FC<KnowledgeBaseListProps> = ({
         </div>
 
         {/* Search and filter area */}
-        <div className="mt-3 flex items-center gap-3">
+        <div className="mt-3 flex items-start gap-3 flex-wrap">
           <Input
             placeholder={t("knowledgeBase.search.placeholder")}
             prefix={<SearchOutlined />}
             value={effectiveSearchKeyword}
             onChange={(e) => handleSearchChange(e.target.value)}
-            style={{ width: 250 }}
+            className="flex-1 min-w-0"
             allowClear
           />
 
@@ -425,7 +425,7 @@ const KnowledgeBaseList: React.FC<KnowledgeBaseListProps> = ({
               placeholder={t("knowledgeBase.filter.source.placeholder")}
               value={effectiveSelectedSources}
               onChange={handleSourcesChange}
-              style={{ minWidth: 150 }}
+              className="flex-1 min-w-0"
               allowClear
               maxTagCount={2}
             >
@@ -445,7 +445,7 @@ const KnowledgeBaseList: React.FC<KnowledgeBaseListProps> = ({
               placeholder={t("knowledgeBase.filter.model.placeholder")}
               value={effectiveSelectedModels}
               onChange={handleModelsChange}
-              style={{ minWidth: 180 }}
+              className="flex-1 min-w-0"
               allowClear
               maxTagCount={2}
             >

--- a/frontend/app/[locale]/knowledges/components/knowledge/KnowledgeBaseList.tsx
+++ b/frontend/app/[locale]/knowledges/components/knowledge/KnowledgeBaseList.tsx
@@ -332,7 +332,7 @@ const KnowledgeBaseList: React.FC<KnowledgeBaseListProps> = ({
               {t("knowledgeBase.list.title")}
             </h3>
           </div>
-          <div className="flex items-center min-w-0" style={{ gap: "6px" }}>
+          <div className="flex items-center min-w-0 overflow-x-auto" style={{ gap: "6px" }}>
             <Button
               style={{
                 padding: "4px 15px",
@@ -391,16 +391,14 @@ const KnowledgeBaseList: React.FC<KnowledgeBaseListProps> = ({
                   backgroundColor: "#1677ff",
                   color: "white",
                   border: "none",
-                  overflow: "hidden",
-                  whiteSpace: "nowrap",
-                  minWidth: 0,
+                  flexShrink: 0,
                 }}
                 className="hover:!bg-blue-600"
                 type="primary"
                 onClick={onDataMateConfig}
                 icon={<SettingOutlined />}
               >
-                <span className="overflow-hidden text-ellipsis">
+                <span className="truncate max-w-[120px]">
                   {t("knowledgeBase.button.dataMateConfig")}
                 </span>
               </Button>

--- a/frontend/app/[locale]/knowledges/components/upload/UploadArea.tsx
+++ b/frontend/app/[locale]/knowledges/components/upload/UploadArea.tsx
@@ -29,6 +29,7 @@ interface UploadAreaProps {
   indexName?: string;
   newKnowledgeBaseName?: string;
   modelMismatch?: boolean;
+  onNameStatusChange?: (status: string) => void;
 }
 
 export interface UploadAreaRef {
@@ -48,6 +49,7 @@ const UploadArea = forwardRef<UploadAreaRef, UploadAreaProps>(
       newKnowledgeBaseName = "",
       selectedFiles = [],
       modelMismatch = false,
+      onNameStatusChange,
     },
     ref
   ) => {
@@ -65,13 +67,18 @@ const UploadArea = forwardRef<UploadAreaRef, UploadAreaProps>(
       prevFileListRef.current = fileList;
     }, [fileList]);
 
+    const updateNameStatus = useCallback((status: string) => {
+      setNameStatus(status);
+      onNameStatusChange?.(status);
+    }, [onNameStatusChange]);
+
     // Function to reset all states
     const resetAllStates = useCallback(() => {
       setFileList([]);
-      setNameStatus("available");
+      updateNameStatus("available");
       setIsLoading(true);
       setIsKnowledgeBaseReady(false);
-    }, []);
+    }, [updateNameStatus]);
 
     // Listen for knowledge base changes, reset file list and get knowledge base info
     useEffect(() => {
@@ -140,17 +147,17 @@ const UploadArea = forwardRef<UploadAreaRef, UploadAreaProps>(
     // Check if knowledge base name already exists
     useEffect(() => {
       if (!isCreatingMode || !newKnowledgeBaseName) {
-        setNameStatus("available");
+        updateNameStatus("available");
         return;
       }
 
       const checkName = async () => {
         try {
           const result = await checkKnowledgeBaseName(newKnowledgeBaseName, t);
-          setNameStatus(result.status);
+          updateNameStatus(result.status);
         } catch (error) {
           log.error(t("knowledgeBase.error.checkName"), error);
-          setNameStatus(NAME_CHECK_STATUS.CHECK_FAILED); // Handle check failure
+          updateNameStatus(NAME_CHECK_STATUS.CHECK_FAILED); // Handle check failure
         }
       };
 

--- a/frontend/app/[locale]/knowledges/components/upload/UploadAreaUI.tsx
+++ b/frontend/app/[locale]/knowledges/components/upload/UploadAreaUI.tsx
@@ -169,13 +169,14 @@ const UploadAreaUI: React.FC<UploadAreaUIProps> = ({
                   {...uploadProps}
                   className="!h-full flex flex-col justify-center !bg-transparent !border-gray-200"
                   showUploadList={false}
+                  style={{ height: "100%", overflow: "auto" }}
                 >
-                  <div className="flex flex-col items-center justify-center h-full">
+                  <div className="flex flex-col items-center justify-center">
                     <p className="ant-upload-drag-icon !mb-4">
                       <Inbox size={48} className="text-blue-600" />
                     </p>
                     <p className="ant-upload-text !mb-2 text-base">
-                      {t("knowledgeBase.upload.dragHint")}
+                      {t("knowledgeBase.upload.dragHint")}   
                     </p>
                     <p className="ant-upload-hint text-gray-500">
                       {t("knowledgeBase.upload.supportedFormats")}


### PR DESCRIPTION
1、知识库重名时在input框上展示错误提示并高亮红框，更明确
<img width="2421" height="1197" alt="image" src="https://github.com/user-attachments/assets/27b743e6-7576-420f-963d-4d41ca682478" />
2、知识库创建页标题输入框增加最小宽度保护，窗口缩小时不再塌陷
3、模型下拉选择器增加自适应与最小宽度，窄屏下自动换行避免横向溢出
<img width="2469" height="1056" alt="屏幕截图 2026-07-07 173150" src="https://github.com/user-attachments/assets/2cd172a8-ecf6-4335-8dfe-d74478c972f6" />

Close #3251
Close #3391 