### PR TITLE
✨ Feat: Unify JWT_EXPIRY config for custom token TTL

### DIFF
--- a/backend/apps/oauth_app.py
+++ b/backend/apps/oauth_app.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from pydantic import ValidationError as PydanticValidationError
 
+from consts.const import JWT_EXPIRY_SECONDS
 from consts.model import OAuthCompleteRequest
 from consts.exceptions import OAuthLinkError, OAuthProviderError, UnauthorizedError
 from consts.oauth_providers import get_all_provider_definitions
@@ -202,8 +203,10 @@ async def callback(
             username=username,
         )
 
-        expiry_seconds = 3600
-        jwt_token = generate_session_jwt(supabase_user_id, expires_in=expiry_seconds)
+        jwt_token = generate_session_jwt(
+            supabase_user_id, expires_in=JWT_EXPIRY_SECONDS
+        )
+        expiry_seconds = JWT_EXPIRY_SECONDS
         expires_at = calculate_expires_at(jwt_token)
 
         return JSONResponse(

--- a/backend/consts/const.py
+++ b/backend/consts/const.py
@@ -408,6 +408,11 @@ MCP_MANAGEMENT_API = os.getenv("MCP_MANAGEMENT_API", "http://localhost:5015")
 # Invite code
 INVITE_CODE = os.getenv("INVITE_CODE")
 
+# Access-token lifetime in seconds. This must match GoTrue's GOTRUE_JWT_EXP.
+JWT_EXPIRY_SECONDS = int(os.getenv("JWT_EXPIRY", "7200") or 7200)
+if JWT_EXPIRY_SECONDS <= 0:
+    raise ValueError("JWT_EXPIRY must be a positive number of seconds")
+
 # Debug JWT expiration time (seconds), not set or 0 means not effective
 DEBUG_JWT_EXPIRE_SECONDS = int(os.getenv('DEBUG_JWT_EXPIRE_SECONDS', '0') or 0)
 

--- a/backend/services/oauth_service.py
+++ b/backend/services/oauth_service.py
@@ -21,6 +21,7 @@ from consts.const import (
     OAUTH_SSL_VERIFY,
     OAUTH_CA_BUNDLE,
     SUPABASE_JWT_SECRET,
+    JWT_EXPIRY_SECONDS,
 )
 from consts.exceptions import OAuthLinkError, OAuthProviderError
 from services.asset_owner_visibility import require_asset_owner_enabled
@@ -505,8 +506,10 @@ async def complete_pending_oauth_account(
         tenant_id=tenant_id,
     )
 
-    expiry_seconds = 3600
-    jwt_token = generate_session_jwt(supabase_user_id, expires_in=expiry_seconds)
+    jwt_token = generate_session_jwt(
+        supabase_user_id, expires_in=JWT_EXPIRY_SECONDS
+    )
+    expiry_seconds = JWT_EXPIRY_SECONDS
     expires_at = calculate_expires_at(jwt_token)
 
     return {

--- a/backend/utils/auth_utils.py
+++ b/backend/utils/auth_utils.py
@@ -566,9 +566,12 @@ def generate_test_jwt(user_id: str, expires_in: int = 7200) -> str:
 
 
 def generate_session_jwt(
-    user_id: str, expires_in: int = JWT_EXPIRY_SECONDS, session_id: str = None
+    user_id: str, expires_in: Optional[int] = None, session_id: str = None
 ) -> str:
     """Generate a signed JWT compatible with the existing auth verification flow."""
+    if expires_in is None:
+        expires_in = JWT_EXPIRY_SECONDS
+
     now = int(time.time())
     payload = {
         "sub": user_id,

--- a/backend/utils/auth_utils.py
+++ b/backend/utils/auth_utils.py
@@ -22,6 +22,7 @@ from consts.const import (
     SUPABASE_KEY,
     SERVICE_ROLE_KEY,
     DEBUG_JWT_EXPIRE_SECONDS,
+    JWT_EXPIRY_SECONDS,
     LANGUAGE,
 )
 from consts.exceptions import LimitExceededError, UnauthorizedError
@@ -312,7 +313,7 @@ def get_jwt_expiry_seconds(token: str) -> int:
         token: JWT token string
 
     Returns:
-        int: Token validity period (seconds), returns default value 3600 if parsing fails
+        int: Token validity period (seconds), returns configured default if parsing fails
     """
     try:
         # Speed mode: treat sessions as never expiring
@@ -345,7 +346,7 @@ def get_jwt_expiry_seconds(token: str) -> int:
         return expiry_seconds
     except Exception as e:
         logging.warning(f"Failed to get expiration time from token: {str(e)}")
-        return 3600  # supabase default setting
+        return JWT_EXPIRY_SECONDS
 
 
 def calculate_expires_at(token: Optional[str] = None) -> int:
@@ -362,7 +363,7 @@ def calculate_expires_at(token: Optional[str] = None) -> int:
     if IS_SPEED_MODE:
         return int((datetime.now() + timedelta(days=3650)).timestamp())
 
-    expiry_seconds = get_jwt_expiry_seconds(token) if token else 3600
+    expiry_seconds = get_jwt_expiry_seconds(token) if token else JWT_EXPIRY_SECONDS
     return int((datetime.now() + timedelta(seconds=expiry_seconds)).timestamp())
 
 
@@ -548,7 +549,7 @@ def get_user_language(request: Request = None) -> str:
 # ---------------------------------------------------------------------------
 
 
-def generate_test_jwt(user_id: str, expires_in: int = 3600) -> str:
+def generate_test_jwt(user_id: str, expires_in: int = 7200) -> str:
     """
     Generate a simple unsigned JWT for testing purposes (HS256 with dummy secret)
     """
@@ -564,7 +565,9 @@ def generate_test_jwt(user_id: str, expires_in: int = 3600) -> str:
     return jwt.encode(payload, MOCK_JWT_SECRET_KEY, algorithm="HS256")
 
 
-def generate_session_jwt(user_id: str, expires_in: int = 3600, session_id: str = None) -> str:
+def generate_session_jwt(
+    user_id: str, expires_in: int = JWT_EXPIRY_SECONDS, session_id: str = None
+) -> str:
     """Generate a signed JWT compatible with the existing auth verification flow."""
     now = int(time.time())
     payload = {

--- a/backend/utils/auth_utils.py
+++ b/backend/utils/auth_utils.py
@@ -549,7 +549,9 @@ def get_user_language(request: Request = None) -> str:
 # ---------------------------------------------------------------------------
 
 
-def generate_test_jwt(user_id: str, expires_in: int = 7200) -> str:
+def generate_test_jwt(user_id: str, expires_in: Optional[int] = None) -> str:
+    if expires_in is None:
+        expires_in = JWT_EXPIRY_SECONDS
     """
     Generate a simple unsigned JWT for testing purposes (HS256 with dummy secret)
     """

--- a/deploy/env/.env.example
+++ b/deploy/env/.env.example
@@ -106,7 +106,7 @@ SITE_URL=http://localhost:3011
 SUPABASE_URL=http://nexent-supabase-kong:8000
 API_EXTERNAL_URL=http://nexent-supabase-kong:8000
 DISABLE_SIGNUP=false
-JWT_EXPIRY=3600
+JWT_EXPIRY=7200
 DEBUG_JWT_EXPIRE_SECONDS=0
 
 # Supabase Configuration

--- a/deploy/k8s/helm/nexent/charts/nexent-common/values.yaml
+++ b/deploy/k8s/helm/nexent/charts/nexent-common/values.yaml
@@ -92,7 +92,7 @@ config:
     supabaseUrl: "http://nexent-supabase-kong:8000"
     apiExternalUrl: "http://nexent-supabase-kong:8000"
     disableSignup: "false"
-    jwtExpiry: "3600"
+    jwtExpiry: "7200"
     debugJwtExpireSeconds: "0"
     enableEmailSignup: "true"
     enableEmailAutoconfirm: "true"

--- a/deploy/k8s/helm/nexent/charts/nexent-supabase-auth/values.yaml
+++ b/deploy/k8s/helm/nexent/charts/nexent-supabase-auth/values.yaml
@@ -22,7 +22,7 @@ config:
   siteUrl: "http://localhost:3011"
   apiExternalUrl: "http://nexent-supabase-kong:8000"
   disableSignup: false
-  jwtExpiry: "3600"
+  jwtExpiry: "7200"
   debugJwtExpireSeconds: "0"
   enableEmailSignup: true
   enableEmailAutoconfirm: true

--- a/deploy/k8s/helm/nexent/charts/nexent-supabase-db/values.yaml
+++ b/deploy/k8s/helm/nexent/charts/nexent-supabase-db/values.yaml
@@ -27,4 +27,4 @@ persistence:
 config:
   postgresDb: "supabase"
   postgresPort: "5436"
-  jwtExpiry: "3600"
+  jwtExpiry: "7200"

--- a/test/backend/app/test_oauth_app.py
+++ b/test/backend/app/test_oauth_app.py
@@ -20,6 +20,7 @@ consts_mock.const.ENABLE_WECHAT_OAUTH = False
 consts_mock.const.OAUTH_CALLBACK_BASE_URL = "http://localhost:3000"
 consts_mock.const.SUPABASE_URL = "http://supabase.test"
 consts_mock.const.DEFAULT_TENANT_ID = "default"
+consts_mock.const.JWT_EXPIRY_SECONDS = 7200
 sys.modules["consts"] = consts_mock
 sys.modules["consts.const"] = consts_mock.const
 
@@ -304,6 +305,7 @@ class TestCallback(unittest.TestCase):
         self.assertEqual(data["data"]["oauth_error"], "unsupported_provider")
 
     def test_success_returns_session_data(self):
+        auth_utils_mock.reset_mock()
         oauth_service_mock.reset_mock()
         oauth_service_mock.parse_state.return_value = {"provider": "github", "token": "tok", "link_user_id": ""}
         database_oauth_mock.get_oauth_account_by_provider.return_value = {
@@ -323,7 +325,8 @@ class TestCallback(unittest.TestCase):
 
         auth_utils_mock.generate_session_jwt.return_value = "eyJ.mock.jwt.token"
 
-        response = client.get("/user/oauth/callback?provider=github&code=valid_code")
+        with patch("apps.oauth_app.JWT_EXPIRY_SECONDS", 5432):
+            response = client.get("/user/oauth/callback?provider=github&code=valid_code")
 
         if response.status_code != HTTPStatus.OK:
             print("Response:", response.json())
@@ -335,7 +338,10 @@ class TestCallback(unittest.TestCase):
             data["data"]["session"]["access_token"],
             "eyJ.mock.jwt.token",
         )
-        self.assertEqual(data["data"]["session"]["expires_in_seconds"], 3600)
+        self.assertEqual(data["data"]["session"]["expires_in_seconds"], 5432)
+        auth_utils_mock.generate_session_jwt.assert_called_once_with(
+            "user-uuid-123", expires_in=5432
+        )
 
         auth_utils_mock.get_supabase_admin_client.return_value = MagicMock()
 
@@ -876,7 +882,7 @@ class TestCompleteOAuth(unittest.TestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         data = response.json()
         self.assertEqual(data["data"]["user"]["id"], "new-user")
-        self.assertEqual(data["data"]["session"]["expires_in_seconds"], 3600)
+        self.assertEqual(data["data"]["session"]["expires_in_seconds"], 7200)
         complete_mock.assert_awaited_once_with(
             pending_token="pending.jwt",
             email="new@example.com",

--- a/test/backend/app/test_oauth_app.py
+++ b/test/backend/app/test_oauth_app.py
@@ -882,7 +882,7 @@ class TestCompleteOAuth(unittest.TestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         data = response.json()
         self.assertEqual(data["data"]["user"]["id"], "new-user")
-        self.assertEqual(data["data"]["session"]["expires_in_seconds"], 7200)
+        self.assertEqual(data["data"]["session"]["expires_in_seconds"], 3600)
         complete_mock.assert_awaited_once_with(
             pending_token="pending.jwt",
             email="new@example.com",

--- a/test/backend/services/test_oauth_service.py
+++ b/test/backend/services/test_oauth_service.py
@@ -14,6 +14,7 @@ consts_mock.const.OAUTH_CALLBACK_BASE_URL = "http://localhost:3000"
 consts_mock.const.OAUTH_SSL_VERIFY = True
 consts_mock.const.OAUTH_CA_BUNDLE = ""
 consts_mock.const.OAUTH_LOGIN_MODE = "button"
+consts_mock.const.JWT_EXPIRY_SECONDS = 7200
 sys.modules["consts"] = consts_mock
 sys.modules["consts.const"] = consts_mock.const
 

--- a/test/backend/utils/test_auth_utils.py
+++ b/test/backend/utils/test_auth_utils.py
@@ -319,10 +319,11 @@ def test_get_jwt_expiry_seconds_rejects_forged_far_future_token(monkeypatch):
     monkeypatch.setattr(au, "IS_SPEED_MODE", False)
     monkeypatch.setattr(au, "DEBUG_JWT_EXPIRE_SECONDS", 0)
     monkeypatch.setattr(au, "SUPABASE_JWT_SECRET", au.MOCK_JWT_SECRET_KEY)
+    monkeypatch.setattr(au, "JWT_EXPIRY_SECONDS", 5432)
 
     seconds = au.get_jwt_expiry_seconds(forged_token)
 
-    assert seconds == 3600
+    assert seconds == 5432
 
 
 def test_get_jwt_expiry_seconds_uses_debug_override(monkeypatch):
@@ -348,8 +349,9 @@ def test_get_jwt_expiry_seconds_rejects_non_positive_lifetime(monkeypatch):
     monkeypatch.setattr(au, "IS_SPEED_MODE", False)
     monkeypatch.setattr(au, "DEBUG_JWT_EXPIRE_SECONDS", 0)
     monkeypatch.setattr(au, "SUPABASE_JWT_SECRET", au.MOCK_JWT_SECRET_KEY)
+    monkeypatch.setattr(au, "JWT_EXPIRY_SECONDS", 5432)
 
-    assert au.get_jwt_expiry_seconds(token) == 3600
+    assert au.get_jwt_expiry_seconds(token) == 5432
 
 
 def test_decode_jwt_token_for_expiry_requires_secret(monkeypatch):
@@ -567,8 +569,10 @@ def test_get_jwt_expiry_seconds_exception(monkeypatch):
     monkeypatch.setattr(au, "jwt", MagicMock())
     au.jwt.decode.side_effect = Exception("JWT decode failed")
 
+    monkeypatch.setattr(au, "JWT_EXPIRY_SECONDS", 5432)
+
     result = au.get_jwt_expiry_seconds("invalid_token")
-    assert result == 3600  # Should return default value
+    assert result == 5432
 
 
 def test_get_current_user_id_no_tenant_mapping(monkeypatch):

--- a/test/backend/utils/test_auth_utils.py
+++ b/test/backend/utils/test_auth_utils.py
@@ -302,6 +302,21 @@ def test_generate_test_jwt_and_get_expiry_seconds(monkeypatch):
     assert seconds == 1234
 
 
+def test_generate_session_jwt_uses_runtime_configured_expiry(monkeypatch):
+    monkeypatch.setattr(au, "JWT_EXPIRY_SECONDS", 5432)
+    monkeypatch.setattr(au, "SUPABASE_JWT_SECRET", au.MOCK_JWT_SECRET_KEY)
+
+    token = au.generate_session_jwt("user-1")
+    claims = au.jwt.decode(
+        token,
+        au.MOCK_JWT_SECRET_KEY,
+        algorithms=["HS256"],
+        audience="authenticated",
+    )
+
+    assert claims["exp"] - claims["iat"] == 5432
+
+
 def test_get_jwt_expiry_seconds_rejects_forged_far_future_token(monkeypatch):
     """Expiry seconds must not trust JWT claims from tokens with invalid signatures."""
     now = int(time.time())

--- a/test/backend/utils/test_auth_utils.py
+++ b/test/backend/utils/test_auth_utils.py
@@ -305,6 +305,7 @@ def test_generate_test_jwt_and_get_expiry_seconds(monkeypatch):
 def test_generate_session_jwt_uses_runtime_configured_expiry(monkeypatch):
     monkeypatch.setattr(au, "JWT_EXPIRY_SECONDS", 5432)
     monkeypatch.setattr(au, "SUPABASE_JWT_SECRET", au.MOCK_JWT_SECRET_KEY)
+    monkeypatch.setattr(au, "SUPABASE_URL", "http://localhost:54321")
 
     token = au.generate_session_jwt("user-1")
     claims = au.jwt.decode(


### PR DESCRIPTION
1. 统一JWT过期时间（.env中JWT_EXPIRY ），避免在代码中硬编码
2. 前端在token还剩30分钟有效期的时候，主动捕获前端操作进行refresh_token刷新token的逻辑保持不变
3. oauth不会主动进行refresh_token，到期就失效