### PR TITLE
🐛 Bugfix: fix status tag icon misalignment and localize auth dialog slogan

### DIFF
--- a/frontend/app/[locale]/layout.tsx
+++ b/frontend/app/[locale]/layout.tsx
@@ -18,11 +18,13 @@ export async function generateMetadata({
 }: {
   params: Promise<{ locale?: string }>;
 }): Promise<Metadata> {
-  // Simple metadata for now - can be enhanced later with i18n
+  const { locale } = await params;
+  const isZh = locale === "zh";
   return {
     title: `AI Agent Platform`,
-    description:
-      "A powerful AI agent platform for intelligent conversations and automation",
+    description: isZh
+      ? "一个强大的 AI 智能体平台，支持智能对话与流程自动化"
+      : "A powerful AI agent platform for intelligent conversations and automation",
     icons: {
       icon: "/favicon.png",
       shortcut: "/favicon.png",

--- a/frontend/app/[locale]/resource-manage/components/resources/AgentList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/AgentList.tsx
@@ -362,10 +362,17 @@ export default function AgentList({ tenantId }: { tenantId: string | null }) {
             <div className="flex items-center gap-2 min-w-0">
               <Tag
                 color="#AEB6BF"
-                className="inline-flex items-center"
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  whiteSpace: "nowrap",
+                  flexShrink: 0,
+                }}
                 variant="solid"
               >
-                <Clock className="w-3 h-3 mr-1" />
+                <span className="inline-flex items-center mr-1">
+                  <Clock className="w-3 h-3" />
+                </span>
                 {t("agent.status.unpublished")}
               </Tag>
             </div>
@@ -387,15 +394,15 @@ export default function AgentList({ tenantId }: { tenantId: string | null }) {
                 style={{
                   display: "inline-flex",
                   alignItems: "center",
-                  padding: "2px 8px",
-                  lineHeight: "20px",
-                  height: "auto",
                   whiteSpace: "nowrap",
+                  flexShrink: 0,
                 }}
                 variant="solid"
               >
-                <CheckCircle className="w-3 h-3 mr-1" />
-                <span>{t("mcpConfig.status.available")}</span>
+                <span className="inline-flex items-center mr-1">
+                  <CheckCircle className="w-3 h-3" />
+                </span>
+                {t("mcpConfig.status.available")}
               </Tag>
             ) : (
               <Tooltip
@@ -407,15 +414,15 @@ export default function AgentList({ tenantId }: { tenantId: string | null }) {
                   style={{
                     display: "inline-flex",
                     alignItems: "center",
-                    padding: "2px 8px",
-                    lineHeight: "20px",
-                    height: "auto",
                     whiteSpace: "nowrap",
+                    flexShrink: 0,
                   }}
                   variant="solid"
                 >
-                  <CircleSlash className="w-3.5 h-3 mr-1" />
-                  <span>{t("mcpConfig.status.unavailable")}</span>
+                  <span className="inline-flex items-center mr-1">
+                    <CircleSlash className="w-3.5 h-3" />
+                  </span>
+                  {t("mcpConfig.status.unavailable")}
                 </Tag>
               </Tooltip>
             )}

--- a/frontend/app/[locale]/resource-manage/components/resources/InvitationList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/InvitationList.tsx
@@ -367,13 +367,13 @@ export default function InvitationList({
 
           const icon =
             status === "IN_USE" ? (
-              <CheckCircle className="w-3 h-3 mr-1" />
+              <CheckCircle className="w-3 h-3" />
             ) : status === "EXPIRE" ? (
-              <Clock className="w-3 h-3 mr-1" />
+              <Clock className="w-3 h-3" />
             ) : status === "RUN_OUT" ? (
-              <CircleSlash className="w-3.5 h-3 mr-1" />
+              <CircleSlash className="w-3.5 h-3" />
             ) : (
-              <XCircle className="w-3 h-3 mr-1" />
+              <XCircle className="w-3 h-3" />
             );
 
           return (
@@ -382,15 +382,13 @@ export default function InvitationList({
               style={{
                 display: "inline-flex",
                 alignItems: "center",
-                padding: "2px 8px",
-                lineHeight: "20px",
-                height: "auto",
                 whiteSpace: "nowrap",
+                flexShrink: 0,
               }}
               variant="solid"
             >
-              {icon}
-              <span>{t(`tenantResources.invitation.status.${status}`)}</span>
+              <span className="inline-flex items-center mr-1">{icon}</span>
+              {t(`tenantResources.invitation.status.${status}`)}
             </Tag>
           );
         },

--- a/frontend/app/[locale]/resource-manage/components/resources/McpList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/McpList.tsx
@@ -508,10 +508,8 @@ export default function McpList({ tenantId }: { tenantId: string | null }) {
             style={{
               display: "inline-flex",
               alignItems: "center",
-              padding: "2px 8px",
-              lineHeight: "20px",
-              height: "auto",
               whiteSpace: "nowrap",
+              flexShrink: 0,
             }}
             variant="solid"
           >
@@ -524,10 +522,8 @@ export default function McpList({ tenantId }: { tenantId: string | null }) {
               style={{
                 display: "inline-flex",
                 alignItems: "center",
-                padding: "2px 8px",
-                lineHeight: "20px",
-                height: "auto",
                 whiteSpace: "nowrap",
+                flexShrink: 0,
                 cursor: "pointer",
               }}
               variant="solid"
@@ -545,27 +541,26 @@ export default function McpList({ tenantId }: { tenantId: string | null }) {
       render: (_: any, record: McpServer) => {
         const isAvailable = record.status;
         const key = `${record.service_name}__${record.mcp_url}`;
+        const statusIcon = healthCheckLoading[key] ? (
+          <LoaderCircle className="w-3 h-3 animate-spin" />
+        ) : isAvailable ? (
+          <CheckCircle className="w-3 h-3" />
+        ) : (
+          <CircleX className="w-3 h-3" />
+        );
         return (
           <Tag
             color={healthCheckLoading[key] ? "#2E4053" : isAvailable ? "#229954" : "#E74C3C"}
             style={{
               display: "inline-flex",
               alignItems: "center",
-              padding: "2px 8px",
-              lineHeight: "20px",
-              height: "auto",
               whiteSpace: "nowrap",
+              flexShrink: 0,
             }}
             variant="solid"
           >
-            {healthCheckLoading[key] ? (
-              <LoaderCircle className="w-3 h-3 animate-spin mr-1" />
-            ) : isAvailable ? (
-              <CheckCircle className="w-3 h-3 mr-1" />
-            ) : (
-              <CircleX className="w-3 h-3 mr-1" />
-            )}
-            <span>{t(isAvailable ? "mcpConfig.status.available" : "mcpConfig.status.unavailable")}</span>
+            <span className="inline-flex items-center mr-1">{statusIcon}</span>
+            {t(isAvailable ? "mcpConfig.status.available" : "mcpConfig.status.unavailable")}
           </Tag>
         );
       },
@@ -676,15 +671,13 @@ export default function McpList({ tenantId }: { tenantId: string | null }) {
             style={{
               display: "inline-flex",
               alignItems: "center",
-              padding: "2px 8px",
-              lineHeight: "20px",
-              height: "auto",
               whiteSpace: "nowrap",
+              flexShrink: 0,
             }}
             variant="solid"
           >
-            <span className="mr-1">{config.icon}</span>
-            <span>{status || "unknown"}</span>
+            <span className="inline-flex items-center mr-1">{config.icon}</span>
+            {status || "unknown"}
           </Tag>
         );
       },

--- a/frontend/app/[locale]/resource-manage/components/resources/ModelList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/ModelList.tsx
@@ -11,7 +11,17 @@ import {
   Segmented,
   Tooltip,
 } from "antd";
-import { Edit, Trash2, RefreshCw, TriangleAlert } from "lucide-react";
+import {
+  CheckCircle,
+  CircleEllipsis,
+  CircleHelp,
+  CircleSlash,
+  Edit,
+  RefreshCw,
+  Trash2,
+  TriangleAlert,
+  XCircle,
+} from "lucide-react";
 import { ColumnsType } from "antd/es/table";
 import type { TablePaginationConfig } from "antd";
 import { FilterValue, SorterResult } from "antd/es/table/interface";
@@ -25,14 +35,6 @@ import { MODEL_TYPES } from "@/const/modelConfig";
 import { ModelAddDialog } from "../../../models/components/model/ModelAddDialog";
 import { ModelEditDialog } from "../../../models/components/model/ModelEditDialog";
 import ModelCapacityCoverageWidget from "./ModelCapacityCoverageWidget";
-import {
-  CheckCircle,
-  CircleSlash,
-  XCircle,
-  CircleEllipsis,
-  CircleHelp,
-} from "lucide-react";
-
 interface UnifiedModelRow extends ModelOption {
   request_count?: number;
   error_rate?: number;
@@ -320,15 +322,15 @@ export default function ModelList({ tenantId }: { tenantId: string | null }) {
 
         const icon =
           status === "available" ? (
-            <CheckCircle className="w-3 h-3 mr-1" />
+            <CheckCircle className="w-3 h-3" />
           ) : status === "unavailable" ? (
-            <CircleSlash className="w-3 h-3 mr-1" />
+            <CircleSlash className="w-3 h-3" />
           ) : status === "detecting" ? (
-            <CircleEllipsis className="w-3 h-3 mr-1" />
+            <CircleEllipsis className="w-3 h-3" />
           ) : status === "not_detected" ? (
-            <CircleHelp className="w-3.5 h-3.5 mr-1" />
+            <CircleHelp className="w-3.5 h-3.5" />
           ) : (
-            <XCircle className="w-3 h-3 mr-1" />
+            <XCircle className="w-3 h-3" />
           );
         return (
           <Tag
@@ -336,15 +338,13 @@ export default function ModelList({ tenantId }: { tenantId: string | null }) {
             style={{
               display: "inline-flex",
               alignItems: "center",
-              padding: "2px 8px",
-              lineHeight: "20px",
-              height: "auto",
               whiteSpace: "nowrap",
+              flexShrink: 0,
             }}
             variant="solid"
           >
-            {icon}
-            <span>{t(`tenantResources.models.status.${status}`)}</span>
+            <span className="inline-flex items-center mr-1">{icon}</span>
+            {t(`tenantResources.models.status.${status}`)}
           </Tag>
         );
       },

--- a/frontend/components/auth/AuthDialogs.tsx
+++ b/frontend/components/auth/AuthDialogs.tsx
@@ -64,9 +64,7 @@ export function AuthDialogs() {
 
           {/* Subtitle */}
           <p className="text-center text-gray-500 mb-8 mt-4 ml-10 mr-10 text-sm">
-            {t(
-              "A powerful AI agent platform for intelligent conversations and automation"
-            )}
+            {t("page.loginPrompt.slogan")}
           </p>
 
           {/* Action buttons */}

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -300,6 +300,7 @@
   ],
   "page.loginPrompt.githubSupport": "Support us on GitHub",
   "page.loginPrompt.noAccount": "Don't have an account yet? Click the \"Register\" button to create your exclusive account~",
+  "page.loginPrompt.slogan": "A powerful AI agent platform for intelligent conversations and automation",
   "page.adminPrompt.close": "OK",
   "page.adminPrompt.unlockHeader": "🌟 Become an administrator and unlock more capabilities!",
   "page.adminPrompt.unlockIntro": "After becoming an administrator, you can:",

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -299,6 +299,7 @@
   "page.loginPrompt.intro": "请登录您的账户以访问此页面。",
   "page.loginPrompt.githubSupport": "在 GitHub 上支持我们",
   "page.loginPrompt.noAccount": "还没有账号？点击\"注册\"按钮创建您的专属账号~",
+  "page.loginPrompt.slogan": "一个强大的 AI 智能体平台，支持智能对话与流程自动化",
   "page.adminPrompt.close": "好的",
   "page.adminPrompt.unlockHeader": "🌟 成为管理员，解锁更多能力！",
   "page.adminPrompt.unlockIntro": "成为管理员后，您可以：",


### PR DESCRIPTION
## Summary

This PR includes two frontend UI bug fixes:

1. **Fix status tag icon misalignment in resource-manage lists** — Fixed incorrect icon alignment in `AgentList`, `InvitationList`, `McpList`, and `ModelList` by replacing `className` shortcuts with explicit inline styles (`display: inline-flex`, `alignItems: center`, `flexShrink: 0`) and wrapping icons in `<span className="inline-flex items-center mr-1">` to ensure Lucide icons and Tag content render correctly across all status variants.
<img width="643" height="515" alt="image" src="https://github.com/user-attachments/assets/80ba8cc1-d8b3-4d7a-9d45-d350fde6acb2" />

2. **Localize auth dialog slogan for zh and en** — Replaced the hardcoded English slogan string in `AuthDialogs.tsx` with a `t("page.loginPrompt.slogan")` i18n key, added the corresponding Chinese translation in `zh/common.json`, and updated `generateMetadata` in `layout.tsx` to return a locale-aware page description. Fix #2936 
<img width="1676" height="941" alt="image" src="https://github.com/user-attachments/assets/6fccf7ed-8d26-4cc1-b448-1d7771eb3b7a" />

---

## Changes

**UI alignment fix**
- `AgentList.tsx` — Unpublished agent tag icon alignment
- `McpList.tsx` — MCP server availability tags, health check loader tags
- `ModelList.tsx` — Model status tags (available, unavailable, detecting, not_detected)
- `InvitationList.tsx` — Invitation status tags (IN_USE, EXPIRE, RUN_OUT)

**i18n fix**
- `AuthDialogs.tsx` — Use `t("page.loginPrompt.slogan")` instead of hardcoded string
- `layout.tsx` — Return locale-aware `description` in metadata
- `en/common.json` — Add `"page.loginPrompt.slogan"`
- `zh/common.json` — Add `"page.loginPrompt.slogan"` with Chinese text

---

## Testing

- Manual browser verification on both zh and en locales
- All four resource management pages render status tags correctly at various container widths