### PR TITLE
🐛 Bugfix: prevent knowledge base drag upload from re-sending previous…

### DIFF
--- a/frontend/app/[locale]/knowledges/components/upload/UploadArea.tsx
+++ b/frontend/app/[locale]/knowledges/components/upload/UploadArea.tsx
@@ -64,6 +64,8 @@ const UploadArea = forwardRef<UploadAreaRef, UploadAreaProps>(
     const currentKnowledgeBaseRef = useRef<string>("");
     const pendingRequestRef = useRef<AbortController | null>(null);
     const prevFileListRef = useRef<UploadFile[]>([]);
+    // UIDs already handed off to the parent upload; kept in the visible list but not re-sent.
+    const uploadedUidsRef = useRef<Set<string>>(new Set());
 
     useEffect(() => {
       prevFileListRef.current = fileList;
@@ -76,7 +78,9 @@ const UploadArea = forwardRef<UploadAreaRef, UploadAreaProps>(
 
     // Function to reset all states
     const resetAllStates = useCallback(() => {
+      uploadedUidsRef.current = new Set();
       setFileList([]);
+      prevFileListRef.current = [];
       updateNameStatus("available");
       setIsLoading(true);
       setIsKnowledgeBaseReady(false);
@@ -176,54 +180,58 @@ const UploadArea = forwardRef<UploadAreaRef, UploadAreaProps>(
     const handleChange = useCallback(
       ({ fileList: newFileList }: { fileList: UploadFile[] }) => {
         // Ensure only updating current knowledge base's file list
-        if (isCreatingMode || indexName === currentKnowledgeBaseRef.current) {
-          // Deduplicate by name + size + lastModified to avoid duplicates within and across selections
-          const seen = new Set<string>();
-          const deduped: UploadFile[] = [];
-          for (const f of newFileList) {
-            const origin = f.originFileObj as RcFile | undefined;
-            const key = origin
-              ? `${origin.name.toLowerCase()}|${origin.size}|${
-                  origin.lastModified
-                }`
-              : f.name.toLowerCase();
-            if (!seen.has(key)) {
-              seen.add(key);
-              deduped.push(f);
-            }
-          }
-          setFileList(deduped);
-
-          // Trigger file selection callback with deduplicated files
-          const files = deduped
-            .map((file) => file.originFileObj)
-            .filter((file): file is RcFile => !!file);
-          if (files.length > 0) {
-            onFileSelect(files as unknown as File[]);
-          }
-        } else {
+        if (!(isCreatingMode || indexName === currentKnowledgeBaseRef.current)) {
           return;
         }
 
-        // Check if upload just completed
+        // Deduplicate by name + size + lastModified to avoid duplicates within and across selections
+        const seen = new Set<string>();
+        const deduped: UploadFile[] = [];
+        for (const f of newFileList) {
+          const origin = f.originFileObj as RcFile | undefined;
+          const key = origin
+            ? `${origin.name.toLowerCase()}|${origin.size}|${
+                origin.lastModified
+              }`
+            : f.name.toLowerCase();
+          if (!seen.has(key)) {
+            seen.add(key);
+            deduped.push(f);
+          }
+        }
+        // Keep completed history visible; accumulate across successive uploads
+        setFileList(deduped);
+
+        // Only pass files not yet uploaded so the API request is the current batch only
+        const pendingFiles = deduped
+          .filter((file) => !uploadedUidsRef.current.has(file.uid))
+          .map((file) => file.originFileObj)
+          .filter((file): file is RcFile => !!file);
+        if (pendingFiles.length > 0) {
+          onFileSelect(pendingFiles as unknown as File[]);
+        }
+
+        // Check if a batch that was uploading has just finished
         const prevFileList = prevFileListRef.current;
         const uploadWasInProgress = prevFileList.some(
           (f) => f.status === "uploading"
         );
         const uploadIsNowFinished =
-          newFileList.length > 0 &&
-          !newFileList.some((f) => f.status === "uploading");
+          deduped.length > 0 &&
+          !deduped.some((f) => f.status === "uploading");
 
         if (uploadWasInProgress && uploadIsNowFinished) {
-          // After upload completion only call external upload completion callback, let KnowledgeBaseManager manage polling uniformly
+          // Parent reads uploadFiles set via onFileSelect (pending only); mark all
+          // currently listed files as uploaded so they are not re-sent next time.
           if (onUpload) {
             onUpload();
           }
+          for (const f of deduped) {
+            uploadedUidsRef.current.add(f.uid);
+          }
         }
-
-        // Note: file selection callback already handled above when list is deduplicated
       },
-      [indexName, onFileSelect, isCreatingMode, newKnowledgeBaseName, onUpload]
+      [indexName, onFileSelect, isCreatingMode, onUpload]
     );
 
     // Handle custom upload request
@@ -257,17 +265,10 @@ const UploadArea = forwardRef<UploadAreaRef, UploadAreaProps>(
       beforeUpload: (file) => validateFileType(file, t, message),
     };
 
-    // Clear previous selection when user starts a new selection via click
-    const handleStartNewSelection = useCallback(() => {
-      setFileList([]);
-      prevFileListRef.current = [];
-    }, []);
-
     return (
       <UploadAreaUI
         fileList={fileList}
         uploadProps={uploadProps}
-        onStartNewSelection={handleStartNewSelection}
         isLoading={isLoading}
         isKnowledgeBaseReady={isKnowledgeBaseReady}
         isCreatingMode={isCreatingMode}

--- a/frontend/app/[locale]/knowledges/components/upload/UploadAreaUI.tsx
+++ b/frontend/app/[locale]/knowledges/components/upload/UploadAreaUI.tsx
@@ -12,7 +12,6 @@ const { Dragger } = Upload;
 interface UploadAreaUIProps {
   fileList: UploadFile[];
   uploadProps: UploadProps;
-  onStartNewSelection?: () => void;
   isLoading: boolean;
   isKnowledgeBaseReady: boolean;
   isCreatingMode: boolean;
@@ -29,7 +28,6 @@ interface UploadAreaUIProps {
 const UploadAreaUI: React.FC<UploadAreaUIProps> = ({
   fileList,
   uploadProps,
-  onStartNewSelection,
   isLoading,
   isKnowledgeBaseReady,
   isCreatingMode,
@@ -166,7 +164,7 @@ const UploadAreaUI: React.FC<UploadAreaUIProps> = ({
                 e.stopPropagation();
               }}
             >
-              <div className="h-full" onClick={() => onStartNewSelection?.()}>
+              <div className="h-full">
                 <Dragger
                   {...uploadProps}
                   className="!h-full flex flex-col justify-center !bg-transparent !border-gray-200"


### PR DESCRIPTION
… files

Keep the completed file list visible across successive uploads, while only passing newly added files to the upload API via uploaded UID tracking.