### PR TITLE
bugfix: pass verification_config to CoreAgent in create_single_agent

### DIFF
--- a/sdk/nexent/core/agents/nexent_agent.py
+++ b/sdk/nexent/core/agents/nexent_agent.py
@@ -674,6 +674,7 @@ class NexentAgent:
                 conversation_id=self.conversation_id,
                 user_id=self.user_id,
                 executor=python_executor,
+                verification_config=getattr(agent_config, "verification_config", None),
             )
             agent.stop_event = self.stop_event
 


### PR DESCRIPTION
NexentAgent.create_single_agent() creates a CoreAgent but does not pass the verification_config from agent_config. This means the guardrail subsystem (guardrail_config rules for mask_phone, mask_email, etc.) is never activated, even when verification_config.enabled=true in the database.

Fix: add verification_config=getattr(agent_config, "verification_config", None) to the CoreAgent() constructor call.

<img width="1753" height="1232" alt="image" src="https://github.com/user-attachments/assets/2144eb12-03a5-4ed8-b128-aee45bfd1b8c" />
