### PR TITLE
🐛Bugfix: Model config race conditions during connectivity verification and provider save

### DIFF
--- a/frontend/app/[locale]/models/components/model/ModelAddDialog.tsx
+++ b/frontend/app/[locale]/models/components/model/ModelAddDialog.tsx
@@ -1419,6 +1419,7 @@ export const ModelAddDialog = ({
             <Switch
               checked={form.isBatchImport}
               onChange={(checked) => handleFormChange("isBatchImport", checked)}
+              disabled={verifyingConnectivity}
             />
           </div>
           <div className="text-xs text-gray-500 mt-1">
@@ -1439,6 +1440,7 @@ export const ModelAddDialog = ({
               style={{ width: "100%" }}
               value={form.provider}
               onChange={(value) => handleFormChange("provider", value)}
+              disabled={verifyingConnectivity}
             >
               <Option value="modelengine">
                 {t("model.provider.modelengine")}
@@ -1459,6 +1461,7 @@ export const ModelAddDialog = ({
                   onChange={(e) =>
                     handleFormChange("modelEngineUrl", e.target.value)
                   }
+                  disabled={verifyingConnectivity}
                 />
               </div>
             )}
@@ -1477,6 +1480,7 @@ export const ModelAddDialog = ({
               value={form.apiKey}
               onChange={(e) => handleFormChange("apiKey", e.target.value)}
               autoComplete="new-password"
+              disabled={verifyingConnectivity}
             />
           </div>
         )}
@@ -1491,6 +1495,7 @@ export const ModelAddDialog = ({
             style={{ width: "100%" }}
             value={form.type}
             onChange={(value) => handleFormChange("type", value)}
+            disabled={verifyingConnectivity}
           >
             <Option value={MODEL_TYPES.LLM}>{t("model.type.llm")}</Option>
             <Option value={MODEL_TYPES.EMBEDDING}>
@@ -1539,6 +1544,7 @@ export const ModelAddDialog = ({
                 onChange={(checked) =>
                   handleFormChange("isMultimodal", checked)
                 }
+                disabled={verifyingConnectivity}
               />
             </div>
             <div className="text-xs text-gray-500 mt-1">
@@ -1564,6 +1570,7 @@ export const ModelAddDialog = ({
               placeholder={t("model.dialog.placeholder.name")}
               value={form.name}
               onChange={handleModelNameChange}
+              disabled={verifyingConnectivity}
             />
           </div>
         )}
@@ -1582,6 +1589,7 @@ export const ModelAddDialog = ({
               placeholder={t("model.dialog.placeholder.displayName")}
               value={form.displayName}
               onChange={(e) => handleFormChange("displayName", e.target.value)}
+              disabled={verifyingConnectivity}
             />
           </div>
         )}
@@ -1609,6 +1617,7 @@ export const ModelAddDialog = ({
               }
               value={form.url}
               onChange={(e) => handleFormChange("url", e.target.value)}
+              disabled={verifyingConnectivity}
             />
           </div>
         )}
@@ -1624,6 +1633,7 @@ export const ModelAddDialog = ({
               style={{ width: "100%" }}
               value={form.sttProvider}
               onChange={(value) => handleFormChange("sttProvider", value)}
+              disabled={verifyingConnectivity}
             >
               <Option value="dashscope">{t("model.provider.dashscope")}</Option>
               <Option value="volcengine">
@@ -1654,6 +1664,7 @@ export const ModelAddDialog = ({
                     handleFormChange("modelAppid", e.target.value)
                   }
                   autoComplete="new-password"
+                  disabled={verifyingConnectivity}
                 />
               </div>
               <div>
@@ -1672,6 +1683,7 @@ export const ModelAddDialog = ({
                     handleFormChange("accessToken", e.target.value)
                   }
                   autoComplete="new-password"
+                  disabled={verifyingConnectivity}
                 />
               </div>
             </>
@@ -1695,6 +1707,7 @@ export const ModelAddDialog = ({
                 value={form.apiKey}
                 onChange={(e) => handleFormChange("apiKey", e.target.value)}
                 autoComplete="new-password"
+                disabled={verifyingConnectivity}
               />
             </div>
           )}
@@ -1710,6 +1723,7 @@ export const ModelAddDialog = ({
               style={{ width: "100%" }}
               value={form.ttsProvider}
               onChange={(value) => handleFormChange("ttsProvider", value)}
+              disabled={verifyingConnectivity}
             >
               <Option value="dashscope">{t("model.provider.dashscope")}</Option>
               <Option value="volcengine">
@@ -1740,6 +1754,7 @@ export const ModelAddDialog = ({
                     handleFormChange("modelAppid", e.target.value)
                   }
                   autoComplete="new-password"
+                  disabled={verifyingConnectivity}
                 />
               </div>
               <div>
@@ -1758,6 +1773,7 @@ export const ModelAddDialog = ({
                     handleFormChange("accessToken", e.target.value)
                   }
                   autoComplete="new-password"
+                  disabled={verifyingConnectivity}
                 />
               </div>
             </>
@@ -1781,6 +1797,7 @@ export const ModelAddDialog = ({
                 value={form.apiKey}
                 onChange={(e) => handleFormChange("apiKey", e.target.value)}
                 autoComplete="new-password"
+                disabled={verifyingConnectivity}
               />
             </div>
           )}
@@ -1801,6 +1818,7 @@ export const ModelAddDialog = ({
               value={form.apiKey}
               onChange={(e) => handleFormChange("apiKey", e.target.value)}
               autoComplete="new-password"
+              disabled={verifyingConnectivity}
             />
           </div>
         )}
@@ -1819,6 +1837,7 @@ export const ModelAddDialog = ({
                   chunkSizeRange: value,
                 }));
               }}
+              disabled={verifyingConnectivity}
             />
           </div>
         )}
@@ -1841,6 +1860,7 @@ export const ModelAddDialog = ({
               onChange={(e) =>
                 handleFormChange("chunkingBatchSize", e.target.value)
               }
+              disabled={verifyingConnectivity}
             />
           </div>
         )}
@@ -1881,6 +1901,7 @@ export const ModelAddDialog = ({
                   size="small"
                   checked={capacitySuggestionEnabled}
                   onChange={setCapacitySuggestionEnabled}
+                  disabled={verifyingConnectivity}
                 />
               </div>
             )}
@@ -1900,6 +1921,7 @@ export const ModelAddDialog = ({
               suggestionLoading={topChecking}
               onUseSuggestion={() => applyCapacitySuggestion(topSuggestion)}
               acceptedSuggestion={topAccepted}
+              disabled={verifyingConnectivity}
             />
           </div>
         )}
@@ -1919,6 +1941,7 @@ export const ModelAddDialog = ({
               placeholder={t("model.dialog.placeholder.maxTokens")}
               value={form.maxTokens}
               onChange={(value) => handleFormChange("maxTokens", value)}
+              disabled={verifyingConnectivity}
             />
           </div>
         )}
@@ -2088,6 +2111,7 @@ export const ModelAddDialog = ({
                             size="small"
                             checked={checked}
                             onChange={toggleSelect}
+                            disabled={verifyingConnectivity}
                           />
                         </div>
                       </div>
@@ -2447,7 +2471,7 @@ export const ModelAddDialog = ({
               !isFormValid() ||
               (!form.isBatchImport && connectivityStatus.status !== "available")
             }
-            loading={loading}
+            loading={loading || verifyingConnectivity}
           >
             {t("model.dialog.button.add")}
           </Button>
@@ -2487,6 +2511,7 @@ export const ModelAddDialog = ({
                       size="small"
                       checked={gearCapacitySuggestionEnabled}
                       onChange={setGearCapacitySuggestionEnabled}
+                      disabled={verifyingConnectivity}
                     />
                     <Button
                       size="small"

--- a/frontend/app/[locale]/models/components/model/ModelCapacityFields.tsx
+++ b/frontend/app/[locale]/models/components/model/ModelCapacityFields.tsx
@@ -90,6 +90,7 @@ interface ModelCapacityFieldsProps {
   applyDefaultsOnEmpty?: boolean;
   /** Currently accepted suggestion, used to detect fuzzy canonicalization mismatch */
   acceptedSuggestion?: CapacitySuggestion | null;
+  disabled?: boolean;
 }
 
 const SOURCE_COLORS: Record<string, string> = {
@@ -279,6 +280,7 @@ export const ModelCapacityFields = ({
   legacyMaxTokensCandidate,
   applyDefaultsOnEmpty = true,
   acceptedSuggestion,
+  disabled = false,
 }: ModelCapacityFieldsProps) => {
   const { t } = useTranslation();
 
@@ -354,6 +356,7 @@ export const ModelCapacityFields = ({
         options={presetOptions}
         placeholder={defaultPlaceholders[field]}
         onChange={(next) => onChange(field, String(next ?? ""))}
+        disabled={disabled}
         filterOption={(input, option) =>
           String(option?.label ?? "")
             .toLowerCase()
@@ -361,7 +364,7 @@ export const ModelCapacityFields = ({
           String(option?.value ?? "").includes(input)
         }
       >
-        <Input inputMode="numeric" pattern="[0-9]*" />
+        <Input inputMode="numeric" pattern="[0-9]*" disabled={disabled} />
       </AutoComplete>
     ) : (
       <Input
@@ -370,6 +373,7 @@ export const ModelCapacityFields = ({
         value={value[field]}
         placeholder={defaultPlaceholders[field]}
         onChange={(event) => onChange(field, event.target.value)}
+        disabled={disabled}
       />
     );
     return (
@@ -441,6 +445,7 @@ export const ModelCapacityFields = ({
                     onClick={() =>
                       onChange(fieldName, String(legacyMaxTokensCandidate))
                     }
+                    disabled={disabled}
                   >
                     {t(labelKey)}
                   </Button>
@@ -486,6 +491,7 @@ export const ModelCapacityFields = ({
                       type="primary"
                       loading={suggestionLoading}
                       onClick={onUseSuggestion}
+                      disabled={disabled}
                     >
                       {t("model.dialog.capacity.suggestion.use")}
                     </Button>

--- a/frontend/app/[locale]/models/components/model/ModelDeleteDialog.tsx
+++ b/frontend/app/[locale]/models/components/model/ModelDeleteDialog.tsx
@@ -482,20 +482,29 @@ export const ModelDeleteDialog = ({
   // Prefetch provider model list (supports Silicon, ModelEngine, DashScope, TokenPony)
   const prefetchProviderModels = async (
     provider: ModelSource,
-    modelType: ModelType | null
+    modelType: ModelType | null,
+    // Optional override for the API key to use for this fetch. Needed
+    // right after a provider config save: `models` state may not have
+    // re-rendered into this closure yet (React state updates are async),
+    // so falling back to getApiKeyByType() here could still read the
+    // pre-save key even though the backend already has the new one.
+    apiKeyOverride?: string
   ): Promise<void> => {
     if (!modelType) return;
     try {
       let result: any[] = [];
       if (provider === MODEL_SOURCES.SILICON) {
-        const apiKey = getApiKeyByType(modelType, MODEL_SOURCES.SILICON);
+        const apiKey =
+          apiKeyOverride ?? getApiKeyByType(modelType, MODEL_SOURCES.SILICON);
         result = await modelService.addProviderModel({
           provider: MODEL_SOURCES.SILICON,
           type: modelType,
           apiKey: apiKey && apiKey.trim() !== "" ? apiKey : "sk-no-api-key",
         });
       } else if (provider === MODEL_SOURCES.MODELENGINE) {
-        const apiKey = getApiKeyByType(modelType, MODEL_SOURCES.MODELENGINE);
+        const apiKey =
+          apiKeyOverride ??
+          getApiKeyByType(modelType, MODEL_SOURCES.MODELENGINE);
         const baseUrl = getProviderBaseUrlByType(modelType);
         result = await modelService.addProviderModel({
           provider: MODEL_SOURCES.MODELENGINE,
@@ -504,14 +513,18 @@ export const ModelDeleteDialog = ({
           baseUrl: baseUrl || undefined,
         });
       } else if (provider === MODEL_SOURCES.DASHSCOPE) {
-        const apiKey = getApiKeyByType(modelType, MODEL_SOURCES.DASHSCOPE);
+        const apiKey =
+          apiKeyOverride ??
+          getApiKeyByType(modelType, MODEL_SOURCES.DASHSCOPE);
         result = await modelService.addProviderModel({
           provider: MODEL_SOURCES.DASHSCOPE,
           type: modelType,
           apiKey: apiKey && apiKey.trim() !== "" ? apiKey : "sk-no-api-key",
         });
       } else if (provider === MODEL_SOURCES.TOKENPONY) {
-        const apiKey = getApiKeyByType(modelType, MODEL_SOURCES.TOKENPONY);
+        const apiKey =
+          apiKeyOverride ??
+          getApiKeyByType(modelType, MODEL_SOURCES.TOKENPONY);
         result = await modelService.addProviderModel({
           provider: MODEL_SOURCES.TOKENPONY,
           type: modelType,
@@ -899,6 +912,15 @@ export const ModelDeleteDialog = ({
       }
     }
     await onSuccess();
+    if (selectedSource && deletingModelType) {
+      // Pass the just-saved apiKey directly instead of re-deriving it from
+      // `models` state, which may still be stale in this closure.
+      await prefetchProviderModels(
+        selectedSource,
+        deletingModelType,
+        apiKey
+      );
+    }
     setIsProviderConfigOpen(false);
   };
 
@@ -1822,7 +1844,16 @@ export const ModelDeleteDialog = ({
           }
         }}
       />
+      {/* key forces full unmount/remount whenever the dialog is (re)opened
+          for a given type/source, so the internal apiKey/maxTokens/etc
+          state always initializes from the latest initialApiKey prop. Without
+          this, the component stays mounted across opens and relies on the
+          [initialApiKey, ...] effect dependency diff to resync -- if that
+          diff doesn't trigger at the right time relative to the parent's
+          models refresh, the API key input can keep showing a stale value
+          after the user saves and reopens the dialog. */}
       <ProviderConfigEditDialog
+        key={`${selectedSource || "__none__"}-${deletingModelType || "__none__"}-${isProviderConfigOpen}`}
         isOpen={isProviderConfigOpen}
         onClose={() => setIsProviderConfigOpen(false)}
         initialApiKey={getApiKeyByType(

--- a/frontend/app/[locale]/models/components/model/ModelEditDialog.tsx
+++ b/frontend/app/[locale]/models/components/model/ModelEditDialog.tsx
@@ -902,6 +902,7 @@ interface ProviderConfigEditDialogProps {
     acceptedSuggestionMatchKind?: string;
     acceptedCapabilityProfileVersion?: string;
   }) => Promise<void> | void;
+  onSuccess?: () => Promise<void> | void;
 }
 
 export const ProviderConfigEditDialog = ({
@@ -919,6 +920,7 @@ export const ProviderConfigEditDialog = ({
   providerHint,
   onClose,
   onSave,
+  onSuccess,
 }: ProviderConfigEditDialogProps) => {
   const { t } = useTranslation();
   const [apiKey, setApiKey] = useState<string>(initialApiKey);
@@ -1091,6 +1093,9 @@ export const ProviderConfigEditDialog = ({
           : {}),
       });
       onClose();
+      if (onSuccess) {
+        await onSuccess();
+      }
     } finally {
       setSaving(false);
     }

--- a/frontend/app/[locale]/models/components/model/ModelMaxTokensInput.tsx
+++ b/frontend/app/[locale]/models/components/model/ModelMaxTokensInput.tsx
@@ -17,6 +17,7 @@ interface ModelMaxTokensInputProps {
   value: string;
   placeholder?: string;
   onChange: (value: string) => void;
+  disabled?: boolean;
 }
 
 export const isValidMaxTokens = (value: string): boolean => {
@@ -33,6 +34,7 @@ export const ModelMaxTokensInput = ({
   value,
   placeholder,
   onChange,
+  disabled = false,
 }: ModelMaxTokensInputProps) => {
   return (
     <AutoComplete
@@ -41,6 +43,7 @@ export const ModelMaxTokensInput = ({
       options={MAX_TOKEN_OPTIONS}
       placeholder={placeholder}
       onChange={onChange}
+      disabled={disabled}
       filterOption={(inputValue, option) =>
         String(option?.label ?? "")
           .toLowerCase()
@@ -48,7 +51,7 @@ export const ModelMaxTokensInput = ({
         String(option?.value ?? "").includes(inputValue)
       }
     >
-      <Input id={id} inputMode="numeric" pattern="[0-9]*" />
+      <Input id={id} inputMode="numeric" pattern="[0-9]*" disabled={disabled} />
     </AutoComplete>
   );
 };


### PR DESCRIPTION
## Summary

Fix two race conditions in the model configuration flow:

1. **Stale connectivity responses** — Users could modify form fields while connectivity verification was in flight, causing returned responses to be applied to outdated state. Fix: lock all form inputs via `disabled={verifyingConnectivity}`, propagating the lock to `ModelCapacityFields` and `ModelMaxTokensInput` through a new `disabled` prop.
<img width="583" height="1016" alt="image" src="https://github.com/user-attachments/assets/f2a74b58-35e0-42c1-8f2d-ba54f258df30" />


2. **Stale API key after provider save** — After saving a new provider API key, the model list was prefetched with the previous key because the parent's `models` state had not yet propagated into the closure. Fix: add an `onSuccess` callback to `ProviderConfigEditDialog` that passes the just-saved `apiKey` directly into `prefetchProviderModels` via a new `apiKeyOverride`, and force a full remount via `key` so the dialog always initializes from the latest `initialApiKey`.
<img width="615" height="556" alt="image" src="https://github.com/user-attachments/assets/6d1886ab-600f-49b1-ba8a-00f1a429b212" />
<img width="590" height="642" alt="image" src="https://github.com/user-attachments/assets/52012167-bc9d-4b3b-a8c1-b77d09bc98f2" />

## Changes

- `frontend/app/[locale]/models/components/model/ModelAddDialog.tsx` — disable all form fields during verification and reflect the verifying state on the Add button
- `frontend/app/[locale]/models/components/model/ModelCapacityFields.tsx` — add `disabled` prop and forward to children
- `frontend/app/[locale]/models/components/model/ModelMaxTokensInput.tsx` — add `disabled` prop and forward to children
- `frontend/app/[locale]/models/components/model/ModelEditDialog.tsx` — add `onSuccess` callback to `ProviderConfigEditDialog`
- `frontend/app/[locale]/models/components/model/ModelDeleteDialog.tsx` — add `apiKeyOverride` to `prefetchProviderModels`, invoke it in `onSuccess` with the saved key, and force remount via `key` prop