### PR TITLE
fix: connectivity check blocking model add in tenant resource management

### DIFF
--- a/frontend/app/[locale]/models/components/model/ModelAddDialog.tsx
+++ b/frontend/app/[locale]/models/components/model/ModelAddDialog.tsx
@@ -663,14 +663,16 @@ export const ModelAddDialog = ({
 
       let connectivity = false;
 
-      // Use manage interface if tenantId is provided
-      if (tenantId) {
-        connectivity = await modelService.checkManageTenantModelConnectivity(
-          tenantId,
-          form.displayName || form.name,
-          modelType
-        );
-      } else if (form.type === MODEL_TYPES.STT) {
+      // Connectivity is a property of the raw model config (base_url + api_key +
+      // model_name) and is independent of the target tenant. In this dialog the
+      // model has not been persisted yet, so BOTH the self-service and the manage
+      // (tenantId) flows must verify against the config-based temporary
+      // healthcheck. Do NOT route the manage flow through
+      // checkManageTenantModelConnectivity: that endpoint looks up an
+      // already-saved record by display_name + tenant and returns "unavailable"
+      // for a brand-new model that has not been created yet, which blocks adding
+      // models from the tenant resource management page.
+      if (form.type === MODEL_TYPES.STT) {
         // For STT models, build the appropriate config based on provider
         const sttConfig: any = {
           modelType: modelType,


### PR DESCRIPTION
﻿## Summary
- Fix connectivity pre-check in the "add model" dialog when used from tenant resource management (`tenantId` present).
- Both self-service and manage add-model flows now use config-based `verifyModelConfigConnectivity` (`/model/temporary_healthcheck`), which does not require the model to exist yet.
- `checkManageTenantModelConnectivity` remains for re-detecting **already saved** models in `ModelList`.

## Root cause
`handleVerifyConnectivity` routed the manage flow through `checkManageTenantModelConnectivity` -> `POST /model/manage/healthcheck`, which looks up a persisted model by `display_name + tenant_id`. For a brand-new model that lookup fails, so the check always reported unavailable and blocked add.

## Test plan
- [ ] Open Tenant Resource Management -> select tenant -> Models -> Add custom model
- [ ] Fill base_url / api_key / model_name for a reachable endpoint
- [ ] Connectivity test returns available
- [ ] Model can be saved successfully
- [ ] Self-service add-model connectivity check still works
- [ ] ModelList "re-detect connectivity" for saved models still works

fixes #3463
