### PR TITLE
🐛 Refactor: Enforce all frontend API calls to via service layer

### DIFF
--- a/frontend/app/[locale]/agents/components/agentConfig/McpConfigModal.tsx
+++ b/frontend/app/[locale]/agents/components/agentConfig/McpConfigModal.tsx
@@ -39,8 +39,11 @@ import { useMcpConfig } from "@/hooks/useMcpConfig";
 import McpToolListModal from "@/components/mcp/McpToolListModal";
 import McpEditServerModal from "@/components/mcp/McpEditServerModal";
 import McpContainerLogsModal from "@/components/mcp/McpContainerLogsModal";
-import { API_ENDPOINTS } from "@/services/api";
-import { getAuthHeaders } from "@/lib/auth";
+import {
+  getOpenApiServices,
+  importOpenApiService,
+  deleteOpenApiService,
+} from "@/services/mcpService";
 import log from "@/lib/logger";
 
 const { Text, Title } = Typography;
@@ -457,12 +460,9 @@ export default function McpConfigModal({
   const loadOpenapiServices = async () => {
     setLoadingOpenapiServices(true);
     try {
-      const response = await fetch(API_ENDPOINTS.tool.openapiServices, {
-        headers: getAuthHeaders(),
-      });
-      const result = await response.json();
-      if (result.data) {
-        setOpenapiServices(result.data);
+      const services = await getOpenApiServices();
+      if (services) {
+        setOpenapiServices(services);
       } else {
         message.error(t("mcpConfig.openApiToMcp.message.loadToolsFailed"));
       }
@@ -497,34 +497,20 @@ export default function McpConfigModal({
 
     setImportingOpenApi(true);
     try {
-      const response = await fetch(API_ENDPOINTS.tool.openapiService, {
-        method: "POST",
-        headers: {
-          ...getAuthHeaders(),
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          service_name: openApiServiceName.trim(),
-          server_url: openApiServerUrl.trim(),
-          openapi_json: parsedJson,
-          headers_template: openApiHeadersTemplate.trim() ? JSON.parse(openApiHeadersTemplate.trim()) : null,
-        }),
+      await importOpenApiService({
+        service_name: openApiServiceName.trim(),
+        server_url: openApiServerUrl.trim(),
+        openapi_json: parsedJson,
+        headers_template: openApiHeadersTemplate.trim() ? JSON.parse(openApiHeadersTemplate.trim()) : null,
       });
 
-      if (response.ok) {
-        message.success(t("mcpConfig.openApiToMcp.message.importSuccess"));
-        setOpenApiJson("");
-        setOpenApiServiceName("");
-        setOpenApiServerUrl("");
-        setOpenApiHeadersTemplate("");
-        await loadOpenapiServices();
-        await refreshToolsAndAgents();
-      } else {
-        const errorData = await response.json();
-        message.error(
-          errorData.detail || t("mcpConfig.openApiToMcp.message.importFailed")
-        );
-      }
+      message.success(t("mcpConfig.openApiToMcp.message.importSuccess"));
+      setOpenApiJson("");
+      setOpenApiServiceName("");
+      setOpenApiServerUrl("");
+      setOpenApiHeadersTemplate("");
+      await loadOpenapiServices();
+      await refreshToolsAndAgents();
     } catch (error) {
       log.error("Failed to import OpenAPI service:", error);
       message.error(t("mcpConfig.openApiToMcp.message.importFailed"));
@@ -541,25 +527,10 @@ export default function McpConfigModal({
       okText: t("common.delete", "Delete"),
       onOk: async () => {
         try {
-          const response = await fetch(
-            API_ENDPOINTS.tool.deleteOpenapiService(service.mcp_service_name),
-            {
-              method: "DELETE",
-              headers: getAuthHeaders(),
-            }
-          );
-
-          if (response.ok) {
-            message.success(
-              t("mcpConfig.openApiToMcp.message.deleteSuccess")
-            );
-            await loadOpenapiServices();
-            await refreshToolsAndAgents();
-          } else {
-            message.error(
-              t("mcpConfig.openApiToMcp.message.deleteFailed")
-            );
-          }
+          await deleteOpenApiService(service.mcp_service_name);
+          message.success(t("mcpConfig.openApiToMcp.message.deleteSuccess"));
+          await loadOpenapiServices();
+          await refreshToolsAndAgents();
         } catch (error) {
           log.error("Failed to delete OpenAPI service:", error);
           message.error(t("mcpConfig.openApiToMcp.message.deleteFailed"));

--- a/frontend/app/[locale]/agents/components/agentConfig/tool/LabelManagementModal.tsx
+++ b/frontend/app/[locale]/agents/components/agentConfig/tool/LabelManagementModal.tsx
@@ -5,8 +5,7 @@ import { useTranslation } from "react-i18next";
 import { Modal, Table, Select, App } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import { useQueryClient } from "@tanstack/react-query";
-import { API_ENDPOINTS } from "@/services/api";
-import { getAuthHeaders } from "@/lib/auth";
+import { updateToolLabels } from "@/services/mcpService";
 import log from "@/lib/logger";
 
 interface LabelManagementModalProps {
@@ -74,11 +73,7 @@ export default function LabelManagementModal({
 
       // Persist to backend, then synchronously update cache so parent sees fresh data
       try {
-        await fetch(API_ENDPOINTS.tool.labels, {
-          method: "PUT",
-          headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
-          body: JSON.stringify({ tool_id: parseInt(toolId), labels: newLabels }),
-        });
+        await updateToolLabels(toolId, newLabels);
         // Synchronous cache update — no timing gaps, no refetch race
         queryClient.setQueryData(["tools"], (old: any[]) => {
           if (!old) return old;

--- a/frontend/app/[locale]/agents/components/agentConfig/tool/ToolConfigModal.tsx
+++ b/frontend/app/[locale]/agents/components/agentConfig/tool/ToolConfigModal.tsx
@@ -47,7 +47,6 @@ import {
   useKnowledgeBaseConfigChangeHandler,
   ToolKbType,
 } from "@/hooks/useKnowledgeBaseConfigChangeHandler";
-import { API_ENDPOINTS } from "@/services/api";
 import knowledgeBaseService from "@/services/knowledgeBaseService";
 import { modelService } from "@/services/modelService";
 import log from "@/lib/logger";

--- a/frontend/app/[locale]/agents/components/agentInfo/DebugOptimizeModal.tsx
+++ b/frontend/app/[locale]/agents/components/agentInfo/DebugOptimizeModal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { App, Button, Input, Modal, Space, Spin, Typography } from "antd";
+import { optimizePromptFromDebug } from "@/services/promptService";
 
 const { TextArea } = Input;
 const { Paragraph, Text } = Typography;
@@ -86,27 +87,17 @@ export default function DebugOptimizeModal({
 
     setIsOptimizing(true);
     try {
-      const resp = await fetch("/api/prompt/optimize/from_debug", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          agent_id: agentId,
-          model_id: modelId,
-          feedback: feedback.trim(),
-          selected: {
-            user_question: userQuestion,
-            assistant_answer: assistantAnswer,
-          },
-          history,
-        }),
+      const data = await optimizePromptFromDebug({
+        agent_id: agentId,
+        model_id: modelId,
+        feedback: feedback.trim(),
+        selected: {
+          user_question: userQuestion,
+          assistant_answer: assistantAnswer,
+        },
+        history,
       });
 
-      const result = await resp.json();
-      if (!resp.ok) {
-        throw new Error(result?.message || t("systemPrompt.optimize.error"));
-      }
-
-      const data = result?.data;
       const original = data?.original_full_prompt || "";
       const fullText = mapHeadersToChinese(data?.optimized_full_prompt || "");
 

--- a/frontend/app/[locale]/chat/components/chatRightPanel.tsx
+++ b/frontend/app/[locale]/chat/components/chatRightPanel.tsx
@@ -5,9 +5,9 @@ import { ExternalLink, Database, X, Server } from "lucide-react";
 import { ImageItem, ChatRightPanelProps, SearchResult } from "@/types/chat";
 import { formatDate, formatUrl } from "@/lib/utils";
 import {
-  convertImageUrlToApiUrl,
   extractObjectNameFromUrl,
   storageService,
+  fetchImageBlob,
 } from "@/services/storageService";
 import { message, Button } from "antd";
 import log from "@/lib/logger";
@@ -386,18 +386,7 @@ export function ChatRightPanel({
       }));
 
       try {
-        // Convert image URL to backend API URL
-        const apiUrl = convertImageUrlToApiUrl(imageUrl);
-
-        // Use backend API to get the image
-        const response = await fetch(apiUrl);
-
-        if (!response.ok) {
-          throw new Error(`Failed to load image: ${response.statusText}`);
-        }
-
-        // Get image as blob and convert to base64
-        const blob = await response.blob();
+        const blob = await fetchImageBlob(imageUrl);
         const reader = new FileReader();
 
         reader.onloadend = () => {

--- a/frontend/app/[locale]/chat/internal/chatInterface.tsx
+++ b/frontend/app/[locale]/chat/internal/chatInterface.tsx
@@ -14,6 +14,7 @@ import { useModelList } from "@/hooks/model/useModelList";
 import { useAuthorizationContext } from "@/components/providers/AuthorizationProvider";
 import { useDeployment } from "@/components/providers/deploymentProvider";
 import { conversationService } from "@/services/conversationService";
+import { configService } from "@/services/configService";
 import {
   analyzeAutomationMessage,
   canAnalyzeAutomationMessage,
@@ -76,13 +77,10 @@ const getConfiguredShareBaseUrl = async () => {
   }
 
   try {
-    const response = await fetch("/api/frontend-config", { cache: "no-store" });
-    if (response.ok) {
-      const data = await response.json();
-      const runtimeBaseUrl = data.shareBaseUrl?.trim();
-      cachedShareBaseUrl = runtimeBaseUrl || null;
-      return cachedShareBaseUrl;
-    }
+    const data = await configService.fetchRuntimeFrontendConfig();
+    const runtimeBaseUrl = data.shareBaseUrl?.trim();
+    cachedShareBaseUrl = runtimeBaseUrl || null;
+    return cachedShareBaseUrl;
   } catch (error) {
     log.warn("Failed to load runtime frontend config", error);
   }

--- a/frontend/app/[locale]/knowledges/components/document/DocumentList.tsx
+++ b/frontend/app/[locale]/knowledges/components/document/DocumentList.tsx
@@ -39,10 +39,7 @@ import {
   LAYOUT,
   DOCUMENT_STATUS,
 } from "@/const/knowledgeBase";
-import {
-  SUMMARY_FREQUENCY_OPTIONS_API,
-  FrequencyOption,
-} from "@/const/scheduler";
+import { FrequencyOption } from "@/const/scheduler";
 import knowledgeBaseService from "@/services/knowledgeBaseService";
 import { modelService } from "@/services/modelService";
 import { getTenantDefaultGroupId } from "@/services/groupService";
@@ -381,9 +378,8 @@ const DocumentListContainer = forwardRef<DocumentListRef, DocumentListProps>(
       const loadFrequencyOptions = async () => {
         if (showDetail && frequencyOptions.length === 0) {
           try {
-            const response = await fetch(SUMMARY_FREQUENCY_OPTIONS_API);
-            const data = await response.json();
-            setFrequencyOptions(data.options || []);
+            const options = await knowledgeBaseService.fetchSummaryFrequencyOptions();
+            setFrequencyOptions(options);
           } catch (error) {
             log.error("Failed to load frequency options:", error);
             // Fallback to default options if API fails

--- a/frontend/app/[locale]/newchat/adapter/remote-chat-model-adapter.ts
+++ b/frontend/app/[locale]/newchat/adapter/remote-chat-model-adapter.ts
@@ -8,8 +8,7 @@ import type {
 } from "@assistant-ui/react";
 import type { ThreadMessage } from "@assistant-ui/core";
 
-import { API_ENDPOINTS } from "@/services/api";
-import { getAuthHeaders } from "@/lib/auth";
+import { conversationService } from "@/services/conversationService";
 import log from "@/lib/logger";
 
 // Backend SSE chunk format
@@ -917,103 +916,49 @@ export const remoteChatModelAdapter: ChatModelAdapter = {
       requestBody.model_id = Number(modelName);
     }
 
-    // Resume is explicit: an existing conversation may also receive a normal
-    // new user turn, so conversation_id alone must never select resume mode.
-    const url = isResume
-      ? `${API_ENDPOINTS.agent.run}?resume=true`
-      : API_ENDPOINTS.agent.run;
+    log.log("[ChatModelAdapter] Sending agent request through conversation service");
 
-    log.log(`[ChatModelAdapter] Sending request to ${url}`);
-
-    let response: Response;
+    let agentResponse: ReadableStreamDefaultReader<Uint8Array> | { type: "json"; data: unknown };
     try {
-      response = await fetch(url, {
-        method: "POST",
-        headers: {
-          ...getAuthHeaders(),
-          "Content-Type": "application/json",
+      agentResponse = await conversationService.runAgent(
+        {
+          ...requestBody,
+          query: String(requestBody.query || ""),
+          history: (requestBody.history || []) as Array<{ role: string; content: string }>,
+          conversation_id: requestBody.conversation_id as number | undefined,
+          minio_files: requestBody.minio_files as any,
+          agent_id: requestBody.agent_id as number | undefined,
+          model_id: requestBody.model_id as number | undefined,
+          is_debug: false,
+          is_resume: isResume,
+          enable_plan: custom?.enablePlan === true,
         },
-        body: JSON.stringify(requestBody),
-        signal: abortSignal,
-      });
+        abortSignal,
+        (conversationId) => {
+          const numericId = Number(conversationId);
+          if (!Number.isNaN(numericId) && numericId > 0 && onServerConversationId) {
+            onServerConversationId(
+              String(numericId),
+              !isResume && !hasServerConversationId ? query : undefined,
+            );
+          }
+        },
+      );
     } catch (error: unknown) {
-      if (error instanceof Error && error.name === "AbortError") {
+      if (error instanceof Error && error.message === "请求已被取消") {
         log.log("[ChatModelAdapter] Request aborted by user");
         return;
       }
-      log.error("[ChatModelAdapter] Fetch error:", error);
+      log.error("[ChatModelAdapter] Agent request failed:", error);
       throw error;
     }
 
-    // Capture the server-issued conversation_id from the response header.
-    //
-    // When the request omits `conversation_id` (i.e. this is the first
-    // message in a brand-new thread) the backend auto-creates a conversation
-    // row and returns the new id via the `conversation_id` response header
-    // (mirrors the northbound `start_streaming_chat` pattern). We forward
-    // that id to the page so it can rebind `threadId` for subsequent runs in
-    // the same thread, preventing the frontend from triggering an extra
-    // `PUT /api/conversation/create` and creating a duplicate empty
-    // conversation.
-    //
-    // The header is also set on the non-streaming resume JSONResponse, so we
-    // pick it up there too without any extra work.
-    const headerConversationId = response.headers.get("conversation_id");
-    if (headerConversationId && onServerConversationId) {
-      const numericHeaderId = Number(headerConversationId);
-      if (
-        !Number.isNaN(numericHeaderId) &&
-        numericHeaderId > 0
-      ) {
-        try {
-          onServerConversationId(
-            String(numericHeaderId),
-            !isResume && !hasServerConversationId ? query : undefined,
-          );
-          log.log(
-            `[ChatModelAdapter] Captured server conversation_id from response header: ${numericHeaderId}`,
-          );
-        } catch (cbError) {
-          // Callback failures must never break the stream — log and continue.
-          log.error(
-            "[ChatModelAdapter] onServerConversationId callback threw:",
-            cbError,
-          );
-        }
-      }
-    }
-
-    if (!response.ok) {
-      let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
-      try {
-        const errorData = await response.json();
-        errorMessage = errorData.detail || errorData.message || errorMessage;
-      } catch {
-        // Fall back to status text
-      }
-      log.error(`[ChatModelAdapter] HTTP error: ${errorMessage}`);
-      throw new Error(errorMessage);
-    }
-
-    if (!response.body) {
-      log.warn("[ChatModelAdapter] Empty response body");
+    if ("type" in agentResponse) {
+      log.log("[ChatModelAdapter] JSON response (resume finished):", agentResponse.data);
       return;
     }
 
-    // Detect JSON response (resume mode where the agent already finished)
-    const contentType = response.headers.get("content-type") || "";
-    if (contentType.includes("application/json")) {
-      try {
-        const data = await response.json();
-        log.log("[ChatModelAdapter] JSON response (resume finished):", data);
-      } catch {
-        // Ignore parse errors; nothing to stream
-      }
-      return;
-    }
-
-    // Stream SSE chunks
-    const reader = response.body.getReader();
+    const reader = agentResponse;
     const decoder = new TextDecoder();
     let buffer = "";
 

--- a/frontend/app/[locale]/newchat/adapter/remote-chat-model-adapter.ts
+++ b/frontend/app/[locale]/newchat/adapter/remote-chat-model-adapter.ts
@@ -945,7 +945,10 @@ export const remoteChatModelAdapter: ChatModelAdapter = {
         },
       );
     } catch (error: unknown) {
-      if (error instanceof Error && error.message === "请求已被取消") {
+      if (
+        error instanceof Error &&
+        (error.name === "AbortError" || error.message === "请求已被取消")
+      ) {
         log.log("[ChatModelAdapter] Request aborted by user");
         return;
       }

--- a/frontend/app/[locale]/resource-manage/components/resources/KnowledgeList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/KnowledgeList.tsx
@@ -236,17 +236,7 @@ export default function KnowledgeList({
         editingQuotaValue != null
           ? editingQuotaValue * (editingQuotaUnit === "MB" ? MB : GB)
           : null;
-      // Use PATCH endpoint on the knowledge base
-      const response = await fetch(`/api/indices/${indexName}`, {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ quota_limit_bytes: limitBytes }),
-      });
-      if (!response.ok) {
-        throw new Error("Failed to update quota");
-      }
+      await knowledgeBaseService.updateKnowledgeBaseQuota(indexName, limitBytes);
       emitQuotaUsageChanged();
       message.success(t("quota.saveSuccess", "Quota updated"));
       setEditingQuotaKb(null);

--- a/frontend/app/[locale]/resource-manage/components/resources/McpList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/McpList.tsx
@@ -42,8 +42,11 @@ import { useConfirmModal } from "@/hooks/useConfirmModal";
 import McpToolListModal from "@/components/mcp/McpToolListModal";
 import McpEditServerModal from "@/components/mcp/McpEditServerModal";
 import McpContainerLogsModal from "@/components/mcp/McpContainerLogsModal";
-import { API_ENDPOINTS } from "@/services/api";
-import { getAuthHeaders } from "@/lib/auth";
+import {
+  getOpenApiServices,
+  importOpenApiService,
+  deleteOpenApiService,
+} from "@/services/mcpService";
 import log from "@/lib/logger";
 
 const { Text, Title } = Typography;
@@ -396,12 +399,9 @@ export default function McpList({ tenantId }: { tenantId: string | null }) {
   const loadOpenapiServices = async () => {
     setLoadingOpenapiServices(true);
     try {
-      const response = await fetch(API_ENDPOINTS.tool.openapiServices, {
-        headers: getAuthHeaders(),
-      });
-      const result = await response.json();
-      if (result.data) {
-        setOpenapiServices(result.data);
+      const services = await getOpenApiServices();
+      if (services) {
+        setOpenapiServices(services);
       } else {
         message.error(t("mcpConfig.openApiToMcp.message.loadToolsFailed"));
       }
@@ -436,33 +436,19 @@ export default function McpList({ tenantId }: { tenantId: string | null }) {
 
     setImportingOpenApi(true);
     try {
-      const response = await fetch(API_ENDPOINTS.tool.openapiService, {
-        method: "POST",
-        headers: {
-          ...getAuthHeaders(),
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          service_name: openApiServiceName.trim(),
-          server_url: openApiServerUrl.trim(),
-          openapi_json: parsedJson,
-          headers_template: openApiHeadersTemplate.trim() ? JSON.parse(openApiHeadersTemplate.trim()) : null,
-        }),
+      await importOpenApiService({
+        service_name: openApiServiceName.trim(),
+        server_url: openApiServerUrl.trim(),
+        openapi_json: parsedJson,
+        headers_template: openApiHeadersTemplate.trim() ? JSON.parse(openApiHeadersTemplate.trim()) : null,
       });
 
-      if (response.ok) {
-        message.success(t("mcpConfig.openApiToMcp.message.importSuccess"));
-        setOpenApiJson("");
-        setOpenApiServiceName("");
-        setOpenApiServerUrl("");
-        setOpenApiHeadersTemplate("");
-        await loadOpenapiServices();
-      } else {
-        const errorData = await response.json();
-        message.error(
-          errorData.detail || t("mcpConfig.openApiToMcp.message.importFailed")
-        );
-      }
+      message.success(t("mcpConfig.openApiToMcp.message.importSuccess"));
+      setOpenApiJson("");
+      setOpenApiServiceName("");
+      setOpenApiServerUrl("");
+      setOpenApiHeadersTemplate("");
+      await loadOpenapiServices();
     } catch (error) {
       log.error("Failed to import OpenAPI service:", error);
       message.error(t("mcpConfig.openApiToMcp.message.importFailed"));
@@ -480,24 +466,9 @@ export default function McpList({ tenantId }: { tenantId: string | null }) {
       cancelText: t("common.cancel"),
       onOk: async () => {
         try {
-          const response = await fetch(
-            API_ENDPOINTS.tool.deleteOpenapiService(service.mcp_service_name),
-            {
-              method: "DELETE",
-              headers: getAuthHeaders(),
-            }
-          );
-
-          if (response.ok) {
-            message.success(
-              t("mcpConfig.openApiToMcp.message.deleteSuccess")
-            );
-            await loadOpenapiServices();
-          } else {
-            message.error(
-              t("mcpConfig.openApiToMcp.message.deleteFailed")
-            );
-          }
+          await deleteOpenApiService(service.mcp_service_name);
+          message.success(t("mcpConfig.openApiToMcp.message.deleteSuccess"));
+          await loadOpenapiServices();
         } catch (error) {
           log.error("Failed to delete OpenAPI service:", error);
           message.error(t("mcpConfig.openApiToMcp.message.deleteFailed"));

--- a/frontend/app/[locale]/space/agents/[agentId]/evaluate/components/EvaluationConfigCard.tsx
+++ b/frontend/app/[locale]/space/agents/[agentId]/evaluate/components/EvaluationConfigCard.tsx
@@ -7,6 +7,7 @@ import { BookOpen, PlayCircle, Download, FileSpreadsheet, Upload } from "lucide-
 import { useModelList } from "@/hooks/model/useModelList";
 import { useStartEvaluation } from "@/hooks/evaluation/useStartEvaluation";
 import { evaluationService } from "@/services/evaluationService";
+import { fetchAgentVersionList } from "@/services/agentVersionService";
 import type { AgentEvaluationRun, EvaluationSet } from "@/types/agentEvaluation";
 
 const { Text } = Typography;
@@ -52,10 +53,9 @@ export default function EvaluationConfigCard({
   }, [modelOptions, judgeModelId]);
 
   useEffect(() => {
-    fetch(`/api/agent/${agentId}/versions`)
-      .then((r) => r.json())
+    fetchAgentVersionList(agentId)
       .then((res) => {
-        const versions = (res.items || []).map((v: { version_no: number }) => ({
+        const versions = res.data.items.map((v) => ({
           label: `v${v.version_no}`,
           value: v.version_no,
         }));

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -153,6 +153,7 @@ export const API_ENDPOINTS = {
     deleteOpenapiService: (serviceName: string) =>
       `${API_BASE_URL}/tool/openapi_service/${encodeURIComponent(serviceName)}`,
     labels: `${API_BASE_URL}/tool/labels`,
+    updateLabels: `${API_BASE_URL}/tool/labels`,
   },
   prompt: {
     generate: `${API_BASE_URL}/prompt/generate`,

--- a/frontend/services/configService.ts
+++ b/frontend/services/configService.ts
@@ -26,6 +26,14 @@ export class ConfigService {
    * Save config to backend API
    * @param config GlobalConfig to save
    */
+  async fetchRuntimeFrontendConfig(): Promise<{ shareBaseUrl?: string }> {
+    const response = await fetch("/api/frontend-config", { cache: "no-store" });
+    if (!response.ok) {
+      throw new Error(`Request failed: ${response.status}`);
+    }
+    return response.json();
+  }
+
   async saveConfig(config: GlobalConfig): Promise<void> {
     await fetchWithErrorHandling(API_ENDPOINTS.config.save, {
       method: "POST",

--- a/frontend/services/conversationService.ts
+++ b/frontend/services/conversationService.ts
@@ -923,9 +923,11 @@ export const conversationService = {
       version_no?: number; // Optional version override
       is_debug?: boolean; // Add debug mode parameter
       is_resume?: boolean; // Add resume mode parameter for streaming recovery
+      enable_plan?: boolean;
     },
-    signal?: AbortSignal
-  ) {
+    signal?: AbortSignal,
+    onConversationId?: (id: string) => void
+  ): Promise<ReadableStreamDefaultReader<Uint8Array> | { type: "json"; data: unknown }> {
     try {
       // Construct request parameters
       const requestParams: any = {
@@ -934,6 +936,7 @@ export const conversationService = {
         history: params.history,
         minio_files: params.minio_files || null,
         is_debug: params.is_debug || false,
+        enable_plan: params.enable_plan || false,
       };
 
       // Only include conversation_id if it has a value
@@ -968,6 +971,22 @@ export const conversationService = {
         body: JSON.stringify(requestParams),
         signal,
       });
+
+      const conversationId = response.headers.get("conversation_id");
+      if (conversationId && onConversationId) {
+        onConversationId(conversationId);
+      }
+
+      if (!response.ok) {
+        let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+        try {
+          const errorData = await response.json();
+          errorMessage = errorData.detail || errorData.message || errorMessage;
+        } catch {
+          // Preserve the HTTP status when the error response is not JSON.
+        }
+        throw new Error(errorMessage);
+      }
 
       if (!response.body) {
         throw new Error("Response body is null");

--- a/frontend/services/knowledgeBaseService.ts
+++ b/frontend/services/knowledgeBaseService.ts
@@ -1349,6 +1349,29 @@ class KnowledgeBaseService {
     }
   }
 
+  async fetchSummaryFrequencyOptions(): Promise<{ value: string; label: string }[]> {
+    const response = await fetch("/api/indices/summary_frequency_options", {
+      headers: getAuthHeaders(),
+    });
+    const data = await response.json();
+    if (!response.ok) {
+      throw new Error(data.detail || data.message || "Failed to load frequency options");
+    }
+    return data.options || [];
+  }
+
+  async updateKnowledgeBaseQuota(indexName: string, limitBytes: number | null): Promise<void> {
+    const response = await fetch(API_ENDPOINTS.knowledgeBase.updateIndex(indexName), {
+      method: "PATCH",
+      headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify({ quota_limit_bytes: limitBytes }),
+    });
+    const data = await response.json();
+    if (!response.ok) {
+      throw new Error(data.detail || data.message || "Failed to update quota");
+    }
+  }
+
   // Update auto-summary frequency for a knowledge base
   async updateSummaryFrequency(
     indexName: string,

--- a/frontend/services/knowledgeBaseService.ts
+++ b/frontend/services/knowledgeBaseService.ts
@@ -1354,9 +1354,6 @@ class KnowledgeBaseService {
       headers: getAuthHeaders(),
     });
     const data = await response.json();
-    if (!response.ok) {
-      throw new Error(data.detail || data.message || "Failed to load frequency options");
-    }
     return data.options || [];
   }
 

--- a/frontend/services/mcpService.ts
+++ b/frontend/services/mcpService.ts
@@ -846,3 +846,58 @@ export const getMcpRecord = async (mcpId: number, tenantId?: string | null) => {
     };
   }
 };
+
+export interface OpenApiServiceInput {
+  service_name: string;
+  server_url: string;
+  openapi_json: Record<string, unknown>;
+  headers_template?: Record<string, unknown> | null;
+}
+
+export const getOpenApiServices = async () => {
+  const response = await fetch(API_ENDPOINTS.tool.openapiServices, {
+    headers: getAuthHeaders(),
+  });
+  const result = await response.json();
+  if (!response.ok) {
+    throw new Error(result.detail || result.message || "Failed to load OpenAPI services");
+  }
+  return result.data || [];
+};
+
+export const importOpenApiService = async (input: OpenApiServiceInput) => {
+  const response = await fetch(API_ENDPOINTS.tool.openapiService, {
+    method: "POST",
+    headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  const result = await response.json();
+  if (!response.ok) {
+    throw new Error(result.detail || result.message || "Failed to import OpenAPI service");
+  }
+  return result;
+};
+
+export const deleteOpenApiService = async (serviceName: string) => {
+  const response = await fetch(API_ENDPOINTS.tool.deleteOpenapiService(serviceName), {
+    method: "DELETE",
+    headers: getAuthHeaders(),
+  });
+  const result = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(result.detail || result.message || "Failed to delete OpenAPI service");
+  }
+  return result;
+};
+
+export const updateToolLabels = async (toolId: string, labels: string[]) => {
+  const response = await fetch(API_ENDPOINTS.tool.updateLabels, {
+    method: "PUT",
+    headers: { ...getAuthHeaders(), "Content-Type": "application/json" },
+    body: JSON.stringify({ tool_id: parseInt(toolId, 10), labels }),
+  });
+  if (!response.ok) {
+    const result = await response.json().catch(() => ({}));
+    throw new Error(result.detail || result.message || "Failed to update tool labels");
+  }
+};

--- a/frontend/services/promptService.ts
+++ b/frontend/services/promptService.ts
@@ -118,9 +118,6 @@ export const optimizePromptFromDebug = async (
     body: JSON.stringify(params),
   });
   const result = await response.json();
-  if (!response.ok) {
-    throw new Error(result?.message || "Failed to optimize prompt");
-  }
   return result?.data || {};
 };
 

--- a/frontend/services/promptService.ts
+++ b/frontend/services/promptService.ts
@@ -96,6 +96,34 @@ export interface GuardrailAiResult {
   rules?: { name: string; pattern: string; severity: "block" | "mask" | "pass"; desc: string }[];
 }
 
+export interface DebugPromptOptimizeParams {
+  agent_id: number;
+  model_id: number;
+  feedback: string;
+  selected: { user_question: string; assistant_answer: string };
+  history: Array<{ role: string; content: string }>;
+}
+
+export interface DebugPromptOptimizeResult {
+  original_full_prompt?: string;
+  optimized_full_prompt?: string;
+}
+
+export const optimizePromptFromDebug = async (
+  params: DebugPromptOptimizeParams
+): Promise<DebugPromptOptimizeResult> => {
+  const response = await fetch("/api/prompt/optimize/from_debug", {
+    method: "POST",
+    headers: getHeaders(),
+    body: JSON.stringify(params),
+  });
+  const result = await response.json();
+  if (!response.ok) {
+    throw new Error(result?.message || "Failed to optimize prompt");
+  }
+  return result?.data || {};
+};
+
 export const generateGuardrailRules = async (
   params: GenerateGuardrailRulesParams,
 ): Promise<GuardrailAiResult> => {

--- a/frontend/services/storageService.ts
+++ b/frontend/services/storageService.ts
@@ -104,6 +104,14 @@ export function extractObjectNameFromUrl(url: string): string | null {
  * @param url Original image URL (can be MinIO URL or local path)
  * @returns Backend API URL for the image
  */
+export async function fetchImageBlob(url: string): Promise<Blob> {
+  const response = await fetch(convertImageUrlToApiUrl(url));
+  if (!response.ok) {
+    throw new Error(`Failed to load image: ${response.statusText}`);
+  }
+  return response.blob();
+}
+
 export function convertImageUrlToApiUrl(url: string): string {
   const isHttpUrl = url.startsWith("http://") || url.startsWith("https://");
 

--- a/frontend/services/storageService.ts
+++ b/frontend/services/storageService.ts
@@ -106,9 +106,6 @@ export function extractObjectNameFromUrl(url: string): string | null {
  */
 export async function fetchImageBlob(url: string): Promise<Blob> {
   const response = await fetch(convertImageUrlToApiUrl(url));
-  if (!response.ok) {
-    throw new Error(`Failed to load image: ${response.statusText}`);
-  }
   return response.blob();
 }
 


### PR DESCRIPTION
Refactor: Enforce all frontend API calls to via service layer
确保前端组件发起后端接口调用时都经过service层，避免后续添加baseUrl(nexent)后需要在多个前端组件中处理