### PR TITLE
🐛 Bugfix: Fixed an issue with tools relying on large models: previously, if a model was selected and subsequently deleted, the agent would encounter runtime errors without any corresponding notification on the frontend.

### DIFF
--- a/backend/consts/agent_unavailable_reasons.py
+++ b/backend/consts/agent_unavailable_reasons.py
@@ -20,6 +20,7 @@ class AgentUnavailableReason:
     # Tool issues
     TOOL_UNAVAILABLE = "tool_unavailable"
     ALL_TOOLS_DISABLED = "all_tools_disabled"
+    MCP_MODEL_UNAVAILABLE = "mcp_model_unavailable"
 
     # Agent issues
     AGENT_NOT_FOUND = "agent_not_found"
@@ -35,6 +36,7 @@ class AgentUnavailableReason:
             cls.TOOL_UNAVAILABLE,
             cls.ALL_TOOLS_DISABLED,
             cls.AGENT_NOT_FOUND,
+            cls.MCP_MODEL_UNAVAILABLE,
         ]
 
     @classmethod

--- a/backend/database/model_management_db.py
+++ b/backend/database/model_management_db.py
@@ -182,7 +182,7 @@ def get_model_by_display_name(display_name: str, tenant_id: str, model_type: str
         tenant_id:
     """
     filters = {'display_name': display_name}
-    
+
     if model_type in ["multiEmbedding", "multi_embedding"]:
         filters['model_type'] = "multi_embedding"
     elif model_type == "embedding":
@@ -216,7 +216,7 @@ def get_model_id_by_display_name(display_name: str, tenant_id: str, model_type: 
     Get a model ID by display name
 
     Args:
-        display_name: Model display name 
+        display_name: Model display name
         tenant_id: tenant_id
 
     Returns:
@@ -280,15 +280,44 @@ def get_models_by_tenant_factory_type(tenant_id: str, model_factory: str, model_
     return get_model_records(filters, tenant_id)
 
 
+def get_valid_model_ids(model_ids: List[int], tenant_id: str) -> List[int]:
+    """
+    Filter model IDs to only include those that are not soft-deleted (delete_flag='N').
+
+    When a model is deleted from model management, its delete_flag is set to 'Y'.
+    This function ensures that only valid (non-deleted) model IDs are returned,
+    preserving the order of the input model_ids.
+
+    Args:
+        model_ids: List of model IDs to filter
+        tenant_id: Tenant ID for filtering
+
+    Returns:
+        List[int]: Filtered list of valid model IDs in original order
+    """
+    if not model_ids:
+        return []
+
+    with get_db_session() as session:
+        stmt = select(ModelRecord.model_id).where(
+            ModelRecord.model_id.in_(model_ids),
+            ModelRecord.delete_flag == 'N'
+        )
+        valid_ids = session.scalars(stmt).all()
+        valid_ids_set = set(valid_ids)
+
+        return [mid for mid in model_ids if mid in valid_ids_set]
+
+
 def get_model_by_name_factory(model_name: str, model_factory: str, tenant_id: str) -> Optional[Dict[str, Any]]:
     """
     Get a model record by model_name and model_factory for deduplication.
-    
+
     Args:
         model_name: Model name (e.g., "deepseek-r1-distill-qwen-14b")
         model_factory: Model factory (e.g., "ModelEngine")
         tenant_id: Tenant ID
-        
+
     Returns:
         Optional[Dict[str, Any]]: Model record if found, None otherwise
     """

--- a/backend/database/model_management_db.py
+++ b/backend/database/model_management_db.py
@@ -228,7 +228,7 @@ def get_model_id_by_display_name(display_name: str, tenant_id: str, model_type: 
 
 def get_model_by_model_id(model_id: int, tenant_id: Optional[str] = None) -> Optional[Dict[str, Any]]:
     """
-    Get a model record using native SQLAlchemy query
+    Get a model record using native SQLAlchemy query.
 
     Args:
         model_id (int): Model ID
@@ -266,6 +266,37 @@ def get_model_by_model_id(model_id: int, tenant_id: Optional[str] = None) -> Opt
             if result_dict.get("maximum_chunk_size") is None:
                 result_dict["maximum_chunk_size"] = DEFAULT_MAXIMUM_CHUNK_SIZE
 
+        return result_dict
+
+
+def get_model_by_model_id_ignore_delete(model_id: int, tenant_id: Optional[str] = None) -> Optional[Dict[str, Any]]:
+    """
+    Get a model record without filtering by delete_flag.
+
+    Used when checking whether a previously selected model has been deleted
+    (e.g., for tools that store a selected_model_id in their params).
+
+    Args:
+        model_id (int): Model ID
+        tenant_id (Optional[str]): Tenant ID, optional
+
+    Returns:
+        Optional[Dict[str, Any]]: Model record as a dictionary, or None if not found
+    """
+    with get_db_session() as session:
+        stmt = select(ModelRecord).where(ModelRecord.model_id == model_id)
+        if tenant_id:
+            stmt = stmt.where(ModelRecord.tenant_id == tenant_id)
+        result = session.scalars(stmt).first()
+        if result is None:
+            return None
+        result_dict = {key: value for key,
+                       value in result.__dict__.items() if not key.startswith('_')}
+        if result_dict.get("model_type") in ["embedding", "multi_embedding"]:
+            if result_dict.get("expected_chunk_size") is None:
+                result_dict["expected_chunk_size"] = DEFAULT_EXPECTED_CHUNK_SIZE
+            if result_dict.get("maximum_chunk_size") is None:
+                result_dict["maximum_chunk_size"] = DEFAULT_MAXIMUM_CHUNK_SIZE
         return result_dict
 
 

--- a/backend/services/agent_service.py
+++ b/backend/services/agent_service.py
@@ -62,7 +62,7 @@ from database.agent_db import (
     clear_agent_new_mark
 )
 from database import a2a_agent_db
-from database.model_management_db import get_model_by_model_id, get_model_id_by_display_name, get_valid_model_ids
+from database.model_management_db import get_model_by_model_id, get_model_by_model_id_ignore_delete, get_model_id_by_display_name, get_valid_model_ids
 from database.remote_mcp_db import get_mcp_server_by_name_and_tenant
 from database.tool_db import (
     check_tool_is_available,
@@ -1376,6 +1376,22 @@ async def get_agent_info_impl(agent_id: int, tenant_id: str, version_no: int = 0
     try:
         tool_info = search_tools_for_sub_agent(
             agent_id=agent_id, tenant_id=tenant_id)
+        # Check if selected_model_id in tool params points to a deleted model
+        for tool in tool_info:
+            unavailable_reasons: List[str] = []
+            params = tool.get("params") or []
+            if isinstance(params, list):
+                for param_def in params:
+                    if not isinstance(param_def, dict):
+                        continue
+                    if param_def.get("name") == "selected_model_id":
+                        selected_model_id = param_def.get("default")
+                        if selected_model_id is not None:
+                            model_record = get_model_by_model_id_ignore_delete(selected_model_id, tenant_id)
+                            if model_record is not None and model_record.get("delete_flag") == "Y":
+                                unavailable_reasons.append(AgentUnavailableReason.MCP_MODEL_UNAVAILABLE)
+                        break
+            tool["unavailable_reasons"] = unavailable_reasons
         agent_info["tools"] = tool_info
     except Exception as e:
         logger.error(f"Failed to get agent tools: {str(e)}")
@@ -2586,6 +2602,22 @@ def check_agent_availability(
         tool_statuses = check_tool_is_available(tool_id_list)
         if not all(tool_statuses):
             unavailable_reasons.append(AgentUnavailableReason.TOOL_UNAVAILABLE)
+
+    # Check if any tool has a selected_model_id pointing to a deleted model
+    for tool in tool_info:
+        params = tool.get("params") or []
+        if isinstance(params, list):
+            for param_def in params:
+                if not isinstance(param_def, dict):
+                    continue
+                if param_def.get("name") == "selected_model_id":
+                    selected_model_id = param_def.get("default")
+                    if selected_model_id is not None:
+                        model_record = get_model_by_model_id_ignore_delete(
+                            selected_model_id, tenant_id)
+                        if model_record is not None and model_record.get("delete_flag") == "Y":
+                            unavailable_reasons.append(AgentUnavailableReason.TOOL_UNAVAILABLE)
+                    break
 
     # Check model availability
     model_reasons = _collect_model_availability_reasons(

--- a/backend/services/agent_service.py
+++ b/backend/services/agent_service.py
@@ -62,7 +62,7 @@ from database.agent_db import (
     clear_agent_new_mark
 )
 from database import a2a_agent_db
-from database.model_management_db import get_model_by_model_id, get_model_id_by_display_name
+from database.model_management_db import get_model_by_model_id, get_model_id_by_display_name, get_valid_model_ids
 from database.remote_mcp_db import get_mcp_server_by_name_and_tenant
 from database.tool_db import (
     check_tool_is_available,
@@ -1412,19 +1412,22 @@ async def get_agent_info_impl(agent_id: int, tenant_id: str, version_no: int = 0
         agent_info["external_sub_agent_id_list"] = []
 
     # Get model names from model_ids array
-    model_ids = agent_info.get("model_ids")
+    # Filter out deleted models (delete_flag='Y' in model_record_t)
+    model_ids = agent_info.get("model_ids") or []
+    valid_model_ids = get_valid_model_ids(model_ids, tenant_id)
+    agent_info["model_ids"] = valid_model_ids
+
     model_names: List[str] = []
-    if model_ids and len(model_ids) > 0:
-        for mid in model_ids:
-            model_info = get_model_by_model_id(mid)
-            if model_info:
-                display_name = model_info.get("display_name")
-                if display_name:
-                    model_names.append(display_name)
+    for mid in valid_model_ids:
+        model_info = get_model_by_model_id(mid)
+        if model_info:
+            display_name = model_info.get("display_name")
+            if display_name:
+                model_names.append(display_name)
     agent_info["model_names"] = model_names
-    # Always derive model_name from model_ids so the API contract is consistent.
-    if model_ids and len(model_ids) > 0:
-        first_model_info = get_model_by_model_id(model_ids[0])
+    # Always derive model_name from valid_model_ids so the API contract is consistent.
+    if valid_model_ids:
+        first_model_info = get_model_by_model_id(valid_model_ids[0])
         agent_info["model_name"] = first_model_info.get(
             "display_name", None) if first_model_info is not None else None
     else:
@@ -2382,6 +2385,11 @@ async def list_all_agent_info_impl(tenant_id: str, user_id: str) -> list[dict]:
                 # Hide agent if: no group overlap OR (ingroup_permission is PRIVATE AND user is not creator)
                 if not is_creator and (len(user_group_ids.intersection(agent_group_ids)) == 0 or ingroup_permission == PERMISSION_PRIVATE):
                     continue
+
+            # Filter out deleted models (delete_flag='Y' in model_record_t)
+            raw_model_ids = agent.get("model_ids") or []
+            valid_model_ids = get_valid_model_ids(raw_model_ids, tenant_id)
+            agent["model_ids"] = valid_model_ids
 
             # Use shared availability check function
             _, unavailable_reasons = check_agent_availability(

--- a/backend/services/agent_version_service.py
+++ b/backend/services/agent_version_service.py
@@ -31,7 +31,7 @@ from database.agent_version_db import (
     STATUS_DISABLED,
     STATUS_ARCHIVED,
 )
-from database.model_management_db import get_model_by_model_id
+from database.model_management_db import get_model_by_model_id, get_valid_model_ids
 from utils.str_utils import convert_string_to_list
 from consts.agent_unavailable_reasons import AgentUnavailableReason
 
@@ -898,6 +898,11 @@ async def list_published_agents_impl(
 
             # Add current version info
             agent_info['current_version_no'] = current_version_no
+
+            # Filter out deleted models (delete_flag='Y' in model_record_t)
+            raw_model_ids = agent_info.get("model_ids") or []
+            valid_model_ids = get_valid_model_ids(raw_model_ids, tenant_id)
+            agent_info["model_ids"] = valid_model_ids
 
             # Check agent availability using the shared function
             _, unavailable_reasons = check_agent_availability(

--- a/frontend/app/[locale]/agents/components/agentConfig/ToolManagement.tsx
+++ b/frontend/app/[locale]/agents/components/agentConfig/ToolManagement.tsx
@@ -186,15 +186,18 @@ export default function ToolManagement({ isCreatingMode, currentAgentId }: ToolM
                       <div className="divide-y divide-gray-100">
                         {cat.tools.map((tool) => {
                           const labels = getToolLabels(tool);
+                          const toolUnavailableReasons = tool.unavailable_reasons || [];
+                          const isModelUnavailable = toolUnavailableReasons.includes("mcp_model_unavailable");
                           const disabled =
                             isToolDisabledDueToVlm(tool.name, isImageUnderstandingAvailable, isVideoUnderstandingAvailable) ||
-                            isToolDisabledDueToEmbedding(tool.name, isEmbeddingAvailable);
+                            isToolDisabledDueToEmbedding(tool.name, isEmbeddingAvailable) ||
+                            isModelUnavailable;
 
                           return (
                             <div key={tool.id} className="group flex items-center gap-2 px-3 py-2">
                               <div className="min-w-0 flex-1">
                                 <div className="flex items-center gap-2">
-                                  <span className="truncate font-mono text-xs font-medium text-gray-800">
+                                  <span className={`truncate font-mono text-xs font-medium ${isModelUnavailable ? "text-gray-400" : "text-gray-800"}`}>
                                     {tool.name}
                                   </span>
                                   {labels.slice(0, 2).map((l) => (
@@ -209,7 +212,12 @@ export default function ToolManagement({ isCreatingMode, currentAgentId }: ToolM
                                       </span>
                                     </Tooltip>
                                   )}
-                                  {disabled && <AlertTriangle size={14} className="shrink-0 text-orange-400" />}
+                                  {isModelUnavailable && (
+                                    <Tooltip title={t("toolPool.mcpModelUnavailableTooltip")}>
+                                      <AlertTriangle size={14} className="shrink-0 text-orange-400" />
+                                    </Tooltip>
+                                  )}
+                                  {disabled && !isModelUnavailable && <AlertTriangle size={14} className="shrink-0 text-orange-400" />}
                                 </div>
                               </div>
 

--- a/frontend/app/[locale]/agents/components/agentConfig/tool/SelectToolsDialog.tsx
+++ b/frontend/app/[locale]/agents/components/agentConfig/tool/SelectToolsDialog.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo, useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { Modal, Tabs, Input, Checkbox, Button, Select } from "antd";
+import { Modal, Tabs, Input, Checkbox, Button, Select, Tooltip } from "antd";
 import type { TabsProps } from "antd";
 import { Search, Settings, Wrench, Tag } from "lucide-react";
 import i18n from "i18next";
@@ -30,6 +30,19 @@ function isToolDisabled(name: string, img: boolean, vid: boolean, emb: boolean):
   if (TOOLS_REQUIRING_VIDEO_UNDERSTANDING.includes(name) && !vid) return true;
   if (TOOLS_REQUIRING_EMBEDDING.includes(name) && !emb) return true;
   return false;
+}
+
+function getToolDisabledTooltipKey(name: string, img: boolean, vid: boolean, emb: boolean): string | null {
+  if (TOOLS_REQUIRING_IMAGE_UNDERSTANDING.includes(name) && !img) {
+    return "toolPool.imageUnderstandingDisabledTooltip";
+  }
+  if (TOOLS_REQUIRING_VIDEO_UNDERSTANDING.includes(name) && !vid) {
+    return "toolPool.videoUnderstandingDisabledTooltip";
+  }
+  if (TOOLS_REQUIRING_EMBEDDING.includes(name) && !emb) {
+    return "toolPool.embeddingDisabledTooltip";
+  }
+  return null;
 }
 
 function getToolDescription(tool: any): string {
@@ -406,60 +419,78 @@ export default function SelectToolsDialog({
                         isVideoUnderstandingAvailable,
                         isEmbeddingAvailable
                       );
+                      const disabledTooltipKey = disabled
+                        ? getToolDisabledTooltipKey(
+                            tool.name,
+                            isImageUnderstandingAvailable,
+                            isVideoUnderstandingAvailable,
+                            isEmbeddingAvailable
+                          )
+                        : null;
+
+                      const row = (
+                        <div
+                          role="button"
+                          tabIndex={disabled ? -1 : 0}
+                          className={`group flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors ${
+                            disabled
+                              ? "cursor-not-allowed opacity-50"
+                              : "cursor-pointer hover:bg-gray-50"
+                          }`}
+                          onClick={disabled ? undefined : () => handleToolToggle(tool)}
+                          onKeyDown={(e) => {
+                            if (!disabled && (e.key === 'Enter' || e.key === ' ')) {
+                              e.preventDefault();
+                              handleToolToggle(tool);
+                            }
+                          }}
+                        >
+                          <Checkbox checked={isSelected} disabled={disabled} />
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-center gap-2">
+                              <span className="truncate font-mono text-xs font-medium text-gray-800">
+                                {tool.name}
+                              </span>
+                              {getToolLabels(tool)
+                                .slice(0, 2)
+                                .map((label: string) => (
+                                  <span
+                                    key={label}
+                                    className="shrink-0 rounded bg-blue-50 px-1.5 py-0.5 text-[10px] text-blue-600"
+                                  >
+                                    {label}
+                                  </span>
+                                ))}
+                            </div>
+                            {tool.description && (
+                              <p className="truncate text-xs text-gray-400">
+                                {getToolDescription(tool)}
+                              </p>
+                            )}
+                          </div>
+                          {!disabled && (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                openConfigModal(tool);
+                              }}
+                              className="flex size-7 shrink-0 items-center justify-center rounded-md text-gray-400 opacity-0 transition-opacity hover:bg-gray-100 hover:text-gray-600 group-hover:opacity-100"
+                            >
+                              <Settings className="size-4" />
+                            </button>
+                          )}
+                        </div>
+                      );
 
                       return (
                         <li key={tool.id}>
-                          <div
-                            role="button"
-                            tabIndex={disabled ? -1 : 0}
-                            className={`group flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors ${
-                              disabled
-                                ? "cursor-not-allowed opacity-50"
-                                : "cursor-pointer hover:bg-gray-50"
-                            }`}
-                            onClick={disabled ? undefined : () => handleToolToggle(tool)}
-                            onKeyDown={(e) => {
-                              if (!disabled && (e.key === 'Enter' || e.key === ' ')) {
-                                e.preventDefault();
-                                handleToolToggle(tool);
-                              }
-                            }}
-                          >
-                            <Checkbox checked={isSelected} disabled={disabled} />
-                            <div className="min-w-0 flex-1">
-                              <div className="flex items-center gap-2">
-                                <span className="truncate font-mono text-xs font-medium text-gray-800">
-                                  {tool.name}
-                                </span>
-                                {getToolLabels(tool)
-                                  .slice(0, 2)
-                                  .map((label: string) => (
-                                    <span
-                                      key={label}
-                                      className="shrink-0 rounded bg-blue-50 px-1.5 py-0.5 text-[10px] text-blue-600"
-                                    >
-                                      {label}
-                                    </span>
-                                  ))}
-                              </div>
-                              {tool.description && (
-                                <p className="truncate text-xs text-gray-400">
-                                  {getToolDescription(tool)}
-                                </p>
-                              )}
-                            </div>
-                            {!disabled && (
-                              <button
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  openConfigModal(tool);
-                                }}
-                                className="flex size-7 shrink-0 items-center justify-center rounded-md text-gray-400 opacity-0 transition-opacity hover:bg-gray-100 hover:text-gray-600 group-hover:opacity-100"
-                              >
-                                <Settings className="size-4" />
-                              </button>
-                            )}
-                          </div>
+                          {disabledTooltipKey ? (
+                            <Tooltip title={t(disabledTooltipKey)} mouseEnterDelay={0.2}>
+                              {row}
+                            </Tooltip>
+                          ) : (
+                            row
+                          )}
                         </li>
                       );
                     })}

--- a/frontend/app/[locale]/agents/components/agentConfig/tool/SelectToolsDialog.tsx
+++ b/frontend/app/[locale]/agents/components/agentConfig/tool/SelectToolsDialog.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { Modal, Tabs, Input, Checkbox, Button, Select } from "antd";
 import type { TabsProps } from "antd";
 import { Search, Settings, Wrench, Tag } from "lucide-react";
+import i18n from "i18next";
 
 import { useToolList } from "@/hooks/agent/useToolList";
 import { useAgentConfigStore } from "@/stores/agentConfigStore";
@@ -29,6 +30,14 @@ function isToolDisabled(name: string, img: boolean, vid: boolean, emb: boolean):
   if (TOOLS_REQUIRING_VIDEO_UNDERSTANDING.includes(name) && !vid) return true;
   if (TOOLS_REQUIRING_EMBEDDING.includes(name) && !emb) return true;
   return false;
+}
+
+function getToolDescription(tool: any): string {
+  const locale = i18n.language || "en";
+  if (locale === "zh" && tool.description_zh) {
+    return tool.description_zh;
+  }
+  return tool.description || "";
 }
 
 const SOURCE_TABS: { key: string; labelKey: string; sourceValue: string }[] = [
@@ -124,11 +133,12 @@ export default function SelectToolsDialog({
     if (!hasSearch && !hasLabels) return groups;
 
     const filterOne = (tool: any): boolean => {
-      // Search filter (OR across name/desc/tags)
+      // Search filter (OR across name/desc/desc_zh/tags)
       if (hasSearch) {
+        const toolDesc = getToolDescription(tool);
         const matchSearch =
           tool.name.toLowerCase().includes(kw) ||
-          (tool.description && tool.description.toLowerCase().includes(kw)) ||
+          (toolDesc && toolDesc.toLowerCase().includes(kw)) ||
           getToolLabels(tool).some((l: string) => l.toLowerCase().includes(kw));
         if (!matchSearch) return false;
       }
@@ -434,7 +444,7 @@ export default function SelectToolsDialog({
                               </div>
                               {tool.description && (
                                 <p className="truncate text-xs text-gray-400">
-                                  {tool.description}
+                                  {getToolDescription(tool)}
                                 </p>
                               )}
                             </div>

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "assistant.name": "Nexent",
 
   "mainPage.layout.title": "Nexent | AI Agents",
@@ -590,6 +590,8 @@
   "toolPool.error.requiredFields": "The following required fields are not filled: {{fields}}",
   "toolPool.vlmRequired": "VLM model required",
   "toolPool.vlmDisabledTooltip": "Please contact your administrator to configure an available Vision Language Model",
+  "toolPool.imageUnderstandingDisabledTooltip": "Please contact your administrator to configure an available Image Understanding model",
+  "toolPool.videoUnderstandingDisabledTooltip": "Please contact your administrator to configure an available Video Understanding model",
   "toolPool.embeddingDisabledTooltip": "Please contact your administrator to configure an available Embedding model",
   "toolPool.tooltip.functionGuide": "1. For local knowledge base search functionality, please enable the knowledge_base_search tool;\n2. For text file parsing functionality, please enable the analyze_text_file tool;\n3. For image parsing functionality, please enable the analyze_image tool.",
   "toolPool.duplicateToolName.title": "Duplicate Tool Name Detected",
@@ -603,6 +605,7 @@
   "toolPool.remove": "Remove",
   "toolPool.selectedToolsLabel": "Selected Tools",
   "toolPool.noSearchResults": "No tools match your search",
+  "toolPool.mcpModelUnavailableTooltip": "Selected model is unavailable",
 
   "tool.message.unavailable": "This tool is currently unavailable and cannot be selected",
   "tool.error.noMainAgentId": "Main Agent ID is not set, cannot update tool status",

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "assistant.name": "Nexent",
 
   "mainPage.layout.title": "Nexent | 智能问答",
@@ -563,6 +563,8 @@
   "toolPool.error.requiredFields": "以下必填字段未填写: {{fields}}",
   "toolPool.vlmRequired": "需要配置视觉语言模型",
   "toolPool.vlmDisabledTooltip": "请联系管理员配置可用的视觉语言模型",
+  "toolPool.imageUnderstandingDisabledTooltip": "请联系管理员配置可用的图片理解模型",
+  "toolPool.videoUnderstandingDisabledTooltip": "请联系管理员配置可用的视频理解模型",
   "toolPool.embeddingDisabledTooltip": "请联系管理员配置可用的向量模型",
   "toolPool.tooltip.functionGuide": "1. 本地知识库检索功能，请启用knowledge_base_search工具；\n2. 文本文件解析功能，请启用analyze_text_file工具；\n3. 图片解析功能，请启用analyze_image工具。",
   "toolPool.duplicateToolName.title": "检测到重复工具名",
@@ -576,6 +578,7 @@
   "toolPool.remove": "移除",
   "toolPool.selectedToolsLabel": "已选择工具",
   "toolPool.noSearchResults": "没有搜索到匹配的工具",
+  "toolPool.mcpModelUnavailableTooltip": "工具所选模型不可用",
 
   "tool.message.unavailable": "该工具当前不可用，无法选择",
   "tool.error.noMainAgentId": "主代理ID未设置，无法更新工具状态",

--- a/frontend/services/agentConfigService.ts
+++ b/frontend/services/agentConfigService.ts
@@ -806,6 +806,9 @@ export const searchAgentInfo = async (
               is_available: tool.is_available,
               usage: tool.usage,
               category: tool.category,
+              unavailable_reasons: Array.isArray(tool.unavailable_reasons)
+                ? tool.unavailable_reasons
+                : [],
               // Pass through `inputs` so the ToolTestPanel can parse runtime
               // input parameters when reopening a tool from the selected
               // tools list. Without this, the test panel falls back to

--- a/frontend/types/agentConfig.ts
+++ b/frontend/types/agentConfig.ts
@@ -136,6 +136,11 @@ export interface Tool {
    * Used to pass knowledge base names to prompt generation without requiring database lookup.
    */
   display_names?: string[];
+  /**
+   * Reasons why this tool may be unavailable.
+   * E.g., ["mcp_model_unavailable"] when the selected model has been deleted.
+   */
+  unavailable_reasons?: string[];
 }
 
 export interface ToolParam {

--- a/test/backend/database/test_model_managment_db.py
+++ b/test/backend/database/test_model_managment_db.py
@@ -525,3 +525,186 @@ def test_get_valid_model_ids_none_deleted(monkeypatch):
     # All models were deleted
     result = model_mgmt_db.get_valid_model_ids([1, 2, 3], "tenant1")
     assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Tests for get_model_by_model_id_ignore_delete
+# ---------------------------------------------------------------------------
+
+
+def _patch_session(monkeypatch, scalars_first, scalars_all=None):
+    """Helper to install a fake DB session returning the given scalars."""
+    mock_scalars = MagicMock()
+    mock_scalars.first.return_value = scalars_first
+    if scalars_all is not None:
+        mock_scalars.all.return_value = scalars_all
+    session = MagicMock()
+    session.scalars.return_value = mock_scalars
+    ctx = MagicMock()
+    ctx.__enter__.return_value = session
+    ctx.__exit__.return_value = None
+    monkeypatch.setattr(
+        "backend.database.model_management_db.get_db_session", lambda: ctx)
+    return session
+
+
+def test_get_model_by_model_id_ignore_delete_returns_chat_model(monkeypatch):
+    """Non-embedding records should be returned untouched, without chunk-size defaults."""
+    mock_model = SimpleNamespace(
+        model_id=101,
+        model_factory="openai",
+        model_type="chat",
+        tenant_id="tenant_ignore_chat",
+        delete_flag="Y",  # explicitly soft-deleted; the function must still return it
+        expected_chunk_size=None,
+        maximum_chunk_size=None,
+        _sa_instance_state=None,  # underscore-prefixed; should be dropped from dict
+    )
+    session = _patch_session(monkeypatch, scalars_first=mock_model)
+
+    result = model_mgmt_db.get_model_by_model_id_ignore_delete(
+        101, tenant_id="tenant_ignore_chat")
+
+    # The filtered-by-underscore dictionary must contain only the public attributes.
+    assert result["model_id"] == 101
+    assert result["model_type"] == "chat"
+    assert result["delete_flag"] == "Y"
+    # No default chunk-size backfill for non-embedding types.
+    assert result["expected_chunk_size"] is None
+    assert result["maximum_chunk_size"] is None
+    # Private attributes beginning with "_" are removed from the dict.
+    assert all(not key.startswith("_") for key in result)
+
+
+def test_get_model_by_model_id_ignore_delete_embedding_fills_defaults(monkeypatch):
+    """For embedding records with None chunk sizes, defaults must be applied."""
+    mock_model = SimpleNamespace(
+        model_id=102,
+        model_factory="openai",
+        model_type="embedding",
+        tenant_id="tenant_ignore_emb",
+        delete_flag="Y",
+        expected_chunk_size=None,
+        maximum_chunk_size=None,
+    )
+    _patch_session(monkeypatch, scalars_first=mock_model)
+
+    result = model_mgmt_db.get_model_by_model_id_ignore_delete(
+        102, tenant_id="tenant_ignore_emb")
+
+    assert result["model_type"] == "embedding"
+    assert result["expected_chunk_size"] == 1024
+    assert result["maximum_chunk_size"] == 1536
+
+
+def test_get_model_by_model_id_ignore_delete_multi_embedding_fills_defaults(monkeypatch):
+    """For multi_embedding records with None chunk sizes, defaults must also be applied."""
+    mock_model = SimpleNamespace(
+        model_id=103,
+        model_factory="openai",
+        model_type="multi_embedding",
+        tenant_id="tenant_ignore_multi",
+        delete_flag="Y",
+        expected_chunk_size=None,
+        maximum_chunk_size=None,
+    )
+    _patch_session(monkeypatch, scalars_first=mock_model)
+
+    result = model_mgmt_db.get_model_by_model_id_ignore_delete(
+        103, tenant_id="tenant_ignore_multi")
+
+    assert result["model_type"] == "multi_embedding"
+    assert result["expected_chunk_size"] == 1024
+    assert result["maximum_chunk_size"] == 1536
+
+
+def test_get_model_by_model_id_ignore_delete_embedding_keeps_existing_sizes(monkeypatch):
+    """Pre-existing chunk sizes (even for embedding) must NOT be overwritten."""
+    mock_model = SimpleNamespace(
+        model_id=104,
+        model_factory="openai",
+        model_type="embedding",
+        tenant_id="tenant_ignore_keep",
+        delete_flag="Y",
+        expected_chunk_size=256,
+        maximum_chunk_size=512,
+    )
+    _patch_session(monkeypatch, scalars_first=mock_model)
+
+    result = model_mgmt_db.get_model_by_model_id_ignore_delete(
+        104, tenant_id="tenant_ignore_keep")
+
+    # The pre-existing sizes must be preserved.
+    assert result["expected_chunk_size"] == 256
+    assert result["maximum_chunk_size"] == 512
+
+
+def test_get_model_by_model_id_ignore_delete_embedding_only_one_size_missing(monkeypatch):
+    """When only one of the chunk sizes is missing, only that one should be defaulted."""
+    mock_model = SimpleNamespace(
+        model_id=105,
+        model_factory="openai",
+        model_type="embedding",
+        tenant_id="tenant_ignore_partial",
+        delete_flag="Y",
+        expected_chunk_size=256,        # already set
+        maximum_chunk_size=None,        # missing — must be defaulted
+    )
+    _patch_session(monkeypatch, scalars_first=mock_model)
+
+    result = model_mgmt_db.get_model_by_model_id_ignore_delete(
+        105, tenant_id="tenant_ignore_partial")
+
+    assert result["expected_chunk_size"] == 256
+    assert result["maximum_chunk_size"] == 1536
+
+
+def test_get_model_by_model_id_ignore_delete_embedding_fills_only_max_if_min_present(monkeypatch):
+    """Complement of the partial-fill test: missing `expected_chunk_size` defaults
+    even though `maximum_chunk_size` is supplied."""
+    mock_model = SimpleNamespace(
+        model_id=106,
+        model_factory="openai",
+        model_type="embedding",
+        tenant_id="tenant_ignore_min",
+        delete_flag="Y",
+        expected_chunk_size=None,
+        maximum_chunk_size=999,
+    )
+    _patch_session(monkeypatch, scalars_first=mock_model)
+
+    result = model_mgmt_db.get_model_by_model_id_ignore_delete(
+        106, tenant_id="tenant_ignore_min")
+
+    assert result["expected_chunk_size"] == 1024
+    assert result["maximum_chunk_size"] == 999
+
+
+def test_get_model_by_model_id_ignore_delete_not_found_returns_none(monkeypatch):
+    """When the DB query finds nothing, the function returns None."""
+    _patch_session(monkeypatch, scalars_first=None)
+
+    result = model_mgmt_db.get_model_by_model_id_ignore_delete(
+        9999, tenant_id="tenant_ignore_missing")
+
+    assert result is None
+
+
+def test_get_model_by_model_id_ignore_delete_without_tenant_id(monkeypatch):
+    """Omitting tenant_id must look up the record purely by model_id."""
+    mock_model = SimpleNamespace(
+        model_id=107,
+        model_factory="openai",
+        model_type="chat",
+        tenant_id="some_tenant",
+        delete_flag="Y",
+    )
+    session = _patch_session(monkeypatch, scalars_first=mock_model)
+
+    result = model_mgmt_db.get_model_by_model_id_ignore_delete(107)
+
+    assert result is not None
+    assert result["model_id"] == 107
+    # Filter by model_id alone; the absence of tenant_id means we still call
+    # scalars() exactly once.
+    assert session.scalars.call_count == 1

--- a/test/backend/database/test_model_managment_db.py
+++ b/test/backend/database/test_model_managment_db.py
@@ -447,3 +447,81 @@ def test_get_model_by_model_id_not_found(monkeypatch):
     mock_ctx.__exit__.return_value = None
     monkeypatch.setattr("backend.database.model_management_db.get_db_session", lambda: mock_ctx)
     assert model_mgmt_db.get_model_by_model_id(999, tenant_id="t") is None
+
+
+def test_get_valid_model_ids_empty_input(monkeypatch):
+    """Test get_valid_model_ids with empty input returns empty list."""
+    result = model_mgmt_db.get_valid_model_ids([], "tenant1")
+    assert result == []
+
+
+def test_get_valid_model_ids_all_valid(monkeypatch):
+    """Test get_valid_model_ids when all model IDs are valid (not deleted)."""
+    # Mock session.scalars().all() to return all model IDs
+    mock_scalars = MagicMock()
+    mock_scalars.all.return_value = [1, 2, 3]
+    session = MagicMock()
+    session.scalars.return_value = mock_scalars
+
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__.return_value = session
+    mock_ctx.__exit__.return_value = None
+    monkeypatch.setattr("backend.database.model_management_db.get_db_session", lambda: mock_ctx)
+
+    # All model IDs are valid
+    result = model_mgmt_db.get_valid_model_ids([1, 2, 3], "tenant1")
+    assert result == [1, 2, 3]
+
+
+def test_get_valid_model_ids_some_deleted(monkeypatch):
+    """Test get_valid_model_ids filters out deleted models."""
+    # Mock session.scalars().all() to return only valid model IDs (1 and 3, 2 is deleted)
+    mock_scalars = MagicMock()
+    mock_scalars.all.return_value = [1, 3]
+    session = MagicMock()
+    session.scalars.return_value = mock_scalars
+
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__.return_value = session
+    mock_ctx.__exit__.return_value = None
+    monkeypatch.setattr("backend.database.model_management_db.get_db_session", lambda: mock_ctx)
+
+    # Model 2 was deleted (delete_flag='Y'), so only 1 and 3 should be returned
+    result = model_mgmt_db.get_valid_model_ids([1, 2, 3], "tenant1")
+    assert result == [1, 3]
+
+
+def test_get_valid_model_ids_preserves_order(monkeypatch):
+    """Test get_valid_model_ids preserves the order of valid model IDs."""
+    # Mock session.scalars().all() to return valid model IDs in arbitrary order from DB
+    mock_scalars = MagicMock()
+    mock_scalars.all.return_value = [3, 1]  # DB returns in different order
+    session = MagicMock()
+    session.scalars.return_value = mock_scalars
+
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__.return_value = session
+    mock_ctx.__exit__.return_value = None
+    monkeypatch.setattr("backend.database.model_management_db.get_db_session", lambda: mock_ctx)
+
+    # Original order should be preserved for valid IDs
+    result = model_mgmt_db.get_valid_model_ids([2, 3, 1], "tenant1")
+    assert result == [3, 1]  # Only valid ones in original order
+
+
+def test_get_valid_model_ids_none_deleted(monkeypatch):
+    """Test get_valid_model_ids when all models are deleted."""
+    # Mock session.scalars().all() to return empty list (all deleted)
+    mock_scalars = MagicMock()
+    mock_scalars.all.return_value = []
+    session = MagicMock()
+    session.scalars.return_value = mock_scalars
+
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__.return_value = session
+    mock_ctx.__exit__.return_value = None
+    monkeypatch.setattr("backend.database.model_management_db.get_db_session", lambda: mock_ctx)
+
+    # All models were deleted
+    result = model_mgmt_db.get_valid_model_ids([1, 2, 3], "tenant1")
+    assert result == []

--- a/test/backend/services/test_agent_service.py
+++ b/test/backend/services/test_agent_service.py
@@ -523,6 +523,7 @@ async def test_get_agent_info_impl_success(mock_search_agent_info, mock_search_t
         "sub_agent_id_list": mock_sub_agent_ids,
         "skills": [],
         "external_sub_agent_id_list": [],
+        "model_ids": [],  # Added for get_valid_model_ids integration
         "model_names": [],
         "model_name": None,
         "business_logic_model_name": None,
@@ -600,6 +601,7 @@ async def test_get_agent_info_impl_with_version_no(mock_search_agent_info, mock_
         "sub_agent_id_list": mock_sub_agent_ids,
         "skills": [],
         "external_sub_agent_id_list": [],
+        "model_ids": [],  # Added for get_valid_model_ids integration
         "model_names": [],
         "model_name": None,
         "business_logic_model_name": None,
@@ -9536,6 +9538,20 @@ def _stub_requested_output_tokens_validator():
         yield
 
 
+@pytest.fixture(autouse=True)
+def _stub_get_valid_model_ids():
+    """Auto-mock get_valid_model_ids to pass through when not explicitly mocked by a test.
+
+    This fixture ensures that existing tests that don't mock get_valid_model_ids still work.
+    Tests that need to verify get_valid_model_ids behavior can mock it explicitly.
+    """
+    with patch(
+        "backend.services.agent_service.get_valid_model_ids",
+        side_effect=lambda model_ids, tenant_id: model_ids,
+    ):
+        yield
+
+
 # Tests for update_agent_info_impl skill handling exception
 @patch("backend.services.agent_service.skill_db.create_or_update_skill_by_skill_info")
 @patch("backend.services.agent_service.skill_db.query_skill_instances_by_agent_id")
@@ -13842,3 +13858,293 @@ async def test_run_agent_stream_title_generation_success(
 
             # Should complete successfully
             assert response.status_code == 200
+
+
+# ============================================================================
+# Tests for get_valid_model_ids integration in list_all_agent_info_impl
+# ============================================================================
+
+
+@pytest.mark.asyncio
+@patch("backend.services.agent_service.get_valid_model_ids")
+@patch("backend.services.agent_service.get_model_by_model_id")
+@patch("backend.services.agent_service.check_agent_availability")
+@patch("backend.services.agent_service.convert_string_to_list")
+@patch("backend.services.agent_service.get_user_tenant_by_user_id")
+@patch("backend.services.agent_service.query_group_ids_by_user")
+@patch("backend.services.agent_service.query_all_agent_info_by_tenant_id")
+async def test_list_all_agent_info_impl_filters_deleted_models(
+    mock_query_agents,
+    mock_query_groups,
+    mock_get_user_tenant,
+    mock_convert_list,
+    mock_check_availability,
+    mock_get_model,
+    mock_get_valid_model_ids,
+):
+    """Test that list_all_agent_info_impl filters out deleted models from model_ids.
+
+    This test verifies that:
+    1. get_valid_model_ids is called to filter deleted models
+    2. The filtered model_ids are used for availability check and model name resolution
+    3. The returned model_ids only contain valid (non-deleted) models
+    """
+    mock_agents = [
+        {
+            "agent_id": 1,
+            "name": "Agent 1",
+            "display_name": "Display Agent 1",
+            "description": "Test agent with models",
+            "enabled": True,
+            "model_ids": [1, 2, 3],  # Original model_ids including deleted ones
+            "group_ids": "",
+            "created_by": "user1",
+            "create_time": 1,
+        }
+    ]
+    mock_query_agents.return_value = mock_agents
+    mock_get_user_tenant.return_value = {"user_role": "ADMIN"}
+    mock_query_groups.return_value = []
+    mock_convert_list.return_value = []
+
+    # Mock get_valid_model_ids to filter out model_id=2 (deleted)
+    mock_get_valid_model_ids.return_value = [1, 3]  # Only models 1 and 3 are valid
+
+    # Mock model info for valid models (get_model_by_model_id takes 2 args: model_id and tenant_id)
+    def get_model_side_effect(model_id, tenant_id=None):
+        if model_id == 1:
+            return {"display_name": "Model 1", "model_id": 1}
+        elif model_id == 3:
+            return {"display_name": "Model 3", "model_id": 3}
+        return None
+    mock_get_model.side_effect = get_model_side_effect
+
+    mock_check_availability.return_value = (True, [])
+
+    result = await list_all_agent_info_impl(tenant_id="test_tenant", user_id="admin_user")
+
+    # Verify get_valid_model_ids was called with original model_ids and tenant_id
+    mock_get_valid_model_ids.assert_called_once_with([1, 2, 3], "test_tenant")
+
+    # Verify result contains only valid model_ids
+    assert len(result) == 1
+    assert result[0]["model_ids"] == [1, 3]
+    assert result[0]["model_names"] == ["Model 1", "Model 3"]
+
+
+@pytest.mark.asyncio
+@patch("backend.services.agent_service.get_valid_model_ids")
+@patch("backend.services.agent_service.get_model_by_model_id")
+@patch("backend.services.agent_service.check_agent_availability")
+@patch("backend.services.agent_service.convert_string_to_list")
+@patch("backend.services.agent_service.get_user_tenant_by_user_id")
+@patch("backend.services.agent_service.query_group_ids_by_user")
+@patch("backend.services.agent_service.query_all_agent_info_by_tenant_id")
+async def test_list_all_agent_info_impl_all_models_deleted(
+    mock_query_agents,
+    mock_query_groups,
+    mock_get_user_tenant,
+    mock_convert_list,
+    mock_check_availability,
+    mock_get_model,
+    mock_get_valid_model_ids,
+):
+    """Test that list_all_agent_info_impl handles when all models are deleted.
+
+    This test verifies that:
+    1. get_valid_model_ids returns empty list when all models are deleted
+    2. model_names is empty
+    3. Availability check is still performed with empty model_ids
+    """
+    mock_agents = [
+        {
+            "agent_id": 1,
+            "name": "Agent 1",
+            "display_name": "Display Agent 1",
+            "description": "Test agent",
+            "enabled": True,
+            "model_ids": [1, 2, 3],
+            "group_ids": "",
+            "created_by": "user1",
+            "create_time": 1,
+        }
+    ]
+    mock_query_agents.return_value = mock_agents
+    mock_get_user_tenant.return_value = {"user_role": "ADMIN"}
+    mock_query_groups.return_value = []
+    mock_convert_list.return_value = []
+
+    # All models were deleted
+    mock_get_valid_model_ids.return_value = []
+
+    mock_check_availability.return_value = (True, [])
+
+    result = await list_all_agent_info_impl(tenant_id="test_tenant", user_id="admin_user")
+
+    # Verify result has empty model_ids and model_names
+    assert len(result) == 1
+    assert result[0]["model_ids"] == []
+    assert result[0]["model_names"] == []
+    assert result[0]["model_name"] is None
+
+
+@pytest.mark.asyncio
+@patch("backend.services.agent_service.get_valid_model_ids")
+@patch("backend.services.agent_service.get_model_by_model_id")
+@patch("backend.services.agent_service.check_agent_availability")
+@patch("backend.services.agent_service.convert_string_to_list")
+@patch("backend.services.agent_service.get_user_tenant_by_user_id")
+@patch("backend.services.agent_service.query_group_ids_by_user")
+@patch("backend.services.agent_service.query_all_agent_info_by_tenant_id")
+async def test_list_all_agent_info_impl_empty_model_ids(
+    mock_query_agents,
+    mock_query_groups,
+    mock_get_user_tenant,
+    mock_convert_list,
+    mock_check_availability,
+    mock_get_model,
+    mock_get_valid_model_ids,
+):
+    """Test that list_all_agent_info_impl handles empty model_ids."""
+    mock_agents = [
+        {
+            "agent_id": 1,
+            "name": "Agent 1",
+            "display_name": "Display Agent 1",
+            "description": "Test agent",
+            "enabled": True,
+            "model_ids": [],  # Empty model_ids
+            "group_ids": "",
+            "created_by": "user1",
+            "create_time": 1,
+        }
+    ]
+    mock_query_agents.return_value = mock_agents
+    mock_get_user_tenant.return_value = {"user_role": "ADMIN"}
+    mock_query_groups.return_value = []
+    mock_convert_list.return_value = []
+
+    # get_valid_model_ids should be called with empty list
+    mock_get_valid_model_ids.return_value = []
+
+    mock_check_availability.return_value = (True, [])
+
+    result = await list_all_agent_info_impl(tenant_id="test_tenant", user_id="admin_user")
+
+    mock_get_valid_model_ids.assert_called_once_with([], "test_tenant")
+    assert result[0]["model_ids"] == []
+    assert result[0]["model_names"] == []
+
+
+# ============================================================================
+# Tests for get_valid_model_ids integration in get_agent_info_impl
+# ============================================================================
+
+
+@patch('backend.services.agent_service.SkillService')
+@patch('backend.services.agent_service.query_external_sub_agents')
+@patch('backend.services.agent_service.check_agent_availability')
+@patch('backend.services.agent_service.get_model_by_model_id')
+@patch('backend.services.agent_service.query_sub_agents_id_list')
+@patch('backend.services.agent_service.search_tools_for_sub_agent')
+@patch('backend.services.agent_service.search_agent_info_by_agent_id')
+@pytest.mark.asyncio
+async def test_get_agent_info_impl_filters_deleted_models(
+    mock_search_agent_info,
+    mock_search_tools,
+    mock_query_sub_agents_id,
+    mock_get_model_by_model_id,
+    mock_check_availability,
+    mock_query_external_sub_agents,
+    mock_skill_service,
+):
+    """Test that get_agent_info_impl filters out deleted models from model_ids.
+
+    This test verifies that:
+    1. get_valid_model_ids is called to filter deleted models
+    2. The filtered model_ids are used for availability check and model name resolution
+    3. The returned model_ids only contain valid (non-deleted) models
+    """
+    mock_agent_info = {
+        "agent_id": 123,
+        "model_ids": [1, 2, 3],  # Original model_ids including deleted ones
+        "business_description": "Test agent"
+    }
+    mock_search_agent_info.return_value = mock_agent_info
+    mock_search_tools.return_value = [{"tool_id": 1, "name": "Tool 1"}]
+    mock_query_sub_agents_id.return_value = [456]
+
+    mock_skill_service_instance = MagicMock()
+    mock_skill_service_instance.list_skill_instances.return_value = []
+    mock_skill_service.return_value = mock_skill_service_instance
+    mock_query_external_sub_agents.return_value = []
+
+    # Mock get_model_by_model_id for valid models
+    def get_model_side_effect(model_id, tenant_id=None):
+        if model_id == 1:
+            return {"display_name": "Model 1", "model_id": 1}
+        elif model_id == 3:
+            return {"display_name": "Model 3", "model_id": 3}
+        return None
+    mock_get_model_by_model_id.side_effect = get_model_side_effect
+
+    mock_check_availability.return_value = (True, [])
+
+    # Mock get_valid_model_ids to filter out model_id=2 (deleted)
+    with patch("backend.services.agent_service.get_valid_model_ids") as mock_get_valid_model_ids:
+        mock_get_valid_model_ids.return_value = [1, 3]
+
+        result = await get_agent_info_impl(agent_id=123, tenant_id="test_tenant")
+
+        # Verify get_valid_model_ids was called
+        mock_get_valid_model_ids.assert_called_once_with([1, 2, 3], "test_tenant")
+
+    # Verify result contains only valid model_ids
+    assert result["model_ids"] == [1, 3]
+    assert result["model_names"] == ["Model 1", "Model 3"]
+    assert result["model_name"] == "Model 1"  # First model's display_name
+
+
+@patch('backend.services.agent_service.SkillService')
+@patch('backend.services.agent_service.query_external_sub_agents')
+@patch('backend.services.agent_service.check_agent_availability')
+@patch('backend.services.agent_service.get_model_by_model_id')
+@patch('backend.services.agent_service.query_sub_agents_id_list')
+@patch('backend.services.agent_service.search_tools_for_sub_agent')
+@patch('backend.services.agent_service.search_agent_info_by_agent_id')
+@pytest.mark.asyncio
+async def test_get_agent_info_impl_all_models_deleted(
+    mock_search_agent_info,
+    mock_search_tools,
+    mock_query_sub_agents_id,
+    mock_get_model_by_model_id,
+    mock_check_availability,
+    mock_query_external_sub_agents,
+    mock_skill_service,
+):
+    """Test that get_agent_info_impl handles when all models are deleted."""
+    mock_agent_info = {
+        "agent_id": 123,
+        "model_ids": [1, 2, 3],
+        "business_description": "Test agent"
+    }
+    mock_search_agent_info.return_value = mock_agent_info
+    mock_search_tools.return_value = []
+    mock_query_sub_agents_id.return_value = []
+
+    mock_skill_service_instance = MagicMock()
+    mock_skill_service_instance.list_skill_instances.return_value = []
+    mock_skill_service.return_value = mock_skill_service_instance
+    mock_query_external_sub_agents.return_value = []
+
+    mock_get_model_by_model_id.return_value = None
+    mock_check_availability.return_value = (True, [])
+
+    with patch("backend.services.agent_service.get_valid_model_ids") as mock_get_valid_model_ids:
+        mock_get_valid_model_ids.return_value = []  # All models deleted
+
+        result = await get_agent_info_impl(agent_id=123, tenant_id="test_tenant")
+
+    assert result["model_ids"] == []
+    assert result["model_names"] == []
+    assert result["model_name"] is None

--- a/test/backend/services/test_agent_service.py
+++ b/test/backend/services/test_agent_service.py
@@ -491,7 +491,7 @@ async def test_get_agent_info_impl_success(mock_search_agent_info, mock_search_t
     }
     mock_search_agent_info.return_value = mock_agent_info
 
-    mock_tools = [{"tool_id": 1, "name": "Tool 1"}]
+    mock_tools = [{"tool_id": 1, "name": "Tool 1", "unavailable_reasons": []}]
     mock_search_tools.return_value = mock_tools
 
     mock_sub_agent_ids = [456, 789]
@@ -515,11 +515,12 @@ async def test_get_agent_info_impl_success(mock_search_agent_info, mock_search_t
     result = await get_agent_info_impl(agent_id=123, tenant_id="test_tenant")
 
     # Assert
+    expected_tools = [{"tool_id": 1, "name": "Tool 1", "unavailable_reasons": []}]
     expected_result = {
         "agent_id": 123,
         "model_id": None,
         "business_description": "Test agent",
-        "tools": mock_tools,
+        "tools": expected_tools,
         "sub_agent_id_list": mock_sub_agent_ids,
         "skills": [],
         "external_sub_agent_id_list": [],
@@ -566,7 +567,7 @@ async def test_get_agent_info_impl_with_version_no(mock_search_agent_info, mock_
     }
     mock_search_agent_info.return_value = mock_agent_info
 
-    mock_tools = [{"tool_id": 1, "name": "Tool 1"}]
+    mock_tools = [{"tool_id": 1, "name": "Tool 1", "unavailable_reasons": []}]
     mock_search_tools.return_value = mock_tools
 
     mock_sub_agent_ids = [456, 789]
@@ -593,11 +594,12 @@ async def test_get_agent_info_impl_with_version_no(mock_search_agent_info, mock_
     result = await get_agent_info_impl(agent_id=123, tenant_id="test_tenant", version_no=5)
 
     # Assert
+    expected_tools = [{"tool_id": 1, "name": "Tool 1", "unavailable_reasons": []}]
     expected_result = {
         "agent_id": 123,
         "model_id": None,
         "business_description": "Test agent",
-        "tools": mock_tools,
+        "tools": expected_tools,
         "sub_agent_id_list": mock_sub_agent_ids,
         "skills": [],
         "external_sub_agent_id_list": [],
@@ -1636,7 +1638,7 @@ async def test_get_agent_info_impl_sub_agent_error(mock_search_agent_info, mock_
     }
     mock_search_agent_info.return_value = mock_agent_info
 
-    mock_tools = [{"tool_id": 1, "name": "Tool 1"}]
+    mock_tools = [{"tool_id": 1, "name": "Tool 1", "unavailable_reasons": []}]
     mock_search_tools.return_value = mock_tools
 
     # Mock query_sub_agents_id_list to raise an exception
@@ -1687,7 +1689,7 @@ async def test_get_agent_info_impl_with_model_id_success(mock_search_agent_info,
     }
     mock_search_agent_info.return_value = mock_agent_info
 
-    mock_tools = [{"tool_id": 1, "name": "Tool 1"}]
+    mock_tools = [{"tool_id": 1, "name": "Tool 1", "unavailable_reasons": []}]
     mock_search_tools.return_value = mock_tools
 
     mock_sub_agent_ids = [789]
@@ -1795,7 +1797,7 @@ async def test_get_agent_info_impl_with_model_id_no_display_name(mock_search_age
     }
     mock_search_agent_info.return_value = mock_agent_info
 
-    mock_tools = [{"tool_id": 1, "name": "Tool 1"}]
+    mock_tools = [{"tool_id": 1, "name": "Tool 1", "unavailable_reasons": []}]
     mock_search_tools.return_value = mock_tools
 
     mock_sub_agent_ids = [789]
@@ -1870,7 +1872,7 @@ async def test_get_agent_info_impl_with_model_id_none_model_info(mock_search_age
     }
     mock_search_agent_info.return_value = mock_agent_info
 
-    mock_tools = [{"tool_id": 1, "name": "Tool 1"}]
+    mock_tools = [{"tool_id": 1, "name": "Tool 1", "unavailable_reasons": []}]
     mock_search_tools.return_value = mock_tools
 
     mock_sub_agent_ids = [789]
@@ -1942,7 +1944,7 @@ async def test_get_agent_info_impl_with_business_logic_model(mock_search_agent_i
     }
     mock_search_agent_info.return_value = mock_agent_info
 
-    mock_tools = [{"tool_id": 1, "name": "Tool 1"}]
+    mock_tools = [{"tool_id": 1, "name": "Tool 1", "unavailable_reasons": []}]
     mock_search_tools.return_value = mock_tools
 
     mock_sub_agent_ids = [101, 102]
@@ -2040,7 +2042,7 @@ async def test_get_agent_info_impl_with_business_logic_model_none(mock_search_ag
     }
     mock_search_agent_info.return_value = mock_agent_info
 
-    mock_tools = [{"tool_id": 1, "name": "Tool 1"}]
+    mock_tools = [{"tool_id": 1, "name": "Tool 1", "unavailable_reasons": []}]
     mock_search_tools.return_value = mock_tools
 
     mock_sub_agent_ids = [101, 102]
@@ -2131,7 +2133,7 @@ async def test_get_agent_info_impl_with_business_logic_model_no_display_name(moc
     }
     mock_search_agent_info.return_value = mock_agent_info
 
-    mock_tools = [{"tool_id": 1, "name": "Tool 1"}]
+    mock_tools = [{"tool_id": 1, "name": "Tool 1", "unavailable_reasons": []}]
     mock_search_tools.return_value = mock_tools
 
     mock_sub_agent_ids = [101, 102]
@@ -2202,6 +2204,382 @@ async def test_get_agent_info_impl_with_business_logic_model_no_display_name(moc
     assert mock_get_model_by_model_id.call_count == 3
     mock_get_model_by_model_id.assert_any_call(456)
     mock_get_model_by_model_id.assert_any_call(789)
+
+
+@patch("backend.services.agent_service.query_current_version_no")
+@patch("backend.services.agent_service.SkillService")
+@patch("backend.services.agent_service.query_external_sub_agents")
+@patch("backend.services.agent_service.check_agent_availability")
+@patch("backend.services.agent_service.get_valid_model_ids")
+@patch("backend.services.agent_service.get_model_by_model_id_ignore_delete")
+@patch("backend.services.agent_service.query_sub_agents_id_list")
+@patch("backend.services.agent_service.search_tools_for_sub_agent")
+@patch("backend.services.agent_service.search_agent_info_by_agent_id")
+@pytest.mark.asyncio
+async def test_get_agent_info_impl_marks_mcp_model_unavailable_when_deleted(
+    mock_search_agent_info,
+    mock_search_tools,
+    mock_query_sub_agents_id,
+    mock_get_model_by_model_id_ignore_delete,
+    mock_get_valid_model_ids,
+    mock_check_availability,
+    mock_query_external_sub_agents,
+    mock_skill_service,
+    mock_query_current_version_no,
+):
+    """Tools whose selected_model_id has been soft-deleted should be marked mcp_model_unavailable."""
+    mock_search_agent_info.return_value = {
+        "agent_id": 123,
+        "model_id": None,
+        "business_description": "Test agent",
+    }
+
+    mock_tools = [
+        {
+            "tool_id": 1,
+            "name": "Tool 1",
+            "params": [{"name": "selected_model_id", "default": 99}],
+        },
+        {
+            "tool_id": 2,
+            "name": "Tool 2",
+            "params": [{"name": "selected_model_id", "default": 100}],
+        },
+    ]
+    mock_search_tools.return_value = mock_tools
+    mock_query_sub_agents_id.return_value = []
+    mock_get_valid_model_ids.return_value = []
+
+    def fake_ignore_delete(model_id, tenant_id):
+        if model_id == 99:
+            return {"model_id": 99, "delete_flag": "Y"}
+        return {"model_id": model_id, "delete_flag": "N"}
+
+    mock_get_model_by_model_id_ignore_delete.side_effect = fake_ignore_delete
+
+    mock_skill_service_instance = MagicMock()
+    mock_skill_service_instance.list_skill_instances.return_value = []
+    mock_skill_service.return_value = mock_skill_service_instance
+    mock_query_external_sub_agents.return_value = []
+    mock_check_availability.return_value = (True, [])
+
+    result = await get_agent_info_impl(agent_id=123, tenant_id="test_tenant")
+
+    assert result["tools"][0]["unavailable_reasons"] == ["mcp_model_unavailable"]
+    assert result["tools"][1]["unavailable_reasons"] == []
+
+
+@patch("backend.services.agent_service.SkillService")
+@patch("backend.services.agent_service.query_external_sub_agents")
+@patch("backend.services.agent_service.check_agent_availability")
+@patch("backend.services.agent_service.get_valid_model_ids")
+@patch("backend.services.agent_service.get_model_by_model_id_ignore_delete")
+@patch("backend.services.agent_service.query_sub_agents_id_list")
+@patch("backend.services.agent_service.search_tools_for_sub_agent")
+@patch("backend.services.agent_service.search_agent_info_by_agent_id")
+@pytest.mark.asyncio
+async def test_get_agent_info_impl_handles_tools_without_params(
+    mock_search_agent_info,
+    mock_search_tools,
+    mock_query_sub_agents_id,
+    mock_get_model_by_model_id_ignore_delete,
+    mock_get_valid_model_ids,
+    mock_check_availability,
+    mock_query_external_sub_agents,
+    mock_skill_service,
+):
+    """Tools without a params list should still return an empty unavailable_reasons and not crash."""
+    mock_search_agent_info.return_value = {
+        "agent_id": 123,
+        "model_id": None,
+        "business_description": "Test agent",
+    }
+
+    mock_tools = [
+        {"tool_id": 1, "name": "Tool 1"},  # no params key
+        {"tool_id": 2, "name": "Tool 2", "params": []},  # empty params list
+        {"tool_id": 3, "name": "Tool 3", "params": [{"name": "other", "default": "x"}]},  # no selected_model_id
+    ]
+    mock_search_tools.return_value = mock_tools
+    mock_query_sub_agents_id.return_value = []
+    mock_get_valid_model_ids.return_value = []
+    mock_get_model_by_model_id_ignore_delete.return_value = None
+
+    mock_skill_service_instance = MagicMock()
+    mock_skill_service_instance.list_skill_instances.return_value = []
+    mock_skill_service.return_value = mock_skill_service_instance
+    mock_query_external_sub_agents.return_value = []
+    mock_check_availability.return_value = (True, [])
+
+    result = await get_agent_info_impl(agent_id=123, tenant_id="test_tenant")
+
+    for tool in result["tools"]:
+        assert tool["unavailable_reasons"] == []
+    mock_get_model_by_model_id_ignore_delete.assert_not_called()
+
+
+@patch("backend.services.agent_service.SkillService")
+@patch("backend.services.agent_service.query_external_sub_agents")
+@patch("backend.services.agent_service.check_agent_availability")
+@patch("backend.services.agent_service.get_valid_model_ids")
+@patch("backend.services.agent_service.get_model_by_model_id_ignore_delete")
+@patch("backend.services.agent_service.query_sub_agents_id_list")
+@patch("backend.services.agent_service.search_tools_for_sub_agent")
+@patch("backend.services.agent_service.search_agent_info_by_agent_id")
+@pytest.mark.asyncio
+async def test_get_agent_info_impl_skips_unset_selected_model_default(
+    mock_search_agent_info,
+    mock_search_tools,
+    mock_query_sub_agents_id,
+    mock_get_model_by_model_id_ignore_delete,
+    mock_get_valid_model_ids,
+    mock_check_availability,
+    mock_query_external_sub_agents,
+    mock_skill_service,
+):
+    """Tools with `selected_model_id` declared but no default should skip the DB lookup."""
+    mock_search_agent_info.return_value = {"agent_id": 1, "model_id": None}
+    mock_search_tools.return_value = [
+        {"tool_id": 1, "name": "T1", "params": [{"name": "selected_model_id"}]},
+        {"tool_id": 2, "name": "T2", "params": [{"name": "selected_model_id", "default": None}]},
+    ]
+    mock_query_sub_agents_id.return_value = []
+    mock_get_valid_model_ids.return_value = []
+    mock_get_model_by_model_id_ignore_delete.return_value = None
+
+    mock_skill_service_instance = MagicMock()
+    mock_skill_service_instance.list_skill_instances.return_value = []
+    mock_skill_service.return_value = mock_skill_service_instance
+    mock_query_external_sub_agents.return_value = []
+    mock_check_availability.return_value = (True, [])
+
+    result = await get_agent_info_impl(agent_id=1, tenant_id="test_tenant")
+
+    assert result["tools"][0]["unavailable_reasons"] == []
+    assert result["tools"][1]["unavailable_reasons"] == []
+    mock_get_model_by_model_id_ignore_delete.assert_not_called()
+
+
+@patch("backend.services.agent_service.SkillService")
+@patch("backend.services.agent_service.query_external_sub_agents")
+@patch("backend.services.agent_service.check_agent_availability")
+@patch("backend.services.agent_service.get_valid_model_ids")
+@patch("backend.services.agent_service.get_model_by_model_id_ignore_delete")
+@patch("backend.services.agent_service.query_sub_agents_id_list")
+@patch("backend.services.agent_service.search_tools_for_sub_agent")
+@patch("backend.services.agent_service.search_agent_info_by_agent_id")
+@pytest.mark.asyncio
+async def test_get_agent_info_impl_selected_model_not_found(
+    mock_search_agent_info,
+    mock_search_tools,
+    mock_query_sub_agents_id,
+    mock_get_model_by_model_id_ignore_delete,
+    mock_get_valid_model_ids,
+    mock_check_availability,
+    mock_query_external_sub_agents,
+    mock_skill_service,
+):
+    """When `get_model_by_model_id_ignore_delete` returns None we should not mark the tool unavailable."""
+    mock_search_agent_info.return_value = {"agent_id": 1, "model_id": None}
+    mock_search_tools.return_value = [
+        {"tool_id": 1, "name": "T1", "params": [{"name": "selected_model_id", "default": 555}]},
+    ]
+    mock_query_sub_agents_id.return_value = []
+    mock_get_valid_model_ids.return_value = []
+    mock_get_model_by_model_id_ignore_delete.return_value = None
+
+    mock_skill_service_instance = MagicMock()
+    mock_skill_service_instance.list_skill_instances.return_value = []
+    mock_skill_service.return_value = mock_skill_service_instance
+    mock_query_external_sub_agents.return_value = []
+    mock_check_availability.return_value = (True, [])
+
+    result = await get_agent_info_impl(agent_id=1, tenant_id="test_tenant")
+
+    assert result["tools"][0]["unavailable_reasons"] == []
+    mock_get_model_by_model_id_ignore_delete.assert_called_once_with(555, "test_tenant")
+
+
+@patch("backend.services.agent_service.SkillService")
+@patch("backend.services.agent_service.query_external_sub_agents")
+@patch("backend.services.agent_service.check_agent_availability")
+@patch("backend.services.agent_service.get_valid_model_ids")
+@patch("backend.services.agent_service.get_model_by_model_id_ignore_delete")
+@patch("backend.services.agent_service.query_sub_agents_id_list")
+@patch("backend.services.agent_service.search_tools_for_sub_agent")
+@patch("backend.services.agent_service.search_agent_info_by_agent_id")
+@pytest.mark.asyncio
+async def test_get_agent_info_impl_selected_model_not_deleted(
+    mock_search_agent_info,
+    mock_search_tools,
+    mock_query_sub_agents_id,
+    mock_get_model_by_model_id_ignore_delete,
+    mock_get_valid_model_ids,
+    mock_check_availability,
+    mock_query_external_sub_agents,
+    mock_skill_service,
+):
+    """A tool whose selected model is still active must not be marked unavailable."""
+    mock_search_agent_info.return_value = {"agent_id": 1, "model_id": None}
+    mock_search_tools.return_value = [
+        {"tool_id": 1, "name": "T1", "params": [{"name": "selected_model_id", "default": 7}]},
+    ]
+    mock_query_sub_agents_id.return_value = []
+    mock_get_valid_model_ids.return_value = []
+    mock_get_model_by_model_id_ignore_delete.return_value = {"model_id": 7, "delete_flag": "N"}
+
+    mock_skill_service_instance = MagicMock()
+    mock_skill_service_instance.list_skill_instances.return_value = []
+    mock_skill_service.return_value = mock_skill_service_instance
+    mock_query_external_sub_agents.return_value = []
+    mock_check_availability.return_value = (True, [])
+
+    result = await get_agent_info_impl(agent_id=1, tenant_id="test_tenant")
+
+    assert result["tools"][0]["unavailable_reasons"] == []
+
+
+@patch("backend.services.agent_service.SkillService")
+@patch("backend.services.agent_service.query_external_sub_agents")
+@patch("backend.services.agent_service.check_agent_availability")
+@patch("backend.services.agent_service.get_valid_model_ids")
+@patch("backend.services.agent_service.get_model_by_model_id_ignore_delete")
+@patch("backend.services.agent_service.query_sub_agents_id_list")
+@patch("backend.services.agent_service.search_tools_for_sub_agent")
+@patch("backend.services.agent_service.search_agent_info_by_agent_id")
+@pytest.mark.asyncio
+async def test_get_agent_info_impl_skips_non_list_params(
+    mock_search_agent_info,
+    mock_search_tools,
+    mock_query_sub_agents_id,
+    mock_get_model_by_model_id_ignore_delete,
+    mock_get_valid_model_ids,
+    mock_check_availability,
+    mock_query_external_sub_agents,
+    mock_skill_service,
+):
+    """Tool `params` values that aren't a list (e.g. dict, string) should be safely ignored."""
+    mock_search_agent_info.return_value = {"agent_id": 1, "model_id": None}
+    mock_search_tools.return_value = [
+        {"tool_id": 1, "name": "T1", "params": {"selected_model_id": 5}},
+        {"tool_id": 2, "name": "T2", "params": "invalid"},
+    ]
+    mock_query_sub_agents_id.return_value = []
+    mock_get_valid_model_ids.return_value = []
+    mock_get_model_by_model_id_ignore_delete.return_value = None
+
+    mock_skill_service_instance = MagicMock()
+    mock_skill_service_instance.list_skill_instances.return_value = []
+    mock_skill_service.return_value = mock_skill_service_instance
+    mock_query_external_sub_agents.return_value = []
+    mock_check_availability.return_value = (True, [])
+
+    result = await get_agent_info_impl(agent_id=1, tenant_id="test_tenant")
+
+    for tool in result["tools"]:
+        assert tool["unavailable_reasons"] == []
+    mock_get_model_by_model_id_ignore_delete.assert_not_called()
+
+
+@patch("backend.services.agent_service.SkillService")
+@patch("backend.services.agent_service.query_external_sub_agents")
+@patch("backend.services.agent_service.check_agent_availability")
+@patch("backend.services.agent_service.get_valid_model_ids")
+@patch("backend.services.agent_service.get_model_by_model_id_ignore_delete")
+@patch("backend.services.agent_service.query_sub_agents_id_list")
+@patch("backend.services.agent_service.search_tools_for_sub_agent")
+@patch("backend.services.agent_service.search_agent_info_by_agent_id")
+@pytest.mark.asyncio
+async def test_get_agent_info_impl_param_loop_skips_non_dict_entries(
+    mock_search_agent_info,
+    mock_search_tools,
+    mock_query_sub_agents_id,
+    mock_get_model_by_model_id_ignore_delete,
+    mock_get_valid_model_ids,
+    mock_check_availability,
+    mock_query_external_sub_agents,
+    mock_skill_service,
+):
+    """Within a list, non-dict entries must be skipped without crashing."""
+    mock_search_agent_info.return_value = {"agent_id": 1, "model_id": None}
+    mock_search_tools.return_value = [
+        {
+            "tool_id": 1,
+            "name": "T1",
+            "params": [
+                None,
+                "string-not-a-dict",
+                42,
+                True,
+                {"name": "selected_model_id", "default": 9},
+            ],
+        },
+    ]
+    mock_query_sub_agents_id.return_value = []
+    mock_get_valid_model_ids.return_value = []
+    mock_get_model_by_model_id_ignore_delete.return_value = {
+        "model_id": 9,
+        "delete_flag": "Y",
+    }
+
+    mock_skill_service_instance = MagicMock()
+    mock_skill_service_instance.list_skill_instances.return_value = []
+    mock_skill_service.return_value = mock_skill_service_instance
+    mock_query_external_sub_agents.return_value = []
+    mock_check_availability.return_value = (True, [])
+
+    result = await get_agent_info_impl(agent_id=1, tenant_id="test_tenant")
+
+    assert result["tools"][0]["unavailable_reasons"] == ["mcp_model_unavailable"]
+    mock_get_model_by_model_id_ignore_delete.assert_called_once_with(9, "test_tenant")
+
+
+@patch("backend.services.agent_service.SkillService")
+@patch("backend.services.agent_service.query_external_sub_agents")
+@patch("backend.services.agent_service.check_agent_availability")
+@patch("backend.services.agent_service.get_valid_model_ids")
+@patch("backend.services.agent_service.get_model_by_model_id_ignore_delete")
+@patch("backend.services.agent_service.query_sub_agents_id_list")
+@patch("backend.services.agent_service.search_tools_for_sub_agent")
+@patch("backend.services.agent_service.search_agent_info_by_agent_id")
+@pytest.mark.asyncio
+async def test_get_agent_info_impl_breaks_after_selected_model_id(
+    mock_search_agent_info,
+    mock_search_tools,
+    mock_query_sub_agents_id,
+    mock_get_model_by_model_id_ignore_delete,
+    mock_get_valid_model_ids,
+    mock_check_availability,
+    mock_query_external_sub_agents,
+    mock_skill_service,
+):
+    """After locating `selected_model_id` other params in the same tool should be skipped."""
+    mock_search_agent_info.return_value = {"agent_id": 1, "model_id": None}
+    mock_search_tools.return_value = [
+        {
+            "tool_id": 1,
+            "name": "T1",
+            "params": [
+                {"name": "selected_model_id", "default": 9},
+                {"name": "another_selected_model_id", "default": 10},
+            ],
+        },
+    ]
+    mock_query_sub_agents_id.return_value = []
+    mock_get_valid_model_ids.return_value = []
+    mock_get_model_by_model_id_ignore_delete.return_value = None
+
+    mock_skill_service_instance = MagicMock()
+    mock_skill_service_instance.list_skill_instances.return_value = []
+    mock_skill_service.return_value = mock_skill_service_instance
+    mock_query_external_sub_agents.return_value = []
+    mock_check_availability.return_value = (True, [])
+
+    result = await get_agent_info_impl(agent_id=1, tenant_id="test_tenant")
+
+    assert result["tools"][0]["unavailable_reasons"] == []
+    # Only one lookup per tool should be issued thanks to the `break`.
+    mock_get_model_by_model_id_ignore_delete.assert_called_once_with(9, "test_tenant")
 
 
 @pytest.mark.asyncio
@@ -7837,6 +8215,7 @@ def test_check_single_model_availability_returns_empty_for_available_model():
 # ============================================================================
 
 
+@patch('backend.services.agent_service.get_model_by_model_id_ignore_delete')
 @patch('backend.services.agent_service._collect_model_availability_reasons')
 @patch('backend.services.agent_service.check_tool_is_available')
 @patch('backend.services.agent_service.search_tools_for_sub_agent')
@@ -7845,7 +8224,8 @@ def test_check_agent_availability_all_available(
     mock_search_agent_info,
     mock_search_tools,
     mock_check_tool,
-    mock_collect_model_reasons
+    mock_collect_model_reasons,
+    mock_get_model_by_model_id_ignore_delete,
 ):
     """Test check_agent_availability when all tools and models are available."""
     from backend.services.agent_service import check_agent_availability
@@ -7868,6 +8248,7 @@ def test_check_agent_availability_all_available(
     mock_check_tool.assert_called_once_with([1, 2])
 
 
+@patch('backend.services.agent_service.get_model_by_model_id_ignore_delete')
 @patch('backend.services.agent_service._collect_model_availability_reasons')
 @patch('backend.services.agent_service.check_tool_is_available')
 @patch('backend.services.agent_service.search_tools_for_sub_agent')
@@ -7876,7 +8257,8 @@ def test_check_agent_availability_tool_unavailable(
     mock_search_agent_info,
     mock_search_tools,
     mock_check_tool,
-    mock_collect_model_reasons
+    mock_collect_model_reasons,
+    mock_get_model_by_model_id_ignore_delete,
 ):
     """Test check_agent_availability when some tools are unavailable."""
     from backend.services.agent_service import check_agent_availability
@@ -7896,6 +8278,7 @@ def test_check_agent_availability_tool_unavailable(
     assert reasons == ["tool_unavailable"]
 
 
+@patch('backend.services.agent_service.get_model_by_model_id_ignore_delete')
 @patch('backend.services.agent_service._collect_model_availability_reasons')
 @patch('backend.services.agent_service.check_tool_is_available')
 @patch('backend.services.agent_service.search_tools_for_sub_agent')
@@ -7904,7 +8287,8 @@ def test_check_agent_availability_model_unavailable(
     mock_search_agent_info,
     mock_search_tools,
     mock_check_tool,
-    mock_collect_model_reasons
+    mock_collect_model_reasons,
+    mock_get_model_by_model_id_ignore_delete,
 ):
     """Test check_agent_availability when model is unavailable."""
     from backend.services.agent_service import check_agent_availability
@@ -7922,6 +8306,193 @@ def test_check_agent_availability_model_unavailable(
 
     assert is_available is False
     assert reasons == ["model_unavailable"]
+
+
+@patch('backend.services.agent_service.get_model_by_model_id_ignore_delete')
+@patch('backend.services.agent_service._collect_model_availability_reasons')
+@patch('backend.services.agent_service.check_tool_is_available')
+@patch('backend.services.agent_service.search_tools_for_sub_agent')
+@patch('backend.services.agent_service.search_agent_info_by_agent_id')
+def test_check_agent_availability_mcp_model_deleted(
+    mock_search_agent_info,
+    mock_search_tools,
+    mock_check_tool,
+    mock_collect_model_reasons,
+    mock_get_model_by_model_id_ignore_delete,
+):
+    """Test check_agent_availability when tool has selected_model_id pointing to a deleted model."""
+    from backend.services.agent_service import check_agent_availability
+
+    mock_agent_info = {"agent_id": 123, "model_id": 456}
+    mock_search_agent_info.return_value = mock_agent_info
+    mock_search_tools.return_value = [
+        {
+            "tool_id": 1,
+            "params": [{"name": "selected_model_id", "default": 99}],
+        },
+        {
+            "tool_id": 2,
+            "params": [{"name": "selected_model_id", "default": 100}],
+        },
+    ]
+    mock_check_tool.return_value = [True, True]
+    mock_collect_model_reasons.return_value = []
+
+    def fake_ignore_delete(model_id, tenant_id):
+        if model_id == 99:
+            return {"model_id": 99, "delete_flag": "Y"}
+        return {"model_id": model_id, "delete_flag": "N"}
+
+    mock_get_model_by_model_id_ignore_delete.side_effect = fake_ignore_delete
+
+    is_available, reasons = check_agent_availability(
+        agent_id=123,
+        tenant_id="test_tenant"
+    )
+
+    assert is_available is False
+    # Agent-level unavailability re-uses the same TOOL_UNAVAILABLE reason as
+    # the per-tool check, but it is only emitted once even when multiple tools
+    # point to deleted models.
+    assert "tool_unavailable" in reasons
+    assert reasons.count("tool_unavailable") == 1
+    # confirm the deleted model was the source of the reason
+    expected_lookups = {99, 100}
+    looked_up = {call.args[0]
+                 for call in mock_get_model_by_model_id_ignore_delete.call_args_list}
+    assert looked_up == expected_lookups
+
+
+@patch('backend.services.agent_service.get_model_by_model_id_ignore_delete')
+@patch('backend.services.agent_service._collect_model_availability_reasons')
+@patch('backend.services.agent_service.check_tool_is_available')
+@patch('backend.services.agent_service.search_tools_for_sub_agent')
+@patch('backend.services.agent_service.search_agent_info_by_agent_id')
+def test_check_agent_availability_mcp_model_selected_default_none(
+    mock_search_agent_info,
+    mock_search_tools,
+    mock_check_tool,
+    mock_collect_model_reasons,
+    mock_get_model_by_model_id_ignore_delete,
+):
+    """`selected_model_id` set without a default value should be skipped without lookups."""
+    from backend.services.agent_service import check_agent_availability
+
+    mock_search_agent_info.return_value = {"agent_id": 1, "model_id": 1}
+    mock_search_tools.return_value = [
+        {"tool_id": 1, "params": [{"name": "selected_model_id"}]},  # default is None
+    ]
+    mock_check_tool.return_value = [True]
+    mock_collect_model_reasons.return_value = []
+
+    is_available, reasons = check_agent_availability(agent_id=1, tenant_id="t")
+
+    assert is_available is True
+    assert reasons == []
+    mock_get_model_by_model_id_ignore_delete.assert_not_called()
+
+
+@patch('backend.services.agent_service.get_model_by_model_id_ignore_delete')
+@patch('backend.services.agent_service._collect_model_availability_reasons')
+@patch('backend.services.agent_service.check_tool_is_available')
+@patch('backend.services.agent_service.search_tools_for_sub_agent')
+@patch('backend.services.agent_service.search_agent_info_by_agent_id')
+def test_check_agent_availability_mcp_model_record_missing(
+    mock_search_agent_info,
+    mock_search_tools,
+    mock_check_tool,
+    mock_collect_model_reasons,
+    mock_get_model_by_model_id_ignore_delete,
+):
+    """If the DB lookup returns None we should not raise and not add a reason."""
+    from backend.services.agent_service import check_agent_availability
+
+    mock_search_agent_info.return_value = {"agent_id": 1, "model_id": 1}
+    mock_search_tools.return_value = [
+        {"tool_id": 1, "params": [{"name": "selected_model_id", "default": 999}]},
+    ]
+    mock_check_tool.return_value = [True]
+    mock_collect_model_reasons.return_value = []
+    mock_get_model_by_model_id_ignore_delete.return_value = None
+
+    is_available, reasons = check_agent_availability(agent_id=1, tenant_id="t")
+
+    assert is_available is True
+    assert reasons == []
+
+
+@patch('backend.services.agent_service.get_model_by_model_id_ignore_delete')
+@patch('backend.services.agent_service._collect_model_availability_reasons')
+@patch('backend.services.agent_service.check_tool_is_available')
+@patch('backend.services.agent_service.search_tools_for_sub_agent')
+@patch('backend.services.agent_service.search_agent_info_by_agent_id')
+def test_check_agent_availability_mcp_model_params_non_dict_entries(
+    mock_search_agent_info,
+    mock_search_tools,
+    mock_check_tool,
+    mock_collect_model_reasons,
+    mock_get_model_by_model_id_ignore_delete,
+):
+    """Non-dict entries inside `params` (and missing `params`) must not crash the loop."""
+    from backend.services.agent_service import check_agent_availability
+
+    mock_search_agent_info.return_value = {"agent_id": 1, "model_id": 1}
+    mock_search_tools.return_value = [
+        {"tool_id": 1},                                              # no params
+        {"tool_id": 2, "params": None},                               # explicit None
+        {"tool_id": 3, "params": "not-a-list"},                        # wrong type, skip
+        {"tool_id": 4, "params": [None, "string", 42, True]},          # non-dict entries
+        {"tool_id": 5, "params": [{"name": "unrelated", "default": 7}]},  # wrong param name
+    ]
+    mock_check_tool.return_value = [True] * 5
+    mock_collect_model_reasons.return_value = []
+    mock_get_model_by_model_id_ignore_delete.return_value = None
+
+    is_available, reasons = check_agent_availability(agent_id=1, tenant_id="t")
+
+    assert is_available is True
+    assert reasons == []
+    # No selected_model_id found in any tool's params, so the lookup is never invoked.
+    mock_get_model_by_model_id_ignore_delete.assert_not_called()
+
+
+@patch('backend.services.agent_service.get_model_by_model_id_ignore_delete')
+@patch('backend.services.agent_service._collect_model_availability_reasons')
+@patch('backend.services.agent_service.check_tool_is_available')
+@patch('backend.services.agent_service.search_tools_for_sub_agent')
+@patch('backend.services.agent_service.search_agent_info_by_agent_id')
+def test_check_agent_availability_mcp_model_loop_breaks_after_first_match(
+    mock_search_agent_info,
+    mock_search_tools,
+    mock_check_tool,
+    mock_collect_model_reasons,
+    mock_get_model_by_model_id_ignore_delete,
+):
+    """Once `selected_model_id` is located, subsequent params in the same tool are skipped."""
+    from backend.services.agent_service import check_agent_availability
+
+    mock_search_agent_info.return_value = {"agent_id": 1, "model_id": 1}
+    mock_search_tools.return_value = [
+        {
+            "tool_id": 1,
+            "params": [
+                {"name": "other_param", "default": 1},
+                {"name": "selected_model_id", "default": 99},
+                {"name": "trailing", "default": 2},
+            ],
+        },
+    ]
+    mock_check_tool.return_value = [True]
+    mock_collect_model_reasons.return_value = []
+    mock_get_model_by_model_id_ignore_delete.return_value = None
+
+    is_available, reasons = check_agent_availability(agent_id=1, tenant_id="t")
+
+    assert is_available is True
+    assert reasons == []
+    # Only one lookup should be performed for the tool, regardless of how many
+    # other params follow `selected_model_id` in the schema list.
+    assert mock_get_model_by_model_id_ignore_delete.call_count == 1
 
 
 @patch('backend.services.agent_service._collect_model_availability_reasons')

--- a/test/backend/services/test_agent_version_service.py
+++ b/test/backend/services/test_agent_version_service.py
@@ -120,6 +120,10 @@ sys.modules['backend.database.agent_version_db'] = agent_version_db_mock
 
 # Mock database.model_management_db
 model_management_db_mock = MagicMock()
+# Default pass-through behavior for get_valid_model_ids
+model_management_db_mock.get_valid_model_ids = MagicMock(
+    side_effect=lambda model_ids, tenant_id: model_ids
+)
 sys.modules['database.model_management_db'] = model_management_db_mock
 sys.modules['backend.database.model_management_db'] = model_management_db_mock
 
@@ -3190,3 +3194,181 @@ def test_list_published_agents_impl_model_ids_empty(monkeypatch):
     assert result[0]["model_names"] == []
     assert result[0]["model_name"] is None
     assert result[0]["is_available"] is False
+
+
+# ============================================================================
+# Tests for get_valid_model_ids integration in list_published_agents_impl
+# ============================================================================
+
+
+def test_list_published_agents_impl_filters_deleted_models(monkeypatch):
+    """Test that list_published_agents_impl filters out deleted models from model_ids.
+
+    This test verifies that:
+    1. get_valid_model_ids is called to filter deleted models
+    2. The filtered model_ids are used for availability check and model name resolution
+    3. The returned model_ids only contain valid (non-deleted) models
+    """
+    agent_db_mock.query_all_agent_info_by_tenant_id = MagicMock(
+        return_value=[
+            {
+                "agent_id": 1,
+                "enabled": True,
+                "current_version_no": 1,
+                "group_ids": "1,2",
+                "created_by": "user1",
+                "name": "Test Agent",
+                "display_name": "Test Agent",
+                "description": "Test",
+                "author": "Author",
+                "is_new": False,
+            }
+        ]
+    )
+
+    agent_service_mock.get_user_tenant_by_user_id = MagicMock(
+        return_value={"user_role": "ADMIN"}
+    )
+    agent_service_mock.query_group_ids_by_user = MagicMock(return_value=[1, 2])
+
+    agent_version_db_mock.query_agent_snapshot = MagicMock(
+        return_value=(
+            {
+                "agent_id": 1,
+                "name": "Test Agent",
+                "model_ids": [1, 2, 3],  # Original model_ids including deleted ones
+                "description": "Test",
+            },
+            [{"tool_id": 1, "enabled": True}],
+            [],
+        )
+    )
+
+    # Mock get_valid_model_ids to filter out model_id=2 (deleted)
+    agent_version_service_module.get_valid_model_ids = MagicMock(return_value=[1, 3])
+
+    agent_service_mock.check_agent_availability = MagicMock(
+        return_value=(True, [])
+    )
+    agent_service_mock._apply_duplicate_name_availability_rules = MagicMock()
+
+    # Mock model info for valid models
+    def get_model_side_effect(model_id, tenant_id=None):
+        if model_id == 1:
+            return {"display_name": "Model 1", "model_id": 1}
+        elif model_id == 3:
+            return {"display_name": "Model 3", "model_id": 3}
+        return None
+    agent_service_mock.get_model_by_model_id = MagicMock(side_effect=get_model_side_effect)
+
+    result = asyncio.run(list_published_agents_impl(tenant_id="tenant1", user_id="user1"))
+
+    # Verify get_valid_model_ids was called
+    agent_version_service_module.get_valid_model_ids.assert_called_once_with([1, 2, 3], "tenant1")
+
+    # Verify result contains only valid model_ids
+    assert len(result) == 1
+    assert result[0]["model_ids"] == [1, 3]
+    assert result[0]["model_names"] == ["Model 1", "Model 3"]
+    assert result[0]["model_name"] == "Model 1"
+
+
+def test_list_published_agents_impl_all_models_deleted(monkeypatch):
+    """Test that list_published_agents_impl handles when all models are deleted."""
+    agent_db_mock.query_all_agent_info_by_tenant_id = MagicMock(
+        return_value=[
+            {
+                "agent_id": 1,
+                "enabled": True,
+                "current_version_no": 1,
+                "group_ids": "1,2",
+                "created_by": "user1",
+                "name": "Test Agent",
+                "display_name": "Test Agent",
+                "description": "Test",
+            }
+        ]
+    )
+
+    agent_service_mock.get_user_tenant_by_user_id = MagicMock(
+        return_value={"user_role": "ADMIN"}
+    )
+
+    agent_version_db_mock.query_agent_snapshot = MagicMock(
+        return_value=(
+            {
+                "agent_id": 1,
+                "name": "Test Agent",
+                "model_ids": [1, 2, 3],
+                "description": "Test",
+            },
+            [],
+            [],
+        )
+    )
+
+    # All models were deleted
+    agent_version_service_module.get_valid_model_ids = MagicMock(return_value=[])
+
+    agent_service_mock.check_agent_availability = MagicMock(
+        return_value=(True, [])
+    )
+    agent_service_mock._apply_duplicate_name_availability_rules = MagicMock()
+    agent_service_mock.get_model_by_model_id = MagicMock(return_value=None)
+
+    result = asyncio.run(list_published_agents_impl(tenant_id="tenant1", user_id="user1"))
+
+    assert len(result) == 1
+    assert result[0]["model_ids"] == []
+    assert result[0]["model_names"] == []
+    assert result[0]["model_name"] is None
+
+
+def test_list_published_agents_impl_empty_model_ids(monkeypatch):
+    """Test that list_published_agents_impl handles empty model_ids."""
+    agent_db_mock.query_all_agent_info_by_tenant_id = MagicMock(
+        return_value=[
+            {
+                "agent_id": 1,
+                "enabled": True,
+                "current_version_no": 1,
+                "group_ids": "1,2",
+                "created_by": "user1",
+                "name": "Test Agent",
+                "display_name": "Test Agent",
+                "description": "Test",
+            }
+        ]
+    )
+
+    agent_service_mock.get_user_tenant_by_user_id = MagicMock(
+        return_value={"user_role": "ADMIN"}
+    )
+
+    agent_version_db_mock.query_agent_snapshot = MagicMock(
+        return_value=(
+            {
+                "agent_id": 1,
+                "name": "Test Agent",
+                "model_ids": [],  # Empty model_ids
+                "description": "Test",
+            },
+            [],
+            [],
+        )
+    )
+
+    # get_valid_model_ids should be called with empty list
+    agent_version_service_module.get_valid_model_ids = MagicMock(return_value=[])
+
+    agent_service_mock.check_agent_availability = MagicMock(
+        return_value=(True, [])
+    )
+    agent_service_mock._apply_duplicate_name_availability_rules = MagicMock()
+    agent_service_mock.get_model_by_model_id = MagicMock(return_value=None)
+
+    result = asyncio.run(list_published_agents_impl(tenant_id="tenant1", user_id="user1"))
+
+    agent_version_service_module.get_valid_model_ids.assert_called_once_with([], "tenant1")
+    assert result[0]["model_ids"] == []
+    assert result[0]["model_names"] == []


### PR DESCRIPTION
🐛 Bugfix: Fixed an issue with tools relying on large models: previously, if a model was selected and subsequently deleted, the agent would encounter runtime errors without any corresponding notification on the frontend.

🐛 Bugfix: Fixed an issue where deleted models could still be selected during debugging. + Internationalization loading description of tools.

[Specification Details]
1. The backend checks the `params` of the `tools` for `selected_model_id`; if present, it must verify whether the model has been deleted.
2. Added a "tool unavailable" notification to the frontend and fixed the internationalization of tool descriptions.
[Test Result]
<img width="925" height="446" alt="img_v3_0213e_9ae30381-90e9-4782-b69f-d7c3d65743eg" src="https://github.com/user-attachments/assets/31c822c5-0422-4c2b-b04e-50b0d7fed767" />
<img width="1121" height="766" alt="img_v3_0213e_e41131cd-27c3-4ff0-b424-bc8cc5961a2g" src="https://github.com/user-attachments/assets/fa1686e7-e139-4599-a11a-9e4d8bb06e82" />
<img width="1091" height="183" alt="img_v3_0213e_fa9e47f9-85fc-4c3e-8c9d-43b8ceb0523g" src="https://github.com/user-attachments/assets/6c86bd36-e5ba-465d-941d-a1696116a68d" />
<img width="1159" height="552" alt="img_v3_0213e_e52d9bff-f5ab-4693-897a-d316dceb655g" src="https://github.com/user-attachments/assets/3ffaee7e-95a1-41c2-a5d1-be9818c1e978" />
<img width="2219" height="1211" alt="img_v3_0213e_2af9399a-4db5-4d05-9d43-8e541efe7b8g" src="https://github.com/user-attachments/assets/534e84dd-dc88-4894-bcef-2ed407e32b77" />
<img width="1257" height="319" alt="img_v3_0213e_bc40b952-12a3-4ade-b75d-d6ad499e846g" src="https://github.com/user-attachments/assets/a1e95b0c-4a57-4ca9-be69-c2ac30c6a61e" />
