### PR TITLE
fix: defer step_index creation to migration

### DIFF
--- a/deploy/sql/init.sql
+++ b/deploy/sql/init.sql
@@ -45,7 +45,6 @@ CREATE TABLE IF NOT EXISTS "conversation_message_unit_t" (
   "update_time" timestamp(0) DEFAULT CURRENT_TIMESTAMP,
   "updated_by" varchar(100) COLLATE "pg_catalog"."default",
   "created_by" varchar(100) COLLATE "pg_catalog"."default",
-  "step_index" int4,
   CONSTRAINT "conversation_message_unit_t_pk" PRIMARY KEY ("unit_id")
 );
 ALTER TABLE "conversation_message_unit_t" OWNER TO "root";
@@ -59,7 +58,6 @@ COMMENT ON COLUMN "conversation_message_unit_t"."create_time" IS 'Creation time,
 COMMENT ON COLUMN "conversation_message_unit_t"."update_time" IS 'Update time, audit field';
 COMMENT ON COLUMN "conversation_message_unit_t"."updated_by" IS 'Last updater ID, audit field';
 COMMENT ON COLUMN "conversation_message_unit_t"."created_by" IS 'Creator ID, audit field';
-COMMENT ON COLUMN "conversation_message_unit_t"."step_index" IS 'ReAct step sequence number within this message. Increments on step_count chunks';
 COMMENT ON TABLE "conversation_message_unit_t" IS 'Carries agent output content in each message';
 
 CREATE TABLE IF NOT EXISTS "conversation_record_t" (

--- a/deploy/tests/test_sql_migrations.sh
+++ b/deploy/tests/test_sql_migrations.sh
@@ -96,6 +96,20 @@ fi
 if grep -Eq '^COMMENT ON COLUMN nexent\.model_record_t\.is_deep_thinking ' "$DEPLOY_ROOT/sql/init.sql"; then
   fail "init SQL should not comment model_record_t.is_deep_thinking because a later migration drops that column"
 fi
+if grep -Eq '^[[:space:]]*"step_index"[[:space:]]' "$DEPLOY_ROOT/sql/init.sql"; then
+  fail "init SQL should leave conversation_message_unit_t.step_index to its migration"
+fi
+if grep -Eq '^COMMENT ON COLUMN .*conversation_message_unit_t.*step_index' "$DEPLOY_ROOT/sql/init.sql"; then
+  fail "init SQL should not comment conversation_message_unit_t.step_index before its migration adds the column"
+fi
+
+HISTORY_PROJECTION_MIGRATION="$DEPLOY_ROOT/sql/migrations/v2.3.0_0703_history_projection_fields.sql"
+assert_file_contains "$HISTORY_PROJECTION_MIGRATION" \
+  "ADD COLUMN IF NOT EXISTS step_index INTEGER DEFAULT NULL;" \
+  "history projection migration should add conversation_message_unit_t.step_index"
+assert_file_contains "$HISTORY_PROJECTION_MIGRATION" \
+  "COMMENT ON COLUMN nexent.conversation_message_unit_t.step_index" \
+  "history projection migration should comment conversation_message_unit_t.step_index"
 
 PLAN_FILE="$TMP_DIR/plan.sql"
 PATH="$BIN_DIR:$PATH" \


### PR DESCRIPTION
This pull request removes the `step_index` column and its associated comment from the base `init.sql` schema for the `conversation_message_unit_t` table, ensuring that this column is instead added and commented in a dedicated migration script. The corresponding test script is updated to enforce that `init.sql` does not contain `step_index`, and to verify that the migration script properly adds and documents the column.

Schema changes:

* Removed the `step_index` column from the `conversation_message_unit_t` table definition in `init.sql`, along with its comment, to ensure it is only introduced via migration. [[1]](diffhunk://#diff-8c6c4d2f5768f676f93a73c16b53173f797b714800991204cb105eacaad8791aL48) [[2]](diffhunk://#diff-8c6c4d2f5768f676f93a73c16b53173f797b714800991204cb105eacaad8791aL62)

Test updates:

* Updated `test_sql_migrations.sh` to fail if `init.sql` contains the `step_index` column or its comment, enforcing correct schema initialization.
* Added assertions to `test_sql_migrations.sh` to verify that the `v2.3.0_0703_history_projection_fields.sql` migration script adds and comments the `step_index` column as expected.