### PR TITLE
🐛Bugfix: agent version display, chunk list scrolling, and skill language sync

### DIFF
--- a/backend/services/agent_service.py
+++ b/backend/services/agent_service.py
@@ -2515,6 +2515,7 @@ async def list_all_agent_info_impl(tenant_id: str, user_id: str) -> list[dict]:
                 "group_ids": convert_string_to_list(agent.get("group_ids")),
                 "permission": permission,
                 "is_published": agent.get("current_version_no") is not None,
+                "current_version_no": agent.get("current_version_no"),
                 "is_a2a_server": agent["agent_id"] in a2a_server_agent_ids,
             })
 

--- a/frontend/app/[locale]/agents/components/agentConfig/SkillBuildModal.tsx
+++ b/frontend/app/[locale]/agents/components/agentConfig/SkillBuildModal.tsx
@@ -29,7 +29,6 @@ import {
 } from "@/lib/skillFileUtils";
 import yaml from "js-yaml";
 import {
-  THINKING_STEPS_ZH,
   type SkillFormData,
   type ChatMessage,
   type SkillFileContent,
@@ -41,6 +40,7 @@ import {
   findSkillByName,
   createSkillStream,
   stopSkillCreation,
+  getThinkingSteps,
   type SkillListItem,
   type SkillData,
 } from "@/services/skillService";
@@ -117,7 +117,7 @@ export default function SkillBuildModal({
   editingSkill,
   onBeforeEditSave,
 }: SkillBuildModalProps) {
-  const { t } = useTranslation("common");
+  const { t, i18n } = useTranslation("common");
   const [form] = Form.useForm<SkillFormData>();
   const isEditMode = Boolean(editingSkill);
   const [activeTab, setActiveTab] = useState<string>("interactive");
@@ -594,7 +594,7 @@ export default function SkillBuildModal({
               }
             : undefined,
           complexity: "complicated",
-          language: "zh",
+          language: i18n.language?.startsWith("en") ? "en" : "zh",
         },
         {
           onTaskId: (taskId) => {
@@ -608,7 +608,7 @@ export default function SkillBuildModal({
           },
           onStepCount: (step) => {
             setThinkingDescription(
-              THINKING_STEPS_ZH.find((s) => s.step === step)?.description ||
+              getThinkingSteps(i18n.language).find((s) => s.step === step)?.description ||
                 t("skillManagement.generatingSkill")
             );
           },

--- a/frontend/app/[locale]/knowledges/components/document/DocumentChunk.tsx
+++ b/frontend/app/[locale]/knowledges/components/document/DocumentChunk.tsx
@@ -840,6 +840,15 @@ const DocumentChunk: React.FC<DocumentChunkProps> = ({
           className={`h-full w-full min-h-0 ${TABS_ROOT_CLASS}`}
           rootClassName="h-full"
         />
+        {/* Scoped to .document-chunk-tabs only; targets antd v6's renamed
+            content-holder classes (ant-tabs-body-holder / ant-tabs-body) so
+            height: 100% propagates down to the scrollable chunk list. */}
+        <style jsx global>{`
+          .${TABS_ROOT_CLASS} .ant-tabs-body-holder,
+          .${TABS_ROOT_CLASS} .ant-tabs-body {
+            height: 100%;
+          }
+        `}</style>
         {shouldShowPagination && (
           <div className="sticky bottom-0 left-0 z-10 flex w-full justify-center bg-white px-8 pb-4 pt-2 shadow-[0_-4px_12px_rgba(15,23,42,0.04)]">
             <Pagination

--- a/frontend/app/[locale]/knowledges/components/document/DocumentList.tsx
+++ b/frontend/app/[locale]/knowledges/components/document/DocumentList.tsx
@@ -747,7 +747,9 @@ const DocumentListContainer = forwardRef<DocumentListRef, DocumentListProps>(
         {/* Document list */}
 
         <div
-          className="p-2 overflow-auto flex-grow"
+          className={`p-2 flex-grow min-h-0 ${
+            showChunk ? "overflow-hidden" : "overflow-auto"
+          }`}
           onDragOver={(e) => {
             if (!isCreatingMode && knowledgeBaseName) {
               return;
@@ -769,7 +771,7 @@ const DocumentListContainer = forwardRef<DocumentListRef, DocumentListProps>(
           }}
         >
           {showChunk ? (
-            <div className="flex h-full flex-col px-8">
+            <div className="flex h-full min-h-0 flex-col px-8">
               <DocumentChunk
                 knowledgeBaseName={knowledgeBaseName}
                 knowledgeBaseId={knowledgeBaseId || knowledgeBaseName}

--- a/frontend/app/[locale]/resource-manage/components/resources/AgentList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/AgentList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Table,
@@ -83,10 +83,43 @@ export default function AgentList({ tenantId }: { tenantId: string | null }) {
   // Version list state for each agent
   const [agentVersions, setAgentVersions] = useState<Map<number, AgentVersion[]>>(new Map());
   const [loadingVersions, setLoadingVersions] = useState<Map<number, boolean>>(new Map());
-  // Selected version for each agent (0 means current version)
+  // User's manual selection for each agent (not persisted, cleared on refresh/switch)
   const [selectedVersions, setSelectedVersions] = useState<Map<number, number>>(new Map());
 
   const { agents, isLoading, refetch } = useAgentList(tenantId);
+
+  // Incremented on every component mount so version fetching always runs
+  const [mountKey, setMountKey] = useState(0);
+  useEffect(() => {
+    setMountKey((k) => k + 1);
+  }, []);
+
+  // Auto-fetch versions for all published agents so the Select label renders immediately
+  useEffect(() => {
+    if (!agents || agents.length === 0) return;
+    (agents as AgentListRow[]).forEach((agent: AgentListRow) => {
+      const agentId = Number(agent.id);
+      if (!agent.is_published) return;
+      // Skip if already fetched for current mount
+      if (agentVersions.has(agentId)) return;
+      setLoadingVersions((prev) => new Map(prev).set(agentId, true));
+      fetchAgentVersionList(agentId, tenantId ?? undefined)
+        .then((res) => {
+          if (res.success && res.data) {
+            setAgentVersions((prev) => new Map(prev).set(agentId, res.data.items || []));
+          }
+        })
+        .finally(() => {
+          setLoadingVersions((prev) => {
+            const next = new Map(prev);
+            next.delete(agentId);
+            return next;
+          });
+        });
+    });
+    // mountKey added to dep array ensures this re-runs on component re-mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agents, tenantId, mountKey]);
 
   // Fetch groups for group name mapping and selection
   const { data: groupData } = useGroupList(tenantId);
@@ -131,15 +164,11 @@ export default function AgentList({ tenantId }: { tenantId: string | null }) {
       const agentId = Number(agent.id);
       const isPublished = agent.is_published === true;
 
-      // For published agents, use selected version or current_version_no
-      // For unpublished agents, use version_no=0 (draft)
-      let selectedVersionNo: number;
-      if (isPublished) {
-        const currentVersionNo = agent.current_version_no || 0;
-        selectedVersionNo = selectedVersions.get(agentId) ?? currentVersionNo;
-      } else {
-        selectedVersionNo = 0;
-      }
+      // For published agents: user's manual selection takes priority; otherwise use current_version_no.
+      // For unpublished agents, use version_no=0 (draft).
+      const selectedVersionNo = isPublished
+        ? (selectedVersions.get(agentId) ?? agent.current_version_no ?? 0)
+        : 0;
 
       const res = await searchAgentInfo(agentId, tenantId ?? undefined, selectedVersionNo);
       if (res.success && res.data) {
@@ -288,11 +317,16 @@ export default function AgentList({ tenantId }: { tenantId: string | null }) {
         const isLoading = loadingVersions.get(agentId) || false;
         const currentVersionNo = record.current_version_no || 0;
 
-        // Default to current_version_no if not selected, fallback to first version
-        // Must have a default value, cannot be undefined
-        const selectedVersionNo = selectedVersions.has(agentId)
+        // User's manual selection takes priority; otherwise show current_version_no (the bound version).
+        // Fall back to highest version only if current_version_no is 0 and versions have loaded.
+        const hasUserSelected = selectedVersions.has(agentId);
+        const selectedVersionNo = hasUserSelected
           ? selectedVersions.get(agentId)!
-          : currentVersionNo > 0 ? currentVersionNo : (versions[0]?.version_no || undefined);
+          : currentVersionNo > 0
+          ? currentVersionNo
+          : versions.length > 0
+          ? versions[0].version_no
+          : undefined;
 
         // Build options: only published versions (no draft version 0)
         const options = versions.map((version) => ({
@@ -307,7 +341,7 @@ export default function AgentList({ tenantId }: { tenantId: string | null }) {
             loading={isLoading}
             onDropdownVisibleChange={(open) => handleVersionDropdownOpen(agentId, open)}
             onChange={(value) => {
-              setSelectedVersions(prev => new Map(prev).set(agentId, value));
+              setSelectedVersions((prev) => new Map(prev).set(agentId, value));
             }}
             style={{ width: "100%" }}
             options={options}

--- a/frontend/services/skillService.ts
+++ b/frontend/services/skillService.ts
@@ -14,6 +14,7 @@ import { API_ENDPOINTS, fetchWithErrorHandling } from "@/services/api";
 import { InstallableSkill } from "@/types/agentConfig";
 import {
   THINKING_STEPS_ZH,
+  THINKING_STEPS_EN,
   type CreateSkillStreamRequest,
   type SkillFileContent,
 } from "@/types/skill";
@@ -78,7 +79,7 @@ export interface ThinkingStep {
  * Get thinking steps based on language
  */
 export const getThinkingSteps = (lang: string): ThinkingStep[] => {
-  return lang === "zh" ? THINKING_STEPS_ZH : THINKING_STEPS_ZH;
+  return lang === "zh" ? THINKING_STEPS_ZH : THINKING_STEPS_EN;
 };
 
 /**


### PR DESCRIPTION
## Summary

Three independent bug fixes:

1. Fix #2895 
**Agent version dropdown shows empty on initial render** — The version `Select` for published agents had no default value until the user manually opened the dropdown, so it rendered blank on first load. Versions are now pre-fetched for all published agents on mount, and `current_version_no` is included in the agent list API response so the dropdown can resolve its label immediately.
<img width="2544" height="1273" alt="image" src="https://github.com/user-attachments/assets/9df03686-0d42-4273-99b0-a8225b045bd3" />

2. Fix #3447 
**Incomplete chunk list display in knowledge base pagination overview** — The chunk list inside the document tabs was clipped instead of scrolling, because `height: 100%` wasn't propagating through antd v6's renamed tab content-holder classes. Added scoped `height: 100%` overrides and fixed the container's `overflow`/`min-h-0` so the list scrolls correctly and pagination stays visible.
<img width="2490" height="1220" alt="image" src="https://github.com/user-attachments/assets/5e2779fa-1342-4fb4-91b9-a6a1f4556f51" />

3. Fix #2916 
**Interactive skill creation ignores UI language** — Skill generation always sent `language: "zh"` to the backend regardless of the selected UI language, and a typo in `getThinkingSteps` made it return the Chinese steps for every language. Both now follow `i18n.language`, so English UI users get English-generated skill content and English thinking-step descriptions.
<img width="1300" height="990" alt="image" src="https://github.com/user-attachments/assets/ad9ddf25-0d1a-40b8-93f4-83e8b08b9d92" />

## Changes

- `backend/services/agent_service.py`, `frontend/.../resources/AgentList.tsx`: include `current_version_no` in agent list response; pre-fetch versions on mount; prioritize user's manual selection over fetched current version.
- `frontend/.../document/DocumentChunk.tsx`, `DocumentList.tsx`: fix scroll/height propagation for the chunk list under antd v6 tabs.
- `frontend/services/skillService.ts`, `frontend/.../SkillBuildModal.tsx`: fix `getThinkingSteps` language typo; pass actual UI language to skill creation request and thinking-step lookup.

