### PR TITLE
🐛Bugfix: Fix duplicate frontmatter when editing skills

### DIFF
--- a/frontend/app/[locale]/agents/components/agentConfig/SkillBuildModal.tsx
+++ b/frontend/app/[locale]/agents/components/agentConfig/SkillBuildModal.tsx
@@ -102,6 +102,17 @@ function parseStreamedFrontmatter(content: string): StreamedFrontmatter | null {
   }
 }
 
+function stripLeadingSkillFrontmatter(content: string): string {
+  let normalizedContent = content;
+  const frontmatterPattern = /^(?:\uFEFF)?---\r?\n[\s\S]*?\r?\n---(?:\r?\n)*/;
+
+  while (frontmatterPattern.test(normalizedContent)) {
+    normalizedContent = normalizedContent.replace(frontmatterPattern, "");
+  }
+
+  return normalizedContent;
+}
+
 function mergeGeneratedSkillTabs(
   currentTabs: SkillFileContent[],
   generatedTabs: SkillFileContent[],
@@ -452,7 +463,13 @@ export default function SkillBuildModal({
             if (content === null) {
               throw new Error(`Failed to load skill file: ${path}`);
             }
-            return { path, content };
+            return {
+              path,
+              content:
+                path === "SKILL.md"
+                  ? stripLeadingSkillFrontmatter(content)
+                  : content,
+            };
           })
         );
         if (!cancelled) {
@@ -520,7 +537,10 @@ export default function SkillBuildModal({
       setIsSubmitting(true);
 
       const skillTab = skillTabs.find((t) => t.path === "SKILL.md");
-      const content = skillTab?.content || "";
+      const rawContent = skillTab?.content || "";
+      const content = isEditMode
+        ? stripLeadingSkillFrontmatter(rawContent)
+        : rawContent;
 
       const extraFiles = skillTabs
         .filter((t) => t.path !== "SKILL.md")

--- a/frontend/app/[locale]/agents/components/agentConfig/SkillBuildModal.tsx
+++ b/frontend/app/[locale]/agents/components/agentConfig/SkillBuildModal.tsx
@@ -537,10 +537,7 @@ export default function SkillBuildModal({
       setIsSubmitting(true);
 
       const skillTab = skillTabs.find((t) => t.path === "SKILL.md");
-      const rawContent = skillTab?.content || "";
-      const content = isEditMode
-        ? stripLeadingSkillFrontmatter(rawContent)
-        : rawContent;
+      const content = skillTab?.content || "";
 
       const extraFiles = skillTabs
         .filter((t) => t.path !== "SKILL.md")


### PR DESCRIPTION
修复 Skill 编辑时重复插入 frontmatter 的问题。

before
<img width="1818" height="1394" alt="image" src="https://github.com/user-attachments/assets/fca244a0-3b0a-4494-a782-2baa52c1345b" />


After
<img width="1801" height="1391" alt="image" src="https://github.com/user-attachments/assets/634bbe02-02cd-4a84-af16-c13ed901c875" />
