### PR TITLE
fix: remove erroneously added context_policy column from init.sql

### DIFF
--- a/deploy/sql/init.sql
+++ b/deploy/sql/init.sql
@@ -300,7 +300,6 @@ CREATE TABLE IF NOT EXISTS nexent.ag_tenant_agent_t (
     enabled BOOLEAN DEFAULT FALSE,
     is_main_agent BOOLEAN NOT NULL DEFAULT TRUE,
     provide_run_summary BOOLEAN DEFAULT FALSE,
-    context_policy JSONB,
     create_time TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     update_time TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     created_by VARCHAR(100),


### PR DESCRIPTION
## Summary

Remove the `context_policy JSONB` column that was mistakenly added directly to `deploy/sql/init.sql`.

## Problem

The `context_policy` column was incorrectly inserted into the `ag_tenant_agent_t` table definition in `init.sql`. Per the project's SQL management convention, `init.sql` must remain as the static baseline schema — all subsequent schema changes should only be introduced through versioned migration files under `deploy/sql/migrations/`.

## Fix

- **Removed** line 303 (`context_policy JSONB,`) from `deploy/sql/init.sql`
- The column is already correctly defined in migration file `v2.3.0_0718_add_agent_context_policy.sql`, which uses `ADD COLUMN IF NOT EXISTS` for idempotent application

## Impact

- No functional change — the migration file already handles adding this column for both fresh and existing deployments
- Restores `init.sql` to its correct static baseline state
- Prevents the column from being created twice (once by init.sql, once by migration) on fresh deployments