### PR TITLE
fix: provide local import allowlist before code execution

### DIFF
--- a/backend/agents/create_agent_info.py
+++ b/backend/agents/create_agent_info.py
@@ -2,6 +2,7 @@
 import copy
 import json
 import logging
+import os
 import threading
 from typing import Any, Dict, List, Optional
 from urllib.parse import urljoin
@@ -75,6 +76,16 @@ from consts.exceptions import ValidationError
 
 logger = logging.getLogger("create_agent_info")
 logger.setLevel(logging.INFO)
+
+# The current LocalPythonExecutor import allowlist. This prompt-only list does
+# not change interpreter permissions; it prevents avoidable failed imports.
+LOCAL_PYTHON_IMPORT_ALLOWLIST = [
+    "array", "base64", "bisect", "calendar", "cmath", "collections", "copy",
+    "csv", "datetime", "decimal", "fractions", "functools", "hashlib", "heapq",
+    "hmac", "itertools", "json", "math", "operator", "pprint", "queue", "random",
+    "re", "stat", "statistics", "string", "textwrap", "time", "typing",
+    "unicodedata", "uuid",
+]
 
 
 def _create_fixed_search_memory_tool():
@@ -1201,6 +1212,15 @@ async def create_agent_config(
         else input_budget
     )
 
+    sandbox_policy = agent_info.get("sandbox_policy")
+    configured_sandbox_level = (
+        sandbox_policy.get("level") if isinstance(sandbox_policy, dict) else None
+    )
+    is_local_python_executor = (
+        str(configured_sandbox_level or os.getenv("NEXENT_SANDBOX_DEFAULT_LEVEL", "local"))
+        .strip().lower() == "local"
+    )
+
     context_items = build_context_inputs(
         duty=duty_prompt,
         constraint=constraint_prompt,
@@ -1222,6 +1242,9 @@ async def create_agent_config(
         long_term_memory_prompt=long_term_memory_prompt,
         knowledge_base_summary=knowledge_base_summary,
         kb_ids=kb_ids,
+        restricted_python_authorized_imports=(
+            LOCAL_PYTHON_IMPORT_ALLOWLIST if is_local_python_executor else None
+        ),
     )
 
     logger.debug(

--- a/backend/agents/create_agent_info.py
+++ b/backend/agents/create_agent_info.py
@@ -28,6 +28,7 @@ from nexent.core.models.capacity_budget import (
 )
 from nexent.core.tools.parallel_executor import ParallelExecutorTool
 from nexent.core.agents.sandbox import SandboxConfig
+from nexent.core.agents.nexent_agent import get_local_python_authorized_imports
 
 from consts.capability_profiles import CATALOG as CAPABILITY_CATALOG
 
@@ -76,17 +77,6 @@ from consts.exceptions import ValidationError
 
 logger = logging.getLogger("create_agent_info")
 logger.setLevel(logging.INFO)
-
-# The current LocalPythonExecutor import allowlist. This prompt-only list does
-# not change interpreter permissions; it prevents avoidable failed imports.
-LOCAL_PYTHON_IMPORT_ALLOWLIST = [
-    "array", "base64", "bisect", "calendar", "cmath", "collections", "copy",
-    "csv", "datetime", "decimal", "fractions", "functools", "hashlib", "heapq",
-    "hmac", "itertools", "json", "math", "operator", "pprint", "queue", "random",
-    "re", "stat", "statistics", "string", "textwrap", "time", "typing",
-    "unicodedata", "uuid",
-]
-
 
 def _create_fixed_search_memory_tool():
     """Create the internal search tool lazily to keep import boundaries stable."""
@@ -1243,7 +1233,7 @@ async def create_agent_config(
         knowledge_base_summary=knowledge_base_summary,
         kb_ids=kb_ids,
         restricted_python_authorized_imports=(
-            LOCAL_PYTHON_IMPORT_ALLOWLIST if is_local_python_executor else None
+            get_local_python_authorized_imports() if is_local_python_executor else None
         ),
     )
 

--- a/backend/utils/context_utils.py
+++ b/backend/utils/context_utils.py
@@ -337,6 +337,36 @@ def _build_code_norms_text(
     return content
 
 
+def _build_restricted_python_execution_policy_text(
+    authorized_imports: List[str],
+    language: str = "zh",
+) -> str:
+    """Build pre-execution guidance for the restricted local interpreter."""
+    normalized_imports = sorted({
+        name.strip()
+        for name in authorized_imports
+        if isinstance(name, str) and name.strip()
+    })
+    imports = ", ".join(f"`{name}`" for name in normalized_imports)
+    if language == "zh":
+        lines = ["### Python 代码执行边界"]
+        lines.append("当前代码执行器是受限解释器。写入可执行代码前，必须遵守以下规则：")
+        lines.append(f"1. 仅允许导入这些模块：{imports}。")
+        lines.append("2. 不要导入、安装、探测或依次尝试列表以外的库；`requests`、`urllib`、`pandas`、`numpy`、`openpyxl` 等均不可假定可用。")
+        lines.append("3. Python 包不是工具。只能调用“可用资源”中实际列出的工具或助手；不要把未定义的包函数（例如 `requests.get`）传给 `parallel_executor`。")
+        lines.append("4. 受限 Python 没有通用网络、Shell 或包安装能力。若任务需要这些能力而可用资源中没有对应工具，应直接如实说明限制。")
+        lines.append("5. 本规则优先于“不要放弃”等一般性要求：能力不存在时不要继续猜测替代库或重复失败的执行。")
+    else:
+        lines = ["### Python Code Execution Boundary"]
+        lines.append("The current code executor is a restricted interpreter. Before writing executable code, follow these rules:")
+        lines.append(f"1. You may import only: {imports}.")
+        lines.append("2. Do not import, install, probe, or try alternate libraries outside this list; do not assume `requests`, `urllib`, `pandas`, `numpy`, or `openpyxl` is available.")
+        lines.append("3. A Python package is not a tool. Call only tools or agents actually listed in Available Resources; never pass an undefined package function such as `requests.get` to `parallel_executor`.")
+        lines.append("4. Restricted Python has no general network, shell, or package-install capability. If a task needs one and no listed tool provides it, state the limitation directly.")
+        lines.append("5. This policy takes precedence over general instructions to keep trying: do not guess alternate libraries or repeat failed executions when the capability is unavailable.")
+    return "\n".join(lines)
+
+
 def _build_footer_text(
     few_shots: str,
     language: str = "zh",
@@ -400,6 +430,7 @@ def build_context_inputs(
     long_term_memory_prompt: Optional[str] = None,
     knowledge_base_summary: Optional[str] = None,
     kb_ids: Optional[List[str]] = None,
+    restricted_python_authorized_imports: Optional[List[str]] = None,
     include_tools: bool = True,
     include_skills: bool = True,
     include_memory: bool = True,
@@ -554,6 +585,16 @@ def build_context_inputs(
         ))
     if constraint:
         add_system("constraint", _build_constraint_text(constraint, language), 30)
+    if restricted_python_authorized_imports:
+        add_system(
+            "restricted_python_execution",
+            _build_restricted_python_execution_policy_text(
+                restricted_python_authorized_imports,
+                language,
+            ),
+            25,
+            "platform",
+        )
     add_system("code_norms", _build_code_norms_text(language, is_manager), 20, "platform")
     if few_shots:
         add_system("footer", _build_footer_text(few_shots, language), 10)

--- a/sdk/nexent/core/agents/nexent_agent.py
+++ b/sdk/nexent/core/agents/nexent_agent.py
@@ -37,6 +37,14 @@ SAFE_PYTHON_INTERPRETER_IMPORTS = [
     "uuid", "pprint", "operator", "typing",
 ]
 
+
+def get_local_python_authorized_imports() -> List[str]:
+    """Return the imports permitted by Nexent's default local code executor."""
+    from smolagents.local_python_executor import BASE_BUILTIN_MODULES
+
+    return sorted(set(BASE_BUILTIN_MODULES) | set(SAFE_PYTHON_INTERPRETER_IMPORTS))
+
+
 logger = logging.getLogger(__name__)
 
 

--- a/test/backend/agents/test_create_agent_info.py
+++ b/test/backend/agents/test_create_agent_info.py
@@ -297,6 +297,14 @@ sandbox_module = _create_stub_module(
 )
 nexent_agents_module.sandbox = sandbox_module
 
+nexent_agent_module = _create_stub_module(
+    "nexent.core.agents.nexent_agent",
+    get_local_python_authorized_imports=MagicMock(
+        return_value=["sdk_default_import"]
+    ),
+)
+nexent_agents_module.nexent_agent = nexent_agent_module
+
 
 class MockProviderCapabilityUnknown(Exception):
     pass
@@ -482,7 +490,6 @@ setattr(agents_pkg, "create_agent_info", create_agent_info_module)
 
 # Now import the symbols under test
 from backend.agents.create_agent_info import (
-    LOCAL_PYTHON_IMPORT_ALLOWLIST,
     discover_langchain_tools,
     create_tool_config_list,
     create_agent_config,
@@ -2047,33 +2054,37 @@ class TestCreateAgentConfig:
         assert "instructions" not in mocks["agent_config"].call_args.kwargs
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        ("sandbox_default_level", "expected_authorized_imports"),
-        [
-            ("local", LOCAL_PYTHON_IMPORT_ALLOWLIST),
-            ("docker", None),
-        ],
-    )
+    @pytest.mark.parametrize("sandbox_default_level", ["local", "docker"])
     async def test_create_agent_config_injects_import_policy_only_for_local_executor(
         self,
         sandbox_default_level,
-        expected_authorized_imports,
     ):
+        sdk_authorized_imports = ["sdk_default_import", "sdk_extra_import"]
         with patch(
             "backend.agents.create_agent_info.os.getenv",
             return_value=sandbox_default_level,
-        ):
+        ), patch(
+            "backend.agents.create_agent_info.get_local_python_authorized_imports",
+            return_value=sdk_authorized_imports,
+        ) as get_authorized_imports:
             mocks = await self._run_context_manager_case(
                 enable_context_manager=True,
                 prepared_prompt="",
             )
 
+        expected_authorized_imports = (
+            sdk_authorized_imports if sandbox_default_level == "local" else None
+        )
         assert (
             mocks["build_components"].call_args.kwargs[
                 "restricted_python_authorized_imports"
             ]
             == expected_authorized_imports
         )
+        if sandbox_default_level == "local":
+            get_authorized_imports.assert_called_once_with()
+        else:
+            get_authorized_imports.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_create_agent_config_runs_fixed_search_once_without_exposing_tool(self):

--- a/test/backend/agents/test_create_agent_info.py
+++ b/test/backend/agents/test_create_agent_info.py
@@ -482,6 +482,7 @@ setattr(agents_pkg, "create_agent_info", create_agent_info_module)
 
 # Now import the symbols under test
 from backend.agents.create_agent_info import (
+    LOCAL_PYTHON_IMPORT_ALLOWLIST,
     discover_langchain_tools,
     create_tool_config_list,
     create_agent_config,
@@ -2044,6 +2045,35 @@ class TestCreateAgentConfig:
         assert "search_memory" not in policy
         assert "store_memory" in policy
         assert "instructions" not in mocks["agent_config"].call_args.kwargs
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("sandbox_default_level", "expected_authorized_imports"),
+        [
+            ("local", LOCAL_PYTHON_IMPORT_ALLOWLIST),
+            ("docker", None),
+        ],
+    )
+    async def test_create_agent_config_injects_import_policy_only_for_local_executor(
+        self,
+        sandbox_default_level,
+        expected_authorized_imports,
+    ):
+        with patch(
+            "backend.agents.create_agent_info.os.getenv",
+            return_value=sandbox_default_level,
+        ):
+            mocks = await self._run_context_manager_case(
+                enable_context_manager=True,
+                prepared_prompt="",
+            )
+
+        assert (
+            mocks["build_components"].call_args.kwargs[
+                "restricted_python_authorized_imports"
+            ]
+            == expected_authorized_imports
+        )
 
     @pytest.mark.asyncio
     async def test_create_agent_config_runs_fixed_search_once_without_exposing_tool(self):

--- a/test/backend/utils/test_context_utils.py
+++ b/test/backend/utils/test_context_utils.py
@@ -112,6 +112,29 @@ def test_empty_inputs_emit_only_required_skeleton_and_fallback_items():
     assert all(item.type == ContextItemType.SYSTEM for item in items)
 
 
+@pytest.mark.parametrize("language", ["en", "zh"])
+def test_restricted_python_policy_is_injected_before_code_norms(language):
+    items = build_context_inputs(
+        restricted_python_authorized_imports=["json", "csv", "math", "json"],
+        language=language,
+    )
+
+    policy_item = next(
+        item for item in items if item.id == "system:restricted_python_execution"
+    )
+    policy_text = policy_item.content["text"]
+    item_ids = [item.id for item in items]
+
+    assert policy_item.type == ContextItemType.SYSTEM
+    assert policy_item.metadata["authority"] == "platform"
+    assert policy_item.priority == 25
+    assert "`csv`, `json`, `math`" in policy_text
+    assert "`requests`" in policy_text
+    assert item_ids.index(policy_item.id) < item_ids.index("system:code_norms")
+    if language == "en":
+        assert "### Python Code Execution Boundary" in policy_text
+
+
 def test_all_sources_are_naturally_granular_and_keep_stable_order():
     items = build_context_inputs(
         duty="duty",

--- a/test/sdk/core/agents/test_nexent_agent.py
+++ b/test/sdk/core/agents/test_nexent_agent.py
@@ -362,7 +362,8 @@ with patch.dict("sys.modules", module_mocks):
     from sdk.nexent.core.agents import nexent_agent
     from sdk.nexent.core.agents.nexent_agent import (
         NexentAgent, ActionStep, TaskStep, _has_host_tools, _is_retriever_tool,
-        _build_tool_input, _wrap_tool_with_monitoring, _tool_name
+        _build_tool_input, _wrap_tool_with_monitoring, _tool_name,
+        SAFE_PYTHON_INTERPRETER_IMPORTS, get_local_python_authorized_imports,
     )
     from sdk.nexent.core.agents.agent_model import ToolConfig, ModelConfig, AgentConfig, AgentHistory, ExternalA2AAgentConfig
 
@@ -506,6 +507,17 @@ def mock_core_agent():
 # ----------------------------------------------------------------------------
 # Tests for type-only imports and helper functions
 # ----------------------------------------------------------------------------
+
+
+def test_get_local_python_authorized_imports_matches_executor_defaults(monkeypatch):
+    """The prompt allowlist must mirror the local executor's imports."""
+    executor_module = types.ModuleType("smolagents.local_python_executor")
+    executor_module.BASE_BUILTIN_MODULES = ["json", "queue", "stat"]
+    monkeypatch.setitem(sys.modules, "smolagents.local_python_executor", executor_module)
+
+    assert get_local_python_authorized_imports() == sorted(
+        set(SAFE_PYTHON_INTERPRETER_IMPORTS) | {"json", "queue", "stat"}
+    )
 
 
 def test_type_checking_imports_resolve_context_and_subagent_types(monkeypatch):


### PR DESCRIPTION
## Summary

Expose the local Python import allowlist in the agent context before code execution. This lets the model choose an available approach or report the restriction instead of probing unavailable packages.

## Root cause

In local execution, the interpreter enforces an import allowlist. The original prompt did not describe that boundary, so some models learned it only from failed executions and retried with different unavailable packages.

## Before

The reproduction task triggered attempts to import `requests` and `urllib.request`, both rejected by the local interpreter.
<img width="1009" height="1148" alt="image" src="https://github.com/user-attachments/assets/124bc1b4-6973-4a1c-b7c7-779cddeb38dd" />

## After

The agent receives the permitted imports before planning. The same task no longer runs a restricted import and reports the execution boundary directly.
<img width="969" height="1124" alt="image" src="https://github.com/user-attachments/assets/8f7dfd6f-44de-4416-9e7c-9c514d468624" />

## Validation

- Focused backend tests: `20 passed`.
- Manual reproduction with the same network-request prompt: no restricted import attempt.