### PR TITLE
🐛 Bugfix: Resolve publish failure when latest version is deleted after rollback

### DIFF
--- a/backend/database/agent_version_db.py
+++ b/backend/database/agent_version_db.py
@@ -502,13 +502,16 @@ def get_next_version_no(
     tenant_id: str,
 ) -> int:
     """
-    Calculate the next version number for an agent
+    Calculate the next version number from all historical published snapshots.
+
+    Soft-deleted snapshots remain in the table and retain the composite primary
+    key, so their version numbers must not be reused.
     """
     with get_db_session() as session:
         max_version = session.query(func.max(AgentInfo.version_no)).filter(
             AgentInfo.agent_id == agent_id,
             AgentInfo.tenant_id == tenant_id,
-            AgentInfo.delete_flag == 'N',
+            AgentInfo.version_no > 0,
         ).scalar()
         return (max_version or 0) + 1
 

--- a/backend/database/agent_version_db.py
+++ b/backend/database/agent_version_db.py
@@ -511,7 +511,6 @@ def get_next_version_no(
         max_version = session.query(func.max(AgentInfo.version_no)).filter(
             AgentInfo.agent_id == agent_id,
             AgentInfo.tenant_id == tenant_id,
-            AgentInfo.version_no > 0,
         ).scalar()
         return (max_version or 0) + 1
 

--- a/test/backend/database/test_agent_version_db.py
+++ b/test/backend/database/test_agent_version_db.py
@@ -1161,15 +1161,13 @@ def test_get_next_version_no_includes_soft_deleted_snapshots(monkeypatch, mock_s
     mock_ctx.__exit__.return_value = None
     monkeypatch.setattr(agent_version_db_module, "get_db_session", lambda: mock_ctx)
     db_models_mock.AgentInfo.delete_flag.__eq__.reset_mock()
-    db_models_mock.AgentInfo.version_no.__gt__.reset_mock()
 
     result = get_next_version_no(agent_id=1, tenant_id="tenant1")
 
     assert result == 3
     filter_conditions = query.filter.call_args.args
     assert db_models_mock.AgentInfo.delete_flag.__eq__.call_count == 0
-    assert db_models_mock.AgentInfo.version_no.__gt__.call_args.args == (0,)
-    assert len(filter_conditions) == 3
+    assert len(filter_conditions) == 2
 
 
 def test_delete_version_success(monkeypatch, mock_session):

--- a/test/backend/database/test_agent_version_db.py
+++ b/test/backend/database/test_agent_version_db.py
@@ -1148,6 +1148,30 @@ def test_get_next_version_no_existing_versions(monkeypatch, mock_session):
     assert result == 6  # Should be 5 + 1
 
 
+def test_get_next_version_no_includes_soft_deleted_snapshots(monkeypatch, mock_session):
+    """Test that a soft-deleted snapshot version number is not reused."""
+    session, query = mock_session
+
+    mock_filter = MagicMock()
+    mock_filter.scalar = lambda: 2
+    query.filter.return_value = mock_filter
+
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__.return_value = session
+    mock_ctx.__exit__.return_value = None
+    monkeypatch.setattr(agent_version_db_module, "get_db_session", lambda: mock_ctx)
+    db_models_mock.AgentInfo.delete_flag.__eq__.reset_mock()
+    db_models_mock.AgentInfo.version_no.__gt__.reset_mock()
+
+    result = get_next_version_no(agent_id=1, tenant_id="tenant1")
+
+    assert result == 3
+    filter_conditions = query.filter.call_args.args
+    assert db_models_mock.AgentInfo.delete_flag.__eq__.call_count == 0
+    assert db_models_mock.AgentInfo.version_no.__gt__.call_args.args == (0,)
+    assert len(filter_conditions) == 3
+
+
 def test_delete_version_success(monkeypatch, mock_session):
     """Test successfully deleting a version"""
     session, query = mock_session


### PR DESCRIPTION
#3474 
问题现象：当用户发布v1和v2之后，回滚到v1，删除v2，再发布v3，会报错
问题根源：删除v2是软删除，再发布时，get_next_version_no() 只看 delete_flag = 'N' 的记录，最大版本号变为 v1，于是生成的新版本号仍是 v2，导致报错。
<img width="2266" height="948" alt="image" src="https://github.com/user-attachments/assets/30f38ded-0724-4aee-b9a3-70272b4aeafc" />
