### PR TITLE
fix: compare KB embedding models by displayName

### DIFF
--- a/frontend/app/[locale]/knowledges/KnowledgeBaseConfiguration.tsx
+++ b/frontend/app/[locale]/knowledges/KnowledgeBaseConfiguration.tsx
@@ -316,15 +316,16 @@ function DataConfig({ isActive }: DataConfigProps) {
 
   // Open warning modal only when neither embedding nor multi-embedding is configured.
   useEffect(() => {
-    const singleEmbeddingModelName = modelConfig?.embedding?.modelName?.trim();
+    const singleEmbeddingModelName =
+      modelConfig?.embedding?.displayName?.trim();
     const multiEmbeddingModelName =
-      modelConfig?.multiEmbedding?.modelName?.trim();
+      modelConfig?.multiEmbedding?.displayName?.trim();
     setShowEmbeddingWarning(
       !singleEmbeddingModelName && !multiEmbeddingModelName
     );
   }, [
-    modelConfig?.embedding?.modelName,
-    modelConfig?.multiEmbedding?.modelName,
+    modelConfig?.embedding?.displayName,
+    modelConfig?.multiEmbedding?.displayName,
   ]);
 
   // Add event listener for selecting new knowledge base
@@ -401,9 +402,9 @@ function DataConfig({ isActive }: DataConfigProps) {
     if (kbState.isLoading) return; // avoid running during list loading
     if (hasCleanedRef.current) return; // run once per entry
 
-    const embeddingName = modelConfig?.embedding?.modelName?.trim() || "";
+    const embeddingName = modelConfig?.embedding?.displayName?.trim() || "";
     const multiEmbeddingName =
-      modelConfig?.multiEmbedding?.modelName?.trim() || "";
+      modelConfig?.multiEmbedding?.displayName?.trim() || "";
 
     const allowedModels = new Set<string>();
     if (embeddingName) allowedModels.add(embeddingName);
@@ -414,8 +415,8 @@ function DataConfig({ isActive }: DataConfigProps) {
     isActive,
     kbState.isLoading,
     kbState.knowledgeBases,
-    modelConfig?.embedding?.modelName,
-    modelConfig?.multiEmbedding?.modelName,
+    modelConfig?.embedding?.displayName,
+    modelConfig?.multiEmbedding?.displayName,
     kbDispatch,
   ]);
 
@@ -749,10 +750,11 @@ function DataConfig({ isActive }: DataConfigProps) {
     setNewKbPreserveSourceFile(true);
     // Set default embedding model:
     // 1) configured embedding model, 2) configured multimodal model, 3) first available option.
+    // Use displayName to match availableEmbeddingModels and KB embeddingModel.
     const configEmbeddingModel =
-      modelConfig?.embedding?.modelName?.trim() || "";
+      modelConfig?.embedding?.displayName?.trim() || "";
     const configMultiEmbeddingModel =
-      modelConfig?.multiEmbedding?.modelName?.trim() || "";
+      modelConfig?.multiEmbedding?.displayName?.trim() || "";
     const preferredModel = [
       { modelName: configEmbeddingModel, type: "embedding" },
       { modelName: configMultiEmbeddingModel, type: "multi_embedding" },
@@ -1171,8 +1173,8 @@ function DataConfig({ isActive }: DataConfigProps) {
                 )}
                 currentModel={
                   kbState.activeKnowledgeBase?.is_multimodal
-                    ? modelConfig?.multiEmbedding?.modelName?.trim() || ""
-                    : modelConfig?.embedding?.modelName?.trim() || ""
+                    ? modelConfig?.multiEmbedding?.displayName?.trim() || ""
+                    : modelConfig?.embedding?.displayName?.trim() || ""
                 }
                 knowledgeBaseModel={kbState.activeKnowledgeBase.embeddingModel}
                 embeddingModelInfo={

--- a/frontend/app/[locale]/knowledges/contexts/KnowledgeBaseContext.tsx
+++ b/frontend/app/[locale]/knowledges/contexts/KnowledgeBaseContext.tsx
@@ -178,6 +178,18 @@ export const KnowledgeBaseProvider: React.FC<KnowledgeBaseProviderProps> = ({
     dataMateSyncError: undefined,
   });
 
+  // Keep currentEmbeddingModel aligned with configured embedding displayName
+  // (KB embeddingModel is stored as display_name).
+  useEffect(() => {
+    const displayName = modelConfig?.embedding?.displayName?.trim() || null;
+    if (displayName !== state.currentEmbeddingModel) {
+      dispatch({
+        type: KNOWLEDGE_BASE_ACTION_TYPES.SET_MODEL,
+        payload: displayName,
+      });
+    }
+  }, [modelConfig?.embedding?.displayName, state.currentEmbeddingModel]);
+
   // Check if knowledge base is selectable - memoized with useCallback
   const isKnowledgeBaseSelectable = useCallback(
     (kb: KnowledgeBase): boolean => {
@@ -201,7 +213,7 @@ export const KnowledgeBaseProvider: React.FC<KnowledgeBaseProviderProps> = ({
 
       const currentEmbeddingModel = state.currentEmbeddingModel?.trim() || "";
       const currentMultiEmbeddingModel =
-        modelConfig?.multiEmbedding?.modelName?.trim() || "";
+        modelConfig?.multiEmbedding?.displayName?.trim() || "";
 
       if (kb.is_multimodal) {
         // Multimodal KB is selectable as long as current multimodal model is configured.
@@ -211,10 +223,11 @@ export const KnowledgeBaseProvider: React.FC<KnowledgeBaseProviderProps> = ({
       // Text KB is selectable as long as current embedding model is configured.
       return !!currentEmbeddingModel;
     },
-    [modelConfig?.multiEmbedding?.modelName, state.currentEmbeddingModel]
+    [modelConfig?.multiEmbedding?.displayName, state.currentEmbeddingModel]
   );
 
-  // Check if knowledge base has model mismatch (for display purposes)
+  // Check if knowledge base has model mismatch (for display purposes).
+  // Compare configured displayName with KB embeddingModel (stored as display_name).
   const hasKnowledgeBaseModelMismatch = useCallback(
     (kb: KnowledgeBase): boolean => {
       if (kb.embeddingModel === "unknown") {
@@ -226,14 +239,14 @@ export const KnowledgeBaseProvider: React.FC<KnowledgeBaseProviderProps> = ({
 
       if (kb.is_multimodal) {
         const multiEmbeddingModel =
-          modelConfig?.multiEmbedding?.modelName?.trim() || "";
+          modelConfig?.multiEmbedding?.displayName?.trim() || "";
         return multiEmbeddingModel !== kb.embeddingModel.trim();
       }
 
       const currentEmbeddingModel = state.currentEmbeddingModel?.trim() || "";
       return currentEmbeddingModel !== kb.embeddingModel.trim();
     },
-    [modelConfig?.multiEmbedding?.modelName, state.currentEmbeddingModel]
+    [modelConfig?.multiEmbedding?.displayName, state.currentEmbeddingModel]
   );
 
   // Load knowledge base data (supports force fetch from server and load selected status) - optimized with useCallback
@@ -375,7 +388,7 @@ export const KnowledgeBaseProvider: React.FC<KnowledgeBaseProviderProps> = ({
         return null;
       }
     },
-    [modelConfig?.multiEmbedding?.modelName, state.currentEmbeddingModel, t]
+    [t]
   );
 
   // Delete knowledge base - memoized with useCallback
@@ -541,12 +554,12 @@ export const KnowledgeBaseProvider: React.FC<KnowledgeBaseProviderProps> = ({
     // Use ref to track if data has been loaded to avoid duplicate loading
     let initialDataLoaded = false;
 
-    // Get current model config at initial load
+    // Get current model config at initial load (use displayName to match KB embeddingModel)
     const loadInitialData = async () => {
-      if (modelConfig?.embedding?.modelName) {
+      if (modelConfig?.embedding?.displayName) {
         dispatch({
           type: KNOWLEDGE_BASE_ACTION_TYPES.SET_MODEL,
-          payload: modelConfig.embedding.modelName,
+          payload: modelConfig.embedding.displayName,
         });
       }
 
@@ -555,7 +568,7 @@ export const KnowledgeBaseProvider: React.FC<KnowledgeBaseProviderProps> = ({
 
     loadInitialData();
 
-    // Listen for embedding model change event
+    // Listen for embedding model change event (detail.model is displayName)
     const handleEmbeddingModelChange = (e: CustomEvent) => {
       const newModel = e.detail.model || null;
 
@@ -574,10 +587,10 @@ export const KnowledgeBaseProvider: React.FC<KnowledgeBaseProviderProps> = ({
     // Listen for env config change event
     const handleEnvConfigChanged = () => {
       // Reload env related config
-      if (modelConfig?.embedding?.modelName !== state.currentEmbeddingModel) {
+      if (modelConfig?.embedding?.displayName !== state.currentEmbeddingModel) {
         dispatch({
           type: KNOWLEDGE_BASE_ACTION_TYPES.SET_MODEL,
-          payload: modelConfig?.embedding?.modelName || null,
+          payload: modelConfig?.embedding?.displayName || null,
         });
 
         // Reload knowledge base list when model changes

--- a/frontend/lib/knowledgeBaseCompatibility.ts
+++ b/frontend/lib/knowledgeBaseCompatibility.ts
@@ -11,6 +11,10 @@ export const isMultimodalConstraintMismatch = (
   );
 };
 
+/**
+ * Check whether a knowledge base is compatible with the configured embedding models.
+ * String args must be model display names (matching kb.embeddingModel / display_name).
+ */
 export const isEmbeddingModelCompatible = (
   kb: KnowledgeBase,
   currentEmbeddingModel: string | null,


### PR DESCRIPTION
Avoid false model-mismatch blocks on multimodal knowledge bases when modelName differs from the stored display_name.