### PR TITLE
🐛 Fix: parallel_executor JSON serialization error

### DIFF
--- a/backend/prompts/utils/prompt_generate_en.yaml
+++ b/backend/prompts/utils/prompt_generate_en.yaml
@@ -42,8 +42,8 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
   2. If the application has available assistants and tools, both calling methods should be reflected.
   3. If the tool list includes parallel_executor and the example needs to call multiple independent assistants or tools at the same time, you can use parallel_executor in the code to demonstrate parallel execution (see Tasks 6, 7, 8 below).
   4. parallel_executor syntax:
-    - 2-tuple (returns list): results = parallel_executor((tool_a, {params}), (tool_b, {params})), access via results[0], results[1]
-    - 3-tuple (returns dict): results = parallel_executor((tool_a, {params}, "name_a"), (tool_b, {params}, "name_b")), access via results["name_a"], results["name_b"]
+    - 2-tuple (returns list): results = parallel_executor(tasks=[(tool_a, {params}), (tool_b, {params})]), access via results[0], results[1]
+    - 3-tuple (returns dict): results = parallel_executor(tasks=[(tool_a, {params}, "name_a"), (tool_b, {params}, "name_b")]), access via results["name_a"], results["name_b"]
     - All return values are plain strings — use print() to read them
     - Optional params: timeout=120 (per-task timeout in seconds), max_workers=4 (max concurrent threads)
   5. If not specified, please use English as the output language, with natural and fluent expression.
@@ -184,8 +184,10 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
   Code:
   <code>
   results = parallel_executor(
-      (web_search, {"query": "Python design patterns"}),
-      (web_search, {"query": "Java design patterns"}),
+      tasks=[
+          (web_search, {"query": "Python design patterns"}),
+          (web_search, {"query": "Java design patterns"}),
+      ],
   )
   print(results[0])  # Python design patterns search results
   print(results[1])  # Java design patterns search results
@@ -203,8 +205,10 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
   Code:
   <code>
   results = parallel_executor(
-      (security_scanner, {"task": "Check for SQL injection and XSS vulnerabilities"}, "security"),
-      (style_checker, {"task": "Check PEP8 compliance and naming conventions"}, "style"),
+      tasks=[
+          (security_scanner, {"task": "Check for SQL injection and XSS vulnerabilities"}, "security"),
+          (style_checker, {"task": "Check PEP8 compliance and naming conventions"}, "style"),
+      ],
   )
   print(results["security"])
   print(results["style"])
@@ -222,8 +226,10 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
   Code:
   <code>
   results = parallel_executor(
-      (web_search, {"query": "AI trends 2024"}),
-      (data_analyst, {"task": "Analyze quarterly trends in the sales CSV file"}),
+      tasks=[
+          (web_search, {"query": "AI trends 2024"}),
+          (data_analyst, {"task": "Analyze quarterly trends in the sales CSV file"}),
+      ],
       timeout=60,
       max_workers=2,
   )

--- a/backend/prompts/utils/prompt_generate_zh.yaml
+++ b/backend/prompts/utils/prompt_generate_zh.yaml
@@ -41,8 +41,8 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
   2.如果该应用有可以使用的助手和工具，则两种调用方式都要体现。
   3.如果工具列表中有 parallel_executor，且示例中需要同时调用多个互不依赖的助手或工具，可以在代码中使用 parallel_executor 来展示并行调用（参考下方任务6、7、8）。
   4.parallel_executor 的具体写法：
-    - 二元组（返回列表）：results = parallel_executor((tool_a, {参数}), (tool_b, {参数}))，用 results[0]、results[1] 按顺序取结果
-    - 三元组（返回字典）：results = parallel_executor((tool_a, {参数}, "名称a"), (tool_b, {参数}, "名称b"))，用 results["名称a"]、results["名称b"] 按名称取结果
+    - 二元组（返回列表）：results = parallel_executor(tasks=[(tool_a, {参数}), (tool_b, {参数})])，用 results[0]、results[1] 按顺序取结果
+    - 三元组（返回字典）：results = parallel_executor(tasks=[(tool_a, {参数}, "名称a"), (tool_b, {参数}, "名称b")])，用 results["名称a"]、results["名称b"] 按名称取结果
     - 所有返回值均为纯字符串，用 print() 打印即可
     - 可选参数：timeout=120（单任务超时秒数）、max_workers=4（最大并发线程数）
   5.若未指定语言，请使用中文输出，语言表达要自然流畅。
@@ -181,8 +181,10 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
   代码：
   <code>
   results = parallel_executor(
-      (web_search, {"query": "Python设计模式"}),
-      (web_search, {"query": "Java设计模式"}),
+      tasks=[
+          (web_search, {"query": "Python设计模式"}),
+          (web_search, {"query": "Java设计模式"}),
+      ],
   )
   print(results[0])  # Python设计模式搜索结果
   print(results[1])  # Java设计模式搜索结果
@@ -200,8 +202,10 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
   代码：
   <code>
   results = parallel_executor(
-      (security_scanner, {"task": "检查SQL注入和XSS漏洞"}, "security"),
-      (style_checker, {"task": "检查PEP8规范和函数命名"}, "style"),
+      tasks=[
+          (security_scanner, {"task": "检查SQL注入和XSS漏洞"}, "security"),
+          (style_checker, {"task": "检查PEP8规范和函数命名"}, "style"),
+      ],
   )
   print(results["security"])
   print(results["style"])
@@ -219,8 +223,10 @@ FEW_SHOTS_SYSTEM_PROMPT: |-
   代码：
   <code>
   results = parallel_executor(
-      (web_search, {"query": "2024年AI发展趋势"}),
-      (data_analyst, {"task": "分析销售数据CSV文件中的季度趋势"}),
+      tasks=[
+          (web_search, {"query": "2024年AI发展趋势"}),
+          (data_analyst, {"task": "分析销售数据CSV文件中的季度趋势"}),
+      ],
       timeout=60,
       max_workers=2,
   )

--- a/sdk/nexent/core/agents/core_agent.py
+++ b/sdk/nexent/core/agents/core_agent.py
@@ -276,19 +276,22 @@ def _screened_tool_forward(engine, tool_name, controller, logger, original_forwa
             kwargs = decision.masked_kwargs
     return original_forward(*args, **kwargs)
 def _coerce_observer_arguments(arguments: Any) -> Any:
-    """Coerce AST/Python-literal arguments into a JSON-serializable payload.
+    """Coerce arguments into a JSON-serializable payload.
 
-    smolagents may pass arguments either as a dict (after Python execution) or
-    as a JSON-encoded string (OpenAI-style). We accept both and emit a JSON-
-    friendly value into the observer so the downstream SSE chunk stays
-    consistent with the shape produced by builtin tools.
+    Recursively walks dicts, lists and tuples, replacing callable objects
+    with their ``name`` attribute so that downstream ``json.dumps`` never
+    encounters a Python function / Tool reference.
     """
     if arguments is None:
         return None
     if isinstance(arguments, (str, int, float, bool)):
         return arguments
-    if isinstance(arguments, (dict, list)):
-        return arguments
+    if callable(arguments):
+        return getattr(arguments, "name", str(arguments))
+    if isinstance(arguments, dict):
+        return {k: _coerce_observer_arguments(v) for k, v in arguments.items()}
+    if isinstance(arguments, (list, tuple)):
+        return type(arguments)(_coerce_observer_arguments(v) for v in arguments)
     return str(arguments)
 
 

--- a/sdk/nexent/core/tools/parallel_executor.py
+++ b/sdk/nexent/core/tools/parallel_executor.py
@@ -45,13 +45,14 @@ class ParallelExecutorTool(Tool):
         "tasks": {
             "type": "array",
             "description": (
-                "Variable number of (callable, kwargs_dict) or "
-                "(callable, kwargs_dict, name) tuples.  "
+                "A list of tasks where each task is a 2-tuple (callable, kwargs_dict) "
+                "or 3-tuple (callable, kwargs_dict, \"name\"). "
                 "kwargs values can be any Python object — just reference "
                 "the variable name, no serialization needed."
             ),
             "description_zh": (
-                "可变数量的 (函数名, 参数字典) 或 (函数名, 参数字典, \"名称\") 元组。"
+                "任务列表，每个任务是一个二元组 (函数名, 参数字典) "
+                "或三元组 (函数名, 参数字典, \"名称\")。"
                 "kwargs 值可以是任意 Python 对象，直接引用变量名即可，无需序列化。"
             ),
         },
@@ -75,29 +76,29 @@ class ParallelExecutorTool(Tool):
     }
     output_type = "any"
 
-    def forward(self, *tasks, timeout: int = 120, max_workers: int = 4):
+    def forward(self, tasks, timeout: int = 120, max_workers: int = 4):
         """Execute the tasks in parallel.
 
-        Each positional argument is a 2-tuple ``(func, kwargs)`` or
-        3-tuple ``(func, kwargs, \"name\")``.
+        ``tasks`` is a list where each element is a 2-tuple ``(func, kwargs)``
+        or 3-tuple ``(func, kwargs, \"name\")``.
 
         Returns a list (all 2-tuples) or dict (all 3-tuples).
         """
-        return _parallel_executor(*tasks, timeout=timeout, max_workers=max_workers)
+        return _parallel_executor(tasks, timeout=timeout, max_workers=max_workers)
 
 
 # ---------------------------------------------------------------------------
 # Internal implementation
 # ---------------------------------------------------------------------------
 
-def _parallel_executor(*tasks, timeout: int = 120, max_workers: int = 4):
+def _validate_tasks(tasks):
+    """Validate task format and return (names, has_names)."""
     if not tasks:
-        return []
+        return [], False
 
     n = len(tasks)
-
-    # ----- detect output mode -----
     has_names = any(len(t) == 3 for t in tasks)
+
     if has_names:
         if not all(len(t) == 3 for t in tasks):
             raise ValueError(
@@ -113,30 +114,33 @@ def _parallel_executor(*tasks, timeout: int = 120, max_workers: int = 4):
             )
         names = [None] * n
 
+    return names, has_names
+
+
+def _execute_tasks(tasks, names, timeout, max_workers):
+    """Submit tasks to a thread pool and collect results."""
+    n = len(tasks)
     results = [None] * n
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
         future_to_idx: Dict[concurrent.futures.Future, int] = {}
         for idx, t in enumerate(tasks):
             func, kwargs = t[0], t[1]
+            label = names[idx] or f"task-{idx}"
             if not isinstance(kwargs, dict):
                 results[idx] = (
-                    f"[{names[idx] or f'task-{idx}'}] Invalid: "
+                    f"[{label}] Invalid: "
                     f"kwargs must be a dict, got {type(kwargs).__name__}"
                 )
                 continue
             if not callable(func):
                 results[idx] = (
-                    f"[{names[idx] or f'task-{idx}'}] Not callable: "
-                    f"{type(func).__name__}"
+                    f"[{label}] Not callable: {type(func).__name__}"
                 )
                 continue
             task_context = contextvars.copy_context()
             future_to_idx[pool.submit(task_context.run, func, **kwargs)] = idx
 
-        # Iterate directly over futures so that per-task timeout is effective.
-        # as_completed would wait for each future to finish before yielding,
-        # which makes future.result(timeout=…) a no-op.
         for future, idx in future_to_idx.items():
             label = names[idx] or f"task-{idx}"
             try:
@@ -147,6 +151,14 @@ def _parallel_executor(*tasks, timeout: int = 120, max_workers: int = 4):
                 import traceback as _tb
                 results[idx] = f"[{label}] Failed: {_tb.format_exc(limit=1)}"
 
+    return results
+
+
+def _parallel_executor(tasks, timeout: int = 120, max_workers: int = 4):
+    names, has_names = _validate_tasks(tasks)
+    if not tasks:
+        return []
+    results = _execute_tasks(tasks, names, timeout, max_workers)
     if has_names:
-        return {names[idx]: results[idx] for idx in range(n)}
+        return {names[idx]: results[idx] for idx in range(len(tasks))}
     return results

--- a/test/sdk/core/agents/test_core_agent.py
+++ b/test/sdk/core/agents/test_core_agent.py
@@ -2831,6 +2831,50 @@ def test_coerce_observer_arguments_stringifies_other_values():
     assert core_agent_module._coerce_observer_arguments(value) == str(value)
 
 
+def test_coerce_observer_arguments_replaces_callable_with_name():
+    """Callable objects are replaced with their ``name`` attribute."""
+    tool = type("FakeTool", (), {"name": "my_tool", "__call__": lambda self: None})()
+
+    assert core_agent_module._coerce_observer_arguments(tool) == "my_tool"
+
+
+def test_coerce_observer_arguments_replaces_callable_inside_nested_structures():
+    """Recursively replace callables inside dict/list/tuple — the
+    parallel_executor use case."""
+    tool_a = type("ToolA", (), {"name": "read_skill_config", "__call__": lambda self: None})()
+    tool_b = type("ToolB", (), {"name": "read_skill_md", "__call__": lambda self: None})()
+
+    # Simulate observed_forward kwargs for parallel_executor
+    kwargs = {
+        "tasks": [
+            (tool_a, {"skill_name": "data_analysis"}),
+            (tool_b, {"skill_name": "data_analysis"}, "readme"),
+        ],
+        "timeout": 30,
+        "max_workers": 2,
+    }
+    result = core_agent_module._coerce_observer_arguments(kwargs)
+
+    # callables replaced by name strings; tuples stay tuples; other values unchanged
+    expected_tasks = [
+        ("read_skill_config", {"skill_name": "data_analysis"}),
+        ("read_skill_md", {"skill_name": "data_analysis"}, "readme"),
+    ]
+    assert result == {"tasks": expected_tasks, "timeout": 30, "max_workers": 2}
+
+    # Verify the result is JSON-serializable (the whole point of the fix)
+    import json
+    json.dumps(result)
+
+
+def test_coerce_observer_arguments_preserves_tuple_type():
+    """Tuple without callables keeps its structure."""
+    value = ("a", "b", {"nested": 1})
+    result = core_agent_module._coerce_observer_arguments(value)
+    assert result == ("a", "b", {"nested": 1})
+    assert isinstance(result, tuple)
+
+
 def test_collect_call_arguments_extracts_literals_expressions_and_kwargs():
     """Extract safe literals and retain source for non-literal expressions."""
     call_node = core_agent_module.ast.parse(

--- a/test/sdk/core/tools/test_parallel_executor.py
+++ b/test/sdk/core/tools/test_parallel_executor.py
@@ -37,19 +37,21 @@ def _read_context(**kwargs):
 
 class TestTwoTupleMode:
     def test_empty_tasks_returns_empty_list(self):
-        result = _parallel_executor()
+        result = _parallel_executor([])
         assert result == []
 
     def test_single_task(self):
-        result = _parallel_executor((_echo, {"key": "value"}))
+        result = _parallel_executor([(_echo, {"key": "value"})])
         assert len(result) == 1
         assert "key" in result[0]
 
     def test_two_independent_tasks_execute_in_parallel(self):
         start = time.perf_counter()
         result = _parallel_executor(
-            (_slow, {"seconds": 0.1}),
-            (_slow, {"seconds": 0.1}),
+            [
+                (_slow, {"seconds": 0.1}),
+                (_slow, {"seconds": 0.1}),
+            ],
             max_workers=2,
         )
         elapsed = time.perf_counter() - start
@@ -62,9 +64,11 @@ class TestTwoTupleMode:
 
     def test_results_preserve_input_order(self):
         result = _parallel_executor(
-            (_echo, {"value": 1}),
-            (_echo, {"value": 2}),
-            (_echo, {"value": 3}),
+            [
+                (_echo, {"value": 1}),
+                (_echo, {"value": 2}),
+                (_echo, {"value": 3}),
+            ],
         )
         assert len(result) == 3
         for i in range(3):
@@ -75,8 +79,10 @@ class TestTwoTupleMode:
         token = context_var.set("call-123")
         try:
             result = _parallel_executor(
-                (_read_context, {"context_var": context_var}),
-                (_read_context, {"context_var": context_var}),
+                [
+                    (_read_context, {"context_var": context_var}),
+                    (_read_context, {"context_var": context_var}),
+                ],
             )
         finally:
             context_var.reset(token)
@@ -91,16 +97,20 @@ class TestTwoTupleMode:
 class TestThreeTupleMode:
     def test_named_tasks_return_dict(self):
         result = _parallel_executor(
-            (_echo, {"v": "a"}, "task_a"),
-            (_echo, {"v": "b"}, "task_b"),
+            [
+                (_echo, {"v": "a"}, "task_a"),
+                (_echo, {"v": "b"}, "task_b"),
+            ],
         )
         assert isinstance(result, dict)
         assert set(result.keys()) == {"task_a", "task_b"}
 
     def test_named_results_accessible_by_name(self):
         result = _parallel_executor(
-            (_echo, {"msg": "hello"}, "greeting"),
-            (_echo, {"msg": "world"}, "subject"),
+            [
+                (_echo, {"msg": "hello"}, "greeting"),
+                (_echo, {"msg": "world"}, "subject"),
+            ],
         )
         assert "hello" in result["greeting"]
         assert "world" in result["subject"]
@@ -114,20 +124,22 @@ class TestErrorHandling:
     def test_mixed_two_and_three_tuples_raises_value_error(self):
         with pytest.raises(ValueError, match="same format"):
             _parallel_executor(
-                (_echo, {"a": 1}),
-                (_echo, {"b": 2}, "named"),
+                [
+                    (_echo, {"a": 1}),
+                    (_echo, {"b": 2}, "named"),
+                ],
             )
 
     def test_non_callable_returns_error_string(self):
-        result = _parallel_executor(("not_a_function", {"x": 1}))
+        result = _parallel_executor([("not_a_function", {"x": 1})])
         assert "Not callable" in result[0]
 
     def test_non_dict_kwargs_returns_error_string(self):
-        result = _parallel_executor((_echo, "not_a_dict"))
+        result = _parallel_executor([(_echo, "not_a_dict")])
         assert "kwargs must be a dict" in result[0]
 
     def test_exception_in_task_is_captured(self):
-        result = _parallel_executor((_raise, {}))
+        result = _parallel_executor([(_raise, {})])
         assert "Failed" in result[0]
 
 
@@ -138,7 +150,7 @@ class TestErrorHandling:
 class TestTimeout:
     def test_timeout_is_captured_as_error_string(self):
         result = _parallel_executor(
-            (_slow, {"seconds": 0.5}),
+            [(_slow, {"seconds": 0.5})],
             timeout=0.1,
         )
         assert "Timed out" in result[0]
@@ -153,9 +165,11 @@ class TestMaxWorkers:
         """With max_workers=1, tasks should run sequentially."""
         start = time.perf_counter()
         result = _parallel_executor(
-            (_slow, {"seconds": 0.05}),
-            (_slow, {"seconds": 0.05}),
-            (_slow, {"seconds": 0.05}),
+            [
+                (_slow, {"seconds": 0.05}),
+                (_slow, {"seconds": 0.05}),
+                (_slow, {"seconds": 0.05}),
+            ],
             max_workers=1,
         )
         elapsed = time.perf_counter() - start
@@ -168,8 +182,10 @@ class TestMaxWorkers:
         """Default max_workers=4 — two tasks should run in parallel."""
         start = time.perf_counter()
         result = _parallel_executor(
-            (_slow, {"seconds": 0.1}),
-            (_slow, {"seconds": 0.1}),
+            [
+                (_slow, {"seconds": 0.1}),
+                (_slow, {"seconds": 0.1}),
+            ],
         )
         elapsed = time.perf_counter() - start
 
@@ -186,8 +202,10 @@ class TestParallelExecutorTool:
         """ParallelExecutorTool.forward should delegate to _parallel_executor."""
         tool = ParallelExecutorTool()
         result = tool.forward(
-            (_echo, {"key": "value"}),
-            (_echo, {"x": 1}),
+            tasks=[
+                (_echo, {"key": "value"}),
+                (_echo, {"x": 1}),
+            ],
         )
         assert len(result) == 2
         assert "key" in result[0]
@@ -202,12 +220,14 @@ class TestWrongTupleLength:
     def test_tuple_of_length_1_raises_value_error(self):
         """A 1-tuple (neither 2 nor 3) raises ValueError."""
         with pytest.raises(ValueError, match="each task must be a 2-tuple"):
-            _parallel_executor((_echo,))
+            _parallel_executor([(_echo,)])
 
     def test_mixed_length_without_3tuple_raises_value_error(self):
         """Providing a 2-tuple and a 4-tuple raises ValueError."""
         with pytest.raises(ValueError, match="each task must be a 2-tuple"):
             _parallel_executor(
-                (_echo, {"a": 1}),
-                (_echo, {"b": 1}, "named", "extra"),
+                [
+                    (_echo, {"a": 1}),
+                    (_echo, {"b": 1}, "named", "extra"),
+                ],
             )


### PR DESCRIPTION
## Summary

  `parallel_executor` fails at runtime with `TypeError: Object of type function is not JSON serializable`, making the
  tool unusable when called by the LLM agent.

  ## Trigger

  When the LLM calls `parallel_executor` as prompted by `to_code_prompt()`:

  ```python
  result = parallel_executor(
      tasks=[
          (read_skill_config, {"skill_name": "data_analysis"}),
          (read_skill_md,     {"skill_name": "data_analysis"}, "readme"),
      ],
      max_workers=2
  )
  ```
  It fails with:

  Code execution failed: TypeError: Object of type function is not JSON serializable
  Agent generation (prompt_generate_*.yaml) produces correct code because it contains hand-written examples that the LLM
  copies verbatim. The runtime agent, however, only sees the auto-generated signature from to_code_prompt(), which
  declares the parameter as tasks: array. The LLM naturally writes tasks=[...], triggering two separate bugs in the call
  chain.

  Root Cause

  Bug 1 —forward signature mismatches inputs schema (parallel_executor.py)

  - inputs["tasks"] declares a named parameter tasks, and to_code_prompt() generates the signature
  parallel_executor(tasks: array, ...) accordingly.
  - But forward(self, *tasks, ...) uses variadic positional *tasks, which does not accept tasks= as a keyword argument.

  Bug 2 —Observer wrapper cannot serialize callables (core_agent.py, introduced in PR #3492)

  - _wrap_tool_for_observer (#3492) wraps every tool's forward() with observed_forward, which passes **kwargs to the
  observer for json.dumps event recording.
  - _coerce_observer_arguments returns dicts and lists as-is without recursing into them to sanitize callable objects.
  - parallel_executor's tasks parameter contains Tool instances (callables), which cannot survive json.dumps.

  The call chain:

  1. parallel_executor(tasks=[(Tool_instance, {...})])
  2. observed_forward(tasks=[(Tool_instance, {...})])
  3. observer.add_message(..., tool_arguments={"tasks": [(Tool_instance, ...)]})
  4. Message.to_json() →json.dumps({"tasks": [(Tool_instance, ...)]})
  5. 💥 TypeError: Object of type function is not JSON serializable
  6. forward() never reached

  Solution

  Align forward signature with inputs schema

  Changed forward(self, *tasks, ...) to forward(self, tasks, ...) so that the LLM's tasks=[...] keyword form is
  accepted. This makes the actual function signature consistent with what to_code_prompt() tells the LLM.

  Make observer arguments recursively JSON-safe

  _coerce_observer_arguments now recursively walks dicts, lists, and tuples, replacing any callable objects with their
  .name attribute. This prevents json.dumps from ever encountering a function reference, fixing the root cause without
  changing the observer's interface or behavior for non-callable arguments.

  Update prompt examples to match

  Agent generation prompts (prompt_generate_zh.yaml, prompt_generate_en.yaml) updated to show tasks=[...] style instead
  of positional args, so generated agent examples are consistent with the runtime calling convention.

  Verification

  22/22 tests passed in 3.01s:
<img width="1313" height="1187" alt="image" src="https://github.com/user-attachments/assets/89645674-058f-4f3e-8373-15207768f15c" />
