### PR TITLE
🐛 Bugfix: Multimodal embedding models cannot add

### DIFF
--- a/backend/data_process/tasks.py
+++ b/backend/data_process/tasks.py
@@ -107,7 +107,9 @@ def _count_image_metadata_chunks(chunks: Optional[List[Dict[str, Any]]]) -> int:
     return sum(
         1
         for chunk in chunks
-        if isinstance(chunk, dict) and chunk.get("process_source") == IMAGE_METADATA_PROCESS_SOURCE
+        if isinstance(chunk, dict)
+        and (chunk.get("process_source") or chunk.get("metadata", {}).get("process_source"))
+        == IMAGE_METADATA_PROCESS_SOURCE
     )
 
 

--- a/backend/services/model_health_service.py
+++ b/backend/services/model_health_service.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from nexent.core import MessageObserver
 from nexent.core.models import OpenAIModel, OpenAIVLModel
-from nexent.core.models.embedding_model import JinaEmbedding, OpenAICompatibleEmbedding, DashScopeMultimodalEmbedding
+from nexent.core.models.embedding_model import JinaEmbedding, OpenAICompatibleEmbedding, DashScopeMultimodalEmbedding, SiliconflowMultimodalEmbedding
 from nexent.monitor import set_monitoring_context, set_monitoring_operation
 from nexent.core.models.rerank_model import OpenAICompatibleRerank
 
@@ -17,6 +17,7 @@ logger = logging.getLogger("model_health_service")
 
 DASHSCOPE_MODEL_FACTORY = "dashscope"
 TOKENPONY_MODEL_FACTORY = "tokenpony"
+SILICONFLOW_MODEL_FACTORY = "silicon"
 PROVIDER_CATALOG_HEALTHCHECK_FACTORIES = {DASHSCOPE_MODEL_FACTORY, TOKENPONY_MODEL_FACTORY}
 PROVIDER_CATALOG_HEALTHCHECK_TYPES = {"vlm", "vlm2", "vlm3"}
 
@@ -38,14 +39,16 @@ def _normalize_embedding_url(base_url: str) -> str:
 def _infer_model_factory(model_type: str, base_url: str, current_factory: Optional[str] = None) -> Optional[str]:
     """Infer model_factory from base_url if not already set or is generic.
 
-    For embedding/multi_embedding, uses legacy logic (only dashscope) to avoid
-    changing existing behavior. For other types (VLM), uses extended inference
-    so tokenpony URLs can be recognized for catalog healthcheck.
+    For embedding/multi_embedding, recognizes dashscope and siliconflow URLs.
+    For other types (VLM), uses extended inference so tokenpony URLs can be
+    recognized for catalog healthcheck.
     """
-    # Embedding types: keep legacy behavior (only dashscope)
+    # Embedding types: infer from base_url host
     if model_type in EMBEDDING_TYPES:
         if "dashscope" in base_url.lower():
             return DASHSCOPE_MODEL_FACTORY
+        if "siliconflow" in base_url.lower():
+            return SILICONFLOW_MODEL_FACTORY  # stored as "silicon" for catalog consistency
         return current_factory
 
     # Non-embedding types (VLM, etc): use extended inference
@@ -101,7 +104,7 @@ async def _embedding_dimension_check(
                 ssl_verify=ssl_verify,
             )
         else:
-            embedding_instance = JinaEmbedding(
+            embedding_instance = SiliconflowMultimodalEmbedding(
                 api_key=model_api_key,
                 base_url=model_base_url,
                 model_name=model_name,
@@ -199,7 +202,7 @@ async def _perform_connectivity_check(
                 ssl_verify=ssl_verify,
             )
         else:
-            embedding = JinaEmbedding(
+            embedding = SiliconflowMultimodalEmbedding(
                 api_key=model_api_key,
                 base_url=model_base_url,
                 model_name=model_name,

--- a/backend/services/vectordatabase_service.py
+++ b/backend/services/vectordatabase_service.py
@@ -11,6 +11,7 @@ Main features include:
 """
 import asyncio
 import hashlib
+import inspect
 import json
 import logging
 import os
@@ -21,7 +22,13 @@ from typing import Any, Dict, List, Optional
 
 from fastapi import Body, Depends, Path, Query
 from fastapi.responses import StreamingResponse
-from nexent.core.models.embedding_model import OpenAICompatibleEmbedding, JinaEmbedding, DashScopeMultimodalEmbedding, BaseEmbedding
+from nexent.core.models.embedding_model import (
+    BaseEmbedding,
+    DashScopeMultimodalEmbedding,
+    JinaEmbedding,
+    OpenAICompatibleEmbedding,
+    SiliconflowMultimodalEmbedding,
+)
 from nexent.core.models.rerank_model import OpenAICompatibleRerank, BaseRerank
 from nexent.vector_database.base import VectorDatabaseCore
 from nexent.vector_database.elasticsearch_core import ElasticSearchCore
@@ -352,6 +359,8 @@ def _create_embedding_model(model: dict) -> Any:
         model_factory = model.get("model_factory", "").lower()
         if model_factory == "dashscope":
             return DashScopeMultimodalEmbedding(**common_kwargs)
+        if model_factory == "silicon":
+            return SiliconflowMultimodalEmbedding(**common_kwargs)
         return JinaEmbedding(**common_kwargs)
     return OpenAICompatibleEmbedding(**common_kwargs)
 
@@ -425,33 +434,7 @@ def get_embedding_model_by_id(tenant_id: str, model_id: int) -> tuple[Optional[A
     try:
         model = get_model_by_model_id(model_id, tenant_id)
         if model and model.get("model_type") in ["embedding", "multi_embedding"]:
-            model_config = {
-                "model_repo": model.get("model_repo", ""),
-                "model_name": model["model_name"],
-                "api_key": model.get("api_key", ""),
-                "base_url": model.get("base_url", ""),
-                "model_type": model.get("model_type", "embedding"),
-                "max_tokens": model.get("max_tokens", 1024),
-                "ssl_verify": model.get("ssl_verify", True),
-            }
-            model_type = model.get("model_type", "embedding")
-            if model_type == "multi_embedding":
-                embedding_model = JinaEmbedding(
-                    api_key=model_config.get("api_key", ""),
-                    base_url=model_config.get("base_url", ""),
-                    model_name=get_model_name_from_config(model_config) or "",
-                    embedding_dim=model_config.get("max_tokens", 1024),
-                    ssl_verify=model_config.get("ssl_verify", True),
-                )
-            else:
-                embedding_model = OpenAICompatibleEmbedding(
-                    api_key=model_config.get("api_key", ""),
-                    base_url=model_config.get("base_url", ""),
-                    model_name=get_model_name_from_config(model_config) or "",
-                    embedding_dim=model_config.get("max_tokens", 1024),
-                    ssl_verify=model_config.get("ssl_verify", True),
-                )
-            return embedding_model, model.get("model_id")
+            return _create_embedding_model(model), model.get("model_id")
         else:
             logger.warning(f"Model with id {model_id} not found or is not an embedding model")
     except Exception as e:

--- a/sdk/nexent/core/models/embedding_model.py
+++ b/sdk/nexent/core/models/embedding_model.py
@@ -13,6 +13,23 @@ from ...monitor.monitoring import record_model_call
 ASSETS_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "assets")
 
 
+def _detect_image_mime(img_bytes: bytes) -> str:
+    """Detect image MIME type from raw bytes. Falls back to image/jpeg when unknown."""
+    if not img_bytes:
+        return "image/jpeg"
+    if img_bytes[:8] == b"\x89PNG\r\n\x1a\n":
+        return "image/png"
+    if img_bytes[:3] == b"\xff\xd8\xff":
+        return "image/jpeg"
+    if img_bytes[:4] in (b"GIF87a", b"GIF89a"):
+        return "image/gif"
+    if img_bytes[:4] == b"RIFF" and img_bytes[8:12] == b"WEBP":
+        return "image/webp"
+    if img_bytes[:2] == b"BM":
+        return "image/bmp"
+    return "image/jpeg"
+
+
 class BaseEmbedding(ABC):
     """
     Abstract base class for embedding models, defining methods that all embedding models should implement.
@@ -188,9 +205,28 @@ class JinaEmbedding(MultimodalEmbedding):
 
         self.headers = {"Content-Type": "application/json", "Authorization": f"Bearer {self.api_key}"}
 
-    def _prepare_multimodal_input(self, inputs: List[Dict[str, str]]) -> Dict[str, Any]:
-        """Prepare the input data for the API request."""
-        return {"model": self.model, "input": inputs, "truncate": True}
+    def _prepare_multimodal_input(self, inputs: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Prepare the input data for the API request.
+
+        Args:
+            inputs: List of dictionaries with 'text' or 'image' keys.
+                - Text: {"text": "string"}
+                - Image: {"image": "url_string" | "data:..." | bytes}
+        """
+        prepared = []
+        for item in inputs:
+            if "text" in item:
+                prepared.append(item)
+            elif "image" in item:
+                img = item["image"]
+                # If img is bytes, encode to data URL with correct MIME type
+                if isinstance(img, bytes):
+                    mime = _detect_image_mime(img)
+                    img = f"data:{mime};base64,{base64.b64encode(img).decode('utf-8')}"
+                prepared.append({"image": img})
+            else:
+                prepared.append(item)
+        return {"model": self.model, "input": prepared, "truncate": True}
 
     def _make_request(self, data: Dict[str, Any], timeout: Optional[float] = None) -> Dict[str, Any]:
         """
@@ -360,6 +396,7 @@ class DashScopeMultimodalEmbedding(MultimodalEmbedding):
         self.model = model_name
         self.embedding_dim = embedding_dim
         self.ssl_verify = ssl_verify
+        self.model_type = "multimodal"
 
         self.session = requests.Session()
         self.session.trust_env = False
@@ -368,11 +405,24 @@ class DashScopeMultimodalEmbedding(MultimodalEmbedding):
             "Authorization": f"Bearer {self.api_key}"
         }
 
-    def _prepare_multimodal_input(self, inputs: List[Dict[str, str]]) -> Dict[str, Any]:
-        """Prepare DashScope-compatible multimodal input format."""
+    def _prepare_multimodal_input(self, inputs: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Prepare DashScope-compatible multimodal input format.
+
+        DashScope accepts image URLs or Base64 data URIs. Raw image bytes are
+        encoded as PNG data URIs before being sent to the API.
+        """
+        normalized = []
+        for item in inputs:
+            if "image" in item:
+                img = item["image"]
+                if isinstance(img, bytes):
+                    img = f"data:image/png;base64,{base64.b64encode(img).decode('utf-8')}"
+                normalized.append({"image": img})
+            else:
+                normalized.append(item)
         return {
             "model": self.model,
-            "input": {"contents": inputs}
+            "input": {"contents": normalized}
         }
 
     def _make_request(self, data: Dict[str, Any], timeout: Optional[float] = None) -> Dict[str, Any]:
@@ -460,6 +510,139 @@ class DashScopeMultimodalEmbedding(MultimodalEmbedding):
             return []
         except Exception as e:
             logging.error(f"DashScopeMultimodalEmbedding connection failed: {str(e)}")
+            return []
+
+
+class SiliconflowMultimodalEmbedding(MultimodalEmbedding):
+    """Siliconflow multimodal embedding model (Qwen/Qwen3-VL-Embedding-8B etc.)."""
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str,
+        model_name: str,
+        embedding_dim: int = 1024,
+        ssl_verify: bool = True,
+    ):
+        """Initialize SiliconflowMultimodalEmbedding with configuration."""
+        self.api_key = api_key
+        self.api_url = base_url
+        self.model = model_name
+        self.embedding_dim = embedding_dim
+        self.ssl_verify = ssl_verify
+        self.model_type = "multimodal"
+
+        self.session = requests.Session()
+        self.session.trust_env = False
+        self.headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}"
+        }
+
+    def _prepare_multimodal_input(self, inputs: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Prepare Siliconflow-compatible multimodal input format.
+
+        Siliconflow API expects:
+        - Text: {"text": "..."} or plain string
+        - Image: {"image": "data:image/xxx;base64,..."} or {"image": "url"}
+        """
+        prepared = []
+        for item in inputs:
+            if "text" in item:
+                prepared.append(item["text"])
+            elif "image" in item:
+                img = item["image"]
+                # If img is bytes, encode to data URL with correct MIME type
+                if isinstance(img, bytes):
+                    mime = _detect_image_mime(img)
+                    img = f"data:{mime};base64,{base64.b64encode(img).decode('utf-8')}"
+                prepared.append({"image": img})
+            else:
+                prepared.append(item)
+        return {"model": self.model, "input": prepared}
+
+    def _make_request(self, data: Dict[str, Any], timeout: Optional[float] = None) -> Dict[str, Any]:
+        response = self.session.post(
+            self.api_url,
+            headers=self.headers,
+            json=data,
+            timeout=timeout,
+            verify=self.ssl_verify
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def get_embeddings(
+        self,
+        inputs: Union[str, List[str]],
+        with_metadata: bool = False,
+        timeout: Optional[float] = None,
+        retries: int = 3,
+        retry_timeout_step: float = 5.0,
+    ) -> Union[List[List[float]], Dict[str, Any]]:
+        if isinstance(inputs, str):
+            multimodal_inputs = [{"text": inputs}]
+        else:
+            multimodal_inputs = [{"text": item} for item in inputs]
+        return self.get_multimodal_embeddings(multimodal_inputs, with_metadata, timeout, retries, retry_timeout_step)
+
+    def get_multimodal_embeddings(
+        self,
+        inputs: List[Dict[str, Any]],
+        with_metadata: bool = False,
+        timeout: Optional[float] = None,
+        retries: int = 3,
+        retry_timeout_step: float = 5.0,
+    ) -> Union[List[List[float]], Dict[str, Any]]:
+        with record_model_call("multi_embedding", self.model, display_name=self.model):
+            data = self._prepare_multimodal_input(inputs)
+
+            base_timeout = timeout if timeout is not None else retry_timeout_step
+            attempts = retries + 1
+            last_timeout: Optional[requests.exceptions.Timeout] = None
+            for attempt_index in range(attempts):
+                current_timeout = base_timeout + attempt_index * retry_timeout_step
+                try:
+                    response = self._make_request(data, timeout=current_timeout)
+
+                    if with_metadata:
+                        return response
+
+                    embeddings = [item["embedding"] for item in response["data"]]
+                    return embeddings
+                except requests.exceptions.Timeout as e:
+                    logging.warning(
+                        f"SiliconflowMultimodalEmbedding API timed out in {current_timeout}s ({attempt_index + 1}/{attempts})"
+                    )
+                    last_timeout = e
+                    if attempt_index == attempts - 1:
+                        logging.error("SiliconflowMultimodalEmbedding API timed out.")
+                        raise
+                    continue
+
+            if last_timeout:
+                raise last_timeout
+            return []
+
+    async def dimension_check(self, timeout: float = 5.0) -> List[List[float]]:
+        try:
+            test_image_path = os.path.join(ASSETS_DIR, "test.png")
+            with open(test_image_path, "rb") as f:
+                image_data = f.read()
+            test_inputs = [
+                {"text": "Hello, nexent!"},
+                {"image": image_data}
+            ]
+            embeddings = await asyncio.to_thread(self.get_multimodal_embeddings, test_inputs, timeout=timeout)
+            return embeddings
+        except requests.exceptions.Timeout:
+            logging.error(f"SiliconflowMultimodalEmbedding connection timed out ({timeout} seconds)")
+            return []
+        except requests.exceptions.ConnectionError:
+            logging.error("SiliconflowMultimodalEmbedding connection error")
+            return []
+        except Exception as e:
+            logging.error(f"SiliconflowMultimodalEmbedding connection failed: {str(e)}")
             return []
 
 

--- a/sdk/nexent/vector_database/elasticsearch_core.py
+++ b/sdk/nexent/vector_database/elasticsearch_core.py
@@ -1,5 +1,3 @@
-import base64
-import json
 import logging
 import os
 import threading
@@ -455,10 +453,7 @@ class ElasticSearchCore(VectorDatabaseCore):
                 if doc.get("process_source") == "UniversalImageExtractor":
                     img_bytes = doc.pop("image_bytes", "")
                     if len(img_bytes) > 0:
-                        image_base64_str = base64.b64encode(
-                            img_bytes).decode("utf-8")
-                        data = f"data:image/jpeg;base64,{image_base64_str}"
-                        inputs.append({"image": data})
+                        inputs.append({"image": img_bytes})
                 else:
                     inputs.append({"text": doc[content_field]})
             embeddings = embedding_model.get_multimodal_embeddings(inputs)
@@ -472,6 +467,13 @@ class ElasticSearchCore(VectorDatabaseCore):
             inputs = [doc[content_field] for doc in filtered_docs]
             embeddings = embedding_model.get_embeddings(inputs)
             return filtered_docs, embeddings
+
+    @staticmethod
+    def _normalize_embedding_vector(embedding: Any) -> Any:
+        """Convert numeric vector values to floats for Elasticsearch dense vectors."""
+        if not isinstance(embedding, list):
+            return embedding
+        return [float(value) if isinstance(value, (int, float)) and not isinstance(value, bool) else value for value in embedding]
 
     @staticmethod
     def _build_bulk_operations(
@@ -488,7 +490,7 @@ class ElasticSearchCore(VectorDatabaseCore):
                 if doc.get("process_source") == "UniversalImageExtractor"
                 else "embedding"
             )
-            doc[embedding_field] = embedding
+            doc[embedding_field] = ElasticSearchCore._normalize_embedding_vector(embedding)
             if "embedding_model_name" not in doc:
                 doc["embedding_model_name"] = embedding_model.embedding_model_name
             operations.append(doc)
@@ -551,10 +553,7 @@ class ElasticSearchCore(VectorDatabaseCore):
                                 if doc.get("process_source") == "UniversalImageExtractor":
                                     img_bytes = doc.pop("image_bytes", "")
                                     if len(img_bytes) > 0:
-                                        image_base64_str = base64.b64encode(
-                                            img_bytes).decode('utf-8')
-                                        data = f"data:image/jpeg;base64,{image_base64_str}"
-                                        inputs.append({"image": data})
+                                        inputs.append({"image": img_bytes})
                                         docs_for_embeddings.append(doc)
                                 else:
                                     inputs.append({"text": doc[content_field]})
@@ -609,7 +608,7 @@ class ElasticSearchCore(VectorDatabaseCore):
             for doc, embedding in doc_embedding_pairs:
                 operations.append({"index": {"_index": index_name}})
                 doc["multi_embedding" if doc["process_source"]
-                        == "UniversalImageExtractor" else "embedding"] = embedding
+                        == "UniversalImageExtractor" else "embedding"] = self._normalize_embedding_vector(embedding)
                 if "embedding_model_name" not in doc:
                     doc["embedding_model_name"] = getattr(
                         embedding_model, "embedding_model_name", "unknown")

--- a/sdk/nexent/vector_database/elasticsearch_core.py
+++ b/sdk/nexent/vector_database/elasticsearch_core.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import threading

--- a/test/backend/services/test_model_health_service.py
+++ b/test/backend/services/test_model_health_service.py
@@ -1056,6 +1056,14 @@ async def test_infer_model_factory_dashscope():
 
 
 @pytest.mark.asyncio
+async def test_infer_model_factory_siliconflow():
+    """L47: _infer_model_factory returns SILICONFLOW_MODEL_FACTORY for siliconflow URLs"""
+    from backend.services.model_health_service import _infer_model_factory
+    result = _infer_model_factory("multi_embedding", "https://api.siliconflow.cn/v1/", None)
+    assert result == "silicon"
+
+
+@pytest.mark.asyncio
 async def test_perform_connectivity_check_multi_embedding_dashscope():
     """L181: multi_embedding with model_factory=dasScope uses DashScopeMultimodalEmbedding"""
     with mock.patch("backend.services.model_health_service.DashScopeMultimodalEmbedding") as mock_dashscope:

--- a/test/backend/services/test_model_health_service.py
+++ b/test/backend/services/test_model_health_service.py
@@ -130,7 +130,7 @@ async def test_perform_connectivity_check_embedding():
 @pytest.mark.asyncio
 async def test_perform_connectivity_check_multi_embedding():
     # Setup
-    with mock.patch("backend.services.model_health_service.JinaEmbedding") as mock_embedding:
+    with mock.patch("backend.services.model_health_service.SiliconflowMultimodalEmbedding") as mock_embedding:
         mock_embedding_instance = mock.MagicMock()
         mock_embedding_instance.dimension_check = mock.AsyncMock(return_value=[
             [1]
@@ -711,7 +711,7 @@ async def test_embedding_dimension_check_embedding_success():
 
 @pytest.mark.asyncio
 async def test_embedding_dimension_check_multi_embedding_success():
-    with mock.patch("backend.services.model_health_service.JinaEmbedding") as mock_embedding:
+    with mock.patch("backend.services.model_health_service.SiliconflowMultimodalEmbedding") as mock_embedding:
         mock_embedding_instance = mock.MagicMock()
         mock_embedding_instance.dimension_check = mock.AsyncMock(
             return_value=[[0.1, 0.2, 0.3, 0.4]])
@@ -796,8 +796,8 @@ async def test_embedding_dimension_check_wrapper_exception():
 
 @pytest.mark.asyncio
 async def test_embedding_dimension_check_multi_embedding_empty_response():
-    """Test multi_embedding dimension check with empty response (covers line 48-50)"""
-    with mock.patch("backend.services.model_health_service.JinaEmbedding") as mock_embedding, \
+    """Test multi_embedding dimension check with an empty response."""
+    with mock.patch("backend.services.model_health_service.SiliconflowMultimodalEmbedding") as mock_embedding, \
             mock.patch("backend.services.model_health_service.logging") as mock_logging:
         mock_embedding_instance = mock.MagicMock()
         mock_embedding_instance.dimension_check = mock.AsyncMock(

--- a/test/backend/services/test_vectordatabase_service.py
+++ b/test/backend/services/test_vectordatabase_service.py
@@ -135,6 +135,11 @@ class MockJinaEmbedding:
         pass
 
 
+class MockSiliconflowMultimodalEmbedding:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
 class MockBaseEmbedding:
     pass
 
@@ -143,6 +148,7 @@ embedding_model_module.OpenAICompatibleEmbedding = MockOpenAICompatibleEmbedding
 embedding_model_module.JinaEmbedding = MockJinaEmbedding
 embedding_model_module.BaseEmbedding = MockBaseEmbedding
 embedding_model_module.DashScopeMultimodalEmbedding = MockDashScopeMultimodalEmbedding
+embedding_model_module.SiliconflowMultimodalEmbedding = MockSiliconflowMultimodalEmbedding
 sys.modules['nexent.core.models.embedding_model'] = embedding_model_module
 
 # Mock nexent.core.models.rerank_model with proper class exports
@@ -5958,6 +5964,42 @@ class TestNewEmbeddingModelMethods(unittest.TestCase):
         )
 
     @patch('backend.services.vectordatabase_service.get_model_by_model_id')
+    @patch('backend.services.vectordatabase_service.DashScopeMultimodalEmbedding')
+    @patch('backend.services.vectordatabase_service.get_model_name_from_config')
+    def test_get_embedding_model_by_id_dashscope_multi_embedding(
+        self, mock_get_model_name, mock_dashscope_class, mock_get_model
+    ):
+        """Test that a DashScope model selected by ID uses its matching client."""
+        from backend.services.vectordatabase_service import get_embedding_model_by_id
+
+        mock_get_model.return_value = {
+            "model_id": 48,
+            "model_type": "multi_embedding",
+            "model_factory": "dashscope",
+            "model_name": "multimodal-embedding-v1",
+            "model_repo": "dashscope",
+            "api_key": "dashscope-key",
+            "base_url": "https://dashscope.aliyuncs.com/api/v1/services/embeddings/multimodal-embedding/multimodal-embedding",
+            "max_tokens": 1024,
+            "ssl_verify": True,
+        }
+        mock_get_model_name.return_value = "multimodal-embedding-v1"
+        mock_instance = MagicMock()
+        mock_dashscope_class.return_value = mock_instance
+
+        model, model_id = get_embedding_model_by_id("tenant-1", 48)
+
+        self.assertIs(model, mock_instance)
+        self.assertEqual(model_id, 48)
+        mock_dashscope_class.assert_called_once_with(
+            api_key="dashscope-key",
+            base_url="https://dashscope.aliyuncs.com/api/v1/services/embeddings/multimodal-embedding/multimodal-embedding",
+            model_name="multimodal-embedding-v1",
+            embedding_dim=1024,
+            ssl_verify=True,
+        )
+
+    @patch('backend.services.vectordatabase_service.get_model_by_model_id')
     def test_get_embedding_model_by_id_model_not_found(self, mock_get_model):
         """
         Test get_embedding_model_by_id when model is not found.
@@ -6917,6 +6959,21 @@ class TestCoverageImprovement(unittest.TestCase):
             })
         # Should return a DashScopeMultimodalEmbedding instance (mocked)
         self.assertIsNotNone(result)
+
+    def test_create_embedding_model_siliconflow(self):
+        """Siliconflow multi-embedding models use their provider-specific client."""
+        from backend.services.vectordatabase_service import _create_embedding_model
+        with patch('backend.services.vectordatabase_service.get_model_name_from_config',
+                   return_value="Qwen/Qwen3-VL-Embedding-8B"):
+            result = _create_embedding_model({
+                "model_name": "Qwen/Qwen3-VL-Embedding-8B",
+                "model_type": "multi_embedding",
+                "model_factory": "silicon",
+                "api_key": "test-key",
+                "base_url": "https://api.siliconflow.cn/v1/embeddings",
+            })
+
+        self.assertIsInstance(result, MockSiliconflowMultimodalEmbedding)
 
     # Tests for create_knowledge_base - is_multimodal=False with embedding_model_name (line 668)
     @patch('backend.services.vectordatabase_service.get_embedding_model')

--- a/test/sdk/core/models/test_embedding_model.py
+++ b/test/sdk/core/models/test_embedding_model.py
@@ -1214,3 +1214,499 @@ def test_dashscope_get_multimodal_embeddings_timeout_exhausts_raises(dashscope_e
         timeouts = [call.kwargs.get("timeout")
                     for call in dashscope_embedding_instance._make_request.call_args_list]
         assert timeouts == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# Tests for _detect_image_mime utility
+# ---------------------------------------------------------------------------
+
+
+def test_detect_image_mime_png():
+    from nexent.core.models.embedding_model import _detect_image_mime
+    assert _detect_image_mime(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16) == "image/png"
+
+
+def test_detect_image_mime_jpeg():
+    from nexent.core.models.embedding_model import _detect_image_mime
+    assert _detect_image_mime(b"\xff\xd8\xff\xe0\x00\x10JFIF") == "image/jpeg"
+
+
+def test_detect_image_mime_webp():
+    from nexent.core.models.embedding_model import _detect_image_mime
+    assert _detect_image_mime(b"RIFF" + b"\x00\x00\x00\x00" + b"WEBP") == "image/webp"
+
+
+def test_detect_image_mime_bmp():
+    from nexent.core.models.embedding_model import _detect_image_mime
+    assert _detect_image_mime(b"BM" + b"\x00" * 16) == "image/bmp"
+
+
+def test_detect_image_mime_unknown_falls_back_to_jpeg():
+    from nexent.core.models.embedding_model import _detect_image_mime
+    assert _detect_image_mime(b"TEXT text file content") == "image/jpeg"
+
+
+def test_detect_image_mime_empty_falls_back_to_jpeg():
+    from nexent.core.models.embedding_model import _detect_image_mime
+    assert _detect_image_mime(b"") == "image/jpeg"
+
+
+# ---------------------------------------------------------------------------
+# Tests for JinaEmbedding._prepare_multimodal_input
+# ---------------------------------------------------------------------------
+
+
+def test_jina_prepare_multimodal_input_text_item():
+    from nexent.core.models.embedding_model import JinaEmbedding
+
+    emb = JinaEmbedding(api_key="k", ssl_verify=True)
+    result = emb._prepare_multimodal_input([{"text": "hello"}])
+    assert result["input"] == [{"text": "hello"}]
+    assert result["truncate"] is True
+
+
+def test_jina_prepare_multimodal_input_url_image_item():
+    from nexent.core.models.embedding_model import JinaEmbedding
+
+    emb = JinaEmbedding(api_key="k", ssl_verify=True)
+    result = emb._prepare_multimodal_input([{"image": "https://example.com/img.jpg"}])
+    assert result["input"] == [{"image": "https://example.com/img.jpg"}]
+
+
+def test_jina_prepare_multimodal_input_bytes_image_item():
+    from nexent.core.models.embedding_model import JinaEmbedding
+
+    emb = JinaEmbedding(api_key="k", ssl_verify=True)
+    png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+    result = emb._prepare_multimodal_input([{"image": png_bytes}])
+    assert result["input"][0]["image"].startswith("data:image/png;base64,")
+
+
+def test_jina_prepare_multimodal_input_other_item():
+    """Items with neither 'text' nor 'image' key are passed through as-is."""
+    from nexent.core.models.embedding_model import JinaEmbedding
+
+    emb = JinaEmbedding(api_key="k", ssl_verify=True)
+    result = emb._prepare_multimodal_input([{"video": "http://x.mov"}])
+    assert result["input"] == [{"video": "http://x.mov"}]
+
+
+# ---------------------------------------------------------------------------
+# Tests for JinaEmbedding exhausted-retries fallback [] path
+# ---------------------------------------------------------------------------
+
+
+def test_jina_get_embeddings_exhausted_retries_returns_empty(jina_embedding_instance):
+    """retries=-1 → attempts=0, loop body never runs, last_timeout stays None → returns []. (line 290)"""
+    result = jina_embedding_instance.get_embeddings("x", timeout=None, retries=-1)
+    assert result == []
+
+
+def test_jina_get_multimodal_embeddings_exhausted_retries_returns_empty(jina_embedding_instance):
+    """retries=-1 → attempts=0, loop body never runs, last_timeout stays None → returns []. (line 349)"""
+    result = jina_embedding_instance.get_multimodal_embeddings([{"text": "x"}], timeout=None, retries=-1)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Tests for SiliconflowMultimodalEmbedding
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def siliconflow_embedding_instance():
+    return SiliconflowMultimodalEmbedding(
+        api_key="dummy-key",
+        base_url="https://api.siliconflow.cn/v1/embeddings/multimodal",
+        model_name="Qwen/Qwen3-VL-Embedding-8B",
+        embedding_dim=1024,
+        ssl_verify=True,
+    )
+
+
+def test_siliconflow_init_sets_attributes(siliconflow_embedding_instance):
+    emb = siliconflow_embedding_instance
+    assert emb.api_key == "dummy-key"
+    assert emb.model == "Qwen/Qwen3-VL-Embedding-8B"
+    assert emb.embedding_dim == 1024
+    assert emb.ssl_verify is True
+    assert emb.model_type == "multimodal"
+    assert "Authorization" in emb.headers
+
+
+def test_siliconflow_prepare_multimodal_input_text_converts_to_plain_string():
+    from nexent.core.models.embedding_model import SiliconflowMultimodalEmbedding
+
+    emb = SiliconflowMultimodalEmbedding(
+        api_key="k",
+        base_url="https://api.siliconflow.cn/v1",
+        model_name="qwen-vl",
+    )
+    result = emb._prepare_multimodal_input([{"text": "hello"}])
+    assert result["input"] == ["hello"]
+    assert result["model"] == "qwen-vl"
+
+
+def test_siliconflow_prepare_multimodal_input_url_image_preserved():
+    from nexent.core.models.embedding_model import SiliconflowMultimodalEmbedding
+
+    emb = SiliconflowMultimodalEmbedding(api_key="k", base_url="https://api.x.com", model_name="m")
+    result = emb._prepare_multimodal_input([{"image": "https://cdn.example.com/pic.png"}])
+    assert result["input"] == [{"image": "https://cdn.example.com/pic.png"}]
+
+
+def test_siliconflow_prepare_multimodal_input_bytes_image_encodes():
+    from nexent.core.models.embedding_model import SiliconflowMultimodalEmbedding
+
+    emb = SiliconflowMultimodalEmbedding(api_key="k", base_url="https://api.x.com", model_name="m")
+    jpeg_bytes = b"\xff\xd8\xff\xe0\x00\x10JFIF" + b"\x00" * 8
+    result = emb._prepare_multimodal_input([{"image": jpeg_bytes}])
+    assert result["input"][0]["image"].startswith("data:image/jpeg;base64,")
+
+
+def test_siliconflow_prepare_multimodal_input_other_item_passed_through():
+    from nexent.core.models.embedding_model import SiliconflowMultimodalEmbedding
+
+    emb = SiliconflowMultimodalEmbedding(api_key="k", base_url="https://api.x.com", model_name="m")
+    result = emb._prepare_multimodal_input([{"audio": "http://x.mp3"}])
+    assert result["input"] == [{"audio": "http://x.mp3"}]
+
+
+def test_siliconflow_get_embeddings_string_wraps_to_list(siliconflow_embedding_instance):
+    """Siliconflow get_embeddings converts string to [{"text": ...}] then delegates."""
+    captured = {}
+
+    def side_effect(data, timeout=None):
+        captured["input"] = data["input"]
+        return {"data": [{"embedding": [0.1, 0.2]}]}
+
+    with patch.object(
+        siliconflow_embedding_instance, "_make_request", side_effect=side_effect
+    ):
+        result = siliconflow_embedding_instance.get_embeddings(
+            "hello", with_metadata=False, timeout=3
+        )
+        # Siliconflow wraps text as {"text": "..."} then _prepare_multimodal_input
+        # extracts it back to plain string "hello"
+        assert result == [[0.1, 0.2]]
+
+
+def test_siliconflow_get_embeddings_list_converts_to_text_dicts(siliconflow_embedding_instance):
+    """Siliconflow get_embeddings converts list of strings to plain strings via _prepare_multimodal_input."""
+    captured = {}
+
+    def side_effect(data, timeout=None):
+        captured["input"] = data["input"]
+        return {"data": [{"embedding": [0.3, 0.4]}]}
+
+    with patch.object(
+        siliconflow_embedding_instance, "_make_request", side_effect=side_effect
+    ):
+        result = siliconflow_embedding_instance.get_embeddings(
+            ["a", "b"], with_metadata=False, timeout=3
+        )
+        # _prepare_multimodal_input extracts text values to plain strings
+        assert captured["input"] == ["a", "b"]
+        assert result == [[0.3, 0.4]]
+
+
+def test_siliconflow_get_embeddings_with_metadata(siliconflow_embedding_instance):
+    fake_response = {"data": [{"embedding": [1.0]}], "usage": {"total": 1}}
+
+    with patch.object(
+        siliconflow_embedding_instance, "_make_request", return_value=fake_response
+    ):
+        result = siliconflow_embedding_instance.get_embeddings(
+            ["x"], with_metadata=True, timeout=1
+        )
+        assert result == fake_response
+
+
+def test_siliconflow_get_embeddings_timeout_retry_succeeds(siliconflow_embedding_instance):
+    fake_response = {"data": [{"embedding": [0.9]}]}
+
+    def side_effect(data, timeout=None):
+        calls = side_effect.calls
+        side_effect.calls += 1
+        if calls == 0:
+            raise requests.exceptions.Timeout()
+        return fake_response
+
+    side_effect.calls = 0
+
+    with patch.object(
+        siliconflow_embedding_instance, "_make_request", side_effect=side_effect
+    ):
+        result = siliconflow_embedding_instance.get_embeddings(
+            ["a"], with_metadata=False, timeout=None, retries=2, retry_timeout_step=2
+        )
+        assert result == [[0.9]]
+        timeouts = [
+            call.kwargs.get("timeout")
+            for call in siliconflow_embedding_instance._make_request.call_args_list
+        ]
+        assert timeouts == [2, 4]
+
+
+def test_siliconflow_get_embeddings_timeout_exhausts_raises(siliconflow_embedding_instance):
+    with patch.object(
+        siliconflow_embedding_instance, "_make_request",
+        side_effect=requests.exceptions.Timeout(),
+    ):
+        with pytest.raises(requests.exceptions.Timeout):
+            siliconflow_embedding_instance.get_embeddings(
+                ["x"], with_metadata=False, timeout=None, retries=2, retry_timeout_step=1
+            )
+        timeouts = [
+            call.kwargs.get("timeout")
+            for call in siliconflow_embedding_instance._make_request.call_args_list
+        ]
+        assert timeouts == [1, 2, 3]
+
+
+def test_siliconflow_get_embeddings_returns_empty_when_attempts_skipped(siliconflow_embedding_instance):
+    result = siliconflow_embedding_instance.get_embeddings(
+        ["x"], with_metadata=False, timeout=None, retries=-1
+    )
+    assert result == []
+
+
+def test_siliconflow_get_embeddings_zero_retries_succeeds_first_try(siliconflow_embedding_instance):
+    mock_resp = Mock()
+    mock_resp.raise_for_status = Mock()
+    mock_resp.json.return_value = {"data": [{"embedding": [0.5]}]}
+
+    with patch.object(
+        siliconflow_embedding_instance.session, "post", return_value=mock_resp
+    ):
+        result = siliconflow_embedding_instance.get_embeddings(
+            ["x"], with_metadata=False, timeout=10, retries=0
+        )
+        assert result == [[0.5]]
+        siliconflow_embedding_instance.session.post.assert_called_once()
+
+
+def test_siliconflow_get_embeddings_connection_error_propagates(siliconflow_embedding_instance):
+    with patch.object(
+        siliconflow_embedding_instance.session, "post",
+        side_effect=requests.exceptions.ConnectionError(),
+    ):
+        with pytest.raises(requests.exceptions.ConnectionError):
+            siliconflow_embedding_instance.get_embeddings(
+                ["x"], with_metadata=False, timeout=5
+            )
+
+
+def test_siliconflow_get_embeddings_generic_exception_propagates(siliconflow_embedding_instance):
+    with patch.object(
+        siliconflow_embedding_instance.session, "post",
+        side_effect=RuntimeError("unexpected"),
+    ):
+        with pytest.raises(RuntimeError):
+            siliconflow_embedding_instance.get_embeddings(
+                ["x"], with_metadata=False, timeout=5
+            )
+
+
+def test_siliconflow_get_embeddings_http_error_propagates(siliconflow_embedding_instance):
+    mock_resp = Mock()
+    mock_resp.raise_for_status = Mock(side_effect=requests.HTTPError("Server error"))
+    mock_resp.json = Mock(return_value={"data": []})
+
+    with patch.object(
+        siliconflow_embedding_instance.session, "post", return_value=mock_resp
+    ):
+        with pytest.raises(requests.HTTPError):
+            siliconflow_embedding_instance.get_embeddings(
+                ["x"], with_metadata=False, timeout=5
+            )
+
+
+def test_siliconflow_make_request_invokes_session_post(siliconflow_embedding_instance):
+    mock_resp = Mock()
+    mock_resp.raise_for_status = Mock()
+    mock_resp.json.return_value = {"data": [{"embedding": [0.1]}]}
+
+    with patch.object(
+        siliconflow_embedding_instance.session, "post", return_value=mock_resp
+    ) as mock_post:
+        result = siliconflow_embedding_instance._make_request(
+            {"model": "x", "input": []}, timeout=5
+        )
+        assert result["data"][0]["embedding"] == [0.1]
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args.kwargs
+        assert call_kwargs["timeout"] == 5
+        assert call_kwargs["verify"] is True
+
+
+def test_siliconflow_make_request_raises_http_error(siliconflow_embedding_instance):
+    mock_resp = Mock()
+    mock_resp.raise_for_status = Mock(side_effect=requests.HTTPError("Bad Gateway"))
+    mock_resp.json.return_value = {}
+
+    with patch.object(
+        siliconflow_embedding_instance.session, "post", return_value=mock_resp
+    ):
+        with pytest.raises(requests.HTTPError):
+            siliconflow_embedding_instance._make_request({}, timeout=5)
+
+
+def test_siliconflow_get_embeddings_calls_record_model_call(mocker):
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__ = MagicMock(return_value=None)
+    mock_ctx.__exit__ = MagicMock(return_value=False)
+    mock_record = mocker.patch(
+        "nexent.core.models.embedding_model.record_model_call",
+        return_value=mock_ctx,
+    )
+    mock_resp = Mock()
+    mock_resp.raise_for_status = Mock()
+    mock_resp.json.return_value = {"data": [{"embedding": [0.1, 0.2]}]}
+
+    emb = SiliconflowMultimodalEmbedding(
+        api_key="k",
+        base_url="https://api.siliconflow.cn/v1",
+        model_name="qwen-vl",
+        embedding_dim=2,
+        ssl_verify=True,
+    )
+    mocker.patch.object(emb.session, "post", return_value=mock_resp)
+    emb.get_embeddings(["hello"], with_metadata=False, timeout=5)
+
+    mock_record.assert_called_once_with(
+        "multi_embedding", "qwen-vl", display_name="qwen-vl"
+    )
+
+
+@pytest.mark.asyncio
+async def test_siliconflow_dimension_check_success(siliconflow_embedding_instance):
+    with patch(
+        "nexent.core.models.embedding_model.asyncio.to_thread",
+        new_callable=AsyncMock,
+        return_value=[[0.1, 0.2, 0.3]],
+    ):
+        result = await siliconflow_embedding_instance.dimension_check()
+        assert result == [[0.1, 0.2, 0.3]]
+
+
+@pytest.mark.asyncio
+async def test_siliconflow_dimension_check_timeout_returns_empty(siliconflow_embedding_instance):
+    async def raise_timeout(*args, **kwargs):
+        raise requests.exceptions.Timeout()
+
+    with patch(
+        "nexent.core.models.embedding_model.asyncio.to_thread",
+        side_effect=raise_timeout,
+    ):
+        result = await siliconflow_embedding_instance.dimension_check(timeout=3.0)
+        assert result == []
+
+
+@pytest.mark.asyncio
+async def test_siliconflow_dimension_check_connection_error_returns_empty(siliconflow_embedding_instance):
+    with patch(
+        "nexent.core.models.embedding_model.asyncio.to_thread",
+        new_callable=AsyncMock,
+        side_effect=requests.exceptions.ConnectionError(),
+    ):
+        result = await siliconflow_embedding_instance.dimension_check()
+        assert result == []
+
+
+@pytest.mark.asyncio
+async def test_siliconflow_dimension_check_generic_exception_returns_empty(siliconflow_embedding_instance):
+    with patch(
+        "nexent.core.models.embedding_model.asyncio.to_thread",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("unexpected"),
+    ):
+        result = await siliconflow_embedding_instance.dimension_check()
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Tests for DashScopeMultimodalEmbedding._prepare_multimodal_input bytes path
+# ---------------------------------------------------------------------------
+
+
+def test_dashscope_prepare_multimodal_input_bytes_image_encodes_png():
+    from nexent.core.models.embedding_model import DashScopeMultimodalEmbedding
+
+    emb = DashScopeMultimodalEmbedding(
+        api_key="k",
+        base_url="https://dashscope.example.com",
+        model_name="text-embedding-vision",
+    )
+    png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+    result = emb._prepare_multimodal_input([{"image": png_bytes}])
+    assert result["input"]["contents"][0]["image"].startswith("data:image/png;base64,")
+
+
+def test_dashscope_prepare_multimodal_input_url_image_preserved():
+    from nexent.core.models.embedding_model import DashScopeMultimodalEmbedding
+
+    emb = DashScopeMultimodalEmbedding(
+        api_key="k",
+        base_url="https://dashscope.example.com",
+        model_name="text-embedding-vision",
+    )
+    result = emb._prepare_multimodal_input([{"image": "https://cdn.example.com/photo.jpg"}])
+    assert result["input"]["contents"] == [{"image": "https://cdn.example.com/photo.jpg"}]
+
+
+def test_dashscope_prepare_multimodal_input_text_item_preserved():
+    from nexent.core.models.embedding_model import DashScopeMultimodalEmbedding
+
+    emb = DashScopeMultimodalEmbedding(
+        api_key="k",
+        base_url="https://dashscope.example.com",
+        model_name="text-embedding-vision",
+    )
+    result = emb._prepare_multimodal_input([{"text": "hello dashscope"}])
+    assert result["input"]["contents"] == [{"text": "hello dashscope"}]
+
+
+# ---------------------------------------------------------------------------
+# Tests for DashScopeMultimodalEmbedding exhausted-retries [] path
+# ---------------------------------------------------------------------------
+
+
+def test_dashscope_get_embeddings_exhausted_retries_returns_empty(dashscope_embedding_instance):
+    result = dashscope_embedding_instance.get_embeddings(
+        ["x"], with_metadata=False, timeout=None, retries=-1
+    )
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Tests for MultimodalEmbedding abstract base class super().__init__
+# ---------------------------------------------------------------------------
+
+
+def test_multimodal_embedding_super_init_executes():
+    """Create a concrete subclass of MultimodalEmbedding that calls super().__init__."""
+    from nexent.core.models.embedding_model import MultimodalEmbedding
+
+    class ConcreteMultimodal(MultimodalEmbedding):  # type: ignore[misc]
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+        def get_embeddings(self, *args, **kwargs):
+            return []
+
+        def get_multimodal_embeddings(self, *args, **kwargs):
+            return []
+
+        async def dimension_check(self, timeout: float = 5.0):
+            return []
+
+    inst = ConcreteMultimodal(
+        model_name="m",
+        base_url="u",
+        api_key="k",
+        embedding_dim=512,
+        ssl_verify=False,
+    )
+    assert inst is not None
+    assert isinstance(inst, MultimodalEmbedding)

--- a/test/sdk/core/models/test_embedding_model.py
+++ b/test/sdk/core/models/test_embedding_model.py
@@ -3,7 +3,12 @@ import requests
 import sys
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
-from nexent.core.models.embedding_model import OpenAICompatibleEmbedding, JinaEmbedding, DashScopeMultimodalEmbedding
+from nexent.core.models.embedding_model import (
+    DashScopeMultimodalEmbedding,
+    JinaEmbedding,
+    OpenAICompatibleEmbedding,
+    SiliconflowMultimodalEmbedding,
+)
 
 class DummyResponse:
     def __init__(self, status_code=200, json_data=None):
@@ -750,6 +755,7 @@ def test_dashscope_init_sets_attributes(dashscope_embedding_instance):
     assert emb.model == "text-embedding-vision"
     assert emb.embedding_dim == 1024
     assert emb.ssl_verify is True
+    assert emb.model_type == "multimodal"
     assert "Authorization" in emb.headers
 
 
@@ -759,6 +765,17 @@ def test_dashscope_prepare_multimodal_input_formats_correctly(dashscope_embeddin
     result = dashscope_embedding_instance._prepare_multimodal_input(inputs)
     assert result["model"] == "text-embedding-vision"
     assert result["input"]["contents"] == inputs
+
+
+def test_siliconflow_init_sets_multimodal_model_type():
+    """Siliconflow multimodal clients must declare the indexing model type."""
+    embedding = SiliconflowMultimodalEmbedding(
+        api_key="dummy-key",
+        base_url="https://api.siliconflow.cn/v1/embeddings",
+        model_name="Qwen/Qwen3-VL-Embedding-8B",
+    )
+
+    assert embedding.model_type == "multimodal"
 
 
 def test_dashscope_get_embeddings_with_string_input(dashscope_embedding_instance):

--- a/test/sdk/vector_database/test_elasticsearch_core.py
+++ b/test/sdk/vector_database/test_elasticsearch_core.py
@@ -844,7 +844,7 @@ def test_vectorize_documents_small_batch(elasticsearch_core_instance):
 def test_vectorize_documents_multimodal_sets_multi_embedding(elasticsearch_core_instance):
     embedding_model = MagicMock()
     embedding_model.model_type = "multimodal"
-    embedding_model.get_multimodal_embeddings.return_value = [[0.1, 0.2], [0.3, 0.4]]
+    embedding_model.get_multimodal_embeddings.return_value = [[0, 1], [0.3, 0.4]]
 
     documents = [
         {
@@ -879,6 +879,8 @@ def test_vectorize_documents_multimodal_sets_multi_embedding(elasticsearch_core_
         text_doc = next(doc for doc in doc_entries if doc["process_source"] != "UniversalImageExtractor")
         assert "multi_embedding" in image_doc
         assert "embedding" in text_doc
+        assert image_doc["multi_embedding"] == [0.3, 0.4]
+        assert all(isinstance(value, float) for value in text_doc["embedding"])
 
 
 def test_vectorize_documents_text_embedding_skips_images(elasticsearch_core_instance):

--- a/test/sdk/vector_database/test_elasticsearch_core.py
+++ b/test/sdk/vector_database/test_elasticsearch_core.py
@@ -2060,3 +2060,293 @@ class TestAdditionalElasticsearchCoreCoverage:
             mock_msearch.return_value = {"responses": []}
             assert elasticsearch_core_instance.multi_search([{}], "idx") == {"responses": []}
             mock_msearch.assert_called_once_with(body=[{}], index="idx")
+
+
+class TestElasticsearchCoreAdditionalCoverage:
+    """Additional coverage targets identified via coverage report."""
+
+    def test_apply_bulk_settings_exception_path(self, elasticsearch_core_instance, caplog):
+        """Cover exception path in _apply_bulk_settings (lines 267-268)."""
+        with caplog.at_level("WARNING"):
+            with patch.object(elasticsearch_core_instance.client.indices, "put_settings",
+                              side_effect=RuntimeError("ES error")):
+                elasticsearch_core_instance._apply_bulk_settings("test_index")
+                assert any("Failed to apply bulk settings" in m for m in caplog.messages)
+
+    def test_restore_normal_settings_exception_path(self, elasticsearch_core_instance, caplog):
+        """Cover exception path in _restore_normal_settings (lines 280-281)."""
+        with caplog.at_level("WARNING"):
+            with patch.object(elasticsearch_core_instance.client.indices, "put_settings",
+                              side_effect=RuntimeError("ES error")):
+                elasticsearch_core_instance._restore_normal_settings("test_index")
+                assert any("Failed to restore settings" in m for m in caplog.messages)
+
+    def test_small_batch_insert_skipped_when_no_docs(self, elasticsearch_core_instance, caplog):
+        """Cover the empty docs path in _small_batch_insert (lines 419-421)."""
+        mock_emb = MagicMock()
+        mock_emb.model_type = "text"
+        with caplog.at_level("INFO"):
+            with patch("time.strftime", lambda *a, **k: "2025-01-15T10:30:00"), \
+                 patch("time.time", lambda: 1642234567):
+                result = elasticsearch_core_instance._small_batch_insert(
+                    "idx", [], "content", mock_emb
+                )
+        assert result == 0
+        assert any("Small batch insert skipped" in m for m in caplog.messages)
+
+    def test_normalize_embedding_vector_non_list(self, elasticsearch_core_instance):
+        """Cover _normalize_embedding_vector with non-list input (line 476)."""
+        result = elasticsearch_core_instance._normalize_embedding_vector("not a list")
+        assert result == "not a list"
+
+    def test_normalize_embedding_vector_mixed_types(self, elasticsearch_core_instance):
+        """Cover _normalize_embedding_vector with mixed int/float/bool values."""
+        result = elasticsearch_core_instance._normalize_embedding_vector(
+            [1, 2.0, True, "text"]
+        )
+        assert result == [1.0, 2.0, True, "text"]
+
+    def test_prepare_small_batch_embeddings_non_multimodal(
+        self, elasticsearch_core_instance
+    ):
+        """Cover _prepare_small_batch_embeddings non-multimodal path."""
+        mock_emb = MagicMock()
+        mock_emb.model_type = "text"
+        mock_emb.get_embeddings.return_value = [[0.1] * 4]
+
+        docs = [{"content": "hello", "process_source": "CustomProc"}]
+        processed, embeddings = elasticsearch_core_instance._prepare_small_batch_embeddings(
+            docs, "content", mock_emb
+        )
+        assert embeddings == [[0.1] * 4]
+        mock_emb.get_embeddings.assert_called_once_with(["hello"])
+
+    def test_prepare_small_batch_embeddings_non_multimodal_filters_images(
+        self, elasticsearch_core_instance
+    ):
+        """Cover _prepare_small_batch_embeddings filtering out UniversalImageExtractor docs."""
+        mock_emb = MagicMock()
+        mock_emb.model_type = "text"
+        mock_emb.get_embeddings.return_value = [[0.1]]
+
+        docs = [
+            {"content": "text doc", "process_source": "Unstructured"},
+            {"content": "skip this", "process_source": "UniversalImageExtractor", "image_bytes": b"x"},
+        ]
+        processed, embeddings = elasticsearch_core_instance._prepare_small_batch_embeddings(
+            docs, "content", mock_emb
+        )
+        assert len(processed) == 1
+        assert processed[0]["content"] == "text doc"
+        mock_emb.get_embeddings.assert_called_once_with(["text doc"])
+
+    def test_build_bulk_operations_normalizes_embedding(self, elasticsearch_core_instance):
+        """Cover _build_bulk_operations (lines 604-606) with int embedding values."""
+        mock_emb = MagicMock()
+        mock_emb.embedding_model_name = "test-model"
+        docs = [{"content": "test"}]
+        ops = elasticsearch_core_instance._build_bulk_operations(
+            "idx", docs, [[1, 2, 3]], mock_emb
+        )
+        # All int values should be converted to float
+        assert ops[1]["embedding"] == [1.0, 2.0, 3.0]
+        assert "embedding_model_name" in ops[1]
+
+    def test_build_bulk_operations_multi_embedding(self, elasticsearch_core_instance):
+        """Cover _build_bulk_operations using multi_embedding for image docs."""
+        mock_emb = MagicMock()
+        mock_emb.embedding_model_name = "test-model"
+        docs = [{"content": "img", "process_source": "UniversalImageExtractor"}]
+        ops = elasticsearch_core_instance._build_bulk_operations(
+            "idx", docs, [[0.1, 0.2]], mock_emb
+        )
+        assert "multi_embedding" in ops[1]
+        assert "embedding" not in ops[1]
+
+    def test_large_batch_insert_progress_callback_loop(
+        self, elasticsearch_core_instance
+    ):
+        """Cover progress callback invocation inside _large_batch_insert (lines 628-631)."""
+        mock_emb = MagicMock()
+        mock_emb.model_type = "text"
+        mock_emb.embedding_model_name = "m"
+        mock_emb.get_embeddings.return_value = [[0.1], [0.2]]
+
+        docs = [{"content": "a"}, {"content": "b"}]
+        progress_calls = []
+
+        def track(done, total):
+            progress_calls.append((done, total))
+
+        with patch.object(elasticsearch_core_instance.client, "bulk") as mock_bulk, \
+             patch.object(elasticsearch_core_instance, "_force_refresh_with_retry", return_value=True):
+            mock_bulk.return_value = {"errors": False, "items": []}
+            elasticsearch_core_instance._large_batch_insert(
+                "idx", docs, batch_size=2, content_field="content",
+                embedding_model=mock_emb, embedding_batch_size=2,
+                progress_callback=track
+            )
+        assert progress_calls == [(2, 2)]
+
+    def test_accurate_search_with_dict_filter(self, elasticsearch_core_instance):
+        """Cover accurate_search with filter parameter (lines 1034-1041)."""
+        with patch.object(elasticsearch_core_instance, "exec_query") as mock_exec, \
+             patch.object(elasticsearch_core_module, "calculate_term_weights", return_value={}), \
+             patch.object(elasticsearch_core_module, "build_weighted_query",
+                          return_value={"query": {"match": {"content": "q"}}}):
+            mock_exec.return_value = []
+            result = elasticsearch_core_instance.accurate_search(
+                ["idx"],
+                "q",
+                top_k=5,
+                filter={"term": {"path_or_url": "/a/b.pdf"}}
+            )
+            mock_exec.assert_called_once()
+            _, query = mock_exec.call_args[0]
+            assert "bool" in query["query"]
+            assert query["query"]["bool"]["filter"] == [{"term": {"path_or_url": "/a/b.pdf"}}]
+
+    def test_accurate_search_with_list_filter(self, elasticsearch_core_instance):
+        """Cover accurate_search with filter as list."""
+        with patch.object(elasticsearch_core_instance, "exec_query") as mock_exec, \
+             patch.object(elasticsearch_core_module, "calculate_term_weights", return_value={}), \
+             patch.object(elasticsearch_core_module, "build_weighted_query",
+                          return_value={"query": {"match": {"content": "q"}}}):
+            mock_exec.return_value = []
+            elasticsearch_core_instance.accurate_search(
+                ["idx"], "q", top_k=5, filter=[{"term": {"a": 1}}, {"term": {"b": 2}}]
+            )
+            _, query = mock_exec.call_args[0]
+            assert query["query"]["bool"]["filter"] == [{"term": {"a": 1}}, {"term": {"b": 2}}]
+
+    def test_semantic_search_with_dict_filter(self, elasticsearch_core_instance):
+        """Cover semantic_search with dict filter (lines 1092-1093 knn_filter branch)."""
+        mock_emb = MagicMock()
+        mock_emb.model_type = "text"
+        mock_emb.get_embeddings.return_value = [[0.1] * 8]
+        with patch.object(elasticsearch_core_instance, "exec_query") as mock_exec:
+            mock_exec.return_value = []
+            elasticsearch_core_instance.semantic_search(
+                ["idx"], "q", mock_emb, top_k=5,
+                filter={"term": {"path_or_url": "/x.pdf"}}
+            )
+            _, query = mock_exec.call_args[0]
+            assert query["knn"]["filter"] == {"term": {"path_or_url": "/x.pdf"}}
+
+    def test_semantic_search_multimodal_combines_results(self, elasticsearch_core_instance):
+        """Cover semantic_search multimodal branch (lines 1093-1116)."""
+        mock_emb = MagicMock()
+        mock_emb.model_type = "multimodal"
+        mock_emb.get_embeddings.return_value = [[0.1] * 8]
+        with patch.object(elasticsearch_core_instance, "exec_query") as mock_exec:
+            mock_exec.side_effect = [
+                [{"score": 0.9, "document": {"content": "text"}, "index": "idx"}],
+                [{"score": 0.8, "document": {"content": "image"}, "index": "idx"}],
+            ]
+            result = elasticsearch_core_instance.semantic_search(
+                ["idx"], "q", mock_emb, top_k=5
+            )
+            assert len(result) == 2
+            assert mock_exec.call_count == 2
+
+    def test_hybrid_search_multimodal_text_and_image_results(
+        self, elasticsearch_core_instance
+    ):
+        """Cover hybrid_search multimodal scoring paths (lines 1225, 1242-1258)."""
+        mock_emb = MagicMock()
+        mock_emb.model_type = "multimodal"
+        with patch.object(elasticsearch_core_instance, "accurate_search") as mock_acc, \
+             patch.object(elasticsearch_core_instance, "semantic_search") as mock_sem:
+            mock_acc.return_value = [
+                {"score": 10.0, "document": {"id": "doc1", "content": "t", "process_source": "Unstructured"}, "index": "idx"}
+            ]
+            mock_sem.return_value = [
+                {"score": 0.9, "document": {"id": "doc1", "content": "t", "process_source": "Unstructured"}, "index": "idx"},
+                {"score": 0.8, "document": {"id": "doc2", "content": "i", "process_source": "UniversalImageExtractor"}, "index": "idx"},
+            ]
+            result = elasticsearch_core_instance.hybrid_search(
+                ["idx"], "q", mock_emb, top_k=5, weight_accurate=0.3
+            )
+            assert len(result) == 2
+            doc_ids = [r["document"]["id"] for r in result]
+            assert "doc1" in doc_ids
+            assert "doc2" in doc_ids
+
+    def test_get_documents_detail_success(self, elasticsearch_core_instance):
+        """Cover get_documents_detail success path (lines 1275-1310)."""
+        elasticsearch_core_instance.client = MagicMock()
+        elasticsearch_core_instance.client.search.return_value = {
+            "aggregations": {
+                "unique_sources": {
+                    "buckets": [
+                        {
+                            "doc_count": 5,
+                            "file_sample": {
+                                "hits": {
+                                    "hits": [{
+                                        "_source": {
+                                            "path_or_url": "/a.pdf",
+                                            "filename": "a.pdf",
+                                            "file_size": 1024,
+                                            "create_time": "2025-01-01T00:00:00",
+                                        }
+                                    }]
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+        result = elasticsearch_core_instance.get_documents_detail("idx")
+        assert len(result) == 1
+        assert result[0]["path_or_url"] == "/a.pdf"
+        assert result[0]["chunk_count"] == 5
+
+    def test_get_documents_detail_error_returns_empty(self, elasticsearch_core_instance, caplog):
+        """Cover get_documents_detail exception path."""
+        elasticsearch_core_instance.client = MagicMock()
+        elasticsearch_core_instance.client.search.side_effect = RuntimeError("boom")
+        result = elasticsearch_core_instance.get_documents_detail("idx")
+        assert result == []
+        assert any("Error getting file list" in m for m in caplog.messages)
+
+    def test_get_indices_detail_success(self, elasticsearch_core_instance):
+        """Cover get_indices_detail success path (lines 1311-1375)."""
+        elasticsearch_core_instance.client = MagicMock()
+        elasticsearch_core_instance.client.indices.stats.return_value = {
+            "indices": {
+                "idx": {
+                    "primaries": {
+                        "docs": {"count": 100},
+                        "store": {"size_in_bytes": 2048},
+                        "search": {"query_total": 50},
+                        "request_cache": {"hit_count": 10},
+                    }
+                }
+            }
+        }
+        elasticsearch_core_instance.client.indices.get_settings.return_value = {
+            "idx": {"settings": {"index": {"creation_date": "1642234567000"}}}
+        }
+        elasticsearch_core_instance.client.search.return_value = {
+            "aggregations": {
+                "unique_path_or_url_count": {"value": 10},
+                "process_sources": {"buckets": [{"key": "Unstructured"}]},
+                "embedding_models": {"buckets": [{"key": "jina-clip-v2"}]},
+            }
+        }
+        result = elasticsearch_core_instance.get_indices_detail(["idx"], embedding_dim=1024)
+        assert "idx" in result
+        info = result["idx"]["base_info"]
+        assert info["doc_count"] == 10
+        assert info["chunk_count"] == 100
+        assert info["embedding_model"] == "jina-clip-v2"
+
+    def test_get_indices_detail_error_returns_error_entry(self, elasticsearch_core_instance):
+        """Cover get_indices_detail exception path."""
+        elasticsearch_core_instance.client = MagicMock()
+        elasticsearch_core_instance.client.indices.stats.side_effect = RuntimeError("boom")
+        result = elasticsearch_core_instance.get_indices_detail(["idx"])
+        assert "idx" in result
+        assert "error" in result["idx"]


### PR DESCRIPTION
🐛 Bugfix: Multimodal embedding models cannot add 
🐛 Bugfix: Multimodal embedding models from Siliconflow and Dashscope cannot deal with files with images in knowledge base

# Test Sceenshot
## Jina Embedding (jina-clip-v2)
<img width="586" height="1014" alt="image" src="https://github.com/user-attachments/assets/9c1c23ad-1bc2-4581-8f78-542bd487d29d" />
<img width="2073" height="286" alt="image" src="https://github.com/user-attachments/assets/7095b3b7-f3ff-4cb9-8469-be89ef7e988d" />

## Dashscope (qwen3-vl-embedding)
<img width="580" height="1015" alt="image" src="https://github.com/user-attachments/assets/f78ad19f-cfae-41ec-b2be-c2ef32819b56" />
<img width="2077" height="263" alt="image" src="https://github.com/user-attachments/assets/ccb48947-d8f7-4656-892b-8e1377149928" />

## Siliconflow (Qwen/Qwen3-VL-Embedding-8B)
<img width="576" height="1009" alt="image" src="https://github.com/user-attachments/assets/a64dac90-317d-4c75-b0a0-d082a944d3ef" />
<img width="2134" height="251" alt="image" src="https://github.com/user-attachments/assets/029e3f6f-0282-44b5-a143-e9cd97d0f768" />
