### PR TITLE
Disable context component budget pruning

### DIFF
--- a/backend/agents/create_agent_info.py
+++ b/backend/agents/create_agent_info.py
@@ -958,6 +958,7 @@ async def create_agent_config(
         token_threshold=context_token_threshold,
         soft_input_budget_tokens=soft_input_budget_tokens,
         hard_input_budget_tokens=hard_input_budget_tokens,
+        strategy="full",
     )
     agent_config = AgentConfig(
         name="undefined" if agent_info["name"] is None else agent_info["name"],

--- a/sdk/nexent/core/agents/agent_context/manager.py
+++ b/sdk/nexent/core/agents/agent_context/manager.py
@@ -724,7 +724,7 @@ class ContextManager:
             "buffered": BufferedStrategy,
             "priority": PriorityWeightedStrategy,
         }
-        strategy_class = strategy_map.get(self.config.strategy, TokenBudgetStrategy)
+        strategy_class = strategy_map.get(self.config.strategy, FullStrategy)
 
         if self.config.strategy == "buffered":
             return strategy_class(buffer_size=self.config.buffer_size_per_component)

--- a/sdk/nexent/core/agents/summary_config.py
+++ b/sdk/nexent/core/agents/summary_config.py
@@ -69,11 +69,11 @@ class ContextManagerConfig:
     max_observation_length: int = 0
 
     # === NEW: Strategy Selection ===
-    strategy: StrategyType = "token_budget"
+    strategy: StrategyType = "full"
     """Context component selection strategy.
     
     Options:
-    - 'full': Keep all components (for unlimited context models)
+    - 'full': Keep all components without component budget pruning
     - 'token_budget': Select components within token budget by priority
     - 'buffered': Keep last N components per type
     - 'priority': Weight by importance + relevance scores

--- a/test/sdk/core/agents/test_agent_context/unit/test_component_management.py
+++ b/test/sdk/core/agents/test_agent_context/unit/test_component_management.py
@@ -163,10 +163,10 @@ class TestGetRegisteredComponents:
 class TestGetStrategy:
     """Tests for _get_strategy() method."""
 
-    def test_default_returns_token_budget_strategy(self):
+    def test_default_returns_full_strategy(self):
         cm = ContextManager()
         strategy = cm._get_strategy()
-        assert strategy.get_strategy_name() == "token_budget"
+        assert strategy.get_strategy_name() == "full"
 
     def test_full_strategy(self):
         config = ContextManagerConfig(strategy="full")
@@ -187,11 +187,11 @@ class TestGetStrategy:
         strategy = cm._get_strategy()
         assert strategy.get_strategy_name() == "priority"
 
-    def test_unknown_strategy_defaults_to_token_budget(self):
+    def test_unknown_strategy_defaults_to_full(self):
         config = ContextManagerConfig(strategy="unknown")
         cm = ContextManager(config)
         strategy = cm._get_strategy()
-        assert strategy.get_strategy_name() == "token_budget"
+        assert strategy.get_strategy_name() == "full"
 
 
 class TestBuildSystemPrompt:

--- a/test/sdk/core/agents/test_context_component.py
+++ b/test/sdk/core/agents/test_context_component.py
@@ -742,7 +742,7 @@ class TestExtendedContextManagerConfig:
 
     def test_default_strategy(self):
         config = summary_config_module.ContextManagerConfig()
-        assert config.strategy == "token_budget"
+        assert config.strategy == "full"
 
     def test_all_injection_flags_default_true(self):
         config = summary_config_module.ContextManagerConfig()

--- a/test/sdk/core/agents/test_nexent_agent_component_integration.py
+++ b/test/sdk/core/agents/test_nexent_agent_component_integration.py
@@ -13,6 +13,7 @@ from sdk.nexent.core.agents.summary_config import ContextManagerConfig
 
 
 STRATEGY_TOKEN_BUDGET = "token_budget"
+STRATEGY_FULL = "full"
 
 
 class TestNexentAgentComponentRegistration:
@@ -216,7 +217,7 @@ class TestBackwardCompatibility:
     def test_context_manager_config_without_strategy_defaults(self):
         config = ContextManagerConfig(token_threshold=2000)
 
-        assert config.strategy == STRATEGY_TOKEN_BUDGET
+        assert config.strategy == STRATEGY_FULL
         assert "system_prompt" in config.component_budgets
 
 


### PR DESCRIPTION
## Summary

Disable component-level budget pruning for ContextManager assembly by defaulting the context strategy to `full` and explicitly using `full` when backend agent configs are created.

## Why

The previous `token_budget` default could drop lower-priority context components when component budgets were too conservative. In production this could remove important agent-definition sections such as duty, constraint, and few-shot examples from the assembled context.

## Changes

- Default `ContextManagerConfig.strategy` to `full`.
- Explicitly set backend-created ContextManager configs to `strategy="full"`.
- Fall back to `FullStrategy` for unknown strategy values.
- Update SDK/backend tests for the new default behavior.

## Validation

- `uv run pytest test/sdk/core/agents/test_nexent_agent_component_integration.py -q`
- `uv run pytest test/sdk/core/agents/test_context_component.py test/sdk/core/agents/test_agent_context/unit/test_component_management.py -q`
- `uv run pytest test/backend/agents/test_create_agent_info.py -q`