### PR TITLE
🐛 Bugfix: Unify modules to ES Module

### DIFF
--- a/frontend/build-config.js
+++ b/frontend/build-config.js
@@ -1,6 +1,9 @@
-const fs = require("node:fs");
-const path = require("path");
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 const LOCALES_CONFIG_DIR = path.resolve(__dirname, "./public/locales");
 
 const defaultSize = 10;

--- a/frontend/components/common/markdownRenderer.tsx
+++ b/frontend/components/common/markdownRenderer.tsx
@@ -12,6 +12,7 @@ import rehypeKatex from "rehype-katex";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 // @ts-ignore
 import { oneLight } from "react-syntax-highlighter/dist/esm/styles/prism";
+import { unified } from "unified";
 import { visit } from "unist-util-visit";
 import { SearchResult } from "@/types/chat";
 import { resolveS3UrlToDataUrl } from "@/services/storageService";
@@ -172,7 +173,6 @@ const extractParsedMarkdownHeadings = (content: string): ParsedMarkdownHeading[]
   try {
     const createId = createHeadingIdGenerator();
     const headings: ParsedMarkdownHeading[] = [];
-    const { unified } = require("unified") as { unified: () => any };
     const tree = unified()
       .use(remarkParse)
       .use(remarkGfm)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "nexent",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "node server.js",
     "build": "next build",

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -1,23 +1,28 @@
-const { createServer } = require("http");
-const fs = require("node:fs");
-const http = require("http");
-const https = require("https");
-const { parse } = require("url");
-const next = require("next");
-const { createProxyServer } = require("http-proxy");
-const cookie = require("cookie");
-const path = require("path");
-const multiparty = require("multiparty");
+import { fileURLToPath } from "node:url";
+import { createServer } from "node:http";
+import fs from "node:fs";
+import http from "node:http";
+import https from "node:https";
+import { parse } from "node:url";
+import next from "next";
+import httpProxy from "http-proxy";
+import cookie from "cookie";
+import path from "node:path";
+import multiparty from "multiparty";
+import dotenv from "dotenv";
+import { ensureDir, readLocaleConfig, saveLocaleConfig } from "./build-config.js";
+
+const { createProxyServer } = httpProxy;
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // Load environment variables from deploy/env/.env
 // In container environments, env vars are injected directly by Docker, so .env file may not exist
 // Using optional: true to avoid errors if .env file is not found
-require("dotenv").config({
+dotenv.config({
   path: path.resolve(__dirname, "../deploy/env/.env"),
   override: false, // Don't override existing environment variables (important for Docker)
 });
-
-const { ensureDir, readLocaleConfig, saveLocaleConfig } = require("./build-config");
 
 const dev = process.env.NODE_ENV !== "production";
 const app = next({

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss"
+import tailwindcssAnimate from "tailwindcss-animate"
 
 const config = {
   darkMode: ["class"],
@@ -75,9 +76,7 @@ const config = {
       },
     },
   },
-  plugins: [
-    require("tailwindcss-animate"),
-  ],
+  plugins: [tailwindcssAnimate],
 } satisfies Config
 
 export default config


### PR DESCRIPTION
当前前端业务代码采用 ESM/现代 TypeScript 模式，但自定义 Node 服务层仍主要是 CommonJS。目前将Node 服务统一使用 ESM，改造 server.js、build-config.js 以及相关依赖导入方式