### PR TITLE
🐛 Bugfix: Fixed an issue where clicking to view skills before the skills API returned a response would result in a blank screen on the agent editing page.

### DIFF
--- a/frontend/app/[locale]/agents/components/agentConfig/SelectedSkillManagement.tsx
+++ b/frontend/app/[locale]/agents/components/agentConfig/SelectedSkillManagement.tsx
@@ -78,7 +78,7 @@ export default function SelectedSkillManagement({
   // them by ID so an agent reloaded after saving keeps both its selection and
   // the canonical card content.
   const groupedSkills = useMemo<SelectedSkillGroup[]>(() => {
-    const catalogById = new Map(
+    const catalogById = new Map<number, Skill>(
       catalogSkills.map((skill: Skill) => [Number(skill.skill_id), skill])
     );
     const grouped = new Map<SkillSourceKey, Skill[]>([

--- a/frontend/app/[locale]/agents/components/agentConfig/SelectedSkillManagement.tsx
+++ b/frontend/app/[locale]/agents/components/agentConfig/SelectedSkillManagement.tsx
@@ -66,8 +66,7 @@ export default function SelectedSkillManagement({
     (state) => state.editedAgent.skills
   );
   const updateSkills = useAgentConfigStore((state) => state.updateSkills);
-  const { skills: catalogSkillData } = useSkillList({ enabled: true });
-  const catalogSkills = catalogSkillData as Skill[];
+  const { availableSkills: catalogSkills } = useSkillList({ enabled: true });
   const [detailSkill, setDetailSkill] = useState<Skill | null>(null);
   const [configSkill, setConfigSkill] = useState<Skill | null>(null);
   const [collapsedGroups, setCollapsedGroups] = useState<


### PR DESCRIPTION
🐛 Bugfix: Fixed an issue where clicking to view skills before the skills API returned a response would result in a blank screen on the agent editing page.
[Specification Details]
<img width="799" height="731" alt="image" src="https://github.com/user-attachments/assets/5e7eec6e-d0da-4abd-860e-282d469652ac" />
