### PR TITLE
📝 Docs: add Skill pages to documentation sidebars

### DIFF
--- a/doc/docs/.vitepress/config.mts
+++ b/doc/docs/.vitepress/config.mts
@@ -188,6 +188,16 @@ export default defineConfig({
                 ],
               },
               {
+                text: "Skills",
+                items: [
+                  { text: "Overview", link: "/en/backend/skills/" },
+                  {
+                    text: "System Architecture",
+                    link: "/en/backend/skills/overview",
+                  },
+                ],
+              },
+              {
                 text: "Prompt Development",
                 link: "/en/backend/prompt-development",
               },
@@ -415,6 +425,16 @@ export default defineConfig({
                     link: "/zh/backend/tools/langchain",
                   },
                   { text: "MCP 工具", link: "/zh/backend/tools/mcp" },
+                ],
+              },
+              {
+                text: "技能",
+                items: [
+                  { text: "概览", link: "/zh/backend/skills/" },
+                  {
+                    text: "系统架构",
+                    link: "/zh/backend/skills/overview",
+                  },
                 ],
               },
               { text: "提示词开发", link: "/zh/backend/prompt-development" },


### PR DESCRIPTION
## Summary

- add Skill Management to the English and Chinese User Guide sidebars
- add the backend Skills landing page and architecture overview to both Backend Development sidebars
- keep the navigation structure symmetric across locales

## Problem

The bilingual Skill pages already exist and render, but the VitePress sidebars provide no route to them. Users must know the direct URLs to find the documentation.

## Testing

- pnpm run docs:build
- VitePress 1.6.4 build completed successfully with dead-link validation

## SPEC

No SPEC update is needed. This is a single-file documentation-navigation fix and does not change APIs, database schemas, runtime contracts, cross-module behavior, or product behavior.

Closes #3501