### PR TITLE
🐛 Bugfix: display skill group names in editor

### DIFF
--- a/frontend/app/[locale]/agents/components/agentConfig/SkillBuildModal.tsx
+++ b/frontend/app/[locale]/agents/components/agentConfig/SkillBuildModal.tsx
@@ -163,6 +163,16 @@ export default function SkillBuildModal({
   const [form] = Form.useForm<SkillFormData>();
   const isEditMode = Boolean(editingSkill);
   const { data: groupData } = useGroupList(user?.tenantId ?? null);
+  const groupNamesById = useMemo(
+    () =>
+      new Map(
+        (groupData?.groups ?? []).map((group) => [
+          group.group_id,
+          group.group_name,
+        ])
+      ),
+    [groupData?.groups]
+  );
   const accessibleGroupIds = useMemo(
     () => getAccessibleGroupIds(),
     [getAccessibleGroupIds]
@@ -1205,6 +1215,7 @@ export default function SkillBuildModal({
       shouldAutoScrollRef={shouldAutoScrollRef}
       onTextareaScroll={handleTextareaScroll}
       groupSelectOptions={groupSelectOptions}
+      groupNamesById={groupNamesById}
     />
   );
 

--- a/frontend/app/[locale]/agents/components/agentConfig/SkillDraftPanel.tsx
+++ b/frontend/app/[locale]/agents/components/agentConfig/SkillDraftPanel.tsx
@@ -33,6 +33,7 @@ interface SkillDraftPanelProps {
   shouldAutoScrollRef?: MutableRefObject<Record<string, boolean>>;
   onTextareaScroll?: (tabPath: string) => void;
   groupSelectOptions?: Array<{ label: string; value: number }>;
+  groupNamesById?: Map<number, string>;
   className?: string;
 }
 
@@ -49,6 +50,7 @@ export default function SkillDraftPanel({
   shouldAutoScrollRef,
   onTextareaScroll,
   groupSelectOptions = [],
+  groupNamesById = new Map(),
   className,
 }: SkillDraftPanelProps) {
   const { t } = useTranslation("common");
@@ -241,6 +243,9 @@ export default function SkillDraftPanel({
                       placeholder={t("agent.userGroup")}
                       options={groupSelectOptions}
                       allowClear
+                      labelRender={({ label, value }) =>
+                        groupNamesById.get(Number(value)) ?? label
+                      }
                     />
                   </Form.Item>
                 </Col>


### PR DESCRIPTION

Fixes Skill editor group labels showing numeric group IDs when a selected group is outside the current user's selectable group list.

Before
<img width="1960" height="1504" alt="image" src="https://github.com/user-attachments/assets/c234e0bc-4bb4-45d8-b8ea-874d8cbb9a3d" />


after
<img width="2009" height="1574" alt="image" src="https://github.com/user-attachments/assets/d1b2c2c4-1ff8-4f88-b827-2b3fee6c4b90" />
