### PR TITLE
test: establish Phase 0 context migration baselines

### DIFF
--- a/test/backend/context_baseline/prompt_equivalence_snapshot.json
+++ b/test/backend/context_baseline/prompt_equivalence_snapshot.json
@@ -1,0 +1,314 @@
+{
+  "zh_empty": {
+    "legacy": {
+      "chars": 2355,
+      "sha256": "84d60986962a35d18bf2389af1b53b4172d22a1040175f7fa7431b89ff540891"
+    },
+    "managed": {
+      "components": [
+        "system_prompt",
+        "system_prompt",
+        "system_prompt",
+        "system_prompt",
+        "skills",
+        "system_prompt",
+        "system_prompt",
+        "system_prompt"
+      ],
+      "messages": [
+        {
+          "role": "system",
+          "chars": 30,
+          "sha256": "23e51d094e4294b85a13d954d7e6f28860e677a36788c375d0e0c4e8a3b13ed3"
+        },
+        {
+          "role": "system",
+          "chars": 194,
+          "sha256": "0c48bc143ebae59d8d4970123f878038bcb21bf8030e6b96ed8580f4980ab9e7"
+        },
+        {
+          "role": "system",
+          "chars": 1398,
+          "sha256": "b78cc33e03428fd00051ec0fea784481d09d6897721c8113b55b635a26d76c00"
+        },
+        {
+          "role": "system",
+          "chars": 8,
+          "sha256": "fc084fa251663c59f82483ccc7ecfcda81f274d7c5b249a0b781cfd757e1eb06"
+        },
+        {
+          "role": "system",
+          "chars": 17,
+          "sha256": "5bdb350e187c81a7ccbbc94453380006ac33812acf1a9a2bd7a3574f39e692d3"
+        },
+        {
+          "role": "system",
+          "chars": 25,
+          "sha256": "96a808a0ea37f24a3408bfc4df3a85dbc572bb1533d63a03189fecdaae1f9bf4"
+        },
+        {
+          "role": "system",
+          "chars": 592,
+          "sha256": "ea8cfe87467e761b0c2e23c6be80cb569e1e51da7c76de83e91622a435de6ac9"
+        },
+        {
+          "role": "system",
+          "chars": 62,
+          "sha256": "729c5a521c646c1cc9a29dbaf987f9c85e4a35711f9b26ca0771f02f971c8757"
+        }
+      ]
+    }
+  },
+  "zh_full": {
+    "legacy": {
+      "chars": 6856,
+      "sha256": "4327e64877089afee4432d9e2be5002c599ee9c213289490d66083968547b8ee"
+    },
+    "managed": {
+      "components": [
+        "system_prompt",
+        "memory",
+        "system_prompt",
+        "skills",
+        "system_prompt",
+        "system_prompt",
+        "tools",
+        "knowledge_base",
+        "managed_agents",
+        "external_a2a_agents",
+        "skills",
+        "system_prompt",
+        "system_prompt",
+        "system_prompt"
+      ],
+      "messages": [
+        {
+          "role": "system",
+          "chars": 30,
+          "sha256": "23e51d094e4294b85a13d954d7e6f28860e677a36788c375d0e0c4e8a3b13ed3"
+        },
+        {
+          "role": "user",
+          "chars": 544,
+          "sha256": "5d4511550baf4d6cab3eb2c788cd2a79511c0ea00bbeaa570e0fd32eaea2bf0c"
+        },
+        {
+          "role": "system",
+          "chars": 198,
+          "sha256": "76ec24802341088ac7e18e1b1c7bdb5ec7c99277d47dd60d7a2a4fccfb503925"
+        },
+        {
+          "role": "system",
+          "chars": 2463,
+          "sha256": "bb6847e449dd75b5afff2eda0762ed9dad272805e30aa8bdfc939f8a0a06b8ba"
+        },
+        {
+          "role": "system",
+          "chars": 1392,
+          "sha256": "914a30e1073992d116c207ba7312a6a343917be42d553fd56cb281450edddfdd"
+        },
+        {
+          "role": "system",
+          "chars": 33,
+          "sha256": "4cb1a3d2001265527ab3382326e88d4f1684a251d0fb4b2d6f32b2421905f00a"
+        },
+        {
+          "role": "system",
+          "chars": 531,
+          "sha256": "a3bb7123c0848b02dfa4e535126cc0a6716b59561efa05b95d6a3514654ecf74"
+        },
+        {
+          "role": "user",
+          "chars": 88,
+          "sha256": "b8655d442ce90bc68c60e465aa1a3dc8518268b6ea6df4a47d8896575ded95ae"
+        },
+        {
+          "role": "system",
+          "chars": 458,
+          "sha256": "3b26751d90be8be61de545f3af082f44c6a056c24ad5231b2243bbd7c7a0c942"
+        },
+        {
+          "role": "system",
+          "chars": 206,
+          "sha256": "f1d1fb9d14fc5ad1024cc1645959d2e2821f6d038c7e03f2928aca3e4aa7f07f"
+        },
+        {
+          "role": "system",
+          "chars": 839,
+          "sha256": "eb72f36c8dd78b06c33a7138de905a34bba19174da0dd64a2f19f2673cb157a7"
+        },
+        {
+          "role": "system",
+          "chars": 25,
+          "sha256": "96a808a0ea37f24a3408bfc4df3a85dbc572bb1533d63a03189fecdaae1f9bf4"
+        },
+        {
+          "role": "system",
+          "chars": 642,
+          "sha256": "bb6cb21988325ee56deac360581b21550b07a719920c509be89f5e33fcc3f239"
+        },
+        {
+          "role": "system",
+          "chars": 62,
+          "sha256": "729c5a521c646c1cc9a29dbaf987f9c85e4a35711f9b26ca0771f02f971c8757"
+        }
+      ]
+    }
+  },
+  "en_empty": {
+    "legacy": {
+      "chars": 6296,
+      "sha256": "dd62c63eed158a52598a9541957f8fffdd05683f074c4306d382c13e48269bc5"
+    },
+    "managed": {
+      "components": [
+        "system_prompt",
+        "system_prompt",
+        "system_prompt",
+        "system_prompt",
+        "skills",
+        "system_prompt",
+        "system_prompt",
+        "system_prompt"
+      ],
+      "messages": [
+        {
+          "role": "system",
+          "chars": 50,
+          "sha256": "14fbe96ec66f3c0803a59c501086d0810dd68ff99f6761dcfb489df314e1c0a7"
+        },
+        {
+          "role": "system",
+          "chars": 710,
+          "sha256": "8d80ed6ad24312323e245c441bd089a32fa38e7533748099a94b130d03458084"
+        },
+        {
+          "role": "system",
+          "chars": 3779,
+          "sha256": "a8ce8d5217170aa55af534bda46103aa3a4bc5cd86f2d10614c8b1b727d942de"
+        },
+        {
+          "role": "system",
+          "chars": 23,
+          "sha256": "e5046300af7fca8c714832ffff218e160b5b0f235b2ed4dca8fcdcbef26f8704"
+        },
+        {
+          "role": "system",
+          "chars": 45,
+          "sha256": "661b8fd9c0cf0ca687982c3fe14fc3246684da3dc1f5ad6ec380340b6ad8df4f"
+        },
+        {
+          "role": "system",
+          "chars": 46,
+          "sha256": "134b6f109f7cfa75f11d104200a6c42f2232bfadca0eb53f0266be10f1797b2e"
+        },
+        {
+          "role": "system",
+          "chars": 1518,
+          "sha256": "03c819145eab1c20c04e46dfa25d6540b66b15fe739be71ca9c508513f409959"
+        },
+        {
+          "role": "system",
+          "chars": 137,
+          "sha256": "ca0c6e859049f6d8cbb6e034be76ac9b863fd3340011a439e527829ae059cdbb"
+        }
+      ]
+    }
+  },
+  "en_full": {
+    "legacy": {
+      "chars": 14833,
+      "sha256": "49b94c52ef7284436a04f97fd9092a5deb4598b5e6701aa83b674053e3ab9933"
+    },
+    "managed": {
+      "components": [
+        "system_prompt",
+        "memory",
+        "system_prompt",
+        "skills",
+        "system_prompt",
+        "system_prompt",
+        "tools",
+        "knowledge_base",
+        "managed_agents",
+        "external_a2a_agents",
+        "skills",
+        "system_prompt",
+        "system_prompt",
+        "system_prompt"
+      ],
+      "messages": [
+        {
+          "role": "system",
+          "chars": 50,
+          "sha256": "14fbe96ec66f3c0803a59c501086d0810dd68ff99f6761dcfb489df314e1c0a7"
+        },
+        {
+          "role": "user",
+          "chars": 1332,
+          "sha256": "db11e7720569f56dad5936dabd76253a1b1bacf3d8d6c7c6b8616ff5a9f8a574"
+        },
+        {
+          "role": "system",
+          "chars": 710,
+          "sha256": "8d80ed6ad24312323e245c441bd089a32fa38e7533748099a94b130d03458084"
+        },
+        {
+          "role": "system",
+          "chars": 4149,
+          "sha256": "e1284982b11b5dfc00c069775e741c6bf32ad4394cb53fafec45596a4845b942"
+        },
+        {
+          "role": "system",
+          "chars": 3692,
+          "sha256": "80e136c4c3373482a9b1b181d40db1fd1cf6879ef3b17c1bda725be061f9720a"
+        },
+        {
+          "role": "system",
+          "chars": 108,
+          "sha256": "408d6cf91329b0569ec09bed74f0dac6f40f1b96b186479e2c41a3c2f499c9a1"
+        },
+        {
+          "role": "system",
+          "chars": 860,
+          "sha256": "b2669e290ffcb2d677e79c3c7c1b7da0f456e77ca156514858b84fe938cc20c4"
+        },
+        {
+          "role": "user",
+          "chars": 201,
+          "sha256": "bdb5f3957f794cd5d8e20bd13e26e0e6bfcb3b6c5b21c82987be84302df7adf6"
+        },
+        {
+          "role": "system",
+          "chars": 1070,
+          "sha256": "d8e95e23514ff03a8bfc310e62df00ad344906f027bfc2fab68a4b0f83d50c79"
+        },
+        {
+          "role": "system",
+          "chars": 447,
+          "sha256": "88d2c787cc8695b9783f2e84470a282ec4bda338f46ddf72de670818a05dfd1a"
+        },
+        {
+          "role": "system",
+          "chars": 1931,
+          "sha256": "65315279266bdedb79bc792f1ef900e7e13eaeb17ca7f906229958f561cdf66c"
+        },
+        {
+          "role": "system",
+          "chars": 46,
+          "sha256": "134b6f109f7cfa75f11d104200a6c42f2232bfadca0eb53f0266be10f1797b2e"
+        },
+        {
+          "role": "system",
+          "chars": 1605,
+          "sha256": "a3a411fec12b8f35b4ba272c9421b79929e681ad9b926197b864426eb6e20ea7"
+        },
+        {
+          "role": "system",
+          "chars": 137,
+          "sha256": "ca0c6e859049f6d8cbb6e034be76ac9b863fd3340011a439e527829ae059cdbb"
+        }
+      ]
+    }
+  }
+}

--- a/test/backend/context_baseline/test_isolation_baseline.py
+++ b/test/backend/context_baseline/test_isolation_baseline.py
@@ -1,0 +1,116 @@
+"""Current user, tenant, cache, and deployment-mode isolation baseline."""
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+from backend.agents.agent_run_manager import AgentRunManager
+from backend.database.conversation_db import get_conversation
+from backend.database.knowledge_db import get_knowledge_name_map_by_index_names
+from backend.utils import auth_utils
+from nexent.memory.memory_service import search_memory_in_levels
+
+
+@pytest.fixture
+def run_manager():
+    manager = AgentRunManager()
+    manager.agent_runs.clear()
+    manager._conversation_context_managers.clear()
+    manager._conversation_run_counts.clear()
+    return manager
+
+
+def test_speed_mode_uses_the_single_local_identity(monkeypatch):
+    monkeypatch.setattr(auth_utils, "IS_SPEED_MODE", True)
+
+    assert auth_utils.get_current_user_id() == (
+        auth_utils.DEFAULT_USER_ID,
+        auth_utils.DEFAULT_TENANT_ID,
+    )
+
+
+def test_full_mode_resolves_same_tenant_users_and_cross_tenant_users(monkeypatch):
+    """Freeze the authenticated identity matrix before changing data-access boundaries."""
+    identities = {
+        "token-a": ("user-a", "tenant-1"),
+        "token-b": ("user-b", "tenant-1"),
+        "token-c": ("user-c", "tenant-2"),
+    }
+    monkeypatch.setattr(auth_utils, "IS_SPEED_MODE", False)
+    monkeypatch.setattr(
+        auth_utils,
+        "_decode_jwt_token",
+        lambda token: {"sub": identities[token][0]},
+    )
+    monkeypatch.setattr(auth_utils, "ensure_cas_session_active_from_authorization", lambda token: None)
+    monkeypatch.setattr(
+        auth_utils,
+        "get_user_tenant_by_user_id",
+        lambda user_id: {
+            "tenant_id": next(tenant for user, tenant in identities.values() if user == user_id)
+        },
+    )
+
+    assert auth_utils.get_current_user_id("token-a") == identities["token-a"]
+    assert auth_utils.get_current_user_id("token-b") == identities["token-b"]
+    assert auth_utils.get_current_user_id("token-c") == identities["token-c"]
+
+
+def test_user_run_keys_are_isolated_for_same_conversation(run_manager):
+    """The current in-process run registry separates users sharing a conversation ID."""
+    assert run_manager._get_run_key(42, "user-a") != run_manager._get_run_key(42, "user-b")
+
+
+def test_conversation_read_supports_user_ownership_filter():
+    """Record the ownership dimension available at the current DB boundary."""
+    parameters = inspect.signature(get_conversation).parameters
+    assert "user_id" in parameters
+    assert parameters["user_id"].default is None
+
+
+def test_conversation_read_has_no_explicit_tenant_filter_yet():
+    """Known Phase 0 gap: conversation reads do not accept tenant identity."""
+    assert "tenant_id" not in inspect.signature(get_conversation).parameters
+
+
+def test_memory_search_has_explicit_tenant_and_user_dimensions():
+    parameters = inspect.signature(search_memory_in_levels).parameters
+    assert "tenant_id" in parameters
+    assert "user_id" in parameters
+    assert "agent_id" in parameters
+
+
+def test_knowledge_name_lookup_has_no_explicit_tenant_filter_yet():
+    """Known Phase 0 gap for the KB display-name lookup used during assembly."""
+    assert "tenant_id" not in inspect.signature(get_knowledge_name_map_by_index_names).parameters
+
+
+def test_context_manager_cache_is_conversation_only_baseline(run_manager, mocker):
+    """Known Phase 0 gap: the first config is reused solely by conversation ID."""
+    manager_instance = SimpleNamespace(name="first-manager")
+    manager_class = mocker.patch(
+        "nexent.core.agents.agent_context.ContextManager",
+        return_value=manager_instance,
+    )
+    first_config = SimpleNamespace(name="tenant-a-user-a")
+    second_config = SimpleNamespace(name="tenant-b-user-b")
+
+    first = run_manager.get_or_create_context_manager(42, first_config, 10)
+    second = run_manager.get_or_create_context_manager(42, second_config, 20)
+
+    assert first is second
+    manager_class.assert_called_once_with(config=first_config, max_steps=10)
+
+
+def test_different_conversations_do_not_share_context_manager(run_manager, mocker):
+    manager_class = mocker.patch(
+        "nexent.core.agents.agent_context.ContextManager",
+        side_effect=[SimpleNamespace(name="first"), SimpleNamespace(name="second")],
+    )
+
+    first = run_manager.get_or_create_context_manager(41, SimpleNamespace(), 10)
+    second = run_manager.get_or_create_context_manager(42, SimpleNamespace(), 10)
+
+    assert first is not second
+    assert manager_class.call_count == 2

--- a/test/backend/context_baseline/test_prompt_equivalence_snapshot.py
+++ b/test/backend/context_baseline/test_prompt_equivalence_snapshot.py
@@ -1,0 +1,199 @@
+"""Behavior snapshots for legacy and managed context assembly paths."""
+
+import hashlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from jinja2 import StrictUndefined, Template
+
+from backend.utils.context_utils import build_context_components
+from backend.utils.prompt_template_utils import get_agent_prompt_template
+from nexent.core.agents.agent_context import ContextManager
+from nexent.core.agents.summary_config import ContextManagerConfig
+
+
+SNAPSHOT_PATH = Path(__file__).with_name("prompt_equivalence_snapshot.json")
+
+
+def _message_text(message):
+    return "".join(part.get("text", "") for part in message["content"])
+
+
+def _digest(text):
+    return {"chars": len(text), "sha256": hashlib.sha256(text.encode()).hexdigest()}
+
+
+def _case_inputs(language, rich):
+    tool = SimpleNamespace(
+        name="search",
+        description="Search <docs> & data",
+        inputs='{"q":"string"}',
+        output_type="string",
+        source="local",
+    )
+    builtin_tool = SimpleNamespace(
+        name="run_skill_script",
+        description="Run skill script",
+        inputs='{"path":"string"}',
+        output_type="string",
+        source="local",
+    )
+    return {
+        "duty": "Duty <&> 职责",
+        "constraint": "Constraint\n第二行",
+        "few_shots": "User: {x}\nAssistant: ✓",
+        "app_name": "Nexent",
+        "app_description": "Desc & <tag>",
+        "user_id": "user-1",
+        "language": language,
+        "is_manager": rich,
+        "tools": {"search": tool, "run_skill_script": builtin_tool} if rich else {},
+        "skills": (
+            [{"name": "analysis-skill", "description": "Analyze <input> & report"}]
+            if rich
+            else []
+        ),
+        "managed_agents": (
+            {"analyst": SimpleNamespace(name="analyst", description="Internal analyst ✓")}
+            if rich
+            else {}
+        ),
+        "external_a2a_agents": (
+            {
+                "ext-1": SimpleNamespace(
+                    agent_id="ext-1",
+                    name="remote_helper",
+                    description="External & safe",
+                )
+            }
+            if rich
+            else {}
+        ),
+        "memory_list": (
+            [{"memory": "Prefers concise answers <3", "memory_level": "user", "score": 0.91}]
+            if rich
+            else []
+        ),
+        "memory_search_query": "special <query>",
+        "knowledge_base_summary": "**KB**: facts & <evidence>" if rich else "",
+        "kb_ids": ["kb-1"] if rich else [],
+    }
+
+
+def _legacy_prompt(values):
+    template = get_agent_prompt_template(values["is_manager"], values["language"])["system_prompt"]
+    return Template(template, undefined=StrictUndefined).render(
+        duty=values["duty"],
+        constraint=values["constraint"],
+        few_shots=values["few_shots"],
+        tools=values["tools"],
+        skills=values["skills"],
+        managed_agents=values["managed_agents"],
+        external_a2a_agents=values["external_a2a_agents"],
+        APP_NAME=values["app_name"],
+        APP_DESCRIPTION=values["app_description"],
+        memory_list=values["memory_list"],
+        knowledge_base_summary=values["knowledge_base_summary"],
+        user_id=values["user_id"],
+    )
+
+
+def _capture(values):
+    legacy = _legacy_prompt(values)
+    components = build_context_components(**values)
+    messages = [message for component in components for message in component.to_messages()]
+    return {
+        "legacy": _digest(legacy),
+        "managed": {
+            "components": [component.component_type for component in components],
+            "messages": [
+                {"role": message["role"], **_digest(_message_text(message))}
+                for message in messages
+            ],
+        },
+    }
+
+
+@pytest.mark.parametrize("language", ["zh", "en"])
+@pytest.mark.parametrize("rich", [False, True], ids=["empty", "full"])
+def test_legacy_and_managed_prompt_snapshots(language, rich):
+    """Freeze both paths without incorrectly requiring their current outputs to be equal."""
+    expected = json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
+    case_name = f"{language}_{'full' if rich else 'empty'}"
+    assert _capture(_case_inputs(language, rich)) == expected[case_name]
+
+
+def test_full_snapshot_covers_required_context_sources():
+    expected = json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
+    for language in ("zh", "en"):
+        snapshot = expected[f"{language}_full"]["managed"]
+        assert {"tools", "skills", "memory", "knowledge_base"}.issubset(snapshot["components"])
+        assert {"managed_agents", "external_a2a_agents"}.issubset(snapshot["components"])
+        assert [message["role"] for message in snapshot["messages"]].count("user") == 2
+
+
+@pytest.mark.parametrize("language", ["zh", "en"])
+def test_final_managed_message_order_baseline(language):
+    """Freeze ContextManager priority ordering, including dynamic evidence placement."""
+    values = _case_inputs(language, rich=True)
+    components = build_context_components(**values)
+    manager = ContextManager(ContextManagerConfig(strategy="full"))
+    manager.replace_components(components)
+
+    messages = manager.build_context_messages()
+    roles = [message["role"] for message in messages]
+    texts = [_message_text(message) for message in messages]
+
+    assert roles[0:2] == ["system", "user"]
+    assert roles[-2:] == ["user", "system"]
+    assert "Prefers concise answers <3" in texts[1]
+    assert "**KB**: facts & <evidence>" in texts[-2]
+
+
+@pytest.mark.parametrize("language", ["zh", "en"])
+def test_model_call_message_sequence_matches_managed_builder(language):
+    """Freeze roles, order, text parts, and empty-history behavior at the model boundary."""
+    values = _case_inputs(language, rich=True)
+    components = build_context_components(**values)
+    manager = ContextManager(ContextManagerConfig(enabled=False, strategy="full"))
+    manager.replace_components(components)
+    memory = SimpleNamespace(system_prompt=None, steps=[])
+
+    run_context = manager.prepare_run_context(memory, fallback_system_prompt="fallback")
+    final_context = manager.assemble_final_context(
+        model=None,
+        memory=memory,
+        current_run_start_idx=0,
+        run_context=run_context,
+    )
+
+    expected_messages = [*run_context.stable_messages, *run_context.dynamic_messages]
+    assert final_context.messages == expected_messages
+    assert all(message["content"] for message in final_context.messages)
+    assert all(part["type"] == "text" for message in final_context.messages for part in message["content"])
+
+
+def test_none_and_empty_sources_do_not_emit_empty_messages():
+    components = build_context_components(
+        duty=None,
+        constraint="",
+        few_shots=None,
+        app_name=None,
+        app_description="",
+        user_id=None,
+        language="zh",
+        is_manager=False,
+        tools={},
+        skills=[],
+        memory_list=[],
+        knowledge_base_summary="",
+    )
+    manager = ContextManager(ContextManagerConfig(strategy="full"))
+    manager.replace_components(components)
+
+    messages = manager.build_context_messages()
+
+    assert messages
+    assert all(_message_text(message) for message in messages)

--- a/test/sdk/core/agents/test_agent_context/unit/test_phase0_budget_baseline.py
+++ b/test/sdk/core/agents/test_agent_context/unit/test_phase0_budget_baseline.py
@@ -1,0 +1,42 @@
+"""Phase 0 snapshots for current context budget and compression triggers."""
+
+from factories import make_cm, make_memory_mixed, make_model, make_original_messages
+
+
+def test_default_budget_snapshot():
+    manager = make_cm(enabled=True, threshold=10_000)
+
+    assert manager.config.token_threshold == 10_000
+    assert manager.config.soft_input_budget_tokens == 0
+    assert manager.config.hard_input_budget_tokens == 0
+    assert manager._soft_input_budget_tokens() == 10_000
+    assert manager._hard_input_budget_tokens() == 11_000
+    assert manager.config.keep_recent_steps == 2
+    assert manager.config.keep_recent_pairs == 1
+
+
+def test_disabled_context_manager_never_compresses_baseline():
+    manager = make_cm(enabled=False, threshold=1)
+    memory = make_memory_mixed(n_prev_pairs=2, n_curr_actions=2)
+    original = make_original_messages(memory)
+
+    result = manager.compress_if_needed(None, memory, original, current_run_start_idx=4)
+
+    assert result is original
+    assert manager.compression_calls_log == []
+
+
+def test_soft_budget_is_the_compression_trigger_baseline():
+    manager = make_cm(enabled=True, threshold=999_999, keep_recent_steps=2, keep_recent_pairs=1)
+    manager.config.soft_input_budget_tokens = 10
+    manager.config.hard_input_budget_tokens = 999_999
+    memory = make_memory_mixed(n_prev_pairs=3, n_curr_actions=2)
+    original = make_original_messages(memory)
+    model = make_model('{"task_overview": "phase0 baseline"}')
+
+    result = manager.compress_if_needed(model, memory, original, current_run_start_idx=6)
+
+    assert result is not original
+    model.assert_called_once()
+    assert manager.get_token_counts()["last_uncompressed"] is not None
+    assert manager.get_token_counts()["last_compressed"] is not None


### PR DESCRIPTION
## Summary

- freeze legacy Jinja2 and managed ContextManager prompt/message snapshots for zh/en, empty/full sources, tools, builtin tools, skills, memory, KB, managed/external agents, and special characters
- capture speed/full identity, same-tenant multi-user, cross-tenant, database filter, and ContextManager cache isolation baselines
- freeze current context budget defaults and compression trigger behavior
- production behavior is unchanged

## Behavior and risk

This PR intentionally records current behavior, including known gaps: conversation and KB lookup lack an explicit tenant parameter, and ContextManager caching is keyed only by conversation ID. These assertions are migration guards for later phases, not endorsements of those behaviors.

Risk is limited to test maintenance. Rollback is removal of the four added baseline files.

## Local UT

- `backend/.venv/bin/pytest -q test/backend/context_baseline test/sdk/core/agents/test_agent_context/unit/test_phase0_budget_baseline.py` — 22 passed
- standard runner on the three added test files — 22 passed, 100%
- `test/backend/utils/test_context_utils.py test/backend/utils/test_context_component_types.py` — 179 passed
- `test/sdk/core/agents/test_agent_context` — 243 passed
- relevant agent creation, conversation, and run manager suites — 150 passed
- Ruff and `git diff --check` passed

The repository-wide runner was also attempted with its default 20 file workers. The added Phase 0 files passed, while unrelated backend app files hit the runner's 600-second per-file timeout under resource contention; no Phase 0 assertion failed.

## Functional verification

### SDK / real model / Langfuse

Model: `qwen3.6-plus` through the configured DashScope-compatible endpoint.

- speed: output `SPEED_OK`; Langfuse trace `012f22b87747bb0bf91e638f2d3f1881`
- full: final context included system + memory user + KB user messages; output `FULL_OK`; Langfuse trace `238080b9272f63f17c55e45ef582ecb4`

Traces were inspected for model input/output, final message ordering, usage, latency, and errors.

### Backend API / logs

- speed `/api/agent/run`: SSE completed with `final_answer=API_SPEED_OK`
- full `/api/agent/run` with signed local JWT: identity resolved to `user_id/tenant_id`; SSE completed with `final_answer=API_FULL_OK`
- logs confirmed conversation creation, identity/tenant resolution, memory lookup, context component assembly, ContextManager creation, real model input, token accounting, and cleanup

No frontend production code is changed, so browser validation is not applicable.

## Follow-up

Phase 1 will use these guards to tighten the backend-to-SDK authorized snapshot boundary and fix tenant/user/cache isolation without silently changing prompt content or ordering.