### PR TITLE
bugfix: remove broken builtin volcano_stt/volcano_tts model records

### DIFF
--- a/backend/services/oauth_service.py
+++ b/backend/services/oauth_service.py
@@ -415,7 +415,6 @@ async def complete_pending_oauth_account(
         use_invitation_code,
     )
     from services.tool_configuration_service import init_tool_list_for_tenant
-    from services.user_management_service import generate_tts_stt_4_admin
     from utils.auth_utils import calculate_expires_at, generate_session_jwt
 
     pending = parse_pending_oauth_token(pending_token)
@@ -492,8 +491,6 @@ async def complete_pending_oauth_account(
     if group_ids and not is_asset_owner_registration:
         add_user_to_groups(supabase_user_id, group_ids, supabase_user_id)
 
-    if user_role == "ADMIN":
-        await generate_tts_stt_4_admin(tenant_id, supabase_user_id)
     if not is_asset_owner_registration:
         await init_tool_list_for_tenant(tenant_id, supabase_user_id)
 

--- a/backend/services/user_management_service.py
+++ b/backend/services/user_management_service.py
@@ -275,8 +275,6 @@ async def signup_user_with_invitation(email: EmailStr,
         logging.info(
             f"User {email} registered successfully, role: {user_role}, tenant: {tenant_id}, auto_login={auto_login}")
 
-        if user_role == "ADMIN":
-            await generate_tts_stt_4_admin(tenant_id, user_id)
 
         # Initialize tool list for the new tenant (only once per tenant)
         if not is_asset_owner_registration:
@@ -313,38 +311,6 @@ async def parse_supabase_response(is_admin, response, user_role, auto_login: boo
         "session": session_data,
         "registration_type": "admin" if is_admin else "user"
     }
-
-
-async def generate_tts_stt_4_admin(tenant_id, user_id):
-    tts_model_data = {
-        "model_repo": "",
-        "model_name": "volcano_tts",
-        "model_factory": "OpenAI-API-Compatible",
-        "model_type": "tts",
-        "api_key": "",
-        "base_url": "",
-        "max_tokens": 0,
-        "used_token": 0,
-        "display_name": "volcano_tts",
-        "connect_status": "unavailable",
-        "delete_flag": "N"
-    }
-    stt_model_data = {
-        "model_repo": "",
-        "model_name": "volcano_stt",
-        "model_factory": "OpenAI-API-Compatible",
-        "model_type": "stt",
-        "api_key": "",
-        "base_url": "",
-        "max_tokens": 0,
-        "used_token": 0,
-        "display_name": "volcano_stt",
-        "connect_status": "unavailable",
-        "delete_flag": "N"
-    }
-    create_model_record(tts_model_data, user_id, tenant_id)
-    create_model_record(stt_model_data, user_id, tenant_id)
-
 
 async def verify_invite_code(invite_code):
     logging.info(

--- a/deploy/sql/init.sql
+++ b/deploy/sql/init.sql
@@ -190,20 +190,6 @@ COMMENT ON COLUMN "model_record_t"."update_time" IS 'Update time, audit field';
 COMMENT ON COLUMN "model_record_t"."updated_by" IS 'Last updater ID, audit field';
 COMMENT ON COLUMN "model_record_t"."created_by" IS 'Creator ID, audit field';
 COMMENT ON TABLE "model_record_t" IS 'List of models defined by users in the configuration page';
-
-INSERT INTO "nexent"."model_record_t" ("model_repo", "model_name", "model_factory", "model_type", "api_key", "base_url", "max_tokens", "used_token", "display_name", "connect_status")
-SELECT '', 'volcano_tts', 'OpenAI-API-Compatible', 'tts', '', '', 0, 0, 'volcano_tts', 'unavailable'
-WHERE NOT EXISTS (
-  SELECT 1 FROM "nexent"."model_record_t"
-  WHERE "model_name" = 'volcano_tts' AND "model_type" = 'tts'
-);
-INSERT INTO "nexent"."model_record_t" ("model_repo", "model_name", "model_factory", "model_type", "api_key", "base_url", "max_tokens", "used_token", "display_name", "connect_status")
-SELECT '', 'volcano_stt', 'OpenAI-API-Compatible', 'stt', '', '', 0, 0, 'volcano_stt', 'unavailable'
-WHERE NOT EXISTS (
-  SELECT 1 FROM "nexent"."model_record_t"
-  WHERE "model_name" = 'volcano_stt' AND "model_type" = 'stt'
-);
-
 CREATE TABLE IF NOT EXISTS "knowledge_record_t" (
   "knowledge_id" SERIAL,
   "index_name" varchar(100) COLLATE "pg_catalog"."default",

--- a/test/backend/services/test_user_management_service.py
+++ b/test/backend/services/test_user_management_service.py
@@ -89,7 +89,6 @@ with patch('backend.database.client.MinioClient', return_value=minio_client_mock
         check_auth_service_health,
         signup_user_with_invitation,
         parse_supabase_response,
-        generate_tts_stt_4_admin,
         verify_invite_code,
         signin_user,
         refresh_user_token,
@@ -592,7 +591,6 @@ class TestSignupUserWithInvitation(unittest.IsolatedAsyncioTestCase):
 
     @patch('backend.services.user_management_service.add_user_to_groups')
     @patch('backend.services.user_management_service.parse_supabase_response')
-    @patch('backend.services.user_management_service.generate_tts_stt_4_admin')
     @patch('backend.services.user_management_service.insert_user_tenant')
     @patch('backend.services.user_management_service.get_invitation_by_code')
     @patch('backend.services.user_management_service.check_invitation_available')
@@ -600,7 +598,7 @@ class TestSignupUserWithInvitation(unittest.IsolatedAsyncioTestCase):
     @patch('backend.services.user_management_service.get_supabase_client')
     async def test_signup_user_with_admin_invite_code(self, mock_get_client, mock_use_invite,
                                                      mock_check_available, mock_get_invite_code,
-                                                     mock_insert_tenant, mock_generate_tts, mock_parse_response, mock_add_groups):
+                                                     mock_insert_tenant, mock_parse_response, mock_add_groups):
         """Test user signup with ADMIN_INVITE code"""
         # Setup mocks
         mock_client = MagicMock()
@@ -635,9 +633,6 @@ class TestSignupUserWithInvitation(unittest.IsolatedAsyncioTestCase):
         with patch('backend.services.user_management_service.init_tool_list_for_tenant', new_callable=AsyncMock) as mock_init_tools, \
              patch('backend.services.user_management_service.init_skill_list_for_tenant', new_callable=AsyncMock) as mock_init_skills:
             result = await signup_user_with_invitation("admin@example.com", "Password123", invite_code="ADMIN123")
-
-            # Verify generate_tts_stt_4_admin was called for admin user
-            mock_generate_tts.assert_called_once_with("tenant_id", "user-123")
 
             self.assertEqual(result, {"user": "admin_data"})
             mock_insert_tenant.assert_called_once_with(user_id="user-123", tenant_id="tenant_id", user_role="ADMIN", user_email="admin@example.com")
@@ -799,7 +794,6 @@ class TestSignupUserWithInvitation(unittest.IsolatedAsyncioTestCase):
              patch('backend.services.user_management_service.insert_user_tenant') as mock_insert_tenant, \
              patch('backend.services.user_management_service.parse_supabase_response') as mock_parse, \
              patch('backend.services.user_management_service.use_invitation_code'), \
-             patch('backend.services.user_management_service.generate_tts_stt_4_admin') as mock_generate_tts, \
              patch('backend.services.user_management_service.init_tool_list_for_tenant', new_callable=AsyncMock) as mock_init_tools, \
              patch('backend.services.user_management_service.init_skill_list_for_tenant', new_callable=AsyncMock) as mock_init_skills:
 
@@ -816,7 +810,6 @@ class TestSignupUserWithInvitation(unittest.IsolatedAsyncioTestCase):
 
             # Verify ADMIN role was assigned and TTS/STT generation was called
             mock_insert_tenant.assert_called_with(user_id="user-123", tenant_id="tenant_id", user_role="ADMIN", user_email="admin@example.com")
-            mock_generate_tts.assert_called_once_with("tenant_id", "user-123")
             mock_parse.assert_called_with(False, mock_response, "ADMIN", True)
             mock_init_tools.assert_called_once_with("tenant_id", "user-123")
             mock_init_skills.assert_called_once_with("tenant_id", "user-123")
@@ -871,7 +864,6 @@ class TestSignupUserWithInvitation(unittest.IsolatedAsyncioTestCase):
 
     @patch('backend.services.user_management_service.add_user_to_groups')
     @patch('backend.services.user_management_service.parse_supabase_response')
-    @patch('backend.services.user_management_service.generate_tts_stt_4_admin')
     @patch('backend.services.user_management_service.insert_user_tenant')
     @patch('backend.services.user_management_service.get_invitation_by_code')
     @patch('backend.services.user_management_service.check_invitation_available')
@@ -879,7 +871,7 @@ class TestSignupUserWithInvitation(unittest.IsolatedAsyncioTestCase):
     @patch('backend.services.user_management_service.get_supabase_client')
     async def test_signup_user_with_auto_login_false(self, mock_get_client, mock_use_invite,
                                                      mock_check_available, mock_get_invite_code,
-                                                     mock_insert_tenant, mock_generate_tts, mock_parse_response, mock_add_groups):
+                                                     mock_insert_tenant, mock_parse_response, mock_add_groups):
         """Test user signup with auto_login=False (tenant admin creation scenario)"""
         # Setup mocks
         mock_client = MagicMock()
@@ -919,7 +911,6 @@ class TestSignupUserWithInvitation(unittest.IsolatedAsyncioTestCase):
 
     @patch('backend.services.user_management_service.add_user_to_groups')
     @patch('backend.services.user_management_service.parse_supabase_response')
-    @patch('backend.services.user_management_service.generate_tts_stt_4_admin')
     @patch('backend.services.user_management_service.insert_user_tenant')
     @patch('backend.services.user_management_service.get_invitation_by_code')
     @patch('backend.services.user_management_service.check_invitation_available')
@@ -927,7 +918,7 @@ class TestSignupUserWithInvitation(unittest.IsolatedAsyncioTestCase):
     @patch('backend.services.user_management_service.get_supabase_client')
     async def test_signup_user_with_auto_login_default(self, mock_get_client, mock_use_invite,
                                                      mock_check_available, mock_get_invite_code,
-                                                     mock_insert_tenant, mock_generate_tts, mock_parse_response, mock_add_groups):
+                                                     mock_insert_tenant, mock_parse_response, mock_add_groups):
         """Test user signup with default auto_login (True)"""
         # Setup mocks
         mock_client = MagicMock()
@@ -1024,7 +1015,6 @@ class TestSignupUserWithInvitation(unittest.IsolatedAsyncioTestCase):
         mock_add_groups.return_value = []
         with patch('backend.services.user_management_service.insert_user_tenant'), \
              patch('backend.services.user_management_service.parse_supabase_response', new_callable=AsyncMock) as mock_parse, \
-             patch('backend.services.user_management_service.generate_tts_stt_4_admin'), \
              patch('backend.services.user_management_service.init_tool_list_for_tenant', new_callable=AsyncMock), \
              patch('backend.services.user_management_service.init_skill_list_for_tenant', new_callable=AsyncMock):
             mock_parse.return_value = {"user": "data"}
@@ -1073,7 +1063,6 @@ class TestSignupUserWithInvitation(unittest.IsolatedAsyncioTestCase):
 
         with patch('backend.services.user_management_service.insert_user_tenant'), \
              patch('backend.services.user_management_service.parse_supabase_response', new_callable=AsyncMock) as mock_parse, \
-             patch('backend.services.user_management_service.generate_tts_stt_4_admin'), \
              patch('backend.services.user_management_service.init_tool_list_for_tenant', new_callable=AsyncMock), \
              patch('backend.services.user_management_service.init_skill_list_for_tenant', new_callable=AsyncMock):
             mock_parse.return_value = {"user": "data"}
@@ -1230,32 +1219,6 @@ class TestParseSupabaseResponse(unittest.IsolatedAsyncioTestCase):
 
         # Session should be None because Supabase didn't return it
         self.assertIsNone(result["session"])
-
-
-class TestGenerateTtsStt4Admin(unittest.IsolatedAsyncioTestCase):
-    """Test generate_tts_stt_4_admin"""
-
-    @patch('backend.services.user_management_service.create_model_record')
-    async def test_generate_tts_stt_models(self, mock_create_record):
-        """Test TTS and STT model generation for admin"""
-        await generate_tts_stt_4_admin("tenant-123", "user-123")
-
-        # Should be called twice - once for TTS, once for STT
-        self.assertEqual(mock_create_record.call_count, 2)
-
-        # Check TTS model call
-        tts_call = mock_create_record.call_args_list[0]
-        tts_data = tts_call[0][0]
-        self.assertEqual(tts_data["model_name"], "volcano_tts")
-        self.assertEqual(tts_data["model_type"], "tts")
-
-        # Check STT model call
-        stt_call = mock_create_record.call_args_list[1]
-        stt_data = stt_call[0][0]
-        self.assertEqual(stt_data["model_name"], "volcano_stt")
-        self.assertEqual(stt_data["model_type"], "stt")
-
-
 class TestVerifyInviteCode(unittest.IsolatedAsyncioTestCase):
     """Test verify_invite_code"""
 


### PR DESCRIPTION
- Remove volcano_tts and volcano_stt INSERT seed data from deploy/sql/init.sql
- Remove generate_tts_stt_4_admin() function from user_management_service.py
- Remove generate_tts_stt_4_admin import and call from oauth_service.py
- Remove related test cases and patch decorators from test_user_management_service.py

These model records were created with empty API keys and incorrect model_factory (OpenAI-API-Compatible instead of volc), causing HTTP 401 on every STT/TTS connectivity check. New tenants and fresh deployments will no longer auto-create these broken records.

<img width="2241" height="1223" alt="image" src="https://github.com/user-attachments/assets/331740b7-e948-4d5c-80e6-2ca98c0e35c1" />
