### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Nexent is a zero-code platform for auto-generating production-grade AI agents, b
 
 # 🚀 Get Started Now
 
+[![Listed on TakoAPI](https://takoapi.com/api/badge/modelengine-group-nexent)](https://takoapi.com/agents/modelengine-group-nexent)
+
 > ⭐ Before you get started, please star us on [GitHub](https://github.com/ModelEngine-Group/nexent) — your support drives us forward!
 
 ## Option 1: Try Our Official Demo


### PR DESCRIPTION
Hi! 👋 **nexent** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/modelengine-group-nexent

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building nexent! 🙏