### PR TITLE
test: mock tenant resource limit error

### DIFF
--- a/test/backend/database/test_tenant_config_db.py
+++ b/test/backend/database/test_tenant_config_db.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import types
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
 
 import pytest
@@ -25,6 +26,16 @@ consts_mock.const.TENANT_ID = "tenant_id"
 # Add the mocked consts module to sys.modules
 sys.modules['consts'] = consts_mock
 sys.modules['consts.const'] = consts_mock.const
+
+exceptions_mock = types.ModuleType("consts.exceptions")
+
+
+class MockTenantResourceLimitError(Exception):
+    pass
+
+
+exceptions_mock.TenantResourceLimitError = MockTenantResourceLimitError
+sys.modules['consts.exceptions'] = exceptions_mock
 
 # Mock utils module
 utils_mock = MagicMock()

--- a/test/backend/services/test_vectordatabase_service.py
+++ b/test/backend/services/test_vectordatabase_service.py
@@ -96,10 +96,15 @@ class ValidationError(Exception):
     pass
 
 
+class TenantResourceLimitError(ValidationError, ValueError):
+    pass
+
+
 consts_exceptions_mod.UnauthorizedError = UnauthorizedError
 consts_exceptions_mod.NotFoundException = NotFoundException
 consts_exceptions_mod.DuplicateError = DuplicateError
 consts_exceptions_mod.ValidationError = ValidationError
+consts_exceptions_mod.TenantResourceLimitError = TenantResourceLimitError
 
 # Use real consts.const/scheduler (env vars are configured in test/conftest.py)
 consts_pkg = importlib.import_module("consts")


### PR DESCRIPTION
## Summary

Fix test-time mock module compatibility introduced by tenant resource limit enforcement.

- Add `TenantResourceLimitError` to the mocked `consts.exceptions` module.
- Ensure affected database and vector database service tests can complete collection.
- Keep the fix scoped to test mocks; no production behavior changes.

## Validation

- `test/backend/database/test_tenant_config_db.py` — 23 passed
- `test/backend/services/test_vectordatabase_service.py` — 275 passed

## Related

Follow-up test fix for #3670. Replaces closed PR #3684, which used an outdated branch base and therefore re-included the already merged tenant-limit diff in Codecov patch coverage.