### PR TITLE
🐛 fix : restore ASSET_OWNER nav permissions and improve group selection UX

### DIFF
--- a/deploy/sql/migrations/v2.4.1_0807_restore_asset_owner_left_nav_permissions.sql
+++ b/deploy/sql/migrations/v2.4.1_0807_restore_asset_owner_left_nav_permissions.sql
@@ -1,0 +1,27 @@
+-- Restore ASSET_OWNER left-nav routes that are missing after earlier migrations:
+--   /newchat (1512): inserted by v2.4.0_0721, then removed by v2.4.0_0722 DELETE 1512-1517
+--   /agent-tasks (1513): expected from v2.4.0_0722; ensure present for inconsistent environments
+--   /users (1514): omitted when v2.2.2 rewrote LEFT_NAV_MENU, but avatar menu always links here
+
+BEGIN;
+
+INSERT INTO nexent.role_permission_t (
+    role_permission_id,
+    user_role,
+    permission_category,
+    permission_type,
+    permission_subtype,
+    parent_key
+)
+VALUES
+    (1512, 'ASSET_OWNER', 'VISIBILITY', 'LEFT_NAV_MENU', '/newchat', NULL),
+    (1513, 'ASSET_OWNER', 'VISIBILITY', 'LEFT_NAV_MENU', '/agent-tasks', NULL),
+    (1514, 'ASSET_OWNER', 'VISIBILITY', 'LEFT_NAV_MENU', '/users', NULL)
+ON CONFLICT (role_permission_id) DO UPDATE SET
+    user_role = EXCLUDED.user_role,
+    permission_category = EXCLUDED.permission_category,
+    permission_type = EXCLUDED.permission_type,
+    permission_subtype = EXCLUDED.permission_subtype,
+    parent_key = EXCLUDED.parent_key;
+
+COMMIT;

--- a/deploy/sql/migrations/v2.4_merged_migrations.sql
+++ b/deploy/sql/migrations/v2.4_merged_migrations.sql
@@ -394,9 +394,6 @@ CREATE INDEX IF NOT EXISTS idx_agent_automation_proposal_owner
     ON nexent.agent_automation_proposal_t (tenant_id, user_id, status)
     WHERE delete_flag = 'N';
 
-DELETE FROM nexent.role_permission_t
-WHERE role_permission_id BETWEEN 1512 AND 1517;
-
 -- Keep each permission in the ID range assigned to its role.
 INSERT INTO nexent.role_permission_t (
     role_permission_id,

--- a/frontend/app/[locale]/agents/components/agentInfo/AgentGenerateDetail.tsx
+++ b/frontend/app/[locale]/agents/components/agentInfo/AgentGenerateDetail.tsx
@@ -40,6 +40,7 @@ import { canManageModels } from "@/lib/auth";
 import { USER_ROLES } from "@/const/auth";
 import { useConfig } from "@/hooks/useConfig";
 import { useGroupList, useGroupDetails } from "@/hooks/group/useGroupList";
+import { buildGroupSelectOptions } from "@/hooks/group/buildGroupSelectOptions";
 import { usePromptTemplateList } from "@/hooks/agent/usePromptTemplateList";
 import { Can } from "@/components/permission/Can";
 import { useAgentConfigStore } from "@/stores/agentConfigStore";
@@ -193,12 +194,29 @@ export default function AgentGenerateDetail({}) {
     ).sort((a, b) => a - b);
   };
 
-  const groupSelectOptions = useMemo(() => {
-    return filteredGroups.map((g) => ({
-      label: g.group_name,
-      value: g.group_id,
-    }));
-  }, [filteredGroups]);
+  const selectedAdvancedGroupIds = Form.useWatch(
+    "group_ids",
+    advancedSettingsForm
+  );
+
+  const groupSelectOptions = useMemo(
+    () =>
+      buildGroupSelectOptions({
+        groups: filteredGroups,
+        allGroups,
+        selectedGroupIds:
+          selectedAdvancedGroupIds ??
+          normalizeNumberArray(editedAgent.group_ids || []),
+        deletedGroupLabel: t("group.deleted"),
+      }),
+    [
+      filteredGroups,
+      allGroups,
+      selectedAdvancedGroupIds,
+      editedAgent.group_ids,
+      t,
+    ]
+  );
 
   const selectedMainAgentModel = useMemo(() => {
     const primaryModelId = editedAgent.model_ids?.[0];

--- a/frontend/app/[locale]/knowledges/components/document/DocumentList.tsx
+++ b/frontend/app/[locale]/knowledges/components/document/DocumentList.tsx
@@ -4,6 +4,7 @@ import React, {
   forwardRef,
   useImperativeHandle,
   useEffect,
+  useMemo,
 } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -177,13 +178,17 @@ const DocumentListContainer = forwardRef<DocumentListRef, DocumentListProps>(
     const uploadAreaRef = useRef<any>(null);
     const { state: docState } = useDocumentContext();
     const { modelConfig } = useConfig();
-    const { user, groupIds } = useAuthorizationContext();
+    const { user, getAccessibleGroupIds } = useAuthorizationContext();
     const tenantId = user?.tenantId || null;
     const storageQuota = useStorageQuotaBlocked(tenantId);
 
-    // Fetch tenant groups and limit selections to current user's groups.
+    // Fetch tenant groups and limit selections to accessible groups (all for admin roles).
     const { data: groupData } = useGroupList(tenantId);
-    const { groups } = useGroupDetails(groupData?.groups ?? [], groupIds);
+    const accessibleGroupIds = useMemo(
+      () => getAccessibleGroupIds(),
+      [getAccessibleGroupIds]
+    );
+    const { groups } = useGroupDetails(groupData?.groups ?? [], accessibleGroupIds);
 
     const groupOptions = groups.map((group) => ({
       label: group.group_name,
@@ -331,7 +336,7 @@ const DocumentListContainer = forwardRef<DocumentListRef, DocumentListProps>(
         const initDefaultGroup = async () => {
           try {
             const defaultGroupId = await getTenantDefaultGroupId(tenantId);
-            if (defaultGroupId && groupIds.includes(defaultGroupId)) {
+            if (defaultGroupId && accessibleGroupIds.includes(defaultGroupId)) {
               onSelectedGroupIdsChange([defaultGroupId]);
             }
           } catch (error) {
@@ -340,7 +345,7 @@ const DocumentListContainer = forwardRef<DocumentListRef, DocumentListProps>(
         };
         initDefaultGroup();
       }
-    }, [isCreatingMode, tenantId, groupIds, onSelectedGroupIdsChange]);
+    }, [isCreatingMode, tenantId, accessibleGroupIds, onSelectedGroupIdsChange]);
 
     // Clear group IDs when permission is set to PRIVATE
     React.useEffect(() => {

--- a/frontend/app/[locale]/knowledges/components/knowledge/KnowledgeBaseEditModal.tsx
+++ b/frontend/app/[locale]/knowledges/components/knowledge/KnowledgeBaseEditModal.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Modal, Form, Input, Select, message } from "antd";
 import { useGroupDetails, useGroupList } from "@/hooks/group/useGroupList";
+import { buildGroupSelectOptions } from "@/hooks/group/buildGroupSelectOptions";
 import { Can } from "@/components/permission/Can";
 import { useAuthorizationContext } from "@/components/providers/AuthorizationProvider";
 import knowledgeBaseService from "@/services/knowledgeBaseService";
@@ -28,7 +29,7 @@ export function KnowledgeBaseEditModal({
   onSuccess,
 }: KnowledgeBaseEditModalProps) {
   const { t } = useTranslation("common");
-  const { groupIds } = useAuthorizationContext();
+  const { getAccessibleGroupIds } = useAuthorizationContext();
   const [form] = Form.useForm();
 
   // Name validation state
@@ -41,9 +42,23 @@ export function KnowledgeBaseEditModal({
   const [currentPermission, setCurrentPermission] =
     useState<string>("READ_ONLY");
 
-  // Fetch tenant groups and limit selections to current user's groups.
+  // Fetch tenant groups and limit selections to accessible groups (all for admin roles).
   const { data: groupData } = useGroupList(tenantId);
-  const { groups } = useGroupDetails(groupData?.groups ?? [], groupIds);
+  const accessibleGroupIds = getAccessibleGroupIds();
+  const { groups } = useGroupDetails(groupData?.groups ?? [], accessibleGroupIds);
+
+  const selectedGroupIds = Form.useWatch("group_ids", form);
+
+  const groupSelectOptions = useMemo(
+    () =>
+      buildGroupSelectOptions({
+        groups,
+        allGroups: groupData?.groups ?? [],
+        selectedGroupIds: selectedGroupIds ?? knowledgeBase?.group_ids ?? [],
+        deletedGroupLabel: t("group.deleted"),
+      }),
+    [groups, groupData?.groups, selectedGroupIds, knowledgeBase?.group_ids, t]
+  );
 
   // Reset form and states when knowledge base changes
   React.useEffect(() => {
@@ -102,7 +117,7 @@ export function KnowledgeBaseEditModal({
 
       // Ensure group_ids is empty when permission is PRIVATE
       const groupIds =
-        values.ingroup_permission === "PRIVATE" ? [] : values.group_ids;
+        values.ingroup_permission === "PRIVATE" ? [] : values.group_ids ?? [];
 
       await knowledgeBaseService.updateKnowledgeBase(knowledgeBase.id, {
         knowledge_name: values.knowledge_name,
@@ -218,13 +233,7 @@ export function KnowledgeBaseEditModal({
                   ? t("knowledgeBase.create.permission.groupPlaceholder")
                   : t("tenantResources.knowledgeBase.groupNames")
               }
-              value={
-                isGroupSelectDisabled ? [] : form.getFieldValue("group_ids")
-              }
-              options={groups.map((group) => ({
-                label: group.group_name,
-                value: group.group_id,
-              }))}
+              options={groupSelectOptions}
               disabled={isGroupSelectDisabled}
             />
           </Form.Item>

--- a/frontend/hooks/group/buildGroupSelectOptions.ts
+++ b/frontend/hooks/group/buildGroupSelectOptions.ts
@@ -1,0 +1,38 @@
+import type { Group } from "@/services/groupService";
+
+export interface GroupSelectOption {
+  label: string;
+  value: number;
+}
+
+/**
+ * Build Select options for user groups, including fallback labels for deleted groups
+ * that are still referenced by the current selection.
+ */
+export function buildGroupSelectOptions(params: {
+  groups: Group[];
+  allGroups: Group[];
+  selectedGroupIds: number[] | undefined;
+  deletedGroupLabel: string;
+}): GroupSelectOption[] {
+  const { groups, allGroups, selectedGroupIds, deletedGroupLabel } = params;
+  const existingGroupIds = new Set(allGroups.map((group) => group.group_id));
+  const baseOptions = groups.map((group) => ({
+    label: group.group_name,
+    value: group.group_id,
+  }));
+  const baseValueSet = new Set(baseOptions.map((option) => option.value));
+  const orphanOptions = (selectedGroupIds ?? [])
+    .filter(
+      (id): id is number =>
+        typeof id === "number" &&
+        !existingGroupIds.has(id) &&
+        !baseValueSet.has(id)
+    )
+    .map((id) => ({
+      label: deletedGroupLabel,
+      value: id,
+    }));
+
+  return [...baseOptions, ...orphanOptions];
+}

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -892,6 +892,7 @@
   "knowledgeBase.name.new": "new_base",
   "knowledgeBase.message.getDocumentsFailed": "Failed to get documents",
   "knowledgeBase.create.permission.groupPlaceholder": "No user group",
+  "group.deleted": "Deleted user group",
   "knowledgeBase.create.preserveSourceFile": "Preserve document copy",
   "knowledgeBase.ingroup.permission.EDIT": "In Group Read/Write",
   "knowledgeBase.ingroup.permission.READ_ONLY": "In Group Read Only",

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -860,6 +860,7 @@
   "knowledgeBase.name.new": "新知识库",
   "knowledgeBase.message.getDocumentsFailed": "获取文档列表失败",
   "knowledgeBase.create.permission.groupPlaceholder": "无所属用户组",
+  "group.deleted": "已删除的用户组",
   "knowledgeBase.create.preserveSourceFile": "保留文档副本",
   "knowledgeBase.ingroup.permission.EDIT": "同组可编辑",
   "knowledgeBase.ingroup.permission.READ_ONLY": "同组只读",


### PR DESCRIPTION
Closes #3618 
Closes #3617 
Closes #3616 

- Restore ASSET_OWNER left-nav permissions (/newchat, /agent-tasks, /users) and stop deleting them in v2.4 merged migration
- Use getAccessibleGroupIds for knowledge base group pickers so admins can select all tenant groups
- Show deleted group placeholders in agent/KB group selects via buildGroupSelectOptions