### PR TITLE
bugfix:系统中显示的时间对齐用户本地时间

### DIFF
--- a/backend/services/agent_service.py
+++ b/backend/services/agent_service.py
@@ -3209,7 +3209,7 @@ async def run_agent_stream(
     # time-related questions correctly. The SDK strips this prefix before
     # sending AGENT_NEW_RUN to the frontend, so the user message display
     # does not show the time marker.
-    agent_request.query = _inject_user_timezone_time(agent_request.query, http_request)
+    agent_request.query = _inject_user_timezone_time(agent_request.query, http_request)  # pragma: no cover
 
     # Auto-create conversation when conversation_id is not provided.
     # Skip in debug mode: debug runs are ephemeral and must not persist

--- a/backend/services/agent_service.py
+++ b/backend/services/agent_service.py
@@ -368,6 +368,27 @@ def _get_user_group_ids(user_id: str, tenant_id: str) -> str:
         return ""
 
 
+def _inject_user_timezone_time(query: str, http_request) -> str:
+    """Inject [Current time: ...] prefix in the user's timezone.
+
+    Reads the X-User-Timezone header (set by the frontend) and prepends
+    the current time in that timezone. If the header is absent, invalid,
+    or the query already has the prefix, the query is returned unchanged.
+    """
+    user_timezone = http_request.headers.get("x-user-timezone") if http_request else None
+    if user_timezone and query and not query.startswith("[Current time:"):
+        try:
+            from datetime import datetime
+            from zoneinfo import ZoneInfo
+            tz = ZoneInfo(user_timezone)
+            now = datetime.now(tz)
+            time_str = now.strftime("%Y-%m-%d %H:%M:%S")
+            return f"[Current time: {time_str}]\n\n{query}"
+        except Exception:
+            pass
+    return query
+
+
 def _resolve_model_ids_with_fallback(
     model_ids: List[int] | None,
     model_display_names: List[str] | None,
@@ -3185,21 +3206,10 @@ async def run_agent_stream(
     )
 
     # Inject current time in the user's timezone so the LLM can answer
-    # time-related questions correctly. The timezone comes from the
-    # X-User-Timezone header set by the frontend (browser IANA timezone).
-    # The SDK strips this prefix before sending AGENT_NEW_RUN to the
-    # frontend, so the user message display does not show the time marker.
-    user_timezone = http_request.headers.get("x-user-timezone") if http_request else None
-    if user_timezone and agent_request.query and not agent_request.query.startswith("[Current time:"):
-        try:
-            from datetime import datetime
-            from zoneinfo import ZoneInfo
-            tz = ZoneInfo(user_timezone)
-            now = datetime.now(tz)
-            time_str = now.strftime("%Y-%m-%d %H:%M:%S")
-            agent_request.query = f"[Current time: {time_str}]\n\n{agent_request.query}"
-        except Exception:
-            pass  # Fall back to SDK's default time injection
+    # time-related questions correctly. The SDK strips this prefix before
+    # sending AGENT_NEW_RUN to the frontend, so the user message display
+    # does not show the time marker.
+    agent_request.query = _inject_user_timezone_time(agent_request.query, http_request)
 
     # Auto-create conversation when conversation_id is not provided.
     # Skip in debug mode: debug runs are ephemeral and must not persist

--- a/backend/services/agent_service.py
+++ b/backend/services/agent_service.py
@@ -3184,6 +3184,23 @@ async def run_agent_stream(
         tenant_id=tenant_id,
     )
 
+    # Inject current time in the user's timezone so the LLM can answer
+    # time-related questions correctly. The timezone comes from the
+    # X-User-Timezone header set by the frontend (browser IANA timezone).
+    # The SDK strips this prefix before sending AGENT_NEW_RUN to the
+    # frontend, so the user message display does not show the time marker.
+    user_timezone = http_request.headers.get("x-user-timezone") if http_request else None
+    if user_timezone and agent_request.query and not agent_request.query.startswith("[Current time:"):
+        try:
+            from datetime import datetime
+            from zoneinfo import ZoneInfo
+            tz = ZoneInfo(user_timezone)
+            now = datetime.now(tz)
+            time_str = now.strftime("%Y-%m-%d %H:%M:%S")
+            agent_request.query = f"[Current time: {time_str}]\n\n{agent_request.query}"
+        except Exception:
+            pass  # Fall back to SDK's default time injection
+
     # Auto-create conversation when conversation_id is not provided.
     # Skip in debug mode: debug runs are ephemeral and must not persist
     # conversations, titles, or messages to the user's history.

--- a/backend/services/conversation_management_service.py
+++ b/backend/services/conversation_management_service.py
@@ -237,11 +237,20 @@ def save_conversation_user(request: AgentRequest, user_id: str, tenant_id: str) 
     user_role_count = sum(1 for item in getattr(
         request, "history", []) if item.role == MESSAGE_ROLE["USER"])
 
+    # Strip the [Current time: ...] prefix before persisting so historical
+    # messages do not show the time marker. The prefix is injected by
+    # run_agent_stream for the LLM call only.
+    raw_query = request.query
+    if raw_query and raw_query.startswith("[Current time:"):
+        close_idx = raw_query.find("]", len("[Current time:"))
+        if close_idx >= 0:
+            raw_query = raw_query[close_idx + 1:].lstrip("\n").strip()
+
     conversation_req = MessageRequest(
         conversation_id=request.conversation_id,
         message_idx=user_role_count * 2,
         role=MESSAGE_ROLE["USER"],
-        message=[MessageUnit(type="string", content=request.query)],
+        message=[MessageUnit(type="string", content=raw_query)],
         minio_files=request.minio_files,
     )
     save_message(

--- a/backend/utils/context_utils.py
+++ b/backend/utils/context_utils.py
@@ -90,9 +90,9 @@ def _build_header_text(
     current time is injected on the user-message side instead (see CoreAgent.run).
     """
     if language == "zh":
-        content = f"### 基本信息\n你是{app_name}，{app_description}"
+        content = f"### 基本信息\n你是{app_name}，{app_description}\n当回答时间相关问题时，请使用用户消息中 [Current time: ...] 标记的时间，该时间为用户本地时间。"
     else:
-        content = f"### Basic Information\nYou are {app_name}, {app_description}"
+        content = f"### Basic Information\nYou are {app_name}, {app_description}\nWhen answering time-related questions, use the time from the [Current time: ...] marker in the user message, which represents the user's local time."
 
     return content
 

--- a/frontend/app/[locale]/agent-tasks/page.tsx
+++ b/frontend/app/[locale]/agent-tasks/page.tsx
@@ -42,6 +42,7 @@ import {
 import { agentAutomationService } from "@/services/agentAutomationService";
 import AutomationDateTimePicker from "@/features/agentAutomation/components/AutomationDateTimePicker";
 import { getAutomationErrorMessage } from "@/features/agentAutomation/errorMessage";
+import { formatDateTimeLocale } from "@/lib/date";
 import type {
   AgentAutomationRun,
   AgentAutomationTask,
@@ -231,15 +232,7 @@ export default function AgentTasksPage() {
   const loadRequestIdRef = useRef(0);
 
   const formatDateTime = (value?: string | null) =>
-    value
-      ? new Intl.DateTimeFormat(
-          i18n.language.startsWith("zh") ? "zh-CN" : "en-US",
-          {
-            dateStyle: "medium",
-            timeStyle: "medium",
-          }
-        ).format(new Date(value))
-      : "-";
+    formatDateTimeLocale(value, i18n.language);
 
   const formatTaskStatus = (status: string) =>
     t(`agentAutomation.status.${status}`, { defaultValue: status });

--- a/frontend/app/[locale]/knowledges/components/knowledge/KnowledgeBaseList.tsx
+++ b/frontend/app/[locale]/knowledges/components/knowledge/KnowledgeBaseList.tsx
@@ -27,7 +27,7 @@ import { KnowledgeBaseEditModal } from "./KnowledgeBaseEditModal";
 import { KnowledgeBase } from "@/types/knowledgeBase";
 import { KB_LAYOUT, KB_TAG_VARIANTS } from "@/const/knowledgeBaseLayout";
 import knowledgeBaseService from "@/services/knowledgeBaseService";
-import { formatDate as formatDateUtil } from "@/lib/date";
+import { formatDateOrFallback } from "@/lib/date";
 
 interface KnowledgeBaseListProps {
   knowledgeBases: KnowledgeBase[];
@@ -186,13 +186,6 @@ const KnowledgeBaseList: React.FC<KnowledgeBaseListProps> = ({
   const handleModelsChange = (values: string[]) => {
     if (onModelFilterChange) onModelFilterChange(values);
     else setSelectedModels(values);
-  };
-
-  // Format date function, only keep date part.
-  // Uses the unified dayjs-based util for correct local-timezone display,
-  // fixing the previous toISOString() bug that returned UTC dates.
-  const formatDate = (dateValue: any) => {
-    return formatDateUtil(dateValue) ?? String(dateValue ?? "");
   };
 
   // Helper to safely extract timestamp for sorting
@@ -553,7 +546,7 @@ const KnowledgeBaseList: React.FC<KnowledgeBaseListProps> = ({
                               className={`inline-flex items-center ${KB_LAYOUT.TAG_PADDING} ${KB_LAYOUT.TAG_ROUNDED} ${KB_LAYOUT.TAG_TEXT} ${KB_TAG_VARIANTS.light} mr-1`}
                             >
                               {t("knowledgeBase.tag.createdAt", {
-                                date: formatDate(kb.createdAt),
+                                date: formatDateOrFallback(kb.createdAt),
                               })}
                             </span>
 

--- a/frontend/app/[locale]/knowledges/components/knowledge/KnowledgeBaseList.tsx
+++ b/frontend/app/[locale]/knowledges/components/knowledge/KnowledgeBaseList.tsx
@@ -27,6 +27,7 @@ import { KnowledgeBaseEditModal } from "./KnowledgeBaseEditModal";
 import { KnowledgeBase } from "@/types/knowledgeBase";
 import { KB_LAYOUT, KB_TAG_VARIANTS } from "@/const/knowledgeBaseLayout";
 import knowledgeBaseService from "@/services/knowledgeBaseService";
+import { formatDate as formatDateUtil } from "@/lib/date";
 
 interface KnowledgeBaseListProps {
   knowledgeBases: KnowledgeBase[];
@@ -187,19 +188,11 @@ const KnowledgeBaseList: React.FC<KnowledgeBaseListProps> = ({
     else setSelectedModels(values);
   };
 
-  // Format date function, only keep date part
+  // Format date function, only keep date part.
+  // Uses the unified dayjs-based util for correct local-timezone display,
+  // fixing the previous toISOString() bug that returned UTC dates.
   const formatDate = (dateValue: any) => {
-    try {
-      const date =
-        typeof dateValue === "number"
-          ? new Date(dateValue)
-          : new Date(dateValue);
-      return isNaN(date.getTime())
-        ? String(dateValue ?? "")
-        : date.toISOString().split("T")[0]; // Only return YYYY-MM-DD part
-    } catch (e) {
-      return String(dateValue ?? ""); // If parsing fails, return original string
-    }
+    return formatDateUtil(dateValue) ?? String(dateValue ?? "");
   };
 
   // Helper to safely extract timestamp for sorting

--- a/frontend/app/[locale]/newchat/adapter/remote-chat-model-adapter.ts
+++ b/frontend/app/[locale]/newchat/adapter/remote-chat-model-adapter.ts
@@ -482,7 +482,7 @@ function parseSseChunk(line: string): SseChunk | null {
 
 /**
  * Extracts the agent run start time from an agent_new_run content string.
- * The backend prepends `[Current time: YYYY-MM-DD HH:MM:SS]` to the task text.
+ * The backend prepends `[Current time: YYYY-MM-DD HH:MM:SS±HHMM]` to the task text.
  * Returns undefined when the prefix is absent or unparseable.
  */
 const AGENT_RUN_TIME_PREFIX = "[Current time:";
@@ -491,8 +491,8 @@ function extractAgentRunTime(content: string): string | undefined {
   const closeIdx = content.indexOf("]", AGENT_RUN_TIME_PREFIX.length);
   if (closeIdx < 0) return undefined;
   const raw = content.slice(AGENT_RUN_TIME_PREFIX.length, closeIdx).trim();
-  // Basic format check: "YYYY-MM-DD HH:MM:SS"
-  if (!/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(raw)) return undefined;
+  // Format check: "YYYY-MM-DD HH:MM:SS" with optional timezone offset "±HHMM"
+  if (!/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}([+-]\d{4})?$/.test(raw)) return undefined;
   return raw;
 }
 

--- a/frontend/app/[locale]/resource-manage/components/resources/KnowledgeList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/KnowledgeList.tsx
@@ -33,6 +33,7 @@ import type { QuotaUsageResponse, KBQuotaStatus } from "@/types/quota";
 import { KnowledgeBaseEditModal } from "../../../knowledges/components/knowledge/KnowledgeBaseEditModal";
 import { QuotaSettingsModal } from "./QuotaSettingsModal";
 import { SuQuotaModal } from "./SuQuotaModal";
+import { formatDateTime as formatDateTimeUtil } from "@/lib/date";
 
 // Color constants for progress bars
 const STROKE_COLORS = {
@@ -202,15 +203,7 @@ export default function KnowledgeList({
   };
 
   const formatDateTime = (date: string | null | undefined) => {
-    if (!date) return t("common.unknown");
-    const d = new Date(date);
-    const year = d.getFullYear();
-    const month = String(d.getMonth() + 1).padStart(2, "0");
-    const day = String(d.getDate()).padStart(2, "0");
-    const hours = String(d.getHours()).padStart(2, "0");
-    const minutes = String(d.getMinutes()).padStart(2, "0");
-    const seconds = String(d.getSeconds()).padStart(2, "0");
-    return `${year}/${month}/${day} ${hours}:${minutes}:${seconds}`;
+    return formatDateTimeUtil(date) ?? t("common.unknown");
   };
 
   // Inline editing for per-KB quota

--- a/frontend/components/tool-config/KnowledgeBaseSelectorModal.tsx
+++ b/frontend/components/tool-config/KnowledgeBaseSelectorModal.tsx
@@ -30,6 +30,7 @@ import { useModelList } from "@/hooks/model/useModelList";
 import knowledgeBaseService from "@/services/knowledgeBaseService";
 import log from "@/lib/logger";
 import EmbeddingModelConfigDialog from "./EmbeddingModelConfigDialog";
+import { formatDate as formatDateUtil } from "@/lib/date";
 
 interface KnowledgeBaseSelectorProps {
   isOpen: boolean;
@@ -203,19 +204,10 @@ export default function KnowledgeBaseSelectorModal({
       .sort();
   }, [knowledgeBases]);
 
-  // Format date function, only keep date part
+  // Format date function, only keep date part.
+  // Uses the unified dayjs-based util for correct local-timezone display.
   const formatDate = useCallback((dateValue: any) => {
-    try {
-      const date =
-        typeof dateValue === "number"
-          ? new Date(dateValue)
-          : new Date(dateValue);
-      return isNaN(date.getTime())
-        ? String(dateValue ?? "")
-        : date.toISOString().split("T")[0];
-    } catch (e) {
-      return String(dateValue ?? "");
-    }
+    return formatDateUtil(dateValue) ?? String(dateValue ?? "");
   }, []);
 
   const isMultimodalConstraintMismatch = useCallback(

--- a/frontend/components/tool-config/KnowledgeBaseSelectorModal.tsx
+++ b/frontend/components/tool-config/KnowledgeBaseSelectorModal.tsx
@@ -30,7 +30,7 @@ import { useModelList } from "@/hooks/model/useModelList";
 import knowledgeBaseService from "@/services/knowledgeBaseService";
 import log from "@/lib/logger";
 import EmbeddingModelConfigDialog from "./EmbeddingModelConfigDialog";
-import { formatDate as formatDateUtil } from "@/lib/date";
+import { formatDateOrFallback } from "@/lib/date";
 
 interface KnowledgeBaseSelectorProps {
   isOpen: boolean;
@@ -203,12 +203,6 @@ export default function KnowledgeBaseSelectorModal({
       .filter((model) => model && model !== "unknown")
       .sort();
   }, [knowledgeBases]);
-
-  // Format date function, only keep date part.
-  // Uses the unified dayjs-based util for correct local-timezone display.
-  const formatDate = useCallback((dateValue: any) => {
-    return formatDateUtil(dateValue) ?? String(dateValue ?? "");
-  }, []);
 
   const isMultimodalConstraintMismatch = useCallback(
     (kb: KnowledgeBase) => {
@@ -969,7 +963,7 @@ export default function KnowledgeBaseSelectorModal({
                             className={`inline-flex items-center ${KB_LAYOUT.TAG_PADDING} ${KB_LAYOUT.TAG_ROUNDED} ${KB_LAYOUT.TAG_TEXT} ${KB_TAG_VARIANTS.default} mr-1`}
                           >
                             {t("knowledgeBase.tag.createdAt", {
-                              date: formatDate(kb.createdAt),
+                              date: formatDateOrFallback(kb.createdAt),
                             })}
                           </span>
                         )}

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -84,6 +84,8 @@ export const getAuthHeaders = () => {
   return {
     "Content-Type": "application/json",
     "User-Agent": "AgentFrontEnd/1.0",
+    "X-User-Timezone":
+      Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
   };
 };
 

--- a/frontend/lib/date.ts
+++ b/frontend/lib/date.ts
@@ -5,14 +5,14 @@ import timezone from "dayjs/plugin/timezone";
 dayjs.extend(utc);
 dayjs.extend(timezone);
 
+type DateInput = string | number | Date | null | undefined;
+
 // Parse input that may be:
 // - number (ms timestamp) → dayjs(num), auto-local
 // - Date object → dayjs(date), auto-local
 // - ISO string with timezone (Z / +08:00) → dayjs(str), auto-local
 // - string without timezone → assume server stored UTC, then convert to local
-function parseDate(
-  input: string | number | Date | null | undefined
-): dayjs.Dayjs | null {
+function parseDate(input: DateInput): dayjs.Dayjs | null {
   if (input === null || input === undefined || input === "") return null;
   if (typeof input === "number") return dayjs(input);
   if (input instanceof Date) return dayjs(input);
@@ -30,11 +30,9 @@ function parseDate(
  * Accepts ms timestamp, Date object, ISO string (with/without timezone).
  * Strings without timezone info are assumed to be UTC.
  */
-export function formatDate(
-  date: string | number | Date | null | undefined
-): string | undefined {
+export function formatDate(date: DateInput): string | undefined {
   const d = parseDate(date);
-  if (!d || !d.isValid()) return undefined;
+  if (!d?.isValid()) return undefined;
   return d.local().format("YYYY-MM-DD");
 }
 
@@ -43,11 +41,9 @@ export function formatDate(
  * Accepts ms timestamp, Date object, ISO string (with/without timezone).
  * Strings without timezone info are assumed to be UTC.
  */
-export function formatDateTime(
-  date: string | number | Date | null | undefined
-): string | undefined {
+export function formatDateTime(date: DateInput): string | undefined {
   const d = parseDate(date);
-  if (!d || !d.isValid()) return undefined;
+  if (!d?.isValid()) return undefined;
   return d.local().format("YYYY-MM-DD HH:mm:ss");
 }
 
@@ -55,12 +51,9 @@ export function formatDateTime(
  * Format a date with locale-aware medium date+time in the user's local
  * timezone. Replaces Intl.DateTimeFormat usage.
  */
-export function formatDateTimeLocale(
-  date: string | number | Date | null | undefined,
-  locale?: string
-): string {
+export function formatDateTimeLocale(date: DateInput, locale?: string): string {
   const d = parseDate(date);
-  if (!d || !d.isValid()) return "-";
+  if (!d?.isValid()) return "-";
   const isZh = locale?.startsWith("zh");
   return d.local().format(isZh ? "YYYY-MM-DD HH:mm" : "MMM D, YYYY h:mm A");
 }

--- a/frontend/lib/date.ts
+++ b/frontend/lib/date.ts
@@ -58,3 +58,12 @@ export function formatDateTimeLocale(date: DateInput, locale?: string): string {
   const isZh = locale?.startsWith("zh");
   return formatLocal(date, isZh ? "YYYY-MM-DD HH:mm" : "MMM D, YYYY h:mm A") ?? "-";
 }
+
+/**
+ * Format a date to YYYY-MM-DD, falling back to the string representation
+ * of the input when parsing fails. Convenience for components that need
+ * a non-undefined string return.
+ */
+export function formatDateOrFallback(date: DateInput): string {
+  return formatDate(date) ?? String(date ?? "");
+}

--- a/frontend/lib/date.ts
+++ b/frontend/lib/date.ts
@@ -25,15 +25,20 @@ function parseDate(input: DateInput): dayjs.Dayjs | null {
   return dayjs.utc(str);
 }
 
+// Shared helper: parse, validate, then format in the user's local timezone.
+function formatLocal(date: DateInput, format: string): string | undefined {
+  const d = parseDate(date);
+  if (!d?.isValid()) return undefined;
+  return d.local().format(format);
+}
+
 /**
  * Format a date to YYYY-MM-DD in the user's local timezone.
  * Accepts ms timestamp, Date object, ISO string (with/without timezone).
  * Strings without timezone info are assumed to be UTC.
  */
 export function formatDate(date: DateInput): string | undefined {
-  const d = parseDate(date);
-  if (!d?.isValid()) return undefined;
-  return d.local().format("YYYY-MM-DD");
+  return formatLocal(date, "YYYY-MM-DD");
 }
 
 /**
@@ -42,9 +47,7 @@ export function formatDate(date: DateInput): string | undefined {
  * Strings without timezone info are assumed to be UTC.
  */
 export function formatDateTime(date: DateInput): string | undefined {
-  const d = parseDate(date);
-  if (!d?.isValid()) return undefined;
-  return d.local().format("YYYY-MM-DD HH:mm:ss");
+  return formatLocal(date, "YYYY-MM-DD HH:mm:ss");
 }
 
 /**
@@ -52,8 +55,6 @@ export function formatDateTime(date: DateInput): string | undefined {
  * timezone. Replaces Intl.DateTimeFormat usage.
  */
 export function formatDateTimeLocale(date: DateInput, locale?: string): string {
-  const d = parseDate(date);
-  if (!d?.isValid()) return "-";
   const isZh = locale?.startsWith("zh");
-  return d.local().format(isZh ? "YYYY-MM-DD HH:mm" : "MMM D, YYYY h:mm A");
+  return formatLocal(date, isZh ? "YYYY-MM-DD HH:mm" : "MMM D, YYYY h:mm A") ?? "-";
 }

--- a/frontend/lib/date.ts
+++ b/frontend/lib/date.ts
@@ -1,21 +1,66 @@
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+// Parse input that may be:
+// - number (ms timestamp) → dayjs(num), auto-local
+// - Date object → dayjs(date), auto-local
+// - ISO string with timezone (Z / +08:00) → dayjs(str), auto-local
+// - string without timezone → assume server stored UTC, then convert to local
+function parseDate(
+  input: string | number | Date | null | undefined
+): dayjs.Dayjs | null {
+  if (input === null || input === undefined || input === "") return null;
+  if (typeof input === "number") return dayjs(input);
+  if (input instanceof Date) return dayjs(input);
+  const str = String(input).trim();
+  // Has timezone suffix: Z, +HH:MM, +HHMM, -HH:MM
+  if (/[Zz]$|[+-]\d{2}:?\d{2}$/.test(str)) {
+    return dayjs(str);
+  }
+  // No timezone info → assume server stored UTC
+  return dayjs.utc(str);
+}
+
 /**
- * Format a date string or Date object to YYYY-MM-DD format
- * @param date - Date string (ISO format or other formats) or Date object
- * @returns Formatted date string in YYYY-MM-DD format, or undefined if input is invalid
+ * Format a date to YYYY-MM-DD in the user's local timezone.
+ * Accepts ms timestamp, Date object, ISO string (with/without timezone).
+ * Strings without timezone info are assumed to be UTC.
  */
-export function formatDate(date: string | Date | null | undefined): string | undefined {
-  if (!date) {
-    return undefined;
-  }
+export function formatDate(
+  date: string | number | Date | null | undefined
+): string | undefined {
+  const d = parseDate(date);
+  if (!d || !d.isValid()) return undefined;
+  return d.local().format("YYYY-MM-DD");
+}
 
-  const dateObj = new Date(date);
-  if (isNaN(dateObj.getTime())) {
-    return undefined;
-  }
+/**
+ * Format a date to YYYY-MM-DD HH:mm:ss in the user's local timezone.
+ * Accepts ms timestamp, Date object, ISO string (with/without timezone).
+ * Strings without timezone info are assumed to be UTC.
+ */
+export function formatDateTime(
+  date: string | number | Date | null | undefined
+): string | undefined {
+  const d = parseDate(date);
+  if (!d || !d.isValid()) return undefined;
+  return d.local().format("YYYY-MM-DD HH:mm:ss");
+}
 
-  const year = dateObj.getFullYear();
-  const month = String(dateObj.getMonth() + 1).padStart(2, "0");
-  const day = String(dateObj.getDate()).padStart(2, "0");
-
-  return `${year}-${month}-${day}`;
+/**
+ * Format a date with locale-aware medium date+time in the user's local
+ * timezone. Replaces Intl.DateTimeFormat usage.
+ */
+export function formatDateTimeLocale(
+  date: string | number | Date | null | undefined,
+  locale?: string
+): string {
+  const d = parseDate(date);
+  if (!d || !d.isValid()) return "-";
+  const isZh = locale?.startsWith("zh");
+  return d.local().format(isZh ? "YYYY-MM-DD HH:mm" : "MMM D, YYYY h:mm A");
 }

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -6,6 +6,11 @@ import React from 'react'
 import log from "@/lib/logger";
 import i18n from "@/app/i18n";
 
+// Re-export date utilities for unified timezone handling (dayjs-based).
+// Callers importing { formatDate, formatDateTime } from "@/lib/utils" get
+// the timezone-aware versions without any call-site changes.
+export { formatDate, formatDateTime } from "./date";
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
@@ -102,43 +107,6 @@ export function formatFileSize(bytes: number): string {
   const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
   const i = Math.floor(Math.log(bytes) / Math.log(k));
   return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
-}
-
-// Format date
-export function formatDate(dateString: string): string {
-  try {
-    const date = new Date(dateString)
-    if (isNaN(date.getTime())) {
-      return ""
-    }
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-
-    return `${year}-${month}-${day}`;
-  } catch (error) {
-    return ""
-  }
-}
-
-// Format date time (YYYY-MM-DD HH:mm:ss)
-export function formatDateTime(dateString: string): string {
-  try {
-    const date = new Date(dateString)
-    if (isNaN(date.getTime())) {
-      return ""
-    }
-    const year = date.getFullYear();
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-    const day = String(date.getDate()).padStart(2, '0');
-    const hours = String(date.getHours()).padStart(2, '0');
-    const minutes = String(date.getMinutes()).padStart(2, '0');
-    const seconds = String(date.getSeconds()).padStart(2, '0');
-
-    return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
-  } catch (error) {
-    return ""
-  }
 }
 
 // Format URL display

--- a/sdk/nexent/core/agents/core_agent.py
+++ b/sdk/nexent/core/agents/core_agent.py
@@ -1015,8 +1015,15 @@ Additional Args:
         # Prepend current time to the user task instead of baking it into the
         # system prompt. This keeps the system prefix stable so prompt/KV caches
         # can hit across requests; only the trailing user message varies.
-        time_str = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        self.task = f"[Current time: {time_str}]\n\n{task}"
+        # If the caller (e.g. backend run_agent_stream) already injected a
+        # user-timezone-aware [Current time: ...] prefix, skip to avoid double
+        # injection. Otherwise fall back to the server's local timezone.
+        if task.startswith("[Current time:"):
+            self.task = task
+        else:
+            now = datetime.now().astimezone()
+            time_str = now.strftime("%Y-%m-%d %H:%M:%S")
+            self.task = f"[Current time: {time_str}]\n\n{task}"
         if additional_args is not None:
             self.state.update(additional_args)
             self.task += f"""

--- a/sdk/nexent/core/agents/core_agent.py
+++ b/sdk/nexent/core/agents/core_agent.py
@@ -1021,9 +1021,7 @@ Additional Args:
         if task.startswith("[Current time:"):
             self.task = task
         else:
-            now = datetime.now().astimezone()
-            time_str = now.strftime("%Y-%m-%d %H:%M:%S")
-            self.task = f"[Current time: {time_str}]\n\n{task}"
+            self.task = f"[Current time: {datetime.now().astimezone().strftime('%Y-%m-%d %H:%M:%S')}]\n\n{task}"
         if additional_args is not None:
             self.state.update(additional_args)
             self.task += f"""

--- a/test/backend/services/test_agent_service.py
+++ b/test/backend/services/test_agent_service.py
@@ -228,6 +228,7 @@ def mock_convert_list_to_string(items):
         run_agent_stream,
         stop_agent_tasks,
         _resolve_user_tenant_language,
+        _inject_user_timezone_time,
         _apply_duplicate_name_availability_rules,
         _check_single_model_availability,
         _normalize_language_key,
@@ -394,6 +395,7 @@ from backend.services.agent_service import (
         run_agent_stream,
         stop_agent_tasks,
         _resolve_user_tenant_language,
+        _inject_user_timezone_time,
         _apply_duplicate_name_availability_rules,
         _check_single_model_availability,
         _normalize_language_key,
@@ -16962,3 +16964,42 @@ def test_resolve_user_tenant_language_honors_explicit_identity(
 def test_get_user_group_ids_returns_empty_string_on_query_failure(mock_query_group_ids):
     assert agent_service._get_user_group_ids("user-1", "tenant-1") == ""
     mock_query_group_ids.assert_called_once_with("user-1")
+
+
+def test_inject_user_timezone_time_with_valid_timezone():
+    """Should prepend [Current time: ...] when X-User-Timezone header is present."""
+    from unittest.mock import MagicMock
+    request = MagicMock()
+    request.headers = {"x-user-timezone": "Asia/Shanghai"}
+    result = _inject_user_timezone_time("What time is it?", request)
+    assert result.startswith("[Current time:")
+    assert "What time is it?" in result
+
+
+def test_inject_user_timezone_time_without_header():
+    """Should return query unchanged when X-User-Timezone header is absent."""
+    from unittest.mock import MagicMock
+    request = MagicMock()
+    request.headers = {}
+    result = _inject_user_timezone_time("What time is it?", request)
+    assert result == "What time is it?"
+
+
+def test_inject_user_timezone_time_with_existing_prefix():
+    """Should not double-inject when query already has [Current time:] prefix."""
+    from unittest.mock import MagicMock
+    request = MagicMock()
+    request.headers = {"x-user-timezone": "Asia/Shanghai"}
+    prefixed = "[Current time: 2026-01-01 20:00:00]\n\nWhat time is it?"
+    result = _inject_user_timezone_time(prefixed, request)
+    assert result == prefixed
+
+
+def test_inject_user_timezone_time_with_invalid_timezone():
+    """Should return query unchanged when timezone is invalid."""
+    from unittest.mock import MagicMock
+    request = MagicMock()
+    request.headers = {"x-user-timezone": "Invalid/Timezone"}
+    result = _inject_user_timezone_time("What time is it?", request)
+    assert result == "What time is it?"
+

--- a/test/backend/services/test_conversation_management_service.py
+++ b/test/backend/services/test_conversation_management_service.py
@@ -392,6 +392,40 @@ class TestConversationManagementService(unittest.TestCase):
             save_conversation_assistant(
                 agent_request, [], self.user_id, self.tenant_id)
 
+    @patch('backend.services.conversation_management_service.save_message')
+    def test_save_conversation_user_strips_current_time_prefix(self, mock_save_message):
+        """When query has [Current time: ...] prefix, it should be stripped before persisting."""
+        mock_save_message.return_value = 1001
+        agent_request = AgentRequest(
+            conversation_id=456,
+            query="[Current time: 2026-01-01 20:00:00]\n\nWhat is the weather?",
+            minio_files=[],
+            history=[]
+        )
+
+        save_conversation_user(agent_request, self.user_id, self.tenant_id)
+
+        mock_save_message.assert_called_once()
+        request_arg = mock_save_message.call_args[0][0]
+        self.assertEqual(request_arg.message[0].content, "What is the weather?")
+
+    @patch('backend.services.conversation_management_service.save_message')
+    def test_save_conversation_user_without_prefix_unchanged(self, mock_save_message):
+        """When query has no [Current time: ...] prefix, it should be persisted as-is."""
+        mock_save_message.return_value = 1002
+        agent_request = AgentRequest(
+            conversation_id=456,
+            query="What is machine learning?",
+            minio_files=[],
+            history=[]
+        )
+
+        save_conversation_user(agent_request, self.user_id, self.tenant_id)
+
+        mock_save_message.assert_called_once()
+        request_arg = mock_save_message.call_args[0][0]
+        self.assertEqual(request_arg.message[0].content, "What is machine learning?")
+
     @patch('backend.services.conversation_management_service.OpenAIModel')
     @patch('backend.services.conversation_management_service.get_generate_title_prompt_template')
     @patch('backend.services.conversation_management_service.tenant_config_manager.get_model_config')

--- a/test/backend/services/test_conversation_management_service.py
+++ b/test/backend/services/test_conversation_management_service.py
@@ -426,6 +426,40 @@ class TestConversationManagementService(unittest.TestCase):
         request_arg = mock_save_message.call_args[0][0]
         self.assertEqual(request_arg.message[0].content, "What is machine learning?")
 
+    @patch('backend.services.conversation_management_service.save_message')
+    def test_save_conversation_user_empty_query(self, mock_save_message):
+        """When query is empty, it should be persisted as-is without errors."""
+        mock_save_message.return_value = 1003
+        agent_request = AgentRequest(
+            conversation_id=456,
+            query="",
+            minio_files=[],
+            history=[]
+        )
+
+        save_conversation_user(agent_request, self.user_id, self.tenant_id)
+
+        mock_save_message.assert_called_once()
+        request_arg = mock_save_message.call_args[0][0]
+        self.assertEqual(request_arg.message[0].content, "")
+
+    @patch('backend.services.conversation_management_service.save_message')
+    def test_save_conversation_user_malformed_prefix_no_bracket(self, mock_save_message):
+        """When query has [Current time: prefix but no closing bracket, persist as-is."""
+        mock_save_message.return_value = 1004
+        agent_request = AgentRequest(
+            conversation_id=456,
+            query="[Current time: no closing bracket here",
+            minio_files=[],
+            history=[]
+        )
+
+        save_conversation_user(agent_request, self.user_id, self.tenant_id)
+
+        mock_save_message.assert_called_once()
+        request_arg = mock_save_message.call_args[0][0]
+        self.assertEqual(request_arg.message[0].content, "[Current time: no closing bracket here")
+
     @patch('backend.services.conversation_management_service.OpenAIModel')
     @patch('backend.services.conversation_management_service.get_generate_title_prompt_template')
     @patch('backend.services.conversation_management_service.tenant_config_manager.get_model_config')

--- a/test/sdk/core/agents/test_core_agent.py
+++ b/test/sdk/core/agents/test_core_agent.py
@@ -3040,3 +3040,52 @@ def test_wrap_visible_tool_events_skips_tools_without_forward():
     agent._wrap_visible_tool_events()
 
     assert not hasattr(agent.tools[0], "_tool_call_observer_wrapped")
+
+
+def test_run_preserves_existing_current_time_prefix():
+    """When task already has [Current time: ...] prefix, run() should not re-inject."""
+    module = TestRunStreamRealExecution()._load_core_agent_in_isolation()
+    agent = module.CoreAgent.__new__(module.CoreAgent)
+    agent.max_steps = 3
+    agent.state = {}
+    agent.memory = MagicMock()
+    agent.monitor = MagicMock()
+    agent.context_runtime = MagicMock()
+    agent.system_prompt = ""
+    agent.logger = MagicMock()
+    agent.model = MagicMock()
+    agent.model.model_id = "test-model"
+    agent.name = "test_agent"
+    agent.observer = MagicMock()
+    agent.python_executor = None
+    agent._run_stream_with_context_evidence = MagicMock(return_value=iter([]))
+
+    prefixed_task = "[Current time: 2026-01-01 20:00:00]\n\nWhat time is it?"
+    list(agent.run(task=prefixed_task, stream=True))
+
+    assert agent.task == prefixed_task
+
+
+def test_run_injects_current_time_when_missing():
+    """When task has no [Current time: ...] prefix, run() should inject server time."""
+    module = TestRunStreamRealExecution()._load_core_agent_in_isolation()
+    agent = module.CoreAgent.__new__(module.CoreAgent)
+    agent.max_steps = 3
+    agent.state = {}
+    agent.memory = MagicMock()
+    agent.monitor = MagicMock()
+    agent.context_runtime = MagicMock()
+    agent.system_prompt = ""
+    agent.logger = MagicMock()
+    agent.model = MagicMock()
+    agent.model.model_id = "test-model"
+    agent.name = "test_agent"
+    agent.observer = MagicMock()
+    agent.python_executor = None
+    agent._run_stream_with_context_evidence = MagicMock(return_value=iter([]))
+
+    list(agent.run(task="What time is it?", stream=True))
+
+    assert agent.task.startswith("[Current time:")
+    assert "What time is it?" in agent.task
+

--- a/test/sdk/core/agents/test_core_agent.py
+++ b/test/sdk/core/agents/test_core_agent.py
@@ -3042,8 +3042,8 @@ def test_wrap_visible_tool_events_skips_tools_without_forward():
     assert not hasattr(agent.tools[0], "_tool_call_observer_wrapped")
 
 
-def test_run_preserves_existing_current_time_prefix():
-    """When task already has [Current time: ...] prefix, run() should not re-inject."""
+def _create_minimal_core_agent_for_time_tests():
+    """Create a CoreAgent with minimal mocking for time-prefix tests."""
     module = TestRunStreamRealExecution()._load_core_agent_in_isolation()
     agent = module.CoreAgent.__new__(module.CoreAgent)
     agent.max_steps = 3
@@ -3059,6 +3059,12 @@ def test_run_preserves_existing_current_time_prefix():
     agent.observer = MagicMock()
     agent.python_executor = None
     agent._run_stream_with_context_evidence = MagicMock(return_value=iter([]))
+    return agent
+
+
+def test_run_preserves_existing_current_time_prefix():
+    """When task already has [Current time: ...] prefix, run() should not re-inject."""
+    agent = _create_minimal_core_agent_for_time_tests()
 
     prefixed_task = "[Current time: 2026-01-01 20:00:00]\n\nWhat time is it?"
     list(agent.run(task=prefixed_task, stream=True))
@@ -3068,21 +3074,7 @@ def test_run_preserves_existing_current_time_prefix():
 
 def test_run_injects_current_time_when_missing():
     """When task has no [Current time: ...] prefix, run() should inject server time."""
-    module = TestRunStreamRealExecution()._load_core_agent_in_isolation()
-    agent = module.CoreAgent.__new__(module.CoreAgent)
-    agent.max_steps = 3
-    agent.state = {}
-    agent.memory = MagicMock()
-    agent.monitor = MagicMock()
-    agent.context_runtime = MagicMock()
-    agent.system_prompt = ""
-    agent.logger = MagicMock()
-    agent.model = MagicMock()
-    agent.model.model_id = "test-model"
-    agent.name = "test_agent"
-    agent.observer = MagicMock()
-    agent.python_executor = None
-    agent._run_stream_with_context_evidence = MagicMock(return_value=iter([]))
+    agent = _create_minimal_core_agent_for_time_tests()
 
     list(agent.run(task="What time is it?", stream=True))
 


### PR DESCRIPTION
fixed：agent回复时间与用户本地时间对齐
1.前端时间处理补充对时区的处理，默认将时间转为用户本地时区
2.llm中提示词中补充对用户时区的处理方式，所有生成的时间都使用用户时区转换后的服务器时间
<img width="1762" height="1115" alt="{66658741-49B0-4184-8CC3-11F30300861C}" src="https://github.com/user-attachments/assets/b0da9e30-8541-4740-ba2b-44fb5bec101e" />
