### PR TITLE
fix: support custom headers for A2A agents

### DIFF
--- a/backend/agents/create_agent_info.py
+++ b/backend/agents/create_agent_info.py
@@ -1,4 +1,4 @@
-﻿import json
+import json
 import threading
 import logging
 from typing import Any, Dict, List, Optional
@@ -471,6 +471,7 @@ def _build_external_agent_config(agent: dict, agent_url: str) -> ExternalA2AAgen
         protocol_version=agent.get("protocol_version", "1.0"),
         protocol_type=agent.get("protocol_type", PROTOCOL_JSONRPC),
         timeout=300.0,
+        custom_headers=agent.get("custom_headers"),
         raw_card=agent.get("raw_card"),
     )
 

--- a/backend/apps/a2a_client_app.py
+++ b/backend/apps/a2a_client_app.py
@@ -6,7 +6,7 @@ Used internally for configuring A2A sub-agents.
 """
 import logging
 import uuid
-from typing import Annotated, List, Optional
+from typing import Annotated, Dict, List, Optional
 from http import HTTPStatus
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
@@ -43,6 +43,14 @@ class UpdateAgentProtocolRequest(BaseModel):
     """Request to update the protocol type for an external A2A agent."""
     protocol_type: str = Field(
         description="Protocol type to use: JSONRPC, HTTP+JSON, or GRPC"
+    )
+
+
+class UpdateAgentCallSettingsRequest(BaseModel):
+    """Request to update call settings for an external A2A agent."""
+    custom_headers: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Custom HTTP headers to include when calling the agent"
     )
 
 
@@ -276,6 +284,51 @@ async def delete_external_agent(
         raise HTTPException(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
             detail="Failed to delete agent"
+        )
+
+
+@router.put("/agents/{external_agent_id}/settings")
+async def update_agent_call_settings(
+    external_agent_id: int,
+    request: UpdateAgentCallSettingsRequest,
+    authorization: Annotated[Optional[str], Header()] = None,
+    http_request: Request = None
+):
+    """Update custom call settings for an external A2A agent."""
+    try:
+        user_id, tenant_id, _ = get_current_user_info(authorization, http_request)
+
+        result = a2a_client_service.update_agent_call_settings(
+            external_agent_id=external_agent_id,
+            tenant_id=tenant_id,
+            user_id=user_id,
+            custom_headers=request.custom_headers,
+        )
+
+        if not result:
+            raise HTTPException(
+                status_code=HTTPStatus.NOT_FOUND,
+                detail=f"Agent {external_agent_id} not found"
+            )
+
+        return JSONResponse(
+            status_code=HTTPStatus.OK,
+            content={"status": "success", "data": result}
+        )
+
+    except HTTPException:
+        raise
+    except ValueError as e:
+        logger.error(f"Invalid A2A call settings: {e}")
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail=str(e)
+        )
+    except Exception as e:
+        logger.error(f"Update agent call settings failed: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail="Failed to update agent call settings"
         )
 
 

--- a/backend/database/a2a_agent_db.py
+++ b/backend/database/a2a_agent_db.py
@@ -240,6 +240,7 @@ def create_external_agent_from_url(
             "version": agent.version,
             "agent_url": agent.agent_url,
             "protocol_type": agent.protocol_type,
+            "custom_headers": getattr(agent, "custom_headers", None),
             "streaming": agent.streaming,
             "supported_interfaces": agent.supported_interfaces,
             "source_type": agent.source_type,
@@ -347,6 +348,7 @@ def create_external_agent_from_nacos(
             "version": agent.version,
             "agent_url": agent.agent_url,
             "protocol_type": agent.protocol_type,
+            "custom_headers": getattr(agent, "custom_headers", None),
             "streaming": agent.streaming,
             "supported_interfaces": agent.supported_interfaces,
             "source_type": agent.source_type,
@@ -385,6 +387,7 @@ def get_external_agent_by_id(external_agent_id: int, tenant_id: str) -> Optional
             "agent_url": agent.agent_url,
             "streaming": agent.streaming,
             "protocol_type": agent.protocol_type,
+            "custom_headers": getattr(agent, "custom_headers", None),
             "supported_interfaces": agent.supported_interfaces,
             "source_type": agent.source_type,
             "source_url": agent.source_url,
@@ -443,6 +446,7 @@ def list_external_agents(
                 "agent_url": agent.agent_url,
                 "streaming": agent.streaming,
                 "protocol_type": agent.protocol_type,
+                "custom_headers": getattr(agent, "custom_headers", None),
                 "supported_interfaces": agent.supported_interfaces,
                 "source_type": agent.source_type,
                 "source_url": agent.source_url,
@@ -519,6 +523,74 @@ def _find_interface_by_protocol_type(
     return None
 
 
+def _validate_custom_headers(custom_headers: Optional[Dict[str, Any]]) -> Optional[Dict[str, str]]:
+    """Validate A2A custom headers."""
+    if custom_headers is None:
+        return None
+    if not isinstance(custom_headers, dict):
+        raise ValueError("custom_headers must be an object")
+
+    sanitized = {}
+    for key, value in custom_headers.items():
+        header_name = str(key).strip()
+        if not header_name:
+            raise ValueError("custom header names cannot be empty")
+        if any(ch in header_name for ch in "\r\n:"):
+            raise ValueError(f"invalid custom header name: {header_name}")
+        sanitized[header_name] = str(value)
+    return sanitized
+
+
+def update_external_agent_call_settings(
+    external_agent_id: int,
+    tenant_id: str,
+    user_id: str,
+    custom_headers: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
+    """Update custom call settings for an external A2A agent."""
+    sanitized_headers = _validate_custom_headers(custom_headers)
+
+    with _get_db_session() as session:
+        agent = session.query(A2AExternalAgent).filter(
+            A2AExternalAgent.id == external_agent_id,
+            A2AExternalAgent.tenant_id == tenant_id,
+            A2AExternalAgent.delete_flag != 'Y'
+        ).first()
+
+        if not agent:
+            return None
+
+        if custom_headers is not None:
+            setattr(agent, "custom_headers", sanitized_headers)
+        agent.updated_by = user_id
+        agent.update_time = datetime.now(timezone.utc)
+        session.flush()
+
+        return {
+            "id": agent.id,
+            "name": agent.name,
+            "description": agent.description,
+            "version": agent.version,
+            "agent_url": agent.agent_url,
+            "protocol_type": agent.protocol_type,
+            "custom_headers": getattr(agent, "custom_headers", None),
+            "streaming": agent.streaming,
+            "supported_interfaces": agent.supported_interfaces,
+            "source_type": agent.source_type,
+            "source_url": agent.source_url,
+            "nacos_config_id": agent.nacos_config_id,
+            "nacos_agent_name": agent.nacos_agent_name,
+            "raw_card": agent.raw_card,
+            "is_available": agent.is_available,
+            "last_check_at": agent.last_check_at.isoformat() if agent.last_check_at else None,
+            "last_check_result": agent.last_check_result,
+            "cached_at": agent.cached_at.isoformat() if agent.cached_at else None,
+            "cache_expires_at": agent.cache_expires_at.isoformat() if agent.cache_expires_at else None,
+            "create_time": agent.create_time.isoformat() if agent.create_time else None,
+            "update_time": agent.update_time.isoformat() if agent.update_time else None,
+        }
+
+
 def update_external_agent_protocol(
     external_agent_id: int,
     tenant_id: str,
@@ -567,6 +639,7 @@ def update_external_agent_protocol(
             "version": agent.version,
             "agent_url": agent.agent_url,
             "protocol_type": agent.protocol_type,
+            "custom_headers": getattr(agent, "custom_headers", None),
             "streaming": agent.streaming,
             "supported_interfaces": agent.supported_interfaces,
             "source_type": agent.source_type,
@@ -852,6 +925,7 @@ def query_external_sub_agents(
                 "version": agent.version,
                 "agent_url": agent.agent_url,
                 "protocol_type": agent.protocol_type,
+                "custom_headers": getattr(agent, "custom_headers", None),
                 "streaming": agent.streaming,
                 "supported_interfaces": agent.supported_interfaces,
                 "raw_card": agent.raw_card,

--- a/backend/database/db_models.py
+++ b/backend/database/db_models.py
@@ -1137,6 +1137,8 @@ class A2AExternalAgent(TableBase):
     protocol_type = Column(String(20), default=PROTOCOL_JSONRPC,
                            doc="Protocol type for calling this agent")
 
+    custom_headers = Column(JSON, doc="Custom HTTP headers for calling this agent")
+
     # Capabilities
     streaming = Column(Boolean, default=False,
                        doc="Whether this agent supports SSE streaming")

--- a/backend/services/a2a_client_service.py
+++ b/backend/services/a2a_client_service.py
@@ -426,6 +426,21 @@ class A2AClientService:
             is_available=is_available
         )
 
+    def update_agent_call_settings(
+        self,
+        external_agent_id: int,
+        tenant_id: str,
+        user_id: str,
+        custom_headers: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Update custom call settings for an external agent."""
+        return a2a_agent_db.update_external_agent_call_settings(
+            external_agent_id=external_agent_id,
+            tenant_id=tenant_id,
+            user_id=user_id,
+            custom_headers=custom_headers,
+        )
+
     def update_agent_protocol(
         self,
         external_agent_id: int,
@@ -681,6 +696,7 @@ class A2AClientService:
 
         agent_url = agent["agent_url"]
         protocol_type = agent.get("protocol_type", PROTOCOL_JSONRPC)
+        custom_headers = agent.get("custom_headers")
 
         # Build complete endpoint URL with protocol path
         endpoint_url = self._build_endpoint_url(agent_url, protocol_type, streaming=False)
@@ -707,7 +723,7 @@ class A2AClientService:
 
             logger.info(f"Calling external A2A agent {external_agent_id}: url={endpoint_url}, protocol={protocol_type}, payload={payload}")
 
-            headers = build_a2a_headers()
+            headers = build_a2a_headers(custom_headers=custom_headers)
             async with A2AHttpClient() as client:
                 response = await client.post_json(endpoint_url, payload, headers)
 
@@ -753,6 +769,7 @@ class A2AClientService:
 
         agent_url = agent["agent_url"]
         protocol_type = agent.get("protocol_type", PROTOCOL_JSONRPC)
+        custom_headers = agent.get("custom_headers")
 
         # Build complete endpoint URL with protocol path
         endpoint_url = self._build_endpoint_url(agent_url, protocol_type, streaming=True)
@@ -776,7 +793,7 @@ class A2AClientService:
 
         logger.info(f"Calling external A2A agent {external_agent_id} (streaming): url={endpoint_url}, protocol={protocol_type}, payload={payload}")
 
-        headers = build_a2a_headers(api_key)
+        headers = build_a2a_headers(api_key, custom_headers=custom_headers)
 
         try:
             async with A2AHttpClient() as client:

--- a/backend/utils/a2a_http_client.py
+++ b/backend/utils/a2a_http_client.py
@@ -276,7 +276,10 @@ class A2AHttpClient:
             raise
 
 
-def build_a2a_headers(api_key: Optional[str] = None) -> Dict[str, str]:
+def build_a2a_headers(
+    api_key: Optional[str] = None,
+    custom_headers: Optional[Dict[str, str]] = None
+) -> Dict[str, str]:
     """Build HTTP headers for A2A requests."""
     headers = {
         "Content-Type": CONTENT_TYPE_JSON,
@@ -285,4 +288,6 @@ def build_a2a_headers(api_key: Optional[str] = None) -> Dict[str, str]:
     }
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
+    if custom_headers:
+        headers.update(custom_headers)
     return headers

--- a/deploy/sql/migrations/v2.3.0_0702_add_a2a_call_settings.sql
+++ b/deploy/sql/migrations/v2.3.0_0702_add_a2a_call_settings.sql
@@ -1,0 +1,4 @@
+ALTER TABLE nexent.ag_a2a_external_agent_t
+ADD COLUMN IF NOT EXISTS custom_headers JSONB;
+
+COMMENT ON COLUMN nexent.ag_a2a_external_agent_t.custom_headers IS 'Custom HTTP headers for calling this external A2A agent';

--- a/frontend/app/[locale]/agents/components/a2a/A2AAgentDiscoveryModal.tsx
+++ b/frontend/app/[locale]/agents/components/a2a/A2AAgentDiscoveryModal.tsx
@@ -88,28 +88,65 @@ function extractAvailableProtocols(supportedInterfaces?: Record<string, any>[]):
 // Agent Protocol Setting Popover Component
 interface AgentProtocolSettingProps {
   agent: A2AExternalAgent;
-  onProtocolChange: (agentId: string, protocolType: string) => void;
+  onSettingsChange: (
+    agentId: string,
+    settings: {
+      protocolType: string;
+      customHeaders: Record<string, string> | null;
+    }
+  ) => Promise<boolean>;
 }
 
-function AgentProtocolSetting({ agent, onProtocolChange }: Readonly<AgentProtocolSettingProps>) {
+function AgentProtocolSetting({ agent, onSettingsChange }: Readonly<AgentProtocolSettingProps>) {
   const { t } = useTranslation("common");
   const [open, setOpen] = useState(false);
   const [selectedProtocol, setSelectedProtocol] = useState(
     (agent as any).protocol_type || "JSONRPC"
   );
+  const [customHeaders, setCustomHeaders] = useState(
+    agent.custom_headers ? JSON.stringify(agent.custom_headers, null, 2) : ""
+  );
+  const [settingsError, setSettingsError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
   const availableProtocols = extractAvailableProtocols(agent.supported_interfaces);
 
   useEffect(() => {
     setSelectedProtocol((agent as any).protocol_type || "JSONRPC");
-  }, [(agent as any).protocol_type]);
+    setCustomHeaders(agent.custom_headers ? JSON.stringify(agent.custom_headers, null, 2) : "");
+    setSettingsError(null);
+  }, [(agent as any).protocol_type, agent.custom_headers]);
 
-  const handleSave = () => {
+  const parseCustomHeaders = (): Record<string, string> | null => {
+    const trimmed = customHeaders.trim();
+    if (!trimmed) return null;
+    const parsed = JSON.parse(trimmed);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error(t("a2a.protocol.headersJsonObject", { defaultValue: "Headers must be a JSON object" }));
+    }
+    return Object.fromEntries(
+      Object.entries(parsed).map(([key, value]) => [key, String(value)])
+    );
+  };
+
+  const handleSave = async () => {
+    setSettingsError(null);
+    let parsedHeaders: Record<string, string> | null;
+
+    try {
+      parsedHeaders = parseCustomHeaders();
+    } catch (error) {
+      setSettingsError(error instanceof Error ? error.message : t("a2a.protocol.invalidSettings", { defaultValue: "Invalid settings" }));
+      return;
+    }
+
     setSaving(true);
-    onProtocolChange(String(agent.id), selectedProtocol);
+    const saved = await onSettingsChange(String(agent.id), {
+      protocolType: selectedProtocol,
+      customHeaders: parsedHeaders,
+    });
     setSaving(false);
-    setOpen(false);
+    if (saved) setOpen(false);
   };
 
   return (
@@ -147,6 +184,22 @@ function AgentProtocolSetting({ agent, onProtocolChange }: Readonly<AgentProtoco
               );
             })}
           </Radio.Group>
+          <div style={{ marginTop: 12 }}>
+            <Text type="secondary" className="text-xs">
+              {t("a2a.protocol.customHeadersJson", { defaultValue: "Custom headers JSON" })}
+            </Text>
+            <Input.TextArea
+              rows={4}
+              value={customHeaders}
+              onChange={(e) => setCustomHeaders(e.target.value)}
+              placeholder={'{"Authorization":"Bearer token"}'}
+            />
+          </div>
+          {settingsError && (
+            <Text type="danger" className="text-xs">
+              {settingsError}
+            </Text>
+          )}
           <div style={{ marginTop: 12, textAlign: "right" }}>
             <Space>
               <Button size="small" onClick={() => setOpen(false)}>
@@ -274,15 +327,31 @@ export default function A2AAgentDiscoveryModal({
     }
   };
 
-  // Update agent protocol
-  const handleProtocolChange = async (agentId: string, protocolType: string) => {
-    const result = await a2aClientService.updateAgentProtocol(agentId, protocolType);
-    if (result.success) {
-      messageApi.success(t("a2a.protocol.updateSuccess"));
-      loadAgents();
-    } else {
-      messageApi.error(result.message || t("a2a.protocol.updateFailed"));
+  // Update agent protocol and call settings
+  const handleSettingsChange = async (
+    agentId: string,
+    settings: {
+      protocolType: string;
+      customHeaders: Record<string, string> | null;
     }
+  ): Promise<boolean> => {
+    const protocolResult = await a2aClientService.updateAgentProtocol(agentId, settings.protocolType);
+    if (!protocolResult.success) {
+      messageApi.error(protocolResult.message || t("a2a.protocol.updateFailed"));
+      return false;
+    }
+
+    const settingsResult = await a2aClientService.updateAgentSettings(agentId, {
+      custom_headers: settings.customHeaders,
+    });
+    if (!settingsResult.success) {
+      messageApi.error(settingsResult.message || t("a2a.protocol.updateFailed"));
+      return false;
+    }
+
+    messageApi.success(t("a2a.protocol.updateSuccess"));
+    loadAgents();
+    return true;
   };
 
   // Add to local agent
@@ -395,7 +464,7 @@ export default function A2AAgentDiscoveryModal({
           </Tooltip>
           <AgentProtocolSetting
             agent={record}
-            onProtocolChange={handleProtocolChange}
+            onSettingsChange={handleSettingsChange}
           />
           <Tooltip title={t("a2a.chat.title")}>
             <Button

--- a/frontend/services/a2aService.ts
+++ b/frontend/services/a2aService.ts
@@ -29,6 +29,7 @@ export interface A2AExternalAgent {
   cached_at?: string;
   cache_expires_at?: string;
   create_time?: string;
+  custom_headers?: Record<string, string> | null;
 }
 
 export interface A2AExternalAgentRelation {
@@ -39,6 +40,7 @@ export interface A2AExternalAgentRelation {
   external_agent_name?: string;
   external_agent_url?: string;
   create_time?: string;
+  custom_headers?: Record<string, string> | null;
 }
 
 export interface NacosConfig {
@@ -303,6 +305,38 @@ export const a2aClientService = {
   // ---------------------------------------------------------------------------
   // External Agent Relations
   // ---------------------------------------------------------------------------
+
+  /**
+   * Update call settings for an external agent
+   */
+  async updateAgentSettings(
+    agentId: string,
+    settings: {
+      custom_headers?: Record<string, string> | null;
+    }
+  ): Promise<{
+    success: boolean;
+    data?: A2AExternalAgent;
+    message?: string;
+  }> {
+    try {
+      const response = await fetchWithErrorHandling(API_ENDPOINTS.a2a.agentSettings(agentId), {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(settings),
+      });
+      const data = await response.json();
+
+      if (response.ok && data.status === 'success') {
+        return { success: true, data: data.data };
+      }
+
+      return { success: false, message: data.detail || t('a2a.service.updateSettingsFailed') };
+    } catch (error) {
+      log.error('Failed to update agent settings:', error);
+      return { success: false, message: t('a2a.service.updateSettingsFailed') };
+    }
+  },
 
   /**
    * Add relation between local agent and external A2A agent

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -343,6 +343,8 @@ export const API_ENDPOINTS = {
       `${API_BASE_URL}/a2a/client/agents/${agentId}/refresh`,
     agentProtocol: (agentId: string) =>
       `${API_BASE_URL}/a2a/client/agents/${agentId}/protocol`,
+    agentSettings: (agentId: string) =>
+      `${API_BASE_URL}/a2a/client/agents/${agentId}/settings`,
     // External agent relations
     relations: `${API_BASE_URL}/a2a/client/relations`,
     relation: (localAgentId: number, externalAgentId: number) =>

--- a/sdk/nexent/core/agents/a2a_agent_proxy.py
+++ b/sdk/nexent/core/agents/a2a_agent_proxy.py
@@ -33,6 +33,7 @@ class A2AAgentInfo:
     protocol_version: str = "1.0"
     protocol_type: str = PROTOCOL_JSONRPC
     timeout: float = 300.0
+    custom_headers: Optional[Dict[str, str]] = None
     raw_card: Optional[Dict[str, Any]] = None
 
     def get_protocol_type(self) -> str:
@@ -120,6 +121,8 @@ class ExternalA2AAgentProxy:
         }
         if self.agent_info.api_key:
             headers["Authorization"] = f"Bearer {self.agent_info.api_key}"
+        if self.agent_info.custom_headers:
+            headers.update(self.agent_info.custom_headers)
         return headers
 
     def _build_message_payload(

--- a/sdk/nexent/core/agents/agent_model.py
+++ b/sdk/nexent/core/agents/agent_model.py
@@ -317,6 +317,10 @@ class ExternalA2AAgentConfig(BaseModel):
         default=PROTOCOL_JSONRPC
     )
     timeout: float = Field(description="Request timeout in seconds", default=300.0)
+    custom_headers: Optional[Dict[str, str]] = Field(
+        description="Custom HTTP headers for A2A requests",
+        default=None
+    )
     raw_card: Optional[Dict[str, Any]] = Field(
         description="Raw Agent Card containing skills and capabilities",
         default=None
@@ -373,6 +377,7 @@ class ExternalA2AAgentConfig(BaseModel):
             protocol_version=self.protocol_version,
             protocol_type=self.protocol_type,
             timeout=self.timeout,
+            custom_headers=self.custom_headers,
             raw_card=self.raw_card
         )
 

--- a/test/backend/services/test_a2a_client_service.py
+++ b/test/backend/services/test_a2a_client_service.py
@@ -1573,7 +1573,7 @@ class TestCallAgentStreaming:
                     async for _ in result_gen:
                         pass
 
-                    mock_headers.assert_called_once_with("test-key")
+                    mock_headers.assert_called_once_with("test-key", custom_headers=None)
 
     @pytest.mark.asyncio
     async def test_raises_error_on_client_error(self):

--- a/test/backend/utils/test_a2a_http_client.py
+++ b/test/backend/utils/test_a2a_http_client.py
@@ -46,6 +46,13 @@ class TestBuildA2AHeaders:
         headers = build_a2a_headers(api_key="")
         assert "Authorization" not in headers
 
+    def test_headers_with_custom_headers(self):
+        """Test headers with custom values."""
+        from backend.utils.a2a_http_client import build_a2a_headers
+
+        headers = build_a2a_headers(custom_headers={"X-Tenant": "tenant-1"})
+        assert headers["X-Tenant"] == "tenant-1"
+
 
 class TestA2AHttpClientInit:
     """Test class for A2AHttpClient initialization."""

--- a/test/sdk/core/agents/test_a2a_agent_proxy.py
+++ b/test/sdk/core/agents/test_a2a_agent_proxy.py
@@ -265,6 +265,7 @@ class TestA2AAgentInfo:
         assert info.protocol_version == "1.0"
         assert info.protocol_type == PROTOCOL_JSONRPC
         assert info.timeout == 300.0
+        assert info.custom_headers is None
         assert info.raw_card is None
 
     def test_custom_values(self):
@@ -279,6 +280,7 @@ class TestA2AAgentInfo:
             protocol_version="2.0",
             protocol_type=PROTOCOL_HTTP_JSON,
             timeout=60.0,
+            custom_headers={"X-Agent": "custom"},
             raw_card=raw_card,
         )
         assert info.agent_id == "agent-002"
@@ -287,6 +289,7 @@ class TestA2AAgentInfo:
         assert info.protocol_version == "2.0"
         assert info.protocol_type == PROTOCOL_HTTP_JSON
         assert info.timeout == 60.0
+        assert info.custom_headers == {"X-Agent": "custom"}
         assert info.raw_card == raw_card
 
     def test_get_protocol_type(self):


### PR DESCRIPTION
## Summary
- persist and pass custom headers for A2A agent calls
- add frontend fields and service wiring for custom headers
- cover A2A HTTP client and proxy header propagation

Fixes #3244

## Tests
- Not run in this PR preparation step.