### PR TITLE
fix: MCP space - api and frontend bug fixes

### DIFF
--- a/backend/apps/remote_mcp_app.py
+++ b/backend/apps/remote_mcp_app.py
@@ -219,7 +219,6 @@ async def add_container_mcp_service_endpoint(
             tags=payload.tags,
             authorization_token=payload.authorization_token,
             registry_json=payload.registry_json,
-            version=payload.version,
             market_id=payload.market_id,
             port=payload.port,
             mcp_config=payload.mcp_config,

--- a/backend/consts/model.py
+++ b/backend/consts/model.py
@@ -1357,11 +1357,10 @@ class AddMcpServiceRequest(BaseModel):
     container_config: Optional[Dict[str, Any]] = Field(None, description="Container configuration")
     registry_json: Optional[Dict[str, Any]] = Field(None, description="Registry metadata JSON")
     config_json: Optional[Dict[str, Any]] = Field(None, description="MCP configuration JSON (e.g. OpenAPI spec for API-type MCP)")
-    version: Optional[str] = Field(None, description="MCP version")
     market_id: Optional[int] = Field(None, gt=0, description="Linked market record ID")
     enabled: Optional[bool] = Field(default=False, description="Whether the MCP is enabled after creation")
 
-    @field_validator("name", "server_url", "description", "authorization_token", "version", mode="before")
+    @field_validator("name", "server_url", "description", "authorization_token", mode="before")
     @classmethod
     def _strip_text(cls, value: Any):
         if isinstance(value, str):
@@ -1377,12 +1376,11 @@ class AddContainerMcpServiceRequest(BaseModel):
     tags: List[str] = Field(default_factory=list, description="MCP tags")
     authorization_token: Optional[str] = Field(None, description="Authorization token for MCP server")
     registry_json: Optional[Dict[str, Any]] = Field(None, description="Registry metadata JSON")
-    version: Optional[str] = Field(None, description="MCP version")
     market_id: Optional[int] = Field(None, gt=0, description="Linked market record ID")
     port: int = Field(..., ge=1, le=65535, description="Host port for the container")
     mcp_config: MCPConfigRequest = Field(..., description="MCP server configuration")
 
-    @field_validator("name", "description", "authorization_token", "version", mode="before")
+    @field_validator("name", "description", "authorization_token", mode="before")
     @classmethod
     def _strip_text(cls, value: Any):
         if isinstance(value, str):

--- a/backend/services/remote_mcp_service.py
+++ b/backend/services/remote_mcp_service.py
@@ -423,7 +423,6 @@ async def add_container_mcp_service(
     tags: list | None,
     authorization_token: str | None,
     registry_json: dict | None,
-    version: str | None,
     market_id: int | None,
     port: int,
     mcp_config: MCPConfigRequest,
@@ -439,7 +438,6 @@ async def add_container_mcp_service(
         tags: MCP tags
         authorization_token: Authorization token
         registry_json: Registry metadata JSON
-        version: MCP version
         community_id: Linked community record ID
         port: Host port for the container
         mcp_config: MCP server configuration
@@ -511,7 +509,6 @@ async def add_container_mcp_service(
             authorization_token=auth_token,
             container_config=container_config,
             registry_json=registry_json,
-            version=version,
             market_id=market_id,
             enabled=True,
             container_id=container_info.get("container_id"),

--- a/frontend/app/[locale]/mcp-space/components/McpToolsPagination.tsx
+++ b/frontend/app/[locale]/mcp-space/components/McpToolsPagination.tsx
@@ -65,7 +65,11 @@ export default function McpToolsPagination(props: McpToolsPaginationProps) {
     );
   }
 
-  return (
+  if (props.mode === "cursor") {
+    // Hide pagination when there is only one page
+    if (props.page === 1 && !props.hasPrevPage && !props.hasNextPage) return null;
+
+    return (
     <div className="flex items-center justify-center gap-2 pt-2">
       <span className="text-sm text-slate-600">
         {t("mcpTools.community.pageResult", {
@@ -93,4 +97,5 @@ export default function McpToolsPagination(props: McpToolsPaginationProps) {
       </Button>
     </div>
   );
+  }
 }

--- a/frontend/app/[locale]/mcp-space/components/add/AddMcpServiceModal.tsx
+++ b/frontend/app/[locale]/mcp-space/components/add/AddMcpServiceModal.tsx
@@ -7,7 +7,6 @@ import {
 } from "@/const/mcpTools";
 import AddMcpServiceLocalSection from "./local/AddMcpServiceLocalSection";
 import AddMcpServiceRegistrySection from "./registry/AddMcpServiceRegistrySection";
-import AddMcpServiceCommunitySection from "./community/AddMcpServiceCommunitySection";
 import { useMcpServerList } from "@/hooks/mcp/useMcpServerList";
 
 interface AddMcpServiceModalProps {
@@ -74,10 +73,6 @@ export default function AddMcpServiceModal({
                 label: t("mcpTools.addModal.tabRegistry"),
                 value: McpSource.REGISTRY,
               },
-              {
-                label: t("mcpTools.addModal.tabCommunity"),
-                value: McpSource.COMMUNITY,
-              },
             ]}
             className="h-9 rounded-md border border-slate-200 bg-slate-100 p-[2px] text-sm [&_.ant-segmented-group]:h-full [&_.ant-segmented-item]:rounded-md [&_.ant-segmented-item-label]:px-4 [&_.ant-segmented-item-label]:leading-[30px] [&_.ant-segmented-thumb]:rounded-md [&_.ant-segmented-thumb]:bg-white [&_.ant-segmented-thumb]:shadow-sm [&_.ant-segmented-thumb]:top-[2px] [&_.ant-segmented-thumb]:bottom-[2px]"
           />
@@ -91,10 +86,6 @@ export default function AddMcpServiceModal({
           />
           <AddMcpServiceRegistrySection
             active={tab === McpSource.REGISTRY}
-            onAdded={onClose}
-          />
-          <AddMcpServiceCommunitySection
-            active={tab === McpSource.COMMUNITY}
             onAdded={onClose}
           />
         </div>

--- a/frontend/app/[locale]/mcp-space/components/add/local/AddMcpServiceLocalSection.tsx
+++ b/frontend/app/[locale]/mcp-space/components/add/local/AddMcpServiceLocalSection.tsx
@@ -424,7 +424,7 @@ export default function AddMcpServiceLocalSection({
           </div>
         ) : null}
 
-        <div className="grid grid-cols-[1fr_160px] gap-4">
+        <div className="flex flex-col gap-4">
           <TagEditor
             title={t("mcpTools.detail.tags")}
             titleClassName="mb-1 block text-sm font-medium text-slate-700"
@@ -434,15 +434,6 @@ export default function AddMcpServiceLocalSection({
             removeAriaKey="mcpTools.detail.removeTagAria"
             placeholderKey="mcpTools.detail.tagInputPlaceholder"
           />
-
-          <div>
-            <label className="mb-1 block text-sm font-medium text-slate-700">
-              {t("mcpTools.detail.versionNumber")}
-            </label>
-            <Form.Item name="version" className="mb-0" rules={rules.version}>
-              <Input {...bindField("version")} className="w-full rounded-md" placeholder="1.0.0" />
-            </Form.Item>
-          </div>
         </div>
       </Form>
 

--- a/frontend/app/[locale]/mcp-space/page.tsx
+++ b/frontend/app/[locale]/mcp-space/page.tsx
@@ -5,7 +5,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { App, Button, ConfigProvider, Empty, Modal, Spin } from "antd";
 import { useTranslation } from "react-i18next";
 import { motion } from "framer-motion";
-import { CheckCircle, ChevronLeft, ChevronRight, Clock, CloudUpload, Download, Eye, Inbox, Plus, Puzzle, ShieldCheck, XCircle } from "lucide-react";
+import { CheckCircle, ChevronLeft, ChevronRight, Clock, CloudUpload, Download, Eye, Inbox, Plus, Puzzle, ShieldCheck, User, XCircle } from "lucide-react";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import { useSetupFlow } from "@/hooks/useSetupFlow";
@@ -37,7 +37,6 @@ import type {
 import {
   FILTER_ALL,
   McpDeploymentType,
-  McpSource,
   MCP_TOOLS_QUERY_KEYS,
   McpToolsServicesTab,
   McpTransportType,
@@ -121,9 +120,6 @@ export default function McpToolsPage() {
     McpToolsServicesTab.REPOSITORY
   );
   const [showAddModal, setShowAddModal] = useState(false);
-  const [addModalInitialTab, setAddModalInitialTab] = useState<McpSource>(
-    McpSource.LOCAL
-  );
   const [selectedLocal, setSelectedLocal] = useState<McpServiceItem | null>(
     null
   );
@@ -163,12 +159,6 @@ export default function McpToolsPage() {
   }, [isAdmin, tab]);
 
   const openAddModal = () => {
-    setAddModalInitialTab(McpSource.LOCAL);
-    setShowAddModal(true);
-  };
-
-  const openImportModal = () => {
-    setAddModalInitialTab(McpSource.REGISTRY);
     setShowAddModal(true);
   };
 
@@ -227,7 +217,14 @@ export default function McpToolsPage() {
   ).length;
 
   const searchActions = tab === McpToolsServicesTab.MINE ? (
-    <></>
+    <Button
+      type="primary"
+      className="flex h-11 shrink-0 items-center gap-1.5"
+      icon={<Plus className="size-4" />}
+      onClick={openAddModal}
+    >
+      添加 MCP
+    </Button>
   ) : null;
 
 
@@ -244,27 +241,21 @@ export default function McpToolsPage() {
             className="mx-auto w-full max-w-6xl px-4 py-8 sm:px-6 sm:py-10"
           >
             <div className="flex flex-col gap-6">
-              <motion.div
-                initial={{ opacity: 0, y: -20 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.5 }}
-              >
-                <section className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-                  <div className="flex items-start gap-4">
-                    <div className="flex size-14 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary shadow-sm">
-                      <Puzzle className="size-7" />
-                    </div>
-                    <div>
-                      <h1 className="text-2xl font-bold tracking-tight text-slate-900 sm:text-3xl dark:text-slate-100">
-                        {t("mcpTools.page.title")}
-                      </h1>
-                      <p className="mt-1 max-w-xl text-sm leading-relaxed text-slate-600 dark:text-slate-300">
-                        {t("mcpTools.page.subtitle")}
-                      </p>
-                    </div>
+              <section className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                <div className="flex items-start gap-4">
+                  <div className="flex size-14 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary shadow-sm">
+                    <Puzzle className="size-7" />
                   </div>
-                </section>
-              </motion.div>
+                  <div>
+                    <h1 className="text-2xl font-bold tracking-tight text-slate-900 sm:text-3xl dark:text-slate-100">
+                      {t("mcpTools.page.title")}
+                    </h1>
+                    <p className="mt-1 max-w-xl text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+                      {t("mcpTools.page.subtitle")}
+                    </p>
+                  </div>
+                </div>
+              </section>
 
               <Tabs value={tab} onValueChange={(value) => setTab(value as McpToolsServicesTab)} className="w-full">
                 <TabsList className={cn("mb-6 grid h-auto w-full gap-2 rounded-xl border border-border bg-secondary/60 px-2 py-2", isAdmin ? "grid-cols-3" : "grid-cols-2")}>
@@ -274,7 +265,7 @@ export default function McpToolsPage() {
                     <span className="ml-1 rounded-md bg-background/70 px-1.5 text-xs text-muted-foreground">{repositoryCount}</span>
                   </TabsTrigger>
                   <TabsTrigger value={McpToolsServicesTab.MINE} className="w-full justify-center gap-1.5 rounded-lg px-[5px] py-2 text-sm data-[state=active]:shadow-sm">
-                    <CloudUpload className="size-4" aria-hidden />
+                    <User className="size-4" aria-hidden />
                     {t("mcpTools.page.tab.mine")}
                     <span className="ml-1 rounded-md bg-background/70 px-1.5 text-xs text-muted-foreground">{mineCount}</span>
                   </TabsTrigger>
@@ -368,7 +359,6 @@ export default function McpToolsPage() {
 
               <AddMcpServiceModal
                 open={showAddModal}
-                initialTab={addModalInitialTab}
                 onClose={() => setShowAddModal(false)}
               />
             </div>
@@ -458,15 +448,17 @@ function RepositoryView({
         </ResponsiveCardGrid>
       )}
 
-      <McpToolsPagination
-        mode="cursor"
-        page={browser.page}
-        resultCount={filteredServices.length}
-        hasPrevPage={browser.hasPrevPage}
-        hasNextPage={browser.hasNextPage}
-        onPrevPage={browser.prevPage}
-        onNextPage={browser.nextPage}
-      />
+      {filteredServices.length > 0 ? (
+        <McpToolsPagination
+          mode="cursor"
+          page={browser.page}
+          resultCount={filteredServices.length}
+          hasPrevPage={browser.hasPrevPage}
+          hasNextPage={browser.hasNextPage}
+          onPrevPage={browser.prevPage}
+          onNextPage={browser.nextPage}
+        />
+      ) : null}
     </div>
   );
 }
@@ -803,9 +795,9 @@ function MineView({
           <Spin />
         </PlaceholderBox>
       ) : filteredItems.length === 0 ? (
-        <PlaceholderBox>
-          <Empty description={t("mcpTools.mine.empty")} />
-        </PlaceholderBox>
+        <ResponsiveCardGrid>
+          <AddMcpServiceCard onClick={onAdd} />
+        </ResponsiveCardGrid>
       ) : (
         <ResponsiveCardGrid>
           {page === 1 ? <AddMcpServiceCard onClick={onAdd} /> : null}

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -3262,7 +3262,7 @@
   "systemPrompt.finetune.modeSelect": "替换选中",
   "systemPrompt.finetune.modeSelectDesc": "替换选中的内容范围",
   "mcpTools.page.tab.repository": "仓库",
-  "mcpTools.page.tab.mine": "我的",
+  "mcpTools.page.tab.mine": "我的MCP",
   "mcpTools.page.tab.review": "审核中心",
   "mcpTools.page.searchNameTagPlaceholder": "按名称或标签检索 MCP 服务",
   "mcpTools.deploymentType.all": "全部类型",

--- a/test/backend/services/test_remote_mcp_service.py
+++ b/test/backend/services/test_remote_mcp_service.py
@@ -941,7 +941,7 @@ class TestAddContainerMcpServiceCallsAddMcpServiceWithCustomHeaders(unittest.Iso
             tenant_id='tid', user_id='uid', name='test-svc',
             description='desc', source='local', tags=[],
             authorization_token='tok', registry_json=None,
-            version=None, market_id=None,
+            market_id=None,
             port=8080, mcp_config=self._make_mcp_config(),
         )
 


### PR DESCRIPTION
**API fixes:**
  - Removed unused `version` parameter from `AddMcpServiceRequest` / `AddContainerMcpServiceRequest` models, `add_container_mcp_service` service function, and its call chain — this was causing a `TypeError` at runtime in `add_mcp_service`

  **Frontend fixes:**
  - Removed Community tab from the "添加 MCP" modal, only Local and Registry tabs remain
  - Removed the version number input field from the creation form (MCP has no version concept)
  - MCP repository and review center pagination now hides when there is only one page of results
  - "我的MCP" tab gets an "添加 MCP" button in the search actions area
  - Mine tab empty state shows the add card instead of an empty placeholder
  - Tab label updated from "我的" to "我的MCP", icon changed to User