### PR TITLE
🐛 Bugfix: Simplify agent listing and revert Celery inspect caching

### DIFF
--- a/backend/apps/agent_app.py
+++ b/backend/apps/agent_app.py
@@ -355,18 +355,22 @@ async def list_all_agent_info_api(
     list all agent info
     """
     try:
-        user_id, tenant_id, _ = get_current_user_info(
+        user_id, auth_tenant_id, _ = get_current_user_info(
             authorization, request)
 
-        agent_list = await list_all_agent_info_impl(
+        if tenant_id is None:
+            agent_list = await list_all_agent_info_impl(
+                tenant_id=auth_tenant_id, user_id=user_id
+            )
+            if auth_tenant_id != ASSET_OWNER_TENANT_ID:
+                asset_agent_list = await list_all_agent_info_impl(
+                    tenant_id=ASSET_OWNER_TENANT_ID, user_id=user_id
+                )
+                return agent_list + asset_agent_list
+            return agent_list
+        return await list_all_agent_info_impl(
             tenant_id=tenant_id, user_id=user_id
         )
-        if tenant_id != ASSET_OWNER_TENANT_ID:
-            asset_agent_list = await list_all_agent_info_impl(
-                tenant_id=ASSET_OWNER_TENANT_ID, user_id=user_id
-            )
-            return agent_list + asset_agent_list
-        return agent_list
     except Exception as e:
         logger.error(f"Agent list error: {str(e)}")
         raise HTTPException(

--- a/backend/services/data_process_service.py
+++ b/backend/services/data_process_service.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import concurrent.futures
 import io
 import logging
 import os
@@ -55,20 +56,8 @@ class DataProcessService:
         self._inspector_last_time = 0
         # 5 minutes - inspector is expensive to create (ping all workers)
         self._inspector_ttl = 300
+        self._inspector_lock = None
         self._inspector_lock = threading.Lock()
-
-        # Cache Celery inspect(active/reserved) results to avoid pidbox storms
-        # when knowledge-base upload polling hits get_all_tasks repeatedly
-        # (especially during long-running large-file processing).
-        self._inspect_result_cache = None
-        self._inspect_result_cache_time = 0.0
-        # Slightly below typical frontend document poll interval (~3s)
-        self._inspect_result_cache_ttl = 2.5
-        # Short timeouts cause late pidbox replies: "*.reply.celery.pidbox: No consumers"
-        self._inspect_timeout = 2.0
-        self._inspect_warn_threshold = 2.5
-        # Serialize concurrent inspect calls from overlapping status polls
-        self._inspect_async_lock = asyncio.Lock()
 
     def _init_redis_client(self):
         """Initializes the Redis client and connection pool."""
@@ -116,24 +105,19 @@ class DataProcessService:
         """Stop the data processing service"""
         logger.info("Data processing service stopped")
 
-    def _ensure_celery_broker_configured(self) -> None:
-        """Ensure Celery broker/backend URLs are set before control/inspect calls."""
-        if not celery_app.conf.broker_url or not celery_app.conf.result_backend:
-            celery_app.conf.broker_url = REDIS_URL
-            celery_app.conf.result_backend = REDIS_BACKEND_URL
-            logger.warning(
-                f"Celery broker URL is not configured properly, reconfiguring to {celery_app.conf.broker_url}")
-
     def _get_celery_inspector(self):
         """Get Celery inspector (cached for performance)"""
         with self._inspector_lock:
             now = time.time()
             if self._inspector and now - self._inspector_last_time < self._inspector_ttl:
                 return self._inspector
-            self._ensure_celery_broker_configured()
+            if not celery_app.conf.broker_url or not celery_app.conf.result_backend:
+                celery_app.conf.broker_url = REDIS_URL
+                celery_app.conf.result_backend = REDIS_BACKEND_URL
+                logger.warning(
+                    f"Celery broker URL is not configured properly, reconfiguring to {celery_app.conf.broker_url}")
             try:
-                # Prefer a longer timeout so busy workers can still reply via pidbox.
-                inspector = celery_app.control.inspect(timeout=self._inspect_timeout)
+                inspector = celery_app.control.inspect()
                 self._inspector = inspector
                 self._inspector_last_time = now
                 self._inspector_init_time = now
@@ -142,89 +126,6 @@ class DataProcessService:
                 self._inspector = None
                 raise Exception(
                     f"Failed to create inspector with celery_app: {str(e)}")
-
-    def _inspect_active_and_reserved_sync(self):
-        """Synchronously inspect active/reserved tasks with one control client.
-
-        Important:
-        - Do NOT call inspect() in parallel (active + reserved at once). That opens
-          multiple temporary *.reply.celery.pidbox queues and frequently logs
-          "No consumers" when workers reply after the client already timed out.
-        - Prefer one inspector instance and call active()/reserved() sequentially.
-        """
-        self._ensure_celery_broker_configured()
-        inspector = celery_app.control.inspect(timeout=self._inspect_timeout)
-        active = inspector.active() or {}
-        reserved = inspector.reserved() or {}
-        if not isinstance(active, dict):
-            active = {}
-        if not isinstance(reserved, dict):
-            reserved = {}
-        return active, reserved
-
-    async def _get_active_and_reserved_tasks(self):
-        """Return (active_dict, reserved_dict) with short-lived cache + Redis-safe fallback.
-
-        Temporary mitigation for pidbox noise during knowledge-base file status polling.
-        Cached results reduce control-channel pressure while large files keep workers busy.
-        """
-        # Fast path: serve fresh cache without waiting on the inspect lock.
-        now = time.time()
-        with self._inspector_lock:
-            cached = self._inspect_result_cache
-            cache_age = now - self._inspect_result_cache_time
-            if cached is not None and cache_age < self._inspect_result_cache_ttl:
-                logger.debug(
-                    f"[get_all_tasks] Using cached inspect result (age={cache_age:.3f}s)")
-                return cached
-
-        async with self._inspect_async_lock:
-            # Re-check cache after acquiring lock: another coroutine may have filled it.
-            now = time.time()
-            with self._inspector_lock:
-                cached = self._inspect_result_cache
-                cache_age = now - self._inspect_result_cache_time
-                if cached is not None and cache_age < self._inspect_result_cache_ttl:
-                    logger.debug(
-                        f"[get_all_tasks] Using cached inspect result after wait "
-                        f"(age={cache_age:.3f}s)")
-                    return cached
-
-            celery_start = time.time()
-            try:
-                loop = asyncio.get_running_loop()
-                active_tasks_dict, reserved_tasks_dict = await loop.run_in_executor(
-                    None, self._inspect_active_and_reserved_sync
-                )
-            except Exception as exc:
-                logger.warning(
-                    f"[get_all_tasks] Inspector failed, fallback to Redis only: {exc}")
-                # Keep serving Redis-backed tasks; empty inspect maps are acceptable.
-                active_tasks_dict, reserved_tasks_dict = {}, {}
-                # Cache empty failure briefly to avoid inspect storms under outage.
-                with self._inspector_lock:
-                    self._inspect_result_cache = (active_tasks_dict, reserved_tasks_dict)
-                    self._inspect_result_cache_time = time.time()
-                return active_tasks_dict, reserved_tasks_dict
-
-            celery_duration = time.time() - celery_start
-            active_count = sum(len(v or []) for v in active_tasks_dict.values())
-            reserved_count = sum(len(v or []) for v in reserved_tasks_dict.values())
-            logger.info(
-                f"[get_all_tasks] inspector.active()+reserved() took {celery_duration:.3f}s "
-                f"(active={active_count}, reserved={reserved_count}, timeout={self._inspect_timeout}s)"
-            )
-            if celery_duration > self._inspect_warn_threshold:
-                logger.warning(
-                    f"[get_all_tasks] Inspector took {celery_duration:.3f}s "
-                    f"(expected <{self._inspect_warn_threshold}s); "
-                    f"busy workers may still emit late pidbox replies"
-                )
-
-            with self._inspector_lock:
-                self._inspect_result_cache = (active_tasks_dict, reserved_tasks_dict)
-                self._inspect_result_cache_time = time.time()
-            return active_tasks_dict, reserved_tasks_dict
 
     async def get_task(self, task_id: str) -> Optional[Dict[str, Any]]:
         """Get task by ID (async)"""
@@ -241,6 +142,11 @@ class DataProcessService:
         """
         all_tasks = []
         try:
+            start_time = time.time()
+            inspector_start = time.time()
+            inspector = self._get_celery_inspector()
+            inspector_duration = time.time() - inspector_start
+
             # Collect task IDs from different sources and keep runtime metadata
             task_ids = set()
             runtime_task_meta: Dict[str, Dict[str, Any]] = {}
@@ -265,8 +171,44 @@ class DataProcessService:
                     'original_filename': kwargs.get('original_filename', ''),
                 }
 
-            # Best-effort Celery runtime view; Redis remains the durable source.
-            active_tasks_dict, reserved_tasks_dict = await self._get_active_and_reserved_tasks()
+            celery_start = time.time()
+
+            # Use short timeout for inspector since workers can respond in ~0.1s
+            # Default 1s timeout is unnecessary and causes delay
+            short_timeout = 0.2
+
+            def get_active():
+                t = time.time()
+                # Create fresh inspector with short timeout for each call
+                short_inspector = celery_app.control.inspect(
+                    timeout=short_timeout)
+                result = short_inspector.active()
+                elapsed = time.time() - t
+                logger.info(
+                    f"[get_all_tasks] inspector.active() took {elapsed:.3f}s")
+                return result if result else {}
+
+            def get_reserved():
+                t = time.time()
+                short_inspector = celery_app.control.inspect(
+                    timeout=short_timeout)
+                result = short_inspector.reserved()
+                elapsed = time.time() - t
+                logger.info(
+                    f"[get_all_tasks] inspector.reserved() took {elapsed:.3f}s")
+                return result if result else {}
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                future_active = executor.submit(get_active)
+                future_reserved = executor.submit(get_reserved)
+                active_tasks_dict = future_active.result(
+                    timeout=short_timeout + 0.5)
+                reserved_tasks_dict = future_reserved.result(
+                    timeout=short_timeout + 0.5)
+            celery_duration = time.time() - celery_start
+            if celery_duration > 0.5:
+                logger.warning(
+                    f"[get_all_tasks] Inspector took {celery_duration:.3f}s (expected <0.5s)")
             if active_tasks_dict:
                 for worker, tasks in active_tasks_dict.items():
                     for task in tasks:

--- a/frontend/app/[locale]/agents/components/AgentSelectorHeader.tsx
+++ b/frontend/app/[locale]/agents/components/AgentSelectorHeader.tsx
@@ -33,7 +33,6 @@ import { useAgentList } from "@/hooks/agent/useAgentList";
 import { useAgentVersionList } from "@/hooks/agent/useAgentVersionList";
 import { useAgentVersionDetail } from "@/hooks/agent/useAgentVersionDetail";
 import { useAgentInfo } from "@/hooks/agent/useAgentInfo";
-import { useAuthorizationContext } from "@/components/providers/AuthorizationProvider";
 
 interface AgentSelectorHeaderProps {
   onOpenVersionManage: () => void;
@@ -57,10 +56,9 @@ export default function AgentSelectorHeader({
   const checkUnsavedChanges = useSaveGuard();
   const confirm = useConfirmModal();
   const { token } = theme?.useToken?.() || {};
-  const { user } = useAuthorizationContext();
 
-  // Fetch agent list internally
-  const { agents } = useAgentList(user?.tenantId ?? null);
+  // Resolve tenant from auth (matches AgentManageComp / published_list; keeps ASSET_OWNER merge)
+  const { agents } = useAgentList("");
 
   // Store state
   const currentAgentId = useAgentConfigStore((state) => state.currentAgentId);

--- a/test/backend/app/test_agent_app.py
+++ b/test/backend/app/test_agent_app.py
@@ -1023,11 +1023,9 @@ def test_list_all_agent_info_api_with_explicit_tenant_id(mocker, mock_auth_heade
     )
 
     assert response.status_code == 200
-    assert mock_list_all_agent.call_count == 2
-    mock_list_all_agent.assert_any_call(
-        tenant_id="auth_tenant", user_id="test_user")
-    mock_list_all_agent.assert_any_call(
-        tenant_id=ASSET_OWNER_TENANT_ID, user_id="test_user")
+    mock_list_all_agent.assert_called_once_with(
+        tenant_id=explicit_tenant_id, user_id="test_user")
+    assert response.json() == [{"agent_id": 3, "name": "Agent 3"}]
 
 
 def test_list_all_agent_info_api_asset_owner_tenant_single_query(mocker, mock_auth_header):
@@ -1088,12 +1086,9 @@ def test_list_all_agent_info_api_exception_with_explicit_tenant_id(mocker, mock_
     assert response.status_code == 500
     mock_get_user_info.assert_called_once_with(
         mock_auth_header["Authorization"], ANY)
-    # list_all_agent_info_impl is expected to be called twice:
-    # - once for explicit tenant_id
-    # - once for asset owner tenant_id
-    assert mock_list_all_agent.call_count == 1
-    mock_list_all_agent.assert_any_call(
-        tenant_id="auth_tenant", user_id="test_user")
+    # With explicit tenant_id, list_all_agent_info_impl is called once (no ASSET_OWNER merge)
+    mock_list_all_agent.assert_called_once_with(
+        tenant_id=explicit_tenant_id, user_id="test_user")
     assert "Agent list error" in response.json()["detail"]
 
 

--- a/test/backend/services/test_data_process_service.py
+++ b/test/backend/services/test_data_process_service.py
@@ -576,11 +576,11 @@ class TestDataProcessService(unittest.TestCase):
         """
         asyncio.run(self.async_test_get_task())
 
-    @patch('backend.services.data_process_service.DataProcessService._get_active_and_reserved_tasks')
+    @patch('backend.services.data_process_service.celery_app')
     @patch('backend.services.data_process_service.get_task_info')
     @patch('backend.services.data_process_service.get_all_task_ids_from_redis')
     @pytest.mark.asyncio
-    async def async_test_get_all_tasks(self, mock_get_redis_task_ids, mock_get_task_info, mock_get_active):
+    async def async_test_get_all_tasks(self, mock_get_redis_task_ids, mock_get_task_info, mock_celery_app):
         """
         Async implementation of get_all_tasks testing.
 
@@ -592,11 +592,17 @@ class TestDataProcessService(unittest.TestCase):
         4. Tasks can be filtered based on their properties
         5. The combined task list is returned with all task details
         """
-        # Setup mocks
-        mock_get_active.return_value = (
-            {'worker1': [{'id': 'task1'}, {'id': 'task2'}]},
-            {'worker1': [{'id': 'task3'}]},
-        )
+        # Setup mocks — get_all_tasks creates short-timeout inspectors via celery_app
+        mock_inspector = MagicMock()
+        mock_inspector.active.return_value = {
+            'worker1': [{'id': 'task1'}, {'id': 'task2'}]
+        }
+        mock_inspector.reserved.return_value = {
+            'worker1': [{'id': 'task3'}]
+        }
+        mock_celery_app.control.inspect.return_value = mock_inspector
+        mock_celery_app.conf.broker_url = "redis://mock:6379/0"
+        mock_celery_app.conf.result_backend = "redis://mock:6379/0"
 
         mock_get_redis_task_ids.return_value = ['task2', 'task4', 'task5']
 
@@ -635,11 +641,11 @@ class TestDataProcessService(unittest.TestCase):
         """
         asyncio.run(self.async_test_get_all_tasks())
 
-    @patch('backend.services.data_process_service.DataProcessService._get_active_and_reserved_tasks')
+    @patch('backend.services.data_process_service.celery_app')
     @patch('backend.services.data_process_service.get_task_info')
     @patch('backend.services.data_process_service.get_all_task_ids_from_redis')
     @pytest.mark.asyncio
-    async def test_get_all_tasks_redis_error(self, mock_get_redis_task_ids, mock_get_task_info, mock_get_active):
+    async def test_get_all_tasks_redis_error(self, mock_get_redis_task_ids, mock_get_task_info, mock_celery_app):
         """
         Test get_all_tasks when Redis query fails.
 
@@ -647,10 +653,16 @@ class TestDataProcessService(unittest.TestCase):
         and continues to process tasks from other sources.
         """
         # Setup mocks
-        mock_get_active.return_value = (
-            {'worker1': [{'id': 'task1'}, {'id': 'task2'}]},
-            {'worker1': [{'id': 'task3'}]},
-        )
+        mock_inspector = MagicMock()
+        mock_inspector.active.return_value = {
+            'worker1': [{'id': 'task1'}, {'id': 'task2'}]
+        }
+        mock_inspector.reserved.return_value = {
+            'worker1': [{'id': 'task3'}]
+        }
+        mock_celery_app.control.inspect.return_value = mock_inspector
+        mock_celery_app.conf.broker_url = "redis://mock:6379/0"
+        mock_celery_app.conf.result_backend = "redis://mock:6379/0"
 
         # Mock Redis to raise an exception
         mock_get_redis_task_ids.side_effect = Exception(
@@ -2428,161 +2440,48 @@ class TestDataProcessService(unittest.TestCase):
                 )
             )
 
+    @patch('backend.services.data_process_service.celery_app')
     @patch('backend.services.data_process_service.get_all_task_ids_from_redis', return_value=[])
     @patch('backend.services.data_process_service.get_task_info')
-    def test_get_all_tasks_handles_string_kwargs_and_bad_json(self, mock_get_task_info, _mock_ids):
+    def test_get_all_tasks_handles_string_kwargs_and_bad_json(
+        self, mock_get_task_info, _mock_ids, mock_celery_app
+    ):
         """Cover runtime kwargs normalization fallback branches."""
+        mock_inspector = MagicMock()
+        mock_inspector.active.return_value = {
+            "w1": [{
+                "id": "task-1",
+                "name": "data_process.tasks.process",
+                "kwargs": "{bad-json"
+            }]
+        }
+        mock_inspector.reserved.return_value = {
+            "w1": [{
+                "id": "task-2",
+                "name": "data_process.tasks.forward",
+                "kwargs": ["not-a-dict"],
+            }]
+        }
+        mock_celery_app.control.inspect.return_value = mock_inspector
+        mock_celery_app.conf.broker_url = "redis://mock:6379/0"
+        mock_celery_app.conf.result_backend = "redis://mock:6379/0"
+
         async def _run():
-            with patch.object(
-                self.service,
-                '_get_active_and_reserved_tasks',
-                new=AsyncMock(return_value=(
-                    {
-                        "w1": [{
-                            "id": "task-1",
-                            "name": "data_process.tasks.process",
-                            "kwargs": "{bad-json"
-                        }]
-                    },
-                    {
-                        "w1": [{
-                            "id": "task-2",
-                            "name": "data_process.tasks.forward",
-                            "kwargs": ["not-a-dict"],
-                        }]
-                    },
-                )),
-            ):
-                async def _task_info(task_id):
-                    return {
-                        "id": task_id,
-                        "task_name": "",
-                        "index_name": "",
-                        "path_or_url": "",
-                        "original_filename": "",
-                    }
+            async def _task_info(task_id):
+                return {
+                    "id": task_id,
+                    "task_name": "",
+                    "index_name": "",
+                    "path_or_url": "",
+                    "original_filename": "",
+                }
 
-                mock_get_task_info.side_effect = _task_info
-                rows = await self.service.get_all_tasks(filter=False)
-                self.assertEqual(len(rows), 2)
-                by_id = {row["id"]: row for row in rows}
-                self.assertEqual(by_id["task-1"]["task_name"], "process")
-                self.assertEqual(by_id["task-2"]["task_name"], "forward")
-
-        asyncio.run(_run())
-
-    @patch('backend.services.data_process_service.celery_app')
-    def test_inspect_active_and_reserved_sync_normalizes_non_dict(self, mock_celery_app):
-        """Non-dict active/reserved replies are coerced to empty maps."""
-        inspector = MagicMock()
-        inspector.active.return_value = ["not-a-dict"]
-        inspector.reserved.return_value = ["also-not-a-dict"]
-        mock_celery_app.control.inspect.return_value = inspector
-        mock_celery_app.conf.broker_url = "redis://mock"
-        mock_celery_app.conf.result_backend = "redis://mock"
-
-        active, reserved = self.service._inspect_active_and_reserved_sync()
-        self.assertEqual(active, {})
-        self.assertEqual(reserved, {})
-
-    @patch('backend.services.data_process_service.celery_app')
-    def test_inspect_active_and_reserved_sync_returns_dicts(self, mock_celery_app):
-        inspector = MagicMock()
-        inspector.active.return_value = {"w1": [{"id": "a1"}]}
-        inspector.reserved.return_value = {"w1": [{"id": "r1"}]}
-        mock_celery_app.control.inspect.return_value = inspector
-        mock_celery_app.conf.broker_url = "redis://mock"
-        mock_celery_app.conf.result_backend = "redis://mock"
-
-        active, reserved = self.service._inspect_active_and_reserved_sync()
-        self.assertEqual(active, {"w1": [{"id": "a1"}]})
-        self.assertEqual(reserved, {"w1": [{"id": "r1"}]})
-
-    def test_get_active_and_reserved_tasks_uses_fresh_cache(self):
-        async def _run():
-            cached = ({"w": []}, {"w": []})
-            self.service._inspect_result_cache = cached
-            self.service._inspect_result_cache_time = time.time()
-            with patch.object(
-                self.service, '_inspect_active_and_reserved_sync'
-            ) as mock_inspect:
-                result = await self.service._get_active_and_reserved_tasks()
-                self.assertEqual(result, cached)
-                mock_inspect.assert_not_called()
-
-        asyncio.run(_run())
-
-    def test_get_active_and_reserved_tasks_cache_after_lock_wait(self):
-        """Second coroutine should reuse cache filled while waiting on the lock."""
-        async def _run():
-            self.service._inspect_result_cache = None
-            self.service._inspect_result_cache_time = 0.0
-            filled = ({"w": [{"id": "t1"}]}, {})
-
-            real_lock = self.service._inspect_async_lock
-
-            class _LockProxy:
-                def __init__(self):
-                    self.entered = False
-
-                async def __aenter__(self):
-                    # Simulate another coroutine filling the cache before we inspect.
-                    self.entered = True
-                    self.service_ref._inspect_result_cache = filled
-                    self.service_ref._inspect_result_cache_time = time.time()
-                    await real_lock.__aenter__()
-                    return self
-
-                async def __aexit__(self, *args):
-                    return await real_lock.__aexit__(*args)
-
-            proxy = _LockProxy()
-            proxy.service_ref = self.service
-            self.service._inspect_async_lock = proxy
-
-            with patch.object(
-                self.service, '_inspect_active_and_reserved_sync'
-            ) as mock_inspect:
-                result = await self.service._get_active_and_reserved_tasks()
-                self.assertEqual(result, filled)
-                mock_inspect.assert_not_called()
-
-        asyncio.run(_run())
-
-    def test_get_active_and_reserved_tasks_inspector_failure_caches_empty(self):
-        async def _run():
-            self.service._inspect_result_cache = None
-            self.service._inspect_result_cache_time = 0.0
-            with patch.object(
-                self.service,
-                '_inspect_active_and_reserved_sync',
-                side_effect=RuntimeError("pidbox timeout"),
-            ):
-                active, reserved = await self.service._get_active_and_reserved_tasks()
-                self.assertEqual(active, {})
-                self.assertEqual(reserved, {})
-                self.assertEqual(self.service._inspect_result_cache, ({}, {}))
-
-        asyncio.run(_run())
-
-    def test_get_active_and_reserved_tasks_warns_when_slow(self):
-        async def _run():
-            self.service._inspect_result_cache = None
-            self.service._inspect_result_cache_time = 0.0
-            self.service._inspect_warn_threshold = -1.0
-            with patch.object(
-                self.service,
-                '_inspect_active_and_reserved_sync',
-                return_value=({"w": [{"id": "a"}]}, {"w": [{"id": "r"}]}),
-            ), patch('backend.services.data_process_service.logger') as mock_logger:
-                active, reserved = await self.service._get_active_and_reserved_tasks()
-                self.assertIn("w", active)
-                self.assertIn("w", reserved)
-                self.assertTrue(mock_logger.warning.called)
-                self.assertEqual(
-                    self.service._inspect_result_cache,
-                    ({"w": [{"id": "a"}]}, {"w": [{"id": "r"}]}),
-                )
+            mock_get_task_info.side_effect = _task_info
+            rows = await self.service.get_all_tasks(filter=False)
+            self.assertEqual(len(rows), 2)
+            by_id = {row["id"]: row for row in rows}
+            self.assertEqual(by_id["task-1"]["task_name"], "process")
+            self.assertEqual(by_id["task-2"]["task_name"], "forward")
 
         asyncio.run(_run())
 


### PR DESCRIPTION
Fixes #3532
Only merge ASSET_OWNER agents when tenant_id is omitted; AgentSelectorHeader uses auth tenant via empty tenant param. Revert inspect result caching in data process service.