### PR TITLE
🐛 Bugfix: prevent auth token leaking into task results & restrict age…

### DIFF
--- a/backend/data_process/tasks.py
+++ b/backend/data_process/tasks.py
@@ -340,6 +340,7 @@ def _delete_source_file_via_http_sync(
     index_name: str,
     path_or_url: str,
     scope: str,
+    authorization: Optional[str] = None,
     timeout_s: float = 30.0,
 ) -> Dict[str, Any]:
     base = (base_url or "").rstrip("/")
@@ -347,8 +348,13 @@ def _delete_source_file_via_http_sync(
         raise RuntimeError("ELASTICSEARCH_SERVICE is not configured")
     url = f"{base}/indices/{index_name}/documents"
     params = {"path_or_url": path_or_url, "scope": scope}
+    headers: Dict[str, str] = {}
+    if authorization:
+        headers["Authorization"] = authorization
 
-    resp = requests.delete(url, params=params, timeout=timeout_s)
+    resp = requests.delete(
+        url, params=params, headers=headers, timeout=timeout_s
+    )
     body_text = getattr(resp, "text", "")
     parsed = None
     try:
@@ -1959,12 +1965,19 @@ def forward(
     name="data_process.tasks.cleanup_source",
     queue="forward_q",
 )
-def cleanup_source(self, forward_result: Dict[str, Any]) -> Dict[str, Any]:
+def cleanup_source(
+    self,
+    forward_result: Dict[str, Any],
+    authorization: Optional[str] = None,
+) -> Dict[str, Any]:
     """
     Conditionally delete the MinIO source file after successful indexing.
 
     If the knowledge base is configured with preserve_source_file=false, call:
     DELETE /indices/{index_name}/documents?path_or_url=...&scope=source_only
+
+    authorization is passed as a Celery signature kwarg (not via forward_result)
+    so tokens are not persisted in task result payloads.
     """
     index_name = (forward_result or {}).get("index_name")
     source = (forward_result or {}).get("source")
@@ -2012,6 +2025,7 @@ def cleanup_source(self, forward_result: Dict[str, Any]) -> Dict[str, Any]:
             index_name=index_name,
             path_or_url=source,
             scope="source_only",
+            authorization=authorization,
         )
         cleanup_info["http_status"] = resp.get("http_status")
         cleanup_info["response"] = (
@@ -2085,7 +2099,7 @@ def submit_process_forward_chain(
             original_filename=original_filename,
             authorization=authorization
         ).set(queue='forward_q'),
-        cleanup_source.s().set(queue='forward_q'),
+        cleanup_source.s(authorization=authorization).set(queue='forward_q'),
     )
 
     result = task_chain.apply_async()

--- a/frontend/app/[locale]/agents/components/agentInfo/AgentGenerateDetail.tsx
+++ b/frontend/app/[locale]/agents/components/agentInfo/AgentGenerateDetail.tsx
@@ -37,6 +37,7 @@ import { useDeployment } from "@/components/providers/deploymentProvider";
 import { useModelList } from "@/hooks/model/useModelList";
 import { useCapacityCoverage } from "@/hooks/model/useCapacityCoverage";
 import { canManageModels } from "@/lib/auth";
+import { USER_ROLES } from "@/const/auth";
 import { useConfig } from "@/hooks/useConfig";
 import { useGroupList, useGroupDetails } from "@/hooks/group/useGroupList";
 import { usePromptTemplateList } from "@/hooks/agent/usePromptTemplateList";
@@ -50,6 +51,14 @@ import type { GuardrailConfigContentRef } from "./GuardrailConfigContent";
 import { isAgentPromptsHidden } from "@/lib/agentPromptVisibility";
 
 const { TextArea } = Input;
+
+/** Roles that can edit group settings for any agent (mirrors backend CAN_EDIT_ALL_USER_ROLES). */
+const CAN_EDIT_ALL_ROLES: ReadonlySet<string> = new Set([
+  USER_ROLES.SU,
+  USER_ROLES.ADMIN,
+  USER_ROLES.SPEED,
+  USER_ROLES.ASSET_OWNER,
+]);
 
 export default function AgentGenerateDetail({}) {
   const { t } = useTranslation("common");
@@ -75,6 +84,15 @@ export default function AgentGenerateDetail({}) {
 
   // Determine if form should be editable (based on isReadOnly only, isGenerating handled separately)
   const editable = !isReadOnly;
+
+  // Group settings (用户组 / 组内权限) are editable only by creator or admin roles
+  const isAdmin = !!user?.role && CAN_EDIT_ALL_ROLES.has(user.role);
+  const isCreator =
+    isCreatingMode ||
+    (!!editedAgent.created_by &&
+      !!user?.id &&
+      String(editedAgent.created_by) === String(user.id));
+  const canEditGroupSettings = isAdmin || isCreator;
 
   const { defaultLlmModelConfig } = useConfig();
   const { availableLlmModels, models, isLoading: loadingModels } = useModelList();
@@ -1242,6 +1260,7 @@ export default function AgentGenerateDetail({}) {
                     placeholder={t("agent.userGroup")}
                     options={groupSelectOptions}
                     allowClear
+                    disabled={!editable || isGenerating || !canEditGroupSettings}
                   />
                 </Form.Item>
               </Col>
@@ -1257,6 +1276,7 @@ export default function AgentGenerateDetail({}) {
                       { value: "READ_ONLY", label: t("tenantResources.knowledgeBase.permission.READ_ONLY") },
                       { value: "PRIVATE", label: t("tenantResources.knowledgeBase.permission.PRIVATE") },
                     ]}
+                    disabled={!editable || isGenerating || !canEditGroupSettings}
                   />
                 </Form.Item>
               </Col>

--- a/frontend/components/navigation/NotificationBell.tsx
+++ b/frontend/components/navigation/NotificationBell.tsx
@@ -155,6 +155,15 @@ export function NotificationBell({
             color="#ff4d4f"
             overflowCount={99}
             offset={[-2, 2]}
+            styles={{
+              root: {
+                display: "inline-flex",
+                alignItems: "center",
+                height: 32, // match Button h-8
+                lineHeight: 1,
+                verticalAlign: "middle",
+              },
+            }}
           >
             <Button
               type="text"

--- a/frontend/services/agentConfigService.ts
+++ b/frontend/services/agentConfigService.ts
@@ -826,6 +826,7 @@ export const searchAgentInfo = async (
       group_ids: data.group_ids || [],
       ingroup_permission: data.ingroup_permission || "READ_ONLY",
       permission: data.permission, // Per-agent edit permission
+      created_by: data.created_by ?? null,
       prompts_hidden: data.prompts_hidden === true,
       tools: data.tools
         ? data.tools.map((tool: any) => {

--- a/frontend/stores/agentConfigStore.ts
+++ b/frontend/stores/agentConfigStore.ts
@@ -32,6 +32,7 @@ export type EditableAgent = Pick<
   | "display_name"
   | "description"
   | "author"
+  | "created_by"
   | "model"
   | "model_ids"
   | "max_step"
@@ -167,6 +168,7 @@ function createEmptyEditableAgent(llmConfig?: { id: number | null; name: string;
     display_name: "",
     description: "",
     author: "",
+    created_by: null,
     model: llmConfig?.name || "",
     model_ids: llmConfig?.id ? [llmConfig.id] : [],
     max_step: 15,
@@ -204,6 +206,7 @@ const toEditable = (agent: Agent | null): EditableAgent =>
         display_name: agent.display_name || "",
         description: agent.description,
         author: agent.author || "",
+        created_by: agent.created_by ?? null,
         model: agent.model,
         model_ids: agent.model_ids || [],
         max_step: agent.max_step,

--- a/frontend/types/agentConfig.ts
+++ b/frontend/types/agentConfig.ts
@@ -136,6 +136,8 @@ export interface Agent {
   display_name?: string;
   description: string;
   author?: string;
+  /** Nexent user_id of the agent creator (owner). */
+  created_by?: string | null;
   unavailable_reasons?: string[];
   model: string;
   model_ids?: number[];

--- a/test/backend/data_process/test_tasks.py
+++ b/test/backend/data_process/test_tasks.py
@@ -290,8 +290,8 @@ def import_tasks_with_fake_ray(monkeypatch, initialized=False):
     # Provide a Celery task shim that allows direct calls and supports .s for chaining
 
     class _SignatureShim:
-        def __init__(self):
-            pass
+        def __init__(self, kwargs=None):
+            self.kwargs = kwargs or {}
 
         def set(self, **_kw):
             return self
@@ -306,8 +306,8 @@ def import_tasks_with_fake_ray(monkeypatch, initialized=False):
                 args, kwargs = self._preprocess(args, kwargs)
             return self._run_func(*args, **kwargs)
 
-        def s(self, **_kw):
-            return _SignatureShim()
+        def s(self, **kwargs):
+            return _SignatureShim(kwargs)
 
     # Helper to get unbound run
     def _unbound_run(task_obj):
@@ -2502,9 +2502,10 @@ def test_cleanup_source_calls_delete_with_scope_source_only(monkeypatch):
         def json():
             return {"status": "success"}
 
-    def _delete(url, params=None, timeout=None):
+    def _delete(url, params=None, headers=None, timeout=None):
         captured["url"] = url
         captured["params"] = params
+        captured["headers"] = headers
         captured["timeout"] = timeout
         return FakeResponse()
 
@@ -2514,11 +2515,47 @@ def test_cleanup_source_calls_delete_with_scope_source_only(monkeypatch):
     out = tasks.cleanup_source(
         self,
         {"task_id": "t1", "index_name": "idx", "source": "/a.txt"},
+        authorization="Bearer test-token",
     )
     assert captured["url"] == "http://api/indices/idx/documents"
     assert captured["params"]["path_or_url"] == "/a.txt"
     assert captured["params"]["scope"] == "source_only"
+    assert captured["headers"]["Authorization"] == "Bearer test-token"
     assert out["source_cleanup"]["attempted"] is True
+    assert out["source_cleanup"]["success"] is True
+    # Authorization must not leak into the task result payload
+    assert "authorization" not in out
+    assert "Authorization" not in json.dumps(out)
+
+
+def test_cleanup_source_omits_auth_header_when_authorization_missing(monkeypatch):
+    tasks, _ = import_tasks_with_fake_ray(monkeypatch)
+    monkeypatch.setattr(tasks, "ELASTICSEARCH_SERVICE", "http://api")
+    monkeypatch.setattr(tasks, "get_knowledge_record",
+                        lambda query=None: {"preserve_source_file": False})
+
+    captured = {}
+
+    class FakeResponse:
+        status_code = 200
+        text = ""
+
+        @staticmethod
+        def json():
+            return {"status": "success"}
+
+    def _delete(url, params=None, headers=None, timeout=None):
+        captured["headers"] = headers
+        return FakeResponse()
+
+    monkeypatch.setattr(tasks.requests, "delete", _delete, raising=True)
+
+    self = FakeSelf("cleanup-no-auth-1")
+    out = tasks.cleanup_source(
+        self,
+        {"task_id": "t1", "index_name": "idx", "source": "/a.txt"},
+    )
+    assert captured["headers"] == {}
     assert out["source_cleanup"]["success"] is True
 
 
@@ -2541,3 +2578,42 @@ def test_cleanup_source_failure_is_warning_only(monkeypatch):
     assert out["source_cleanup"]["attempted"] is True
     assert out["source_cleanup"]["success"] is False
     assert "boom" in (out["source_cleanup"]["error"] or "")
+
+
+def test_submit_process_forward_chain_binds_authorization_to_cleanup(monkeypatch):
+    tasks, _ = import_tasks_with_fake_ray(monkeypatch)
+
+    captured = {"args": None}
+
+    class FakeResult:
+        def __init__(self, id):
+            self.id = id
+
+    class FakeChain:
+        def apply_async(self):
+            return FakeResult("auth-chain-1")
+
+    def _capture_chain(*args, **_kwargs):
+        captured["args"] = args
+        return FakeChain()
+
+    monkeypatch.setattr(tasks, "chain", _capture_chain)
+    import backend.data_process.tasks as tasks_module
+    tasks_module.process = tasks.process
+    tasks_module.forward = tasks.forward
+    tasks_module.cleanup_source = tasks.cleanup_source
+
+    chain_id = tasks.submit_process_forward_chain(
+        source="/a.txt",
+        source_type="local",
+        chunking_strategy="basic",
+        index_name="idx",
+        authorization="Bearer chain-token",
+    )
+    assert chain_id == "auth-chain-1"
+    assert captured["args"] is not None
+    assert len(captured["args"]) == 3
+    cleanup_sig = captured["args"][2]
+    assert cleanup_sig.kwargs.get("authorization") == "Bearer chain-token"
+    forward_sig = captured["args"][1]
+    assert forward_sig.kwargs.get("authorization") == "Bearer chain-token"


### PR DESCRIPTION
…nt group settings

- data_process: pass authorization to cleanup_source via Celery signature kwarg and forward it as an Authorization header, so tokens are not persisted in task result payloads (with unit tests)
- agents: only creator or admin roles can edit user group / in-group permission; plumb created_by through types, store and service
- ui: align NotificationBell badge with the button height
- sdk: minor formatting cleanup in core_agent