### PR TITLE
Bugfix: normalize repository tags as arrays

### DIFF
--- a/backend/services/skill_repository_service.py
+++ b/backend/services/skill_repository_service.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import logging
 import math
 import re
@@ -176,6 +177,24 @@ def _as_dict(value: Any) -> Dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
+def _normalize_mine_skill_tags(tags: Any) -> List[str]:
+    """Return mine-tab skill tags as a validated string list."""
+    if isinstance(tags, str):
+        try:
+            tags = json.loads(tags)
+        except (json.JSONDecodeError, TypeError):
+            return []
+
+    if not isinstance(tags, list):
+        return []
+
+    return [
+        tag.strip()
+        for tag in tags
+        if isinstance(tag, str) and tag.strip()
+    ]
+
+
 def _to_repository_info_item(record: Dict[str, Any]) -> Dict[str, Any]:
     """Map a repository DB row to a my-skills repository_info entry."""
     return {
@@ -210,7 +229,7 @@ def _matches_search(skill: Dict[str, Any], search: Optional[str]) -> bool:
         skill.get("source"),
         skill.get("created_by"),
     ]
-    haystack.extend(_as_list(skill.get("tags")))
+    haystack.extend(_normalize_mine_skill_tags(skill.get("tags")))
     return any(keyword in str(value or "").lower() for value in haystack)
 
 
@@ -929,7 +948,7 @@ def _to_mine_skill_item(
         "name": skill.get("name"),
         "description": skill.get("description"),
         "source": skill.get("source"),
-        "tags": skill.get("tags") or [],
+        "tags": _normalize_mine_skill_tags(skill.get("tags")),
         "group_ids": skill.get("group_ids") or [],
         "ingroup_permission": skill.get("ingroup_permission"),
         "created_by": skill.get("created_by"),

--- a/sdk/nexent/skills/skill_loader.py
+++ b/sdk/nexent/skills/skill_loader.py
@@ -41,12 +41,12 @@ class SkillLoader:
         if not frontmatter:
             raise ValueError("SKILL.md must have YAML frontmatter")
 
-        # Try to parse with yaml.safe_load first
+        # Preserve the existing scalar compatibility behavior. Structured
+        # fields such as tags are left untouched by _fix_yaml_frontmatter.
         meta = None
         try:
-            # Fix YAML parsing to handle special characters in values
-            frontmatter = cls._fix_yaml_frontmatter(frontmatter)
-            meta = yaml.safe_load(frontmatter)
+            fixed_frontmatter = cls._fix_yaml_frontmatter(frontmatter)
+            meta = yaml.safe_load(fixed_frontmatter)
         except yaml.YAMLError as e:
             logger.warning(f"YAML parse error, falling back to regex extraction: {e}")
 
@@ -66,11 +66,18 @@ class SkillLoader:
             "name": filtered_meta.get("name"),
             "description": filtered_meta.get("description", ""),
             "allowed_tools": filtered_meta.get("allowed-tools", []),
-            "tags": filtered_meta.get("tags", []),
+            "tags": cls._normalize_tags(filtered_meta.get("tags")),
             "script_outputs": filtered_meta.get("script_outputs", {}),
             "content": body.strip(),
             "source_path": source_path
         }
+
+    @staticmethod
+    def _normalize_tags(tags: Any) -> list[str]:
+        """Return only non-empty string tags from parsed frontmatter."""
+        if not isinstance(tags, list):
+            return []
+        return [tag.strip() for tag in tags if isinstance(tag, str) and tag.strip()]
 
     @classmethod
     def _fix_yaml_frontmatter(cls, frontmatter: str) -> str:
@@ -111,6 +118,11 @@ class SkillLoader:
 
                 # Skip YAML list items (lines starting with '-')
                 if key == '' or line.strip().startswith('-'):
+                    fixed_lines.append(line)
+                    continue
+
+                # Do not turn structured metadata into quoted scalars.
+                if key in {"tags", "allowed-tools"}:
                     fixed_lines.append(line)
                     continue
 

--- a/test/backend/services/test_skill_repository_service.py
+++ b/test/backend/services/test_skill_repository_service.py
@@ -647,6 +647,48 @@ def test_list_my_editable_skills_filters_to_current_user_and_search():
     assert [item["name"] for item in result["items"]] == ["Excel Report"]
 
 
+def test_list_my_editable_skills_normalizes_string_tags_for_response_and_search():
+    class ListSkillService(_SkillServiceMock):
+        def list_skills(self, tenant_id=None):
+            return [{
+                "skill_id": 1,
+                "name": "Clinic Report",
+                "description": "build clinic reports",
+                "source": "custom",
+                "tags": '["table analysis", "visit volume", "medical statistics"]',
+                "created_by": "user-1",
+            }]
+
+    with patch.object(srs, "SkillService", ListSkillService):
+        result = srs.list_my_editable_skills_impl(
+            tenant_id="tenant-1",
+            user_id="user-1",
+            search="visit volume",
+        )
+
+    assert result["items"][0]["tags"] == [
+        "table analysis",
+        "visit volume",
+        "medical statistics",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("tags", "expected"),
+    [
+        ([" tag ", "", 1, "second"], ["tag", "second"]),
+        ('["json", "array"]', ["json", "array"]),
+        ("[table analysis, visit volume]", []),
+        ("plain text", []),
+        ("[invalid", []),
+        (None, []),
+        ({"tag": "value"}, []),
+    ],
+)
+def test_normalize_mine_skill_tags(tags, expected):
+    assert srs._normalize_mine_skill_tags(tags) == expected
+
+
 def test_mine_ownership_uses_creator_not_edit_permission():
     class ListSkillService(_SkillServiceMock):
         def list_skills(self, tenant_id=None):

--- a/test/sdk/skills/test_skill_loader.py
+++ b/test/sdk/skills/test_skill_loader.py
@@ -65,6 +65,60 @@ tags:
         assert result["name"] == "tagged-skill"
         assert result["tags"] == ["python", "ml"]
 
+    def test_parse_with_inline_tags_preserves_array(self):
+        """Test valid inline YAML tags remain a string list."""
+        content = """---
+name: inline-tagged-skill
+description: A tagged skill
+tags: [python, ml, data]
+---
+# Body
+"""
+        result = SkillLoader.parse(content)
+
+        assert result["tags"] == ["python", "ml", "data"]
+
+    def test_parse_with_scalar_compatibility_preserves_inline_tags_array(self):
+        """Test scalar compatibility fixes do not turn inline tags into a string."""
+        content = """---
+name: fallback-tagged-skill
+description: URL: http://example.com
+tags: [python, ml, data]
+---
+# Body
+"""
+        result = SkillLoader.parse(content)
+
+        assert result["description"] == "URL: http://example.com"
+        assert result["tags"] == ["python", "ml", "data"]
+
+    def test_parse_preserves_special_characters_in_description(self):
+        """Test existing scalar compatibility handling remains intact."""
+        content = """---
+name: special-description-skill
+description: hello #tag {special}
+tags: [python, ml]
+---
+# Body
+"""
+        result = SkillLoader.parse(content)
+
+        assert result["description"] == "hello #tag {special}"
+        assert result["tags"] == ["python", "ml"]
+
+    def test_parse_string_tags_returns_empty_list(self):
+        """Test string-valued tags cannot enter the persistence flow."""
+        content = """---
+name: string-tagged-skill
+description: A tagged skill
+tags: "[python, ml, data]"
+---
+# Body
+"""
+        result = SkillLoader.parse(content)
+
+        assert result["tags"] == []
+
     def test_parse_with_file_output_metadata(self):
         """Test parsing the artifact contract from skill frontmatter."""
         content = """---
@@ -162,6 +216,18 @@ description: Array [1, 2, 3]
 """
         fixed = SkillLoader._fix_yaml_frontmatter(frontmatter)
         assert "description: \"Array [1, 2, 3]\"" in fixed
+
+    def test_preserve_inline_structured_metadata(self):
+        """Test inline array metadata is not converted into a quoted scalar."""
+        frontmatter = """name: test
+description: URL: http://example.com
+tags: [python, ml]
+allowed-tools: [search, calculator]
+"""
+        fixed = SkillLoader._fix_yaml_frontmatter(frontmatter)
+
+        assert "tags: [python, ml]" in fixed
+        assert "allowed-tools: [search, calculator]" in fixed
 
     def test_preserve_block_scalar_pipe(self):
         """Test that block scalar with pipe (|) is preserved."""


### PR DESCRIPTION
修复 Skill 仓库“我的 Skill”页面在历史 tags 为字符串时白屏的问题。
后端 `/repository/skill/mine` 统一将 tags 返回为数组：标准 JSON 数组字符串会解析为数组，非标准或无法解析的值返回空数组，避免前端调用 filter 报错。

修复上传 Skill 时行内 YAML tags 被错误转换为字符串的问题。
保留原有标量字段特殊字符兼容逻辑，同时跳过 tags 和 allowed-tools 的自动加引号处理；并统一过滤非数组 tags，确保后续写入数据库的 tags 始终为字符串数组或空数组。

before:
<img width="1229" height="427" alt="image" src="https://github.com/user-attachments/assets/59a7724f-87b0-4e84-8af1-eac612f3834a" />

after
<img width="2064" height="1641" alt="image" src="https://github.com/user-attachments/assets/40be817a-cfc0-4f27-9c91-995c73add542" />
