### PR TITLE
Feat: Add northbound API for agent detail retrieval

### DIFF
--- a/backend/apps/northbound_app.py
+++ b/backend/apps/northbound_app.py
@@ -18,6 +18,7 @@ from services.northbound_service import (
     start_streaming_chat,
     stop_chat,
     get_agent_info_list,
+    get_agent_info_by_name_for_northbound,
     update_conversation_title,
     upload_files_for_northbound,
 )
@@ -344,6 +345,32 @@ async def list_agents(request: Request):
         raise e
     except Exception as e:
         logging.error(f"Failed to list agents: {str(e)}", exc_info=e)
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Internal Server Error")
+
+
+@router.get("/agents/{agent_name}")
+async def get_agent_by_name(
+    request: Request,
+    agent_name: str,
+):
+    try:
+        ctx: NorthboundContext = await _get_northbound_context(request)
+        return await get_agent_info_by_name_for_northbound(ctx=ctx, agent_name=agent_name)
+    except ValueError as e:
+        logging.error(f"Invalid agent detail request: {str(e)}", exc_info=e)
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=str(e))
+    except LookupError as e:
+        logging.info(f"Published agent not found: {agent_name}")
+        raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=str(e))
+    except LimitExceededError as e:
+        logging.error(f"Too Many Requests: rate limit exceeded: {str(e)}", exc_info=e)
+        raise HTTPException(status_code=HTTPStatus.TOO_MANY_REQUESTS,
+                            detail="Too Many Requests: rate limit exceeded")
+    except HTTPException as e:
+        raise e
+    except Exception as e:
+        logging.error(f"Failed to get agent by name: {str(e)}", exc_info=e)
         raise HTTPException(
             status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Internal Server Error")
 

--- a/backend/services/northbound_service.py
+++ b/backend/services/northbound_service.py
@@ -570,27 +570,60 @@ async def get_conversation_history(ctx: NorthboundContext, conversation_id: int)
         raise Exception(f"Failed to get conversation history for conversation_id {conversation_id}: {str(e)}")
 
 
+async def _get_visible_published_agents(ctx: NorthboundContext) -> list[dict]:
+    """Return published agents visible to the northbound caller."""
+    agent_info_list = await list_published_agents_impl(
+        tenant_id=ctx.tenant_id,
+        user_id=ctx.user_id,
+    )
+    if ctx.tenant_id != ASSET_OWNER_TENANT_ID:
+        agent_info_list.extend(await list_published_agents_impl(
+            tenant_id=ASSET_OWNER_TENANT_ID,
+            user_id=ctx.user_id,
+        ))
+    return agent_info_list
+
+
 async def get_agent_info_list(ctx: NorthboundContext) -> Dict[str, Any]:
     try:
-        agent_info_list = await list_published_agents_impl(
-            tenant_id=ctx.tenant_id,
-            user_id=ctx.user_id,
-        )
-        # Match the same scope as /agent/published_list: non-asset-owner tenants
-        # also get the asset owner's published agents merged in.
-        if ctx.tenant_id != ASSET_OWNER_TENANT_ID:
-            asset_agent_list = await list_published_agents_impl(
-                tenant_id=ASSET_OWNER_TENANT_ID,
-                user_id=ctx.user_id,
-            )
-            agent_info_list.extend(asset_agent_list)
-        # Remove internal information that partner don't need
+        agent_info_list = await _get_visible_published_agents(ctx)
         for agent_info in agent_info_list:
             agent_info.pop("agent_id", None)
 
         return {"message": "success", "data": agent_info_list, "requestId": ctx.request_id}
     except Exception as e:
         raise Exception(f"Failed to get agent info list for tenant {ctx.tenant_id}: {str(e)}")
+
+
+async def get_agent_info_by_name_for_northbound(
+    ctx: NorthboundContext,
+    agent_name: str,
+) -> Dict[str, Any]:
+    """Return one visible published agent selected by its exact agent name."""
+    if not agent_name.strip():
+        raise ValueError("agent_name is required")
+
+    try:
+        agent_info_list = await _get_visible_published_agents(ctx)
+        agent_info = next(
+            (
+                item for item in agent_info_list
+                if item.get("name") == agent_name
+            ),
+            None,
+        )
+        if agent_info is None:
+            raise LookupError(f"Published agent not found: {agent_name}")
+
+        result = dict(agent_info)
+        result.pop("agent_id", None)
+        return {"message": "success", "data": result, "requestId": ctx.request_id}
+    except (ValueError, LookupError):
+        raise
+    except Exception as e:
+        raise Exception(
+            f"Failed to get agent info for agent_name {agent_name} in tenant {ctx.tenant_id}: {str(e)}"
+        )
 
 
 async def update_conversation_title(ctx: NorthboundContext, conversation_id: int, title: str, meta_data: Optional[Dict[str, Any]] = None, idempotency_key: Optional[str] = None) -> Dict[str, Any]:

--- a/test/backend/app/test_northbound_app.py
+++ b/test/backend/app/test_northbound_app.py
@@ -304,6 +304,38 @@ def test_get_agent_by_name_not_found():
         assert "missing-agent" in resp.json()["detail"]
 
 
+def test_get_agent_by_name_limit_exceeded():
+    """Test get agent by name returns 429 when limit exceeded."""
+    with patch('apps.northbound_app._get_northbound_context', new_callable=AsyncMock) as mock_ctx, \
+            patch('apps.northbound_app.get_agent_info_by_name_for_northbound', new_callable=AsyncMock) as mock_get:
+
+        mock_ctx.return_value = MagicMock()
+        mock_get.side_effect = LimitExceededError("Rate limit exceeded")
+
+        resp = client.get(
+            "/nb/v1/agents/any-agent",
+            headers=_build_headers(),
+        )
+
+        assert resp.status_code == 429
+
+
+def test_get_agent_by_name_internal_error():
+    """Test get agent by name returns 500 on unexpected internal error."""
+    with patch('apps.northbound_app._get_northbound_context', new_callable=AsyncMock) as mock_ctx, \
+            patch('apps.northbound_app.get_agent_info_by_name_for_northbound', new_callable=AsyncMock) as mock_get:
+
+        mock_ctx.return_value = MagicMock()
+        mock_get.side_effect = Exception("Unexpected internal error")
+
+        resp = client.get(
+            "/nb/v1/agents/any-agent",
+            headers=_build_headers(),
+        )
+
+        assert resp.status_code == 500
+
+
 # =============================================================================
 # List Conversations Tests
 # =============================================================================

--- a/test/backend/app/test_northbound_app.py
+++ b/test/backend/app/test_northbound_app.py
@@ -265,6 +265,45 @@ def test_list_agents_success():
         assert len(data["agents"]) == 2
 
 
+def test_get_agent_by_name_success():
+    """Test successful retrieval of one published agent by name."""
+    with patch('apps.northbound_app._get_northbound_context', new_callable=AsyncMock) as mock_ctx, \
+            patch('apps.northbound_app.get_agent_info_by_name_for_northbound', new_callable=AsyncMock) as mock_get:
+
+        mock_ctx.return_value = MagicMock()
+        mock_get.return_value = {
+            "message": "success",
+            "data": {"name": "agent1", "description": "First agent"},
+            "requestId": "req-123",
+        }
+
+        resp = client.get(
+            "/nb/v1/agents/agent1",
+            headers=_build_headers(),
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["data"]["name"] == "agent1"
+        mock_get.assert_awaited_once()
+
+
+def test_get_agent_by_name_not_found():
+    """Test missing published agent returns 404."""
+    with patch('apps.northbound_app._get_northbound_context', new_callable=AsyncMock) as mock_ctx, \
+            patch('apps.northbound_app.get_agent_info_by_name_for_northbound', new_callable=AsyncMock) as mock_get:
+
+        mock_ctx.return_value = MagicMock()
+        mock_get.side_effect = LookupError("Published agent not found: missing-agent")
+
+        resp = client.get(
+            "/nb/v1/agents/missing-agent",
+            headers=_build_headers(),
+        )
+
+        assert resp.status_code == 404
+        assert "missing-agent" in resp.json()["detail"]
+
+
 # =============================================================================
 # List Conversations Tests
 # =============================================================================

--- a/test/backend/services/test_northbound_service.py
+++ b/test/backend/services/test_northbound_service.py
@@ -842,6 +842,28 @@ class TestGetAgentInfoList:
         assert len(result["data"]) == 2
         agent_version_mod.list_published_agents_impl.assert_called()
 
+    async def test_get_agent_info_by_name_success(self):
+        """Test exact-name lookup returns one published agent without its internal ID."""
+        ctx = MockNorthboundContext(tenant_id="asset-owner-tenant", token_id=0)
+        agent_version_mod.list_published_agents_impl.return_value = [
+            {"agent_id": 42, "name": "target_agent", "description": "Target"},
+            {"agent_id": 43, "name": "other_agent", "description": "Other"},
+        ]
+
+        result = await ns.get_agent_info_by_name_for_northbound(ctx, "target_agent")
+
+        assert result["message"] == "success"
+        assert result["data"]["name"] == "target_agent"
+        assert "agent_id" not in result["data"]
+
+    async def test_get_agent_info_by_name_not_found(self):
+        """Test lookup rejects unpublished or unavailable agent names."""
+        ctx = MockNorthboundContext(tenant_id="asset-owner-tenant", token_id=0)
+        agent_version_mod.list_published_agents_impl.return_value = []
+
+        with pytest.raises(LookupError, match="Published agent not found"):
+            await ns.get_agent_info_by_name_for_northbound(ctx, "missing_agent")
+
 
 @pytest.mark.asyncio
 class TestUpdateConversationTitle:

--- a/test/backend/services/test_northbound_service.py
+++ b/test/backend/services/test_northbound_service.py
@@ -183,7 +183,12 @@ def reset_test_isolation():
     """Reset test isolation state before each test."""
     ns._IDEMPOTENCY_RUNNING.clear()
     ns._RATE_STATE.clear()
-    token_db_mod.log_token_usage.reset_mock()
+    token_db_mod.log_token_usage.reset_mock(side_effect=True)
+    token_db_mod.log_token_usage.return_value = 1
+    agent_version_mod.list_published_agents_impl.reset_mock(side_effect=True)
+    agent_version_mod.list_published_agents_impl.return_value = [
+        {"agent_id": 1, "name": "test_agent", "description": "Test agent"}
+    ]
     yield
     ns._IDEMPOTENCY_RUNNING.clear()
     ns._RATE_STATE.clear()

--- a/test/backend/services/test_northbound_service.py
+++ b/test/backend/services/test_northbound_service.py
@@ -869,6 +869,21 @@ class TestGetAgentInfoList:
         with pytest.raises(LookupError, match="Published agent not found"):
             await ns.get_agent_info_by_name_for_northbound(ctx, "missing_agent")
 
+    async def test_get_agent_info_by_name_empty(self):
+        """Test that empty/whitespace agent_name raises ValueError."""
+        ctx = MockNorthboundContext(tenant_id="asset-owner-tenant", token_id=0)
+
+        with pytest.raises(ValueError, match="agent_name is required"):
+            await ns.get_agent_info_by_name_for_northbound(ctx, "   ")
+
+    async def test_get_agent_info_by_name_internal_error(self):
+        """Test that internal errors from _get_visible_published_agents are wrapped."""
+        ctx = MockNorthboundContext(tenant_id="asset-owner-tenant", token_id=0)
+        agent_version_mod.list_published_agents_impl.side_effect = RuntimeError("DB connection lost")
+
+        with pytest.raises(Exception, match="Failed to get agent info for agent_name"):
+            await ns.get_agent_info_by_name_for_northbound(ctx, "any_agent")
+
 
 @pytest.mark.asyncio
 class TestUpdateConversationTitle:


### PR DESCRIPTION
新增获取agent详情的北向接口，支持获取agent示例问题，已更新至apifox文档：
https://s.apifox.cn/487d01f6-1b3c-45fe-8185-307296a685e5/%E8%8E%B7%E5%8F%96%E5%B7%B2%E5%8F%91%E5%B8%83agent%E4%BF%A1%E6%81%AF-489729457e0

<img width="1046" height="1011" alt="image" src="https://github.com/user-attachments/assets/af38a34e-6972-4921-a2a5-5f068f3bbc78" />
