### PR TITLE
fix: add missing W1 capacity fields to ManageTenantModel request schemas

### DIFF
--- a/backend/consts/model.py
+++ b/backend/consts/model.py
@@ -1108,6 +1108,14 @@ class ManageTenantModelCreateRequest(BaseModel):
     access_token: Optional[str] = Field(None, description="Access token for STT models (e.g., Volcano Engine)")
     timeout_seconds: Optional[int] = Field(None, description="Request timeout in seconds")
     concurrency_limit: Optional[int] = Field(None, description="Maximum concurrent requests for this model")
+    # W1 capacity fields (see W1 ADR). All nullable; resolver applies precedence.
+    context_window_tokens: Optional[int] = Field(None, description="Total combined input/output context window in tokens")
+    max_input_tokens: Optional[int] = Field(None, description="Provider hard input-token limit")
+    max_output_tokens: Optional[int] = Field(None, description="Provider-supported completion output cap")
+    default_output_reserve_tokens: Optional[int] = Field(None, description="Default output allowance reserved per request")
+    tokenizer_family: Optional[str] = Field(None, description="Token-counting strategy or tokenizer identifier")
+    capacity_source: Optional[str] = Field(None, description="Source of the persisted capacity value")
+    capability_profile_version: Optional[str] = Field(None, description="Version of the approved capability profile")
     # W11 accept-signal fields. Same audit-only contract as ModelRequest:
     # the app layer pops them off model_data before the dict reaches the
     # service/DB layer and forwards them to
@@ -1139,6 +1147,14 @@ class ManageTenantModelUpdateRequest(BaseModel):
     access_token: Optional[str] = Field(None, description="Access token for STT models")
     timeout_seconds: Optional[int] = Field(None, description="Request timeout in seconds")
     concurrency_limit: Optional[int] = Field(None, description="Maximum concurrent requests for this model")
+    # W1 capacity fields (see W1 ADR). All nullable; resolver applies precedence.
+    context_window_tokens: Optional[int] = Field(None, description="Total combined input/output context window in tokens")
+    max_input_tokens: Optional[int] = Field(None, description="Provider hard input-token limit")
+    max_output_tokens: Optional[int] = Field(None, description="Provider-supported completion output cap")
+    default_output_reserve_tokens: Optional[int] = Field(None, description="Default output allowance reserved per request")
+    tokenizer_family: Optional[str] = Field(None, description="Token-counting strategy or tokenizer identifier")
+    capacity_source: Optional[str] = Field(None, description="Source of the persisted capacity value")
+    capability_profile_version: Optional[str] = Field(None, description="Version of the approved capability profile")
     # W11 accept-signal fields. See ManageTenantModelCreateRequest for the
     # contract. The app layer pops them before calling the service so
     # update_model_record never sees them.

--- a/test/backend/test_model_consts.py
+++ b/test/backend/test_model_consts.py
@@ -56,6 +56,48 @@ def test_model_request_threads_w11_capacity_and_accept_fields():
     assert not missing, f"ModelRequest missing W11 fields: {missing}"
 
 
+@pytest.mark.parametrize(
+    ("request_type", "required_fields"),
+    [
+        (
+            model_consts.ManageTenantModelCreateRequest,
+            {"tenant_id", "model_name", "model_type"},
+        ),
+        (
+            model_consts.ManageTenantModelUpdateRequest,
+            {"tenant_id", "current_display_name"},
+        ),
+    ],
+)
+def test_manage_model_requests_preserve_capacity_fields(request_type, required_fields):
+    """Manage create/update must not silently discard capacity fields."""
+    capacity_values = {
+        "context_window_tokens": 128_000,
+        "max_input_tokens": 120_000,
+        "max_output_tokens": 8_000,
+        "default_output_reserve_tokens": 4_000,
+        "tokenizer_family": "cl100k_base",
+        "capacity_source": "operator",
+        "capability_profile_version": "2026-07-17",
+    }
+    required_values = {
+        "tenant_id": "tenant-1",
+        "model_name": "test-model",
+        "model_type": "llm",
+        "current_display_name": "Test Model",
+    }
+    request = request_type(
+        **{
+            field: required_values[field]
+            for field in required_fields
+        },
+        **capacity_values,
+    )
+
+    dumped = request.model_dump(exclude_unset=True)
+    assert {field: dumped[field] for field in capacity_values} == capacity_values
+
+
 def test_capacity_suggestion_response_has_required_fields():
     """Pin ModelCapacitySuggestionResponse schema so a downstream rename
     (e.g. suggested_provider -> canonical_provider) trips a test instead


### PR DESCRIPTION
## Problem

Editing model capacity values (context window, max input/output tokens, etc.) in the resource management UI appeared to save successfully, but the values were silently discarded and never persisted to the database.

## Root Cause

`ManageTenantModelCreateRequest` and `ManageTenantModelUpdateRequest` Pydantic schemas in `backend/consts/model.py` were missing the 7 W1 capacity fields. When the frontend submitted these fields in the request body, Pydantic validation stripped them out before they could reach the service/DB layer.

## Fix

Added the following `Optional` fields to both request schemas:

- `context_window_tokens` — Total combined input/output context window in tokens
- `max_input_tokens` — Provider hard input-token limit
- `max_output_tokens` — Provider-supported completion output cap
- `default_output_reserve_tokens` — Default output allowance reserved per request
- `tokenizer_family` — Token-counting strategy or tokenizer identifier
- `capacity_source` — Source of the persisted capacity value
- `capability_profile_version` — Version of the approved capability profile

All fields are `Optional` with `None` default, consistent with the existing nullable pattern in these schemas.

验证：编辑其中一个模型上下文窗口，从200k改成128k，保存配置成功。

<img width="1270" height="638" alt="20260717140402_rec_" src="https://github.com/user-attachments/assets/b1af58c8-d689-4f97-a2b6-1495426176d6" />
