### PR TITLE
🐛Bugfix: model list provider mismatch, delete dialog errors, and password strength reset

### DIFF
--- a/backend/services/providers/dashscope_provider.py
+++ b/backend/services/providers/dashscope_provider.py
@@ -229,4 +229,10 @@ class DashScopeModelProvider(AbstractModelProvider):
             else:
                 return []
         except (httpx.HTTPStatusError, httpx.ConnectTimeout, httpx.ConnectError, Exception) as e:
-            return _classify_provider_error("DashScope", exception=e)
+            status_code = e.response.status_code if isinstance(e, httpx.HTTPStatusError) and getattr(e, "response", None) else None
+            return _classify_provider_error(
+                "DashScope",
+                status_code=status_code,
+                error_message=str(e),
+                exception=e,
+            )

--- a/backend/services/providers/silicon_provider.py
+++ b/backend/services/providers/silicon_provider.py
@@ -134,4 +134,10 @@ class SiliconModelProvider(AbstractModelProvider):
 
             return model_list
         except (httpx.HTTPStatusError, httpx.ConnectTimeout, httpx.ConnectError, Exception) as e:
-            return _classify_provider_error("SiliconFlow", exception=e)
+            status_code = e.response.status_code if isinstance(e, httpx.HTTPStatusError) and getattr(e, "response", None) else None
+            return _classify_provider_error(
+                "SiliconFlow",
+                status_code=status_code,
+                error_message=str(e),
+                exception=e,
+            )

--- a/backend/services/providers/tokenpony_provider.py
+++ b/backend/services/providers/tokenpony_provider.py
@@ -186,4 +186,10 @@ class TokenPonyModelProvider(AbstractModelProvider):
                 return []
 
         except (httpx.HTTPStatusError, httpx.ConnectTimeout, httpx.ConnectError, Exception) as e:
-            return _classify_provider_error("TokenPony", exception=e)
+            status_code = e.response.status_code if isinstance(e, httpx.HTTPStatusError) and getattr(e, "response", None) else None
+            return _classify_provider_error(
+                "TokenPony",
+                status_code=status_code,
+                error_message=str(e),
+                exception=e,
+            )

--- a/frontend/app/[locale]/models/components/model/ModelDeleteDialog.tsx
+++ b/frontend/app/[locale]/models/components/model/ModelDeleteDialog.tsx
@@ -8,6 +8,7 @@ import { ExclamationCircleFilled } from "@ant-design/icons";
 import { MODEL_TYPES, MODEL_SOURCES } from "@/const/modelConfig";
 import { useConfig } from "@/hooks/useConfig";
 import { modelService } from "@/services/modelService";
+import { processProviderResponse } from "@/lib/providerError";
 import {
   CapacityCoverage,
   ModelOption,
@@ -520,11 +521,24 @@ export const ModelDeleteDialog = ({
         return;
       }
 
-      const providerRows = (result || []).map((providerModel: any) =>
+      const { models: providerRows, error } = processProviderResponse(
+        result || [],
+        provider,
+        t
+      );
+
+      if (error) {
+        message.error(error);
+        setProviderModels([]);
+        setPendingSelectedProviderIds(new Set());
+        return;
+      }
+
+      const providerRowsWithSaved = providerRows.map((providerModel: any) =>
         overlaySavedModelConfig(providerModel, provider, modelType)
       );
 
-      setProviderModels(providerRows);
+      setProviderModels(providerRowsWithSaved);
       // Initialize pending selected switch states (based on current models status)
       const currentIds = new Set(
         models
@@ -533,17 +547,15 @@ export const ModelDeleteDialog = ({
       );
       setPendingSelectedProviderIds(
         new Set(
-          providerRows
+          providerRowsWithSaved
             .map((pm: any) => pm.id)
             .filter((id: string) => currentIds.has(id))
         )
       );
-      if (!result || result.length === 0) {
-        message.error(t("model.dialog.error.noModelsFetched"));
-      }
     } catch (e) {
-      message.error(t("model.dialog.error.noModelsFetched"));
       log.error("Failed to prefetch provider models", e);
+      setProviderModels([]);
+      setPendingSelectedProviderIds(new Set());
     }
   };
 

--- a/frontend/components/auth/registerModal.tsx
+++ b/frontend/components/auth/registerModal.tsx
@@ -73,6 +73,7 @@ export function RegisterModal() {
   const resetForm = () => {
     setEmailError("");
     setPasswordError({ target: "", message: "" });
+    setPasswordValue("");
     form.resetFields();
   };
 
@@ -144,6 +145,7 @@ export function RegisterModal() {
 
     setEmailError("");
     setPasswordError({ target: "", message: "" });
+    setPasswordValue("");
     form.resetFields();
     if (registerModalOptions?.email) {
       form.setFieldsValue({ email: registerModalOptions.email });

--- a/frontend/hooks/model/useDashscopeModelList.ts
+++ b/frontend/hooks/model/useDashscopeModelList.ts
@@ -123,11 +123,16 @@ export const useDashscopeModelList = ({
 
   // Auto-fetch model list when batch import is enabled and API key is provided
   useEffect(() => {
+    // Only execute if this hook matches the current provider
+    if (form.provider !== "dashscope") {
+      return;
+    }
+
     if (form.isBatchImport && form.apiKey.trim() !== "") {
       getModelList();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [form.type, form.isBatchImport]);
+  }, [form.type, form.isBatchImport, form.provider]);
 
   return {
     getModelList,

--- a/frontend/hooks/model/useSiliconModelList.ts
+++ b/frontend/hooks/model/useSiliconModelList.ts
@@ -130,6 +130,11 @@ export const useSiliconModelList = ({
 
   // Auto-fetch model list when batch import is enabled and API key is provided
   useEffect(() => {
+    // Only execute if this hook matches the current provider
+    if (form.provider !== "silicon" && form.provider !== "modelengine") {
+      return;
+    }
+
     const requiresUrl =
       form.provider === "modelengine"
         ? ((form as any).modelEngineUrl || "").toString().trim() !== ""
@@ -139,7 +144,7 @@ export const useSiliconModelList = ({
       getModelList();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [form.type, form.isBatchImport]);
+  }, [form.type, form.isBatchImport, form.provider]);
 
   return {
     getModelList,

--- a/frontend/hooks/model/useTokenponyModelList.ts
+++ b/frontend/hooks/model/useTokenponyModelList.ts
@@ -125,11 +125,16 @@ export const useTokenPonyModelList = ({
 
   // Auto-fetch model list when batch import is enabled and API key is provided
   useEffect(() => {
+    // Only execute if this hook matches the current provider
+    if (form.provider !== "tokenpony") {
+      return;
+    }
+
     if (form.isBatchImport && form.apiKey.trim() !== "") {
       getModelList();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [form.type, form.isBatchImport]);
+  }, [form.type, form.isBatchImport, form.provider]);
 
   return {
     getModelList,

--- a/frontend/lib/providerError.ts
+++ b/frontend/lib/providerError.ts
@@ -52,7 +52,7 @@ export function detectProviderError(errorResponse: unknown): ProviderErrorType {
   const error = errorResponse as Record<string, unknown>;
   const errorCode = error._error as string;
   const errorMessage = ((error._message as string) || "").toLowerCase();
-  const httpCode = error.httpCode as number;
+  const httpCode = error._http_code as number;
 
   // Check error code first
   if (errorCode) {
@@ -213,7 +213,7 @@ export function processProviderResponse<T extends Record<string, unknown>>(
       type: errorType,
       message: response[0]._message as string,
       provider,
-      httpCode: response[0].httpCode as number,
+      httpCode: response[0]._http_code as number,
     };
     return {
       models: [],

--- a/test/backend/services/providers/test_dashscope_provider.py
+++ b/test/backend/services/providers/test_dashscope_provider.py
@@ -1070,7 +1070,35 @@ class TestDashScopeModelProvider:
 
         assert isinstance(result, list)
         assert len(result) == 1
-        assert result[0]["_error"] == "connection_failed"
+        assert result[0]["_error"] == "server_error"
+
+    @pytest.mark.asyncio
+    async def test_get_models_401_returns_authentication_failed(self, mocker: MockFixture):
+        """401 from provider surfaces the authentication_failed error code."""
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = httpx.HTTPStatusError(
+            "Unauthorized",
+            request=MagicMock(),
+            response=MagicMock(status_code=401),
+        )
+
+        mock_cm = MagicMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+        mocker.patch(
+            "backend.services.providers.dashscope_provider.httpx.AsyncClient",
+            return_value=mock_cm,
+        )
+
+        provider = DashScopeModelProvider()
+        result = await provider.get_models({
+            "model_type": "llm",
+            "api_key": "test-api-key",
+        })
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["_error"] == "authentication_failed"
 
     @pytest.mark.asyncio
     async def test_get_models_connect_error(self, mocker: MockFixture):

--- a/test/backend/services/providers/test_silicon_provider.py
+++ b/test/backend/services/providers/test_silicon_provider.py
@@ -372,7 +372,42 @@ class TestSiliconModelProvider:
 
         assert isinstance(result, list)
         assert len(result) == 1
-        assert result[0]["_error"] == "connection_failed"
+        assert result[0]["_error"] == "server_error"
+
+    @pytest.mark.asyncio
+    async def test_get_models_401_returns_authentication_failed(self, mocker: MockFixture):
+        """401 from provider surfaces the authentication_failed error code."""
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = httpx.HTTPStatusError(
+            "Unauthorized",
+            request=MagicMock(),
+            response=MagicMock(status_code=401),
+        )
+
+        mock_cm = MagicMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+        mocker.patch(
+            "backend.services.providers.silicon_provider.httpx.AsyncClient",
+            return_value=mock_cm
+        )
+        mocker.patch(
+            "backend.services.providers.silicon_provider.SILICON_GET_URL",
+            "https://api.siliconflow.com/v1/models"
+        )
+
+        provider = SiliconModelProvider()
+        provider_config = {
+            "model_type": "llm",
+            "api_key": "test-api-key"
+        }
+
+        result = await provider.get_models(provider_config)
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["_error"] == "authentication_failed"
 
     @pytest.mark.asyncio
     async def test_get_models_connect_error(self, mocker: MockFixture):

--- a/test/backend/services/providers/test_tokenpony_provider.py
+++ b/test/backend/services/providers/test_tokenpony_provider.py
@@ -569,7 +569,42 @@ class TestTokenPonyModelProvider:
 
         assert isinstance(result, list)
         assert len(result) == 1
-        assert result[0]["_error"] == "connection_failed"
+        assert result[0]["_error"] == "server_error"
+
+    @pytest.mark.asyncio
+    async def test_get_models_401_returns_authentication_failed(self, mocker: MockFixture):
+        """401 from provider surfaces the authentication_failed error code."""
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = httpx.HTTPStatusError(
+            "Unauthorized",
+            request=MagicMock(),
+            response=MagicMock(status_code=401),
+        )
+
+        mock_cm = MagicMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+        mocker.patch(
+            "backend.services.providers.tokenpony_provider.httpx.AsyncClient",
+            return_value=mock_cm
+        )
+        mocker.patch(
+            "backend.services.providers.tokenpony_provider.TOKENPONY_GET_URL",
+            "https://api.tokenpony.cn/v1/models"
+        )
+
+        provider = TokenPonyModelProvider()
+        provider_config = {
+            "model_type": "llm",
+            "api_key": "test-api-key"
+        }
+
+        result = await provider.get_models(provider_config)
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["_error"] == "authentication_failed"
 
     @pytest.mark.asyncio
     async def test_get_models_connect_error(self, mocker: MockFixture):


### PR DESCRIPTION
## PR Description

### Summary

Three independent bug fixes:

1. Fix #3066 
**Fix incorrect model list when switching provider during batch add** — The three model-list hooks (`useDashscopeModelList`, `useSiliconModelList`, `useTokenponyModelList`) trigger their auto-fetch effect without checking `form.provider`, so switching providers lets the previous provider's stale request overwrite the new provider's model list. Fix: each hook now checks that `form.provider` matches before fetching.
<img width="575" height="1113" alt="image" src="https://github.com/user-attachments/assets/d90b60bd-7f38-43c0-b604-84af295da052" />


2. Fix #2761 
**Fix model deletion dialog showing garbage rows when API key is invalid** — When a provider request fails, the backend didn't pass `status_code`, and the frontend rendered the error object as if it were model data, producing "ghost rows" in the delete dialog. Fix: the backend now attaches `status_code` on caught exceptions, and the frontend uses `processProviderResponse` to detect errors and clear the polluted state instead of rendering it.
<img width="690" height="553" alt="image" src="https://github.com/user-attachments/assets/0ef97453-a065-4d24-8291-7c162ac2732c" />


3. Fix #3204 
**Fix password strength indicator not resetting on re-entering register page** — `resetForm` never cleared the local `passwordValue` state, so the strength indicator kept showing the previously entered password's strength. Fix: added `setPasswordValue("")` to the reset logic.
<img width="479" height="736" alt="image" src="https://github.com/user-attachments/assets/680c56ba-877f-4c3f-88ca-3a4d5d2672b8" />

### Changes

- `frontend/hooks/model/{useDashscopeModelList,useSiliconModelList,useTokenponyModelList}.ts` — validate `form.provider` before auto-fetching
- `backend/services/providers/{dashscope,silicon,tokenpony}_provider.py` — attach `status_code` on caught exceptions
- `frontend/app/[locale]/models/components/model/ModelDeleteDialog.tsx` — use `processProviderResponse` to detect errors and clear state
- `frontend/components/auth/registerModal.tsx` — clear `passwordValue` on reset