### PR TITLE
Bugfix: Fix MCP tool status display showing "enabled" when enabled is false

### DIFF
--- a/frontend/app/[locale]/newchat/assistant-ui/threadlist-sidebar.tsx
+++ b/frontend/app/[locale]/newchat/assistant-ui/threadlist-sidebar.tsx
@@ -25,10 +25,14 @@ import { useTranslation } from "react-i18next";
 interface ThreadListSidebarProps extends SidebarProps {
   className?: string;
   generatedTitles?: ReadonlyMap<string, string>;
+  onPrepareNewConversation?: () => void;
+  onNewConversation?: () => void | Promise<void>;
 }
 
 export function ThreadListSidebar({
   generatedTitles,
+  onPrepareNewConversation,
+  onNewConversation,
   ...props
 }: ThreadListSidebarProps) {
   const { state, toggleSidebar } = useSidebar();
@@ -64,6 +68,7 @@ export function ThreadListSidebar({
                 variant="ghost"
                 size="icon"
                 className="size-8"
+                onClick={onNewConversation}
               >
                 <PlusIcon className="size-4" />
               </TooltipIconButton>
@@ -102,7 +107,10 @@ export function ThreadListSidebar({
         >
           <SidebarHeader>
             <div className="flex items-center gap-2 px-1">
-              <ThreadListPrimitive.New className="flex h-9 flex-1 items-center gap-2 rounded-lg border px-3 text-sm hover:bg-muted truncate">
+              <ThreadListPrimitive.New
+                className="flex h-9 flex-1 items-center gap-2 rounded-lg border px-3 text-sm hover:bg-muted truncate"
+                onClick={onPrepareNewConversation}
+              >
                 <PlusIcon className="size-4 shrink-0" />
                 {t("chat.sidebar.newConversation")}
               </ThreadListPrimitive.New>

--- a/frontend/app/[locale]/newchat/page.tsx
+++ b/frontend/app/[locale]/newchat/page.tsx
@@ -326,6 +326,17 @@ const HomeContent: FC<{
     onBack();
   }, [onBack]);
 
+  const handlePrepareNewConversation = useCallback(() => {
+    // Do not restore the agent from the thread that is being left.
+    shouldRestoreAgentRef.current = false;
+    onBack();
+  }, [onBack]);
+
+  const handleNewConversation = useCallback(async () => {
+    handlePrepareNewConversation();
+    await runtime.threads.switchToNewThread();
+  }, [handlePrepareNewConversation, runtime]);
+
   const handleAgentSelectedFromLanding = useCallback(
     async (agent: Agent) => {
       shouldRestoreAgentRef.current = true;
@@ -348,7 +359,11 @@ const HomeContent: FC<{
     <div className="flex w-full h-full">
       <div className="shrink-0 h-full">
         <SidebarProvider className="w-auto h-full">
-          <ThreadListSidebar generatedTitles={generatedTitles} />
+          <ThreadListSidebar
+            generatedTitles={generatedTitles}
+            onPrepareNewConversation={handlePrepareNewConversation}
+            onNewConversation={handleNewConversation}
+          />
         </SidebarProvider>
       </div>
 

--- a/frontend/app/[locale]/resource-manage/components/resources/McpList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/McpList.tsx
@@ -501,7 +501,7 @@ export default function McpList({ tenantId }: { tenantId: string | null }) {
       key: "enabled",
       width: "10%",
       render: (_: any, record: McpServer) => {
-        const isEnabled = Boolean(record.status);
+        const isEnabled = record.enabled;
         return isEnabled ? (
           <Tag
             color="#229954"

--- a/frontend/types/agentConfig.ts
+++ b/frontend/types/agentConfig.ts
@@ -552,6 +552,7 @@ export interface McpServer {
   service_name: string;
   mcp_url: string;
   status: boolean;
+  enabled: boolean;
   remote_mcp_server_name?: string;
   remote_mcp_server?: string;
   authorization_token?: string | null;


### PR DESCRIPTION
1. [修复mcp工具的enabled状态为false的时候还显示“已启用](https://github.com/ModelEngine-Group/nexent/commit/a3f5b5b66e459748b746ab8aee0a034bb7ce1e48)
<img width="2289" height="1061" alt="image" src="https://github.com/user-attachments/assets/9cb136d6-4360-4fd6-a23e-e3af047527c7" />

2. [修复无法正常创建新会话的问题](https://github.com/ModelEngine-Group/nexent/commit/c58e5c2b0a58da47a85e1b9b3ec416c9806bdc9d)
https://github.com/user-attachments/assets/d23f79c3-15dc-4ee6-8a32-95d1986ba4b9

