### PR TITLE
🐛 Bugfix: Fix the issue where the agent cannot run after the sandbox is enabled.

### DIFF
--- a/sdk/nexent/core/agents/sandbox.py
+++ b/sdk/nexent/core/agents/sandbox.py
@@ -697,8 +697,38 @@ class _DockerKernelLease:
         return RemotePythonExecutor.install_packages(self, additional_imports)
 
     def _patch_final_answer_with_exception(self, final_answer_tool: Any) -> None:
-        from smolagents.remote_executors import RemotePythonExecutor
-        RemotePythonExecutor._patch_final_answer_with_exception(self, final_answer_tool)
+        """Patch final_answer while preserving its class-defined implementation."""
+        import inspect
+
+        instance_forward = final_answer_tool.forward
+        original_forward = getattr(instance_forward, "__func__", None)
+        wrapped_instance_forward = original_forward is None
+        if wrapped_instance_forward:
+            original_forward = getattr(type(final_answer_tool), "forward", None)
+        if not callable(original_forward):
+            raise TypeError("final_answer tool must define a callable forward method")
+
+        class _FinalAnswerTool(final_answer_tool.__class__):
+            pass
+
+        def forward(self, *args, **kwargs) -> Any:
+            import base64
+            import pickle
+
+            class FinalAnswerException(Exception):
+                def __init__(self, value):
+                    self.value = value
+
+            raise FinalAnswerException(base64.b64encode(pickle.dumps(self._forward(*args, **kwargs))).decode())
+
+        _FinalAnswerTool.forward = forward
+        _FinalAnswerTool._forward = original_forward
+        _FinalAnswerTool._forward.__source__ = inspect.getsource(original_forward).replace(
+            "def forward(", "def _forward("
+        )
+        if wrapped_instance_forward:
+            del final_answer_tool.forward
+        final_answer_tool.__class__ = _FinalAnswerTool
 
     def send_tools(self, tools: dict[str, Any]) -> None:
         from smolagents.remote_executors import RemotePythonExecutor

--- a/test/sdk/core/agents/test_sandbox.py
+++ b/test/sdk/core/agents/test_sandbox.py
@@ -2260,7 +2260,6 @@ class TestTargetedSandboxCoverage:
         remote = SimpleNamespace(
             send_variables=MagicMock(),
             install_packages=MagicMock(return_value=["pkg"]),
-            _patch_final_answer_with_exception=MagicMock(),
             send_tools=MagicMock(),
         )
         monkeypatch.setitem(sys.modules, "smolagents.remote_executors", SimpleNamespace(RemotePythonExecutor=remote))
@@ -2268,13 +2267,34 @@ class TestTargetedSandboxCoverage:
 
         lease.send_variables({"x": 1})
         assert lease.install_packages(["pkg"]) == ["pkg"]
-        lease._patch_final_answer_with_exception("final")
         lease.send_tools({"tool": object()})
 
         remote.send_variables.assert_called_once_with(lease, {"x": 1})
         remote.install_packages.assert_called_once_with(lease, ["pkg"])
-        remote._patch_final_answer_with_exception.assert_called_once_with(lease, "final")
         remote.send_tools.assert_called_once()
+
+    @pytest.mark.parametrize("wrap_instance_forward", [False, True])
+    def test_kernel_lease_patches_final_answer_with_bound_or_wrapped_forward(self, wrap_instance_forward):
+        class FinalAnswerTool:
+            def forward(self, answer):
+                return answer
+
+        final_answer = FinalAnswerTool()
+        if wrap_instance_forward:
+            original_forward = final_answer.forward
+
+            def observed_forward(*args, **kwargs):
+                return original_forward(*args, **kwargs)
+
+            final_answer.forward = observed_forward
+
+        lease = object.__new__(sandbox_module._DockerKernelLease)
+        lease._patch_final_answer_with_exception(final_answer)
+
+        assert final_answer._forward("done") == "done"
+        with pytest.raises(Exception) as exc_info:
+            final_answer.forward("done")
+        assert exc_info.value.value
 
     def test_system_non_docker_acquire_builds_and_tracks_executor(self, monkeypatch):
         pool = SandboxPoolManager.get_instance()


### PR DESCRIPTION
🐛 Bugfix: Fix the issue where the agent cannot run after the sandbox is enabled.
[Specification Details]
1. 在 sandbox.py 的 _DockerKernelLease 中实现了兼容补丁：
forward 为绑定方法时，沿用原有处理。
forward 被实例包装为普通函数时，回退到工具类上原始的 forward 实现
2. 添加测试用例。
[Test Result]
<img width="1000" height="1264" alt="976235f7-b633-4a2b-b446-c99ff0284b33" src="https://github.com/user-attachments/assets/10385a47-a4f7-4831-9545-78a5d6c51ac6" />
