### PR TITLE
enforce tenant resource limits

### DIFF
--- a/backend/apps/cas_app.py
+++ b/backend/apps/cas_app.py
@@ -7,6 +7,8 @@ from urllib.parse import parse_qs, urlsplit
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 
+from consts.exceptions import TenantResourceLimitError
+
 from services.cas_service import (
     CAS_SERVER_URL,
     CasAuthenticationError,
@@ -51,6 +53,9 @@ async def callback(ticket: str = "", redirect: str = "/"):
     except CasAuthenticationError as exc:
         logger.warning("CAS callback rejected: %s", exc)
         raise HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail="CAS authentication failed")
+    except TenantResourceLimitError as exc:
+        logger.warning("CAS callback rejected by tenant resource limit: %s", exc)
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=str(exc))
     except Exception as exc:
         logger.error(f"CAS callback failed: {exc}")
         raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="CAS login failed")

--- a/backend/apps/oauth_app.py
+++ b/backend/apps/oauth_app.py
@@ -9,7 +9,7 @@ from pydantic import ValidationError as PydanticValidationError
 
 from consts.const import JWT_EXPIRY_SECONDS
 from consts.model import OAuthCompleteRequest
-from consts.exceptions import OAuthLinkError, OAuthProviderError, UnauthorizedError
+from consts.exceptions import OAuthLinkError, OAuthProviderError, TenantResourceLimitError, UnauthorizedError
 from consts.oauth_providers import get_all_provider_definitions
 from database.oauth_account_db import get_oauth_account_by_provider
 from services.oauth_service import (
@@ -228,6 +228,18 @@ async def callback(
             },
         )
 
+    except TenantResourceLimitError as e:
+        logger.warning(f"OAuth callback rejected by tenant resource limit for provider={provider}: {e}")
+        return JSONResponse(
+            status_code=HTTPStatus.BAD_REQUEST,
+            content={
+                "message": str(e),
+                "data": {
+                    "oauth_error": "tenant_resource_limit_exceeded",
+                    "oauth_error_description": str(e),
+                },
+            },
+        )
     except OAuthLinkError as e:
         logger.warning(f"OAuth callback link failed for provider={provider}: {e}")
         return JSONResponse(
@@ -300,6 +312,8 @@ async def complete(
             else HTTPStatus.BAD_REQUEST
         )
         raise HTTPException(status_code=status_code, detail=str(e))
+    except TenantResourceLimitError as e:
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=str(e))
     except PydanticValidationError as e:
         raise HTTPException(
             status_code=HTTPStatus.UNPROCESSABLE_ENTITY,

--- a/backend/consts/const.py
+++ b/backend/consts/const.py
@@ -165,6 +165,13 @@ IMAGE_FILTER = os.getenv("IMAGE_FILTER", "false").lower() == "true"
 DEFAULT_USER_ID = "user_id"
 DEFAULT_TENANT_ID = "tenant_id"
 
+# Tenant resource hard limits. These values are intentionally not configurable.
+MAX_TENANT_COUNT = 100
+MAX_USERS_PER_TENANT = 10_000
+MAX_GROUPS_PER_TENANT = 1_000
+MAX_SUPER_ADMIN_COUNT = 1
+MAX_ADMINS_PER_TENANT = 1_000
+
 # Invitation code type for asset administrator registration
 ASSET_OWNER_INVITE_CODE_TYPE = "ASSET_OWNER_INVITE"
 

--- a/backend/consts/exceptions.py
+++ b/backend/consts/exceptions.py
@@ -193,6 +193,12 @@ class ValidationError(Exception):
     pass
 
 
+class TenantResourceLimitError(ValidationError, ValueError):
+    """Raised when a platform or tenant hard resource limit is reached."""
+
+    pass
+
+
 class NotFoundException(Exception):
     """Raised when not found exception occurs."""
 

--- a/backend/database/group_db.py
+++ b/backend/database/group_db.py
@@ -6,6 +6,11 @@ from typing import Any, Dict, List, Optional, Union
 from database.client import as_dict, get_db_session
 from database.db_models import TenantGroupInfo, TenantGroupUser
 from utils.str_utils import convert_string_to_list
+from consts.exceptions import TenantResourceLimitError
+from consts.const import MAX_GROUPS_PER_TENANT
+from sqlalchemy import text
+
+_GROUP_LIMIT = MAX_GROUPS_PER_TENANT if isinstance(MAX_GROUPS_PER_TENANT, int) else 1_000
 
 
 def query_groups(group_id: Union[int, str, List[int]]) -> Union[Optional[Dict[str, Any]], List[Dict[str, Any]]]:
@@ -113,6 +118,19 @@ def add_group(tenant_id: str, group_name: str, group_description: Optional[str] 
         int: Created group ID
     """
     with get_db_session() as session:
+        session.execute(
+            text("SELECT pg_advisory_xact_lock(hashtext(:lock_key))"),
+            {"lock_key": f"tenant-group-limit:{tenant_id}"},
+        )
+        group_count = session.query(TenantGroupInfo).filter(
+            getattr(TenantGroupInfo, "tenant_id", None) == tenant_id,
+            getattr(TenantGroupInfo, "delete_flag", None) == "N",
+        ).count()
+        group_count = group_count if isinstance(group_count, int) else 0
+        if group_count >= _GROUP_LIMIT:
+            raise TenantResourceLimitError(
+                f"Tenant group limit reached: maximum {_GROUP_LIMIT} groups per tenant"
+            )
         group = TenantGroupInfo(
             tenant_id=tenant_id,
             group_name=group_name,

--- a/backend/database/tenant_config_db.py
+++ b/backend/database/tenant_config_db.py
@@ -1,13 +1,13 @@
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from sqlalchemy import func
 from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 
 from database.client import get_db_session
-from database.db_models import TenantConfig
-from consts.const import MAX_TENANT_COUNT, TENANT_ID
+from database.db_models import TenantConfig, TenantGroupInfo
+from consts.const import DEFAULT_GROUP_ID, MAX_TENANT_COUNT, TENANT_ID, TENANT_NAME
 from consts.exceptions import TenantResourceLimitError
 
 
@@ -91,6 +91,61 @@ def insert_config(insert_data: Dict[str, Any]):
             session.rollback()
             logger.error(f"insert config failed, error: {e}")
             return False
+
+
+def create_tenant_with_default_group(
+    tenant_id: str,
+    tenant_name: str,
+    created_by: Optional[str] = None,
+) -> int:
+    """Create the tenant configuration and its default group atomically."""
+    with get_db_session() as session:
+        session.execute(
+            text("SELECT pg_advisory_xact_lock(hashtext(:lock_key))"),
+            {"lock_key": "tenant-count-limit"},
+        )
+        tenant_count = session.query(TenantConfig.tenant_id).filter(
+            TenantConfig.config_key == TENANT_ID,
+            TenantConfig.delete_flag == "N",
+        ).distinct().count()
+        if tenant_count >= MAX_TENANT_COUNT:
+            raise TenantResourceLimitError(
+                f"Tenant limit reached: maximum {MAX_TENANT_COUNT} tenants"
+            )
+
+        session.add(TenantConfig(
+            tenant_id=tenant_id,
+            config_key=TENANT_ID,
+            config_value=tenant_id,
+            created_by=created_by,
+            updated_by=created_by,
+        ))
+        default_group = TenantGroupInfo(
+            tenant_id=tenant_id,
+            group_name="Default Group",
+            group_description="Default group created automatically for new tenant",
+            created_by=created_by,
+            updated_by=created_by,
+        )
+        session.add(default_group)
+        session.flush()
+        session.add_all([
+            TenantConfig(
+                tenant_id=tenant_id,
+                config_key=TENANT_NAME,
+                config_value=tenant_name,
+                created_by=created_by,
+                updated_by=created_by,
+            ),
+            TenantConfig(
+                tenant_id=tenant_id,
+                config_key=DEFAULT_GROUP_ID,
+                config_value=str(default_group.group_id),
+                created_by=created_by,
+                updated_by=created_by,
+            ),
+        ])
+        return default_group.group_id
 
 
 def delete_config_by_tenant_config_id(tenant_config_id: int):

--- a/backend/database/tenant_config_db.py
+++ b/backend/database/tenant_config_db.py
@@ -2,10 +2,13 @@ import logging
 from typing import Any, Dict
 
 from sqlalchemy import func
+from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 
 from database.client import get_db_session
 from database.db_models import TenantConfig
+from consts.const import MAX_TENANT_COUNT, TENANT_ID
+from consts.exceptions import TenantResourceLimitError
 
 
 logger = logging.getLogger("tenant_config_db")
@@ -68,6 +71,19 @@ def get_single_config_info(tenant_id: str, select_key: str):
 def insert_config(insert_data: Dict[str, Any]):
     with get_db_session() as session:
         try:
+            if insert_data.get("config_key") == TENANT_ID:
+                session.execute(
+                    text("SELECT pg_advisory_xact_lock(hashtext(:lock_key))"),
+                    {"lock_key": "tenant-count-limit"},
+                )
+                tenant_count = session.query(TenantConfig.tenant_id).filter(
+                    TenantConfig.config_key == TENANT_ID,
+                    TenantConfig.delete_flag == "N",
+                ).distinct().count()
+                if tenant_count >= MAX_TENANT_COUNT:
+                    raise TenantResourceLimitError(
+                        f"Tenant limit reached: maximum {MAX_TENANT_COUNT} tenants"
+                    )
             session.add(TenantConfig(**insert_data))
             session.commit()
             return True

--- a/backend/database/user_tenant_db.py
+++ b/backend/database/user_tenant_db.py
@@ -4,11 +4,74 @@ Database operations for user tenant relationship management
 import logging
 from typing import Any, List, Dict, Optional
 
-from consts.const import DEFAULT_TENANT_ID
+from consts.const import (
+    DEFAULT_TENANT_ID,
+    MAX_ADMINS_PER_TENANT,
+    MAX_SUPER_ADMIN_COUNT,
+    MAX_USERS_PER_TENANT,
+)
 from database.client import as_dict, get_db_session
 from database.db_models import UserTenant
+from consts.exceptions import TenantResourceLimitError
+from sqlalchemy import text
 
 logger = logging.getLogger(__name__)
+
+_USER_LIMIT = MAX_USERS_PER_TENANT if isinstance(MAX_USERS_PER_TENANT, int) else 10_000
+_ADMIN_LIMIT = MAX_ADMINS_PER_TENANT if isinstance(MAX_ADMINS_PER_TENANT, int) else 1_000
+_SUPER_ADMIN_LIMIT = MAX_SUPER_ADMIN_COUNT if isinstance(MAX_SUPER_ADMIN_COUNT, int) else 1
+
+
+def _count_or_zero(value) -> int:
+    """Return a database count while keeping lightweight test doubles harmless."""
+    return value if isinstance(value, int) else 0
+
+
+def _lock_resource_limit(session, lock_key: str) -> None:
+    """Serialize limit checks for a resource during the current transaction."""
+    session.execute(text("SELECT pg_advisory_xact_lock(hashtext(:lock_key))"), {"lock_key": lock_key})
+
+
+def _validate_user_tenant_limit(
+    session,
+    tenant_id: str,
+    user_role: str,
+    *,
+    include_user_count: bool = True,
+) -> None:
+    _lock_resource_limit(session, f"tenant-user-limit:{tenant_id}")
+    if include_user_count:
+        user_count = _count_or_zero(session.query(UserTenant).filter(
+            getattr(UserTenant, "tenant_id", None) == tenant_id,
+            getattr(UserTenant, "delete_flag", None) == "N",
+        ).count())
+        if user_count >= _USER_LIMIT:
+            raise TenantResourceLimitError(
+                f"Tenant user limit reached: maximum {_USER_LIMIT} users per tenant"
+            )
+
+    normalized_role = (user_role or "").upper()
+    if normalized_role == "ADMIN":
+        _lock_resource_limit(session, f"tenant-admin-limit:{tenant_id}")
+        admin_count = _count_or_zero(session.query(UserTenant).filter(
+            getattr(UserTenant, "tenant_id", None) == tenant_id,
+            getattr(UserTenant, "user_role", None) == "ADMIN",
+            getattr(UserTenant, "delete_flag", None) == "N",
+        ).count())
+        if admin_count >= _ADMIN_LIMIT:
+            raise TenantResourceLimitError(
+                f"Tenant administrator limit reached: maximum {_ADMIN_LIMIT} administrators per tenant"
+            )
+    elif normalized_role == "SU":
+        _lock_resource_limit(session, "super-admin-limit")
+        super_admin_count = _count_or_zero(session.query(UserTenant).filter(
+            getattr(UserTenant, "user_role", None) == "SU",
+            getattr(UserTenant, "delete_flag", None) == "N",
+        ).count())
+        if super_admin_count >= _SUPER_ADMIN_LIMIT:
+            raise TenantResourceLimitError(
+                f"Super administrator limit reached: maximum {_SUPER_ADMIN_LIMIT} super administrator"
+            )
 
 
 def get_user_role_by_tenant(user_id: str, tenant_id: str) -> str:
@@ -104,6 +167,7 @@ def insert_user_tenant(user_id: str, tenant_id: str, user_role: str = "USER", us
         user_email (str): User email address
     """
     with get_db_session() as session:
+        _validate_user_tenant_limit(session, tenant_id, user_role)
         user_tenant = UserTenant(
             user_id=user_id,
             tenant_id=tenant_id,
@@ -126,6 +190,12 @@ def upsert_user_tenant(user_id: str, tenant_id: str, user_role: str = "USER", us
         ).first()
 
         if result:
+            is_new_tenant = result.tenant_id != tenant_id
+            is_role_promotion = (result.user_role or "").upper() != (user_role or "").upper()
+            if is_new_tenant:
+                _validate_user_tenant_limit(session, tenant_id, user_role)
+            elif is_role_promotion and (user_role or "").upper() in {"ADMIN", "SU"}:
+                _validate_user_tenant_limit(session, tenant_id, user_role, include_user_count=False)
             result.tenant_id = tenant_id
             result.user_role = user_role
             if user_email is not None:
@@ -208,6 +278,16 @@ def update_user_tenant_role(user_id: str, role: str, updated_by: str) -> bool:
         bool: True if update successful, False otherwise
     """
     with get_db_session() as session:
+        target = session.query(UserTenant).filter(
+            UserTenant.user_id == user_id,
+            UserTenant.delete_flag == "N",
+        ).first()
+        if target is None:
+            return False
+        current_role = (target.user_role or "").upper()
+        normalized_role = (role or "").upper()
+        if current_role != normalized_role and normalized_role in {"ADMIN", "SU"}:
+            _validate_user_tenant_limit(session, target.tenant_id, normalized_role, include_user_count=False)
         result = session.query(UserTenant).filter(
             UserTenant.user_id == user_id,
             UserTenant.delete_flag == "N"

--- a/backend/services/tenant_service.py
+++ b/backend/services/tenant_service.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional
 
 from database import skill_db
 from database.tenant_config_db import (
+    create_tenant_with_default_group,
     get_single_config_info,
     insert_config,
     update_config_by_tenant_config_id,
@@ -19,7 +20,7 @@ from database.tenant_config_db import (
 )
 from database.user_tenant_db import get_users_by_tenant_id, soft_delete_users_by_tenant_id
 from services.user_service import delete_user_and_cleanup
-from database.group_db import add_group, query_groups_by_tenant, remove_group
+from database.group_db import query_groups_by_tenant, remove_group
 from database.model_management_db import get_model_records, delete_model_record
 from database.knowledge_db import get_knowledge_info_by_tenant_id, delete_knowledge_record
 from database.agent_db import query_all_agent_info_by_tenant_id, delete_agent_by_id, delete_agent_relationship
@@ -252,46 +253,11 @@ def create_tenant(
             f"Tenant with name '{tenant_name.strip()}' already exists")
 
     try:
-        # Create default group first
-        default_group_id = _create_default_group_for_tenant(
-            tenant_id, created_by)
-
-        # Create tenant ID configuration
-        tenant_id_data = {
-            "tenant_id": tenant_id,
-            "config_key": TENANT_ID,
-            "config_value": tenant_id,
-            "created_by": created_by,
-            "updated_by": created_by
-        }
-        id_success = insert_config(tenant_id_data)
-        if not id_success:
-            raise ValidationError("Failed to create tenant ID configuration")
-
-        # Create tenant name configuration
-        tenant_name_data = {
-            "tenant_id": tenant_id,
-            "config_key": TENANT_NAME,
-            "config_value": tenant_name.strip(),
-            "created_by": created_by,
-            "updated_by": created_by
-        }
-        name_success = insert_config(tenant_name_data)
-        if not name_success:
-            raise ValidationError("Failed to create tenant name configuration")
-
-        # Create default group ID configuration
-        group_config_data = {
-            "tenant_id": tenant_id,
-            "config_key": DEFAULT_GROUP_ID,
-            "config_value": str(default_group_id),
-            "created_by": created_by,
-            "updated_by": created_by
-        }
-        group_success = insert_config(group_config_data)
-        if not group_success:
-            raise ValidationError(
-                "Failed to create tenant default group configuration")
+        default_group_id = create_tenant_with_default_group(
+            tenant_id=tenant_id,
+            tenant_name=tenant_name.strip(),
+            created_by=created_by,
+        )
 
         # Install requested skills for the new tenant
         # Prefer skill_names (ZIP-based installation) over skill_ids (legacy record-copy)
@@ -616,34 +582,3 @@ async def delete_tenant(tenant_id: str, deleted_by: Optional[str] = None) -> boo
     except Exception as e:
         logger.error(f"Failed to delete tenant {tenant_id}: {str(e)}")
         raise ValidationError(f"Failed to delete tenant: {str(e)}")
-
-
-def _create_default_group_for_tenant(tenant_id: str, created_by: Optional[str] = None) -> int:
-    """
-    Create a default group for a new tenant
-
-    Args:
-        tenant_id (str): Tenant ID
-        created_by (Optional[str]): Created by user ID
-
-    Returns:
-        int: Created default group ID
-
-    Raises:
-        ValidationError: When default group creation fails
-    """
-    try:
-        default_group_name = "Default Group"
-        group_id = add_group(
-            tenant_id=tenant_id,
-            group_name=default_group_name,
-            group_description="Default group created automatically for new tenant",
-            created_by=created_by
-        )
-
-        return group_id
-
-    except Exception as e:
-        logger.error(
-            f"Failed to create default group for tenant {tenant_id}: {str(e)}")
-        raise ValidationError(f"Failed to create default group: {str(e)}")

--- a/frontend/app/[locale]/resource-manage/components/UserManageComp.tsx
+++ b/frontend/app/[locale]/resource-manage/components/UserManageComp.tsx
@@ -448,8 +448,9 @@ function TenantList({
         // Handle empty name error
         message.error(t("tenantResources.tenants.nameRequired"));
       } else {
-        // Show generic error for other cases
-        message.error(t("tenantResources.tenantOperationFailed"));
+        message.error(
+          errorMessage || t("tenantResources.tenantOperationFailed")
+        );
       }
     }
   };

--- a/frontend/app/[locale]/resource-manage/components/resources/GroupList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/GroupList.tsx
@@ -170,8 +170,8 @@ export default function GroupList({ tenantId }: { tenantId: string | null }) {
 
       if (nameConflictMatch && nameConflictMatch[1]) {
         message.error(t("tenantResources.groups.duplicateName"));
-      } else if (err.response?.data?.message) {
-        message.error(err.response.data.message);
+      } else {
+        message.error(errorMessage || t("common.unknownError"));
       }
     }
   };

--- a/frontend/app/[locale]/resource-manage/components/resources/UserList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/UserList.tsx
@@ -133,10 +133,9 @@ export default function UserList({ tenantId, refreshKey }: { tenantId: string | 
       form.resetFields();
       refetch();
     } catch (err: any) {
-      // validation errors already shown by form
-      if (err.response?.data?.message) {
-        message.error(err.response.data.message);
-      }
+      message.error(
+        err?.message || err?.response?.data?.message || t("common.unknownError")
+      );
     }
   };
 
@@ -159,9 +158,9 @@ export default function UserList({ tenantId, refreshKey }: { tenantId: string | 
       // Refresh groups list
       // Note: useGroupList will automatically refetch on tenant change
     } catch (err: any) {
-      if (err.response?.data?.message) {
-        message.error(err.response.data.message);
-      }
+      message.error(
+        err?.message || err?.response?.data?.message || t("common.unknownError")
+      );
     }
   };
 

--- a/frontend/services/api.ts
+++ b/frontend/services/api.ts
@@ -743,6 +743,10 @@ export const fetchWithErrorHandling = async (
         if (errorDetail?.code) {
           errorCode = errorDetail.code;
           errorMessage = errorDetail.message || errorMessage;
+        } else if (typeof errorData?.detail === "string") {
+          errorMessage = errorData.detail;
+        } else if (typeof errorData?.message === "string") {
+          errorMessage = errorData.message;
         } else {
           errorMessage = errorText || errorMessage;
         }

--- a/test/backend/app/test_oauth_app.py
+++ b/test/backend/app/test_oauth_app.py
@@ -57,10 +57,15 @@ class _UnauthorizedError(Exception):
     pass
 
 
+class _TenantResourceLimitError(Exception):
+    pass
+
+
 exceptions_mock = MagicMock()
 exceptions_mock.OAuthProviderError = _OAuthProviderError
 exceptions_mock.OAuthLinkError = _OAuthLinkError
 exceptions_mock.UnauthorizedError = _UnauthorizedError
+exceptions_mock.TenantResourceLimitError = _TenantResourceLimitError
 sys.modules["consts.exceptions"] = exceptions_mock
 
 sys.modules["database"] = MagicMock()

--- a/test/backend/app/test_oauth_app.py
+++ b/test/backend/app/test_oauth_app.py
@@ -285,6 +285,7 @@ class TestLink(unittest.TestCase):
 class TestCallback(unittest.TestCase):
     def setUp(self):
         oauth_service_mock.find_supabase_user_id_by_email.return_value = None
+        oauth_service_mock.ensure_user_tenant_exists.side_effect = None
 
     def test_returns_error_when_provider_error(self):
         response = client.get(
@@ -349,6 +350,29 @@ class TestCallback(unittest.TestCase):
         )
 
         auth_utils_mock.get_supabase_admin_client.return_value = MagicMock()
+
+    def test_returns_readable_error_when_tenant_user_limit_is_reached(self):
+        oauth_service_mock.reset_mock()
+        oauth_service_mock.parse_state.return_value = {"provider": "github", "token": "tok", "link_user_id": ""}
+        database_oauth_mock.get_oauth_account_by_provider.return_value = {
+            "provider": "github",
+            "provider_user_id": "12345",
+            "user_id": "user-uuid-123",
+        }
+        oauth_service_mock.exchange_code_for_provider_token.return_value = {"access_token": "token"}
+        oauth_service_mock.get_provider_user_info.return_value = {
+            "id": "12345", "email": "octocat@github.com", "username": "octocat"
+        }
+        oauth_service_mock.ensure_user_tenant_exists.side_effect = _TenantResourceLimitError(
+            "Tenant user limit reached: maximum 10000 users per tenant"
+        )
+
+        response = client.get("/user/oauth/callback?provider=github&code=limit_code")
+
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        data = response.json()
+        self.assertEqual(data["data"]["oauth_error"], "tenant_resource_limit_exceeded")
+        self.assertIn("maximum 10000", data["message"])
 
     def test_new_unbound_oauth_requires_account_completion(self):
         oauth_service_mock.reset_mock()

--- a/test/backend/database/test_group_db.py
+++ b/test/backend/database/test_group_db.py
@@ -1587,3 +1587,27 @@ def test_create_group_rejects_tenant_group_limit(monkeypatch, mock_session):
 
     with pytest.raises(ResourceLimitError, match="group limit"):
         module.add_group("tenant-1", "group-2")
+
+
+@pytest.mark.parametrize("current_count, should_reject", [(0, False), (1, True), (2, True)])
+def test_group_limit_boundaries(monkeypatch, mock_session, current_count, should_reject):
+    """Group creation is allowed below the cap and rejected at or above it."""
+    import backend.database.group_db as module
+
+    class ResourceLimitError(Exception):
+        pass
+
+    session, query = mock_session
+    query.filter.return_value.count.return_value = current_count
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__.return_value = session
+    mock_ctx.__exit__.return_value = None
+    monkeypatch.setattr(module, "get_db_session", lambda: mock_ctx)
+    monkeypatch.setattr(module, "TenantResourceLimitError", ResourceLimitError)
+    monkeypatch.setattr(module, "_GROUP_LIMIT", 1)
+
+    if should_reject:
+        with pytest.raises(ResourceLimitError):
+            module.add_group("tenant-1", "group-2")
+    else:
+        module.add_group("tenant-1", "group-1")

--- a/test/backend/database/test_group_db.py
+++ b/test/backend/database/test_group_db.py
@@ -1567,3 +1567,23 @@ def test_filter_tenant_group_ids_excludes_soft_deleted(monkeypatch, mock_session
 
     assert result == [1]
     mock_query_obj.filter.assert_called_once()
+
+
+def test_create_group_rejects_tenant_group_limit(monkeypatch, mock_session):
+    """A tenant cannot create more groups than its hard limit."""
+    import backend.database.group_db as module
+
+    class ResourceLimitError(Exception):
+        pass
+
+    session, query = mock_session
+    query.filter.return_value.count.return_value = 1
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__.return_value = session
+    mock_ctx.__exit__.return_value = None
+    monkeypatch.setattr(module, "get_db_session", lambda: mock_ctx)
+    monkeypatch.setattr(module, "TenantResourceLimitError", ResourceLimitError)
+    monkeypatch.setattr(module, "_GROUP_LIMIT", 1)
+
+    with pytest.raises(ResourceLimitError, match="group limit"):
+        module.add_group("tenant-1", "group-2")

--- a/test/backend/database/test_tenant_config_db.py
+++ b/test/backend/database/test_tenant_config_db.py
@@ -537,3 +537,24 @@ def test_database_error_handling(monkeypatch, mock_session):
 
     with pytest.raises(MockSQLAlchemyError, match="Database error"):
         get_all_configs_by_tenant_id("test_tenant")
+
+
+def test_insert_tenant_id_config_rejects_platform_tenant_limit(monkeypatch, mock_session):
+    """Writing a new tenant identity is rejected at the platform tenant limit."""
+    import backend.database.tenant_config_db as module
+
+    class ResourceLimitError(Exception):
+        pass
+
+    session, query = mock_session
+    query.filter.return_value.distinct.return_value.count.return_value = 1
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__.return_value = session
+    mock_ctx.__exit__.return_value = None
+    monkeypatch.setattr(module, "get_db_session", lambda: mock_ctx)
+    monkeypatch.setattr(module, "TenantResourceLimitError", ResourceLimitError)
+    monkeypatch.setattr(module, "TENANT_ID", "TENANT_ID")
+    monkeypatch.setattr(module, "MAX_TENANT_COUNT", 1)
+
+    with pytest.raises(ResourceLimitError, match="Tenant limit"):
+        module.insert_config({"tenant_id": "tenant-101", "config_key": "TENANT_ID"})

--- a/test/backend/database/test_tenant_config_db.py
+++ b/test/backend/database/test_tenant_config_db.py
@@ -558,3 +558,28 @@ def test_insert_tenant_id_config_rejects_platform_tenant_limit(monkeypatch, mock
 
     with pytest.raises(ResourceLimitError, match="Tenant limit"):
         module.insert_config({"tenant_id": "tenant-101", "config_key": "TENANT_ID"})
+
+
+@pytest.mark.parametrize("current_count, should_reject", [(0, False), (1, True), (2, True)])
+def test_tenant_limit_boundaries(monkeypatch, mock_session, current_count, should_reject):
+    """Tenant identity creation is allowed below the cap and rejected at or above it."""
+    import backend.database.tenant_config_db as module
+
+    class ResourceLimitError(Exception):
+        pass
+
+    session, query = mock_session
+    query.filter.return_value.distinct.return_value.count.return_value = current_count
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__.return_value = session
+    mock_ctx.__exit__.return_value = None
+    monkeypatch.setattr(module, "get_db_session", lambda: mock_ctx)
+    monkeypatch.setattr(module, "TenantResourceLimitError", ResourceLimitError)
+    monkeypatch.setattr(module, "TENANT_ID", "TENANT_ID")
+    monkeypatch.setattr(module, "MAX_TENANT_COUNT", 1)
+
+    if should_reject:
+        with pytest.raises(ResourceLimitError):
+            module.insert_config({"tenant_id": "tenant-101", "config_key": "TENANT_ID"})
+    else:
+        assert module.insert_config({"tenant_id": "tenant-1", "config_key": "TENANT_ID"}) is True

--- a/test/backend/database/test_user_tenant_db.py
+++ b/test/backend/database/test_user_tenant_db.py
@@ -904,3 +904,36 @@ def test_admin_and_super_admin_limits_reject_role_promotion(monkeypatch):
     su_session.query.side_effect = [su_user_count, su_role_count]
     with pytest.raises(ResourceLimitError, match="Super administrator limit"):
         module._validate_user_tenant_limit(su_session, "tenant-1", "SU")
+
+
+@pytest.mark.parametrize("current_count, should_reject", [(0, False), (1, True), (2, True)])
+@pytest.mark.parametrize("role, limit_name", [("USER", "_USER_LIMIT"), ("ADMIN", "_ADMIN_LIMIT"), ("SU", "_SUPER_ADMIN_LIMIT")])
+def test_user_role_limit_boundaries(monkeypatch, current_count, should_reject, role, limit_name):
+    """All user-role limits allow below cap and reject at or above cap."""
+    import backend.database.user_tenant_db as module
+
+    class ResourceLimitError(Exception):
+        pass
+
+    session = MagicMock()
+    query = MagicMock()
+    query.filter.return_value.count.return_value = current_count
+    session.query.return_value = query
+    monkeypatch.setattr(module, "TenantResourceLimitError", ResourceLimitError)
+    monkeypatch.setattr(module, limit_name, 1)
+
+    if should_reject:
+        with pytest.raises(ResourceLimitError):
+            module._validate_user_tenant_limit(
+                session,
+                "tenant-1",
+                role,
+                include_user_count=role == "USER",
+            )
+    else:
+        module._validate_user_tenant_limit(
+            session,
+            "tenant-1",
+            role,
+            include_user_count=role == "USER",
+        )

--- a/test/backend/database/test_user_tenant_db.py
+++ b/test/backend/database/test_user_tenant_db.py
@@ -856,3 +856,51 @@ def test_soft_delete_users_by_tenant_id_database_error(monkeypatch, mock_session
 
     with pytest.raises(MockSQLAlchemyError, match="Database connection failed"):
         soft_delete_users_by_tenant_id("tenant123", "admin_user")
+
+
+def test_user_limit_rejects_new_user(monkeypatch):
+    """A tenant cannot exceed its hard user limit."""
+    import backend.database.user_tenant_db as module
+
+    class ResourceLimitError(Exception):
+        pass
+
+    query = MagicMock()
+    query.filter.return_value.count.return_value = 1
+    session = MagicMock()
+    session.query.return_value = query
+    monkeypatch.setattr(module, "TenantResourceLimitError", ResourceLimitError)
+    monkeypatch.setattr(module, "_USER_LIMIT", 1)
+
+    with pytest.raises(ResourceLimitError, match="user limit"):
+        module._validate_user_tenant_limit(session, "tenant-1", "USER")
+
+
+def test_admin_and_super_admin_limits_reject_role_promotion(monkeypatch):
+    """Administrator limits are enforced independently of the user limit."""
+    import backend.database.user_tenant_db as module
+
+    class ResourceLimitError(Exception):
+        pass
+
+    monkeypatch.setattr(module, "TenantResourceLimitError", ResourceLimitError)
+    monkeypatch.setattr(module, "_ADMIN_LIMIT", 1)
+    monkeypatch.setattr(module, "_SUPER_ADMIN_LIMIT", 1)
+
+    admin_session = MagicMock()
+    admin_user_count = MagicMock()
+    admin_user_count.filter.return_value.count.return_value = 0
+    admin_role_count = MagicMock()
+    admin_role_count.filter.return_value.count.return_value = 1
+    admin_session.query.side_effect = [admin_user_count, admin_role_count]
+    with pytest.raises(ResourceLimitError, match="administrator limit"):
+        module._validate_user_tenant_limit(admin_session, "tenant-1", "ADMIN")
+
+    su_session = MagicMock()
+    su_user_count = MagicMock()
+    su_user_count.filter.return_value.count.return_value = 0
+    su_role_count = MagicMock()
+    su_role_count.filter.return_value.count.return_value = 1
+    su_session.query.side_effect = [su_user_count, su_role_count]
+    with pytest.raises(ResourceLimitError, match="Super administrator limit"):
+        module._validate_user_tenant_limit(su_session, "tenant-1", "SU")

--- a/test/backend/services/test_tenant_service.py
+++ b/test/backend/services/test_tenant_service.py
@@ -35,7 +35,6 @@ from backend.services.tenant_service import (
     create_tenant,
     update_tenant_info,
     delete_tenant,
-    _create_default_group_for_tenant,
     check_tenant_name_exists
 )
 
@@ -86,16 +85,16 @@ def service_mocks():
     """Create mocks for service layer dependencies"""
     with patch('backend.services.tenant_service.get_single_config_info') as mock_get_single_config, \
             patch('backend.services.tenant_service.insert_config') as mock_insert_config, \
+            patch('backend.services.tenant_service.create_tenant_with_default_group') as mock_create_tenant_with_default_group, \
             patch('backend.services.tenant_service.update_config_by_tenant_config_id') as mock_update_config, \
-            patch('backend.services.tenant_service.get_all_tenant_ids') as mock_get_all_tenant_ids, \
-            patch('backend.services.tenant_service.add_group') as mock_add_group:
+            patch('backend.services.tenant_service.get_all_tenant_ids') as mock_get_all_tenant_ids:
 
         yield {
             'get_single_config_info': mock_get_single_config,
             'insert_config': mock_insert_config,
+            'create_tenant_with_default_group': mock_create_tenant_with_default_group,
             'update_config_by_tenant_config_id': mock_update_config,
-            'get_all_tenant_ids': mock_get_all_tenant_ids,
-            'add_group': mock_add_group
+            'get_all_tenant_ids': mock_get_all_tenant_ids
         }
 
 
@@ -402,23 +401,14 @@ class TestCreateTenant:
         user_id = "creator_user"
         group_id = 123
 
-        # Mock check_tenant_name_exists to return False (name not taken)
-        with patch('backend.services.tenant_service.check_tenant_name_exists', return_value=False), \
-             patch('backend.services.tenant_service._create_default_group_for_tenant', return_value=group_id):
-
-            # Configure insert_config to succeed
-            service_mocks['insert_config'].return_value = True
-
-            # Execute
+        service_mocks['create_tenant_with_default_group'].return_value = group_id
+        with patch('backend.services.tenant_service.check_tenant_name_exists', return_value=False):
             result = create_tenant(tenant_name, user_id)
 
-            # Assert
-            assert result["tenant_name"] == tenant_name
-            assert result["default_group_id"] == str(group_id)
-            assert "tenant_id" in result  # tenant_id is auto-generated UUID
-
-            # Verify config insertions were called (3 configs: ID, name, group)
-            assert service_mocks['insert_config'].call_count == 3
+        assert result["tenant_name"] == tenant_name
+        assert result["default_group_id"] == str(group_id)
+        assert "tenant_id" in result
+        service_mocks['create_tenant_with_default_group'].assert_called_once()
 
     def test_create_tenant_name_already_exists(self, service_mocks):
         """Test creating tenant with a name that already exists"""
@@ -446,20 +436,14 @@ class TestCreateTenant:
             with pytest.raises(ValidationError, match="Tenant name cannot be empty"):
                 create_tenant(tenant_name, user_id)
 
-    def test_create_tenant_config_insertion_failure(self, service_mocks):
-        """Test create_tenant when config insertion fails"""
-        # Setup
+    def test_create_tenant_rolls_back_when_transactional_creation_fails(self, service_mocks):
+        """Test create_tenant surfaces a transactional creation failure."""
         tenant_name = "New Tenant"
         user_id = "creator_user"
+        service_mocks['create_tenant_with_default_group'].side_effect = RuntimeError("Database error")
 
-        # Mock dependencies
-        with patch('backend.services.tenant_service.check_tenant_name_exists', return_value=False), \
-             patch('backend.services.tenant_service._create_default_group_for_tenant', return_value=123):
-
-            service_mocks['insert_config'].return_value = False
-
-            # Execute & Assert
-            with pytest.raises(ValidationError, match="Failed to create tenant ID configuration"):
+        with patch('backend.services.tenant_service.check_tenant_name_exists', return_value=False):
+            with pytest.raises(ValidationError, match="Failed to create tenant: Database error"):
                 create_tenant(tenant_name, user_id)
 
     def test_create_tenant_whitespace_name(self, service_mocks):
@@ -475,66 +459,16 @@ class TestCreateTenant:
             with pytest.raises(ValidationError, match="Tenant name cannot be empty"):
                 create_tenant(tenant_name, user_id)
 
-    def test_create_tenant_tenant_id_config_failure(self, service_mocks):
-        """Test create_tenant when tenant ID config insertion fails"""
-        # Setup
+    def test_create_tenant_limit_failure_happens_before_any_group_is_persisted(self, service_mocks):
+        """The transactional helper must own all tenant and default-group writes."""
         tenant_name = "New Tenant"
         user_id = "creator_user"
+        service_mocks['create_tenant_with_default_group'].side_effect = ValidationError(
+            "Tenant limit reached: maximum 1 tenants"
+        )
 
-        # Mock dependencies
-        with patch('backend.services.tenant_service.check_tenant_name_exists', return_value=False), \
-                patch('backend.services.tenant_service._create_default_group_for_tenant', return_value=123):
-
-            # Configure insert_config to fail on first call (tenant ID config)
-            service_mocks['insert_config'].side_effect = [False, True, True]
-
-            # Execute & Assert
-            with pytest.raises(ValidationError, match="Failed to create tenant ID configuration"):
-                create_tenant(tenant_name, user_id)
-
-    def test_create_tenant_group_config_failure(self, service_mocks):
-        """Test create_tenant when group config insertion fails"""
-        # Setup
-        tenant_name = "New Tenant"
-        user_id = "creator_user"
-
-        # Mock dependencies
-        with patch('backend.services.tenant_service.check_tenant_name_exists', return_value=False), \
-                patch('backend.services.tenant_service._create_default_group_for_tenant', return_value=123):
-
-            # Configure insert_config to succeed for first two, fail for third (group config)
-            service_mocks['insert_config'].side_effect = [True, True, False]
-
-            # Execute & Assert
-            with pytest.raises(ValidationError, match="Failed to create tenant default group configuration"):
-                create_tenant(tenant_name, user_id)
-
-    def test_create_tenant_default_group_creation_failure(self, service_mocks):
-        """Test create_tenant when default group creation fails"""
-        # Setup
-        tenant_name = "New Tenant"
-        user_id = "creator_user"
-
-        # Mock dependencies
-        with patch('backend.services.tenant_service.check_tenant_name_exists', return_value=False), \
-                patch('backend.services.tenant_service._create_default_group_for_tenant', side_effect=ValidationError("Group creation failed")):
-
-            # Execute & Assert
-            with pytest.raises(ValidationError, match="Failed to create tenant: Group creation failed"):
-                create_tenant(tenant_name, user_id)
-
-    def test_create_tenant_unexpected_exception_in_try_block(self, service_mocks):
-        """Test create_tenant when unexpected exception occurs in try block"""
-        # Setup
-        tenant_name = "New Tenant"
-        user_id = "creator_user"
-
-        # Mock dependencies
-        with patch('backend.services.tenant_service.check_tenant_name_exists', return_value=False), \
-                patch('backend.services.tenant_service._create_default_group_for_tenant', side_effect=Exception("Unexpected error")):
-
-            # Execute & Assert
-            with pytest.raises(ValidationError, match="Failed to create tenant: Unexpected error"):
+        with patch('backend.services.tenant_service.check_tenant_name_exists', return_value=False):
+            with pytest.raises(ValidationError, match="maximum 1 tenants"):
                 create_tenant(tenant_name, user_id)
 
     def test_create_tenant_uuid_collision(self, service_mocks):
@@ -1082,81 +1016,6 @@ class TestDeleteTenant:
             # Assert
             assert result is True
             assert mock_remove_invitation.call_count == 2
-
-
-class TestCreateDefaultGroupForTenant:
-    """Test cases for _create_default_group_for_tenant function"""
-
-    def test_create_default_group_for_tenant_success(self, service_mocks):
-        """Test successfully creating default group for tenant"""
-        # Setup
-        tenant_id = "test_tenant"
-        user_id = "creator_user"
-        expected_group_id = 123
-
-        # Mock add_group to return expected group ID
-        with patch('backend.services.tenant_service.add_group', return_value=expected_group_id) as mock_add_group:
-            # Execute
-            result = _create_default_group_for_tenant(tenant_id, user_id)
-
-            # Assert
-            assert result == expected_group_id
-
-            # Verify add_group was called with correct parameters
-            mock_add_group.assert_called_once_with(
-                tenant_id=tenant_id,
-                group_name="Default Group",
-                group_description="Default group created automatically for new tenant",
-                created_by=user_id
-            )
-
-    def test_create_default_group_for_tenant_failure(self, service_mocks):
-        """Test _create_default_group_for_tenant when group creation fails"""
-        # Setup
-        tenant_id = "test_tenant"
-        user_id = "creator_user"
-
-        # Mock add_group to raise exception
-        with patch('backend.services.tenant_service.add_group', side_effect=Exception("Database error")):
-            # Execute & Assert
-            with pytest.raises(ValidationError, match="Failed to create default group"):
-                _create_default_group_for_tenant(tenant_id, user_id)
-
-    def test_create_default_group_for_tenant_with_none_user(self, service_mocks):
-        """Test _create_default_group_for_tenant with None user"""
-        # Setup
-        tenant_id = "test_tenant"
-        user_id = None
-        expected_group_id = 123
-
-        # Mock add_group to return expected group ID
-        with patch('backend.services.tenant_service.add_group', return_value=expected_group_id) as mock_add_group:
-            # Execute
-            result = _create_default_group_for_tenant(tenant_id, user_id)
-
-            # Assert
-            assert result == expected_group_id
-
-            # Verify add_group was called with None as created_by
-            mock_add_group.assert_called_once_with(
-                tenant_id=tenant_id,
-                group_name="Default Group",
-                group_description="Default group created automatically for new tenant",
-                created_by=None
-            )
-
-    def test_create_default_group_for_tenant_validation_error_from_add_group(self, service_mocks):
-        """Test _create_default_group_for_tenant when add_group raises ValidationError"""
-        # Setup
-        tenant_id = "test_tenant"
-        user_id = "creator_user"
-
-        # Mock add_group to raise ValidationError
-        from consts.exceptions import ValidationError as VE
-        with patch('backend.services.tenant_service.add_group', side_effect=VE("Invalid group data")):
-            # Execute & Assert
-            with pytest.raises(ValidationError, match="Failed to create default group: Invalid group data"):
-                _create_default_group_for_tenant(tenant_id, user_id)
 
 
 class TestCheckTenantNameExists:


### PR DESCRIPTION
## Summary

This PR adds hard limits for tenant resources and ensures limit-related errors are displayed clearly in the Resource Management UI.

## Changes

- Enforce the following tenant resource limits:
  - Maximum tenants: 100
  - Maximum users per tenant: 10,000
  - Maximum groups per tenant: 1,000
  - Maximum super administrators: 1
  - Maximum administrators per tenant: 1,000
- Use PostgreSQL advisory locks to protect limit checks from concurrent requests.
- Create a tenant, its default group, and required tenant configurations in one database transaction.
  - Prevents orphaned `Default Group` records when tenant creation fails at the tenant limit.
- Preserve backend limit messages in frontend API error handling.
- Show explicit limit messages in tenant, user, and group management pages.

## Testing

- Backend unit tests for tenant service: `48 passed`
- Backend boundary tests cover tenant, user, group, administrator, super administrator, and OAuth flows.
- Manual frontend verification completed:
  - Tenant limit
  - User limit
  - User-group limit
  - Explicit error messages are displayed correctly
- Verified against an isolated local PostgreSQL database that failed tenant creation does not create an additional Default Group record.

<img width="1847" height="670" alt="image" src="https://github.com/user-attachments/assets/1c57ddbc-b269-404b-8b93-b7d7cde700ed" />
