### PR TITLE
fix context manager builtin tool context

### DIFF
--- a/backend/agents/create_agent_info.py
+++ b/backend/agents/create_agent_info.py
@@ -862,12 +862,14 @@ async def create_agent_config(
     skills = _get_skills_for_template(agent_id, tenant_id, version_no)
 
     is_manager = len(managed_agents) > 0 or len(external_a2a_agents) > 0
+    builtin_tools = _get_skill_script_tools(agent_id, tenant_id, version_no)
+    available_tools = tool_list + builtin_tools
 
     render_kwargs = {
         "duty": duty_prompt,
         "constraint": constraint_prompt,
         "few_shots": few_shots_prompt,
-        "tools": {tool.name: tool for tool in tool_list},
+        "tools": {tool.name: tool for tool in available_tools},
         "skills": skills,
         "managed_agents": {agent.name: agent for agent in managed_agents},
         "external_a2a_agents": {agent.agent_id: agent for agent in external_a2a_agents},
@@ -969,7 +971,7 @@ async def create_agent_config(
             language=language,
             agent_id=agent_id
         ),
-        tools=tool_list + _get_skill_script_tools(agent_id, tenant_id, version_no),
+        tools=available_tools,
         max_steps=agent_info.get("max_steps", 15),
         requested_output_tokens=requested_output_tokens,
         model_name=model_name,

--- a/test/backend/agents/test_create_agent_info.py
+++ b/test/backend/agents/test_create_agent_info.py
@@ -1835,6 +1835,34 @@ class TestCreateAgentConfig:
         assert mocks["agent_config"].call_args.kwargs["context_manager_config"].enabled is True
 
     @pytest.mark.asyncio
+    async def test_create_agent_config_managed_path_includes_builtin_tools_in_context(self):
+        """Managed path should describe the same builtin tools that AgentConfig exposes."""
+        builtin_tools = [
+            types.SimpleNamespace(name="run_skill_script"),
+            types.SimpleNamespace(name="read_skill_md"),
+            types.SimpleNamespace(name="read_skill_config"),
+            types.SimpleNamespace(name="write_skill_file"),
+        ]
+        with patch(
+            'backend.agents.create_agent_info._get_skill_script_tools',
+            return_value=builtin_tools,
+        ):
+            mocks = await self._run_context_manager_case(
+                enable_context_manager=True,
+                template="legacy {{duty}}",
+                prepared_prompt="",
+            )
+
+        context_tools = mocks["build_components"].call_args.kwargs["tools"]
+        agent_tools = mocks["agent_config"].call_args.kwargs["tools"]
+
+        assert "run_skill_script" in context_tools
+        assert "read_skill_md" in context_tools
+        assert "read_skill_config" in context_tools
+        assert "write_skill_file" in context_tools
+        assert set(context_tools) == {tool.name for tool in agent_tools}
+
+    @pytest.mark.asyncio
     async def test_create_agent_config_legacy_path_renders_prompt_and_skips_components(self):
         """Legacy path should render the Jinja prompt and not build managed components."""
         mocks = await self._run_context_manager_case(


### PR DESCRIPTION
## Summary

- Build a single available tool list from selected tools plus builtin skill tools during agent config creation.
- Use that same list for both `AgentConfig.tools` and the ContextManager tool context.
- Add a regression test that ensures builtin tools are included in managed context assembly.

## Root Cause

When ContextManager was enabled, backend context assembly passed only the selected database tool list into `build_context_components`. Builtin skill tools were appended later to `AgentConfig.tools`, so executors could discover them while the model did not receive their tool descriptions in the final ContextManager context.

## Impact

ContextManager-enabled agents now see the same builtin tool descriptions that are available for execution, including `run_skill_script`, `read_skill_md`, `read_skill_config`, and `write_skill_file`.

## Validation

- `PYTHONPATH=backend backend/.venv/bin/python -m pytest test/backend/agents/test_create_agent_info.py -q`
- `git diff --check`

<img width="1822" height="1186" alt="image" src="https://github.com/user-attachments/assets/85e3cba2-01c6-4460-a3e4-d5dcac9216b0" />
