### PR TITLE
🐛 Bugfix: prevent empty agent final answers

### DIFF
--- a/sdk/nexent/core/agents/core_agent.py
+++ b/sdk/nexent/core/agents/core_agent.py
@@ -41,6 +41,10 @@ from .verification import (
 from ..utils.token_estimation import msg_token_count
 from .plan_repo import PlanRepo
 
+
+logger = logging.getLogger(__name__)
+
+
 def parse_code_blobs(text: str) -> str:
     """Extract code blocks from the LLM's output for execution.
 
@@ -846,6 +850,15 @@ Additional Args:
                     "or return the actual user-facing final answer.",
                     self.logger,
                 )
+            # Guard: if the model returned empty or whitespace-only content,
+            # treat it as a generation error so the retry loop can recover,
+            # instead of silently terminating the conversation with no output.
+            if not model_output or not str(model_output).strip():
+                raise AgentGenerationError(
+                    "Model returned empty or whitespace-only output; "
+                    "this is likely a transient API issue and the step will be retried.",
+                    self.logger,
+                )
             self.logger.log_markdown(
                 content=model_output, title="AGENT FINAL ANSWER", level=LogLevel.INFO)
             raise FinalAnswerError()
@@ -1189,6 +1202,19 @@ You have been provided with these additional arguments, that you can access usin
 
                 if isinstance(output, ActionOutput) and output.is_final_answer:
                     candidate_answer = output.output
+                    if candidate_answer is None or not str(candidate_answer).strip():
+                        diagnostics = getattr(self.model, "last_response_diagnostics", None)
+                        logger.warning(
+                            "event=empty_final_answer_candidate source=final_answer_tool "
+                            "step_number=%s model_diagnostics=%s",
+                            self.step_number,
+                            diagnostics,
+                        )
+                        raise AgentExecutionError(
+                            "The final_answer tool returned empty content. Call final_answer again "
+                            "with a non-empty user-facing response.",
+                            self.logger,
+                        )
                     self.logger.log(
                         Text(f"Final answer: {candidate_answer}", style=f"bold {YELLOW_HEX}"),
                         level=LogLevel.INFO,
@@ -1228,6 +1254,19 @@ You have been provided with these additional arguments, that you can access usin
                 candidate_answer = action_step.model_output
                 if isinstance(candidate_answer, str):
                     candidate_answer = convert_code_format(candidate_answer)
+                if candidate_answer is None or not str(candidate_answer).strip():
+                    diagnostics = getattr(self.model, "last_response_diagnostics", None)
+                    logger.warning(
+                        "event=empty_final_answer_candidate source=direct_model_output "
+                        "step_number=%s model_diagnostics=%s",
+                        self.step_number,
+                        diagnostics,
+                    )
+                    action_step.error = AgentGenerationError(
+                        "Model returned empty content instead of a final answer; the step will be retried.",
+                        self.logger,
+                    )
+                    continue
 
                 if verification_config.enabled and verification_config.final_verification_enabled:
                     final_verification_round += 1
@@ -1438,6 +1477,17 @@ You have been provided with these additional arguments, that you can access usin
             # Fallback to error message if streaming fails
             model_output = f"Error in generating final LLM output: {e}"
             self.logger.log(f"Error in final answer generation: {e}", level=LogLevel.ERROR)
+
+        # Guard: if the model returned empty content at max-steps, provide a
+        # meaningful fallback instead of an empty final_answer.
+        if not model_output or not str(model_output).strip():
+            model_output = (
+                "The agent was unable to generate a valid response after reaching "
+                "the maximum number of steps. Please try rephrasing your request."
+            )
+            logger.warning(
+                "_handle_max_steps_reached: model returned empty content, using fallback"
+            )
 
         # Finalize the memory step
         final_memory_step.timing.end_time = time.time()

--- a/sdk/nexent/core/agents/nexent_agent.py
+++ b/sdk/nexent/core/agents/nexent_agent.py
@@ -48,6 +48,16 @@ def get_local_python_authorized_imports() -> List[str]:
 logger = logging.getLogger(__name__)
 
 
+def _ensure_non_empty_final_answer(answer: str, lang: str) -> str:
+    """Return a user-visible fallback when final-answer cleanup removes all content."""
+    if answer.strip():
+        return answer
+    logger.warning("Final answer was empty after removing reasoning content")
+    if lang == "zh":
+        return "智能体未能生成有效的最终回复，请重试或换一种方式描述需求。"
+    return "The agent could not generate a valid final response. Please try again or rephrase your request."
+
+
 def _tool_name(tool_obj: Any) -> str:
     """Return the most useful tool name for monitoring."""
     return (
@@ -893,6 +903,10 @@ class NexentAgent:
                     # Remove thinking prefix content (until two newlines)
                     final_answer_str = re.sub(
                         THINK_PREFIX_PATTERN, "", final_answer_str, flags=re.DOTALL)
+                    final_answer_str = _ensure_non_empty_final_answer(
+                        final_answer_str,
+                        getattr(observer, "lang", "en"),
+                    )
                     final_answer_for_trace = final_answer_str
                     monitoring_manager.set_openinference_output(final_answer_str)
                     observer.add_message(self.agent.agent_name,

--- a/sdk/nexent/core/models/openai_llm.py
+++ b/sdk/nexent/core/models/openai_llm.py
@@ -37,6 +37,10 @@ from .message_utils import prepare_messages_for_smolagents_text_flattening
 logger = logging.getLogger("openai_llm")
 
 
+class EmptyModelResponseError(RuntimeError):
+    """Raised when a completed provider stream contains no user-visible content."""
+
+
 class OpenAIModel(OpenAIServerModel):
     def _prepare_completion_kwargs(self, *args, **kwargs) -> Dict[str, Any]:
         """
@@ -105,6 +109,7 @@ class OpenAIModel(OpenAIServerModel):
         self.last_provider_cache_advice = None
         self.last_prompt_cache_usage = None
         self.last_cached_input_token_count = 0
+        self.last_response_diagnostics = None
         self.safe_input_budget_snapshot = safe_input_budget_snapshot
         self.capacity_snapshot = capacity_snapshot
         if max_output_tokens is None and max_tokens is not None:
@@ -195,6 +200,7 @@ class OpenAIModel(OpenAIServerModel):
 
         token_tracker = _token_tracker or self._monitoring.create_token_tracker(
             self.model_id)
+        self.last_response_diagnostics = None
 
         # Normalize incoming messages so we can accept plain dict payloads like
         # {"role": "user", "content": "..."} alongside ChatMessage instances.
@@ -326,6 +332,11 @@ class OpenAIModel(OpenAIServerModel):
         role = None
         finish_reason = None
         self.last_finish_reason = None
+        content_chunk_count = 0
+        reasoning_chunk_count = 0
+        reasoning_char_count = 0
+        empty_choices_chunk_count = 0
+        nonstandard_chunk_count = 0
 
         # Reset output mode
         self.observer.current_mode = ProcessType.MODEL_OUTPUT_THINKING
@@ -344,10 +355,12 @@ class OpenAIModel(OpenAIServerModel):
                         chunk_str = str(chunk)
                         logger.warning(f"Received non-standard chunk (no 'choices'): {chunk_str[:200]}")
                     chunk_list.append(chunk)
+                    nonstandard_chunk_count += 1
                     continue
 
                 if not chunk.choices:
                     chunk_list.append(chunk)
+                    empty_choices_chunk_count += 1
                     continue
 
                 chunk_finish_reason = getattr(chunk.choices[0], "finish_reason", None)
@@ -360,6 +373,8 @@ class OpenAIModel(OpenAIServerModel):
 
                 # Handle reasoning_content if it exists and is not null
                 if reasoning_content is not None:
+                    reasoning_chunk_count += 1
+                    reasoning_char_count += len(str(reasoning_content))
                     self.observer.add_model_reasoning_content(
                         reasoning_content)
                     if token_tracker and not first_token_received:
@@ -367,6 +382,7 @@ class OpenAIModel(OpenAIServerModel):
                         first_token_received = True
 
                 if new_token is not None:
+                    content_chunk_count += 1
                     # Record first token timing
                     if token_tracker and not first_token_received:
                         token_tracker.record_first_token()
@@ -454,6 +470,23 @@ class OpenAIModel(OpenAIServerModel):
                 token_tracker.record_completion(
                     input_tokens, output_tokens)
 
+            response_diagnostics = {
+                "finish_reason": finish_reason,
+                "chunk_count": len(chunk_list),
+                "content_chunk_count": content_chunk_count,
+                "content_char_count": len(model_output),
+                "reasoning_chunk_count": reasoning_chunk_count,
+                "reasoning_char_count": reasoning_char_count,
+                "empty_choices_chunk_count": empty_choices_chunk_count,
+                "nonstandard_chunk_count": nonstandard_chunk_count,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            }
+            self.last_response_diagnostics = response_diagnostics
+            self._monitoring.set_span_attributes(
+                **{f"llm.response.{key}": value for key, value in response_diagnostics.items()}
+            )
+
             if token_tracker:
                 total_duration = time.time() - stream_start_time
                 self._monitoring.set_openinference_output(model_output)
@@ -462,6 +495,32 @@ class OpenAIModel(OpenAIServerModel):
                     "output_length": len(model_output),
                     "chunk_count": len(chunk_list)
                 })
+
+            if not model_output.strip():
+                logger.warning(
+                    "event=empty_model_response model_id=%s provider=%s "
+                    "finish_reason=%s chunk_count=%d content_chunk_count=%d "
+                    "reasoning_chunk_count=%d reasoning_char_count=%d "
+                    "empty_choices_chunk_count=%d nonstandard_chunk_count=%d "
+                    "input_tokens=%d output_tokens=%d",
+                    self.model_id,
+                    self.model_factory or "unknown",
+                    finish_reason,
+                    len(chunk_list),
+                    content_chunk_count,
+                    reasoning_chunk_count,
+                    reasoning_char_count,
+                    empty_choices_chunk_count,
+                    nonstandard_chunk_count,
+                    input_tokens,
+                    output_tokens,
+                )
+                self._monitoring.add_span_event("empty_model_response", response_diagnostics)
+                raise EmptyModelResponseError(
+                    "Model stream completed without user-visible content "
+                    f"(finish_reason={finish_reason}, reasoning_chunks={reasoning_chunk_count}, "
+                    f"output_tokens={output_tokens})"
+                )
 
             message = ChatMessage.from_dict(
                 ChatCompletionMessage(role=role if role else "assistant",  # If there is no explicit role, default to "assistant"

--- a/sdk/nexent/core/utils/constants.py
+++ b/sdk/nexent/core/utils/constants.py
@@ -1,4 +1,6 @@
-THINK_TAG_PATTERN = r"(?:<think>)?.*?</think>"
+# A think block must include its opening tag.  Making that tag optional lets a
+# closing tag consume all preceding answer text during final-answer cleanup.
+THINK_TAG_PATTERN = r"<think>.*?</think>"
 RERANK_OVERSEARCH_MULTIPLIER = 10 #5
 
 # Pattern to match "思考：" or "思考:" followed by content until two newlines

--- a/test/sdk/core/agents/test_core_agent.py
+++ b/test/sdk/core/agents/test_core_agent.py
@@ -2584,12 +2584,13 @@ class TestRunStreamRealExecution:
         assert len(agent.memory.steps) == 2
         assert agent.memory.steps[0].error is not None
 
-    def test_run_stream_retries_empty_direct_answer_then_verifies_valid_answer(self, monkeypatch):
-        """An empty direct response is retried before a later valid response is verified."""
+    def test_planning_run_retries_empty_direct_answer_then_verifies_valid_answer(self, monkeypatch):
+        """Planning runs reset state, retry an empty answer, and verify the next answer."""
         module = core_agent_module
 
         agent = self._create_canonical_run_agent(
             monkeypatch,
+            enable_planning=True,
             model=MagicMock(last_response_diagnostics={"finish_reason": "length"}),
             verification_config=SimpleNamespace(
                 enabled=True,
@@ -2597,6 +2598,8 @@ class TestRunStreamRealExecution:
                 max_final_rounds=2,
             ),
         )
+        agent.current_plan = "stale plan"
+        agent.current_step_index = 99
         agent.verification_controller = MagicMock()
         agent.verification_controller.verify_final_answer.return_value = SimpleNamespace(
             passed=True
@@ -2616,31 +2619,14 @@ class TestRunStreamRealExecution:
         results = list(agent._run_stream("test task", max_steps=2))
 
         assert results[-1].output == "valid direct answer"
+        assert agent.current_plan is None
+        assert agent.current_step_index == 0
         assert len(agent.memory.steps) == 2
         assert agent.memory.steps[0].error is not None
         agent.verification_controller.verify_final_answer.assert_called_once()
         assert agent.verification_controller.verify_final_answer.call_args.kwargs[
             "candidate"
         ] == "valid direct answer"
-
-    def test_run_stream_initializes_lazy_planning_state(self, monkeypatch):
-        """Planning-enabled runs reset lazy plan state before executing the first step."""
-        agent = self._create_canonical_run_agent(monkeypatch, enable_planning=True)
-        agent.current_plan = "stale plan"
-        agent.current_step_index = 99
-        agent._handle_max_steps_reached = MagicMock(return_value="max steps")
-
-        def mock_step_stream(_action_step):
-            if False:
-                yield None
-
-        agent._step_stream = mock_step_stream
-
-        list(agent._run_stream("test task", max_steps=0))
-
-        assert agent.current_plan is None
-        assert agent.current_step_index == 0
-
 
 # ----------------------------------------------------------------------------
 # Tests for _handle_max_steps_reached method

--- a/test/sdk/core/agents/test_core_agent.py
+++ b/test/sdk/core/agents/test_core_agent.py
@@ -2028,7 +2028,6 @@ class TestRunStreamRealExecution:
         # Load CoreAgent in isolation
         module = self._load_core_agent_in_isolation()
         CoreAgent = module.CoreAgent
-
         # Verify CoreAgent is a real class, not a Mock
         assert not isinstance(CoreAgent, MagicMock), "CoreAgent should not be MagicMock"
 
@@ -2036,9 +2035,15 @@ class TestRunStreamRealExecution:
         def mock_add_message(agent_name, process_type, data):
             observer_calls.append((agent_name, process_type, data))
 
-        # Create mock action output
-        mock_action_output = MagicMock()
-        mock_action_output.is_final_answer = False
+        # Use a real output type so the isinstance branch is covered while
+        # is_final_answer=False continues to the max-step fallback.
+        class FakeActionOutput:
+            def __init__(self):
+                self.output = "intermediate result"
+                self.is_final_answer = False
+
+        module.ActionOutput = FakeActionOutput
+        mock_action_output = FakeActionOutput()
 
         # Track _handle_max_steps_reached
         handle_calls = []
@@ -2087,6 +2092,11 @@ class TestRunStreamRealExecution:
         agent.managed_agents = {}
         agent.provide_run_summary = False
         agent._use_structured_outputs_internally = False
+        agent.enable_planning = False
+        agent.verification_config = SimpleNamespace(
+            enabled=False,
+            final_verification_enabled=False,
+        )
         agent.context_runtime = self._context_runtime_mock()
         agent.step_metrics = []
 
@@ -2231,6 +2241,40 @@ class TestRunStreamRealExecution:
 
         # When the runtime has no raw count, fall back to msg_token_count.
         assert agent._last_uncompressed_est != 5000
+
+    def test_step_stream_rejects_whitespace_only_model_output(self):
+        """Whitespace-only provider content is a generation error, not a final answer."""
+        module = self._load_core_agent_in_isolation()
+        CoreAgent = module.CoreAgent
+        module.AgentExecutionError = type("AgentExecutionError", (Exception,), {})
+        module.AgentGenerationError = type("AgentGenerationError", (Exception,), {})
+
+        agent = object.__new__(CoreAgent)
+        agent.agent_name = "test"
+        agent.observer = MagicMock()
+        agent.step_number = 1
+        agent.memory = MagicMock()
+        agent.memory.steps = []
+        agent.logger = MagicMock()
+        agent.context_runtime = self._context_runtime_mock()
+        final_context = MagicMock()
+        final_context.messages = [MagicMock()]
+        final_context.evidence.over_hard_budget = False
+        agent.context_runtime.prepare_step.return_value = final_context
+        agent._history_step_count = 0
+        agent._context_tools = MagicMock(return_value=[])
+        agent._use_structured_outputs_internally = False
+
+        response = MagicMock()
+        response.content = "   \n\t"
+        response.token_usage = None
+        agent.model = MagicMock(return_value=response)
+
+        action_step = MagicMock()
+        with pytest.raises(Exception, match="empty or whitespace-only output"):
+            next(agent._step_stream(action_step))
+
+        assert action_step.model_output == "   \n\t"
 
     def test_run_stream_stop_event_path_real_execution(self):
         """Test _run_stream with stop_event set (user break)."""
@@ -2511,6 +2555,61 @@ class TestRunStreamRealExecution:
         assert len(agent.memory.steps) == 2
         assert agent.memory.steps[0].error is not None
 
+    def test_run_stream_retries_empty_direct_answer_then_verifies_valid_answer(self):
+        """An empty direct response is retried before a later valid response is verified."""
+        module = self._load_core_agent_in_isolation()
+        CoreAgent = module.CoreAgent
+        module.FinalAnswerStep = lambda output: SimpleNamespace(output=output)
+        module.handle_agent_output_types = lambda output: output
+
+        agent = object.__new__(CoreAgent)
+        agent.agent_name = "test_agent"
+        agent.name = "test_agent"
+        agent.observer = MagicMock()
+        agent.stop_event = MagicMock()
+        agent.stop_event.is_set.return_value = False
+        agent.step_number = 1
+        agent.memory = MagicMock()
+        agent.memory.steps = []
+        agent.logger = MagicMock()
+        agent.model = MagicMock(
+            last_response_diagnostics={"finish_reason": "length"}
+        )
+        agent.final_answer_checks = []
+        agent.enable_planning = False
+        agent.verification_config = SimpleNamespace(
+            enabled=True,
+            final_verification_enabled=True,
+            max_final_rounds=2,
+        )
+        agent.verification_controller = MagicMock()
+        agent.verification_controller.verify_final_answer.return_value = SimpleNamespace(
+            passed=True
+        )
+        agent._build_verification_memory_summary = MagicMock(return_value="summary")
+        agent._finalize_step = MagicMock()
+        agent._collect_step_metrics = MagicMock()
+
+        direct_answers = iter([" \n", "valid direct answer"])
+
+        def mock_step_stream(action_step):
+            action_step.model_output = next(direct_answers)
+            if False:
+                yield None
+            raise module.FinalAnswerError()
+
+        agent._step_stream = mock_step_stream
+
+        results = list(agent._run_stream("test task", max_steps=2))
+
+        assert results[-1].output == "valid direct answer"
+        assert len(agent.memory.steps) == 2
+        assert agent.memory.steps[0].error is not None
+        agent.verification_controller.verify_final_answer.assert_called_once()
+        assert agent.verification_controller.verify_final_answer.call_args.kwargs[
+            "candidate"
+        ] == "valid direct answer"
+
 
 # ----------------------------------------------------------------------------
 # Tests for _handle_max_steps_reached method
@@ -2633,6 +2732,26 @@ class TestHandleMaxStepsReached:
             if call[1].get("level") and "ERROR" in str(call[1].get("level"))
         ]
         assert len(error_calls) >= 1
+
+    def test_handle_max_steps_reached_empty_content_uses_fallback(self, caplog):
+        """Empty max-step synthesis returns a visible fallback and records why."""
+        agent, _module = self._create_agent_for_handle_max_steps_test()
+
+        mock_chat_message = MagicMock()
+        mock_chat_message.role = "assistant"
+        mock_chat_message.content = " \n\t"
+        mock_chat_message.token_usage = None
+        agent.model = MagicMock(return_value=mock_chat_message)
+        agent._finalize_step = MagicMock()
+
+        result = agent._handle_max_steps_reached("original task")
+
+        assert result == (
+            "The agent was unable to generate a valid response after reaching "
+            "the maximum number of steps. Please try rephrasing your request."
+        )
+        assert agent.memory.steps[0].action_output == result
+        assert "model returned empty content, using fallback" in caplog.text
 
     def test_handle_max_steps_reached_creates_memory_step_with_error(self):
         """Test that a memory step with AgentMaxStepsError is created."""

--- a/test/sdk/core/agents/test_core_agent.py
+++ b/test/sdk/core/agents/test_core_agent.py
@@ -2242,12 +2242,12 @@ class TestRunStreamRealExecution:
         # When the runtime has no raw count, fall back to msg_token_count.
         assert agent._last_uncompressed_est != 5000
 
-    def test_step_stream_rejects_whitespace_only_model_output(self):
+    def test_step_stream_rejects_whitespace_only_model_output(self, monkeypatch):
         """Whitespace-only provider content is a generation error, not a final answer."""
-        module = self._load_core_agent_in_isolation()
+        module = core_agent_module
         CoreAgent = module.CoreAgent
-        module.AgentExecutionError = type("AgentExecutionError", (Exception,), {})
-        module.AgentGenerationError = type("AgentGenerationError", (Exception,), {})
+        monkeypatch.setattr(module, "AgentExecutionError", type("AgentExecutionError", (Exception,), {}))
+        monkeypatch.setattr(module, "AgentGenerationError", type("AgentGenerationError", (Exception,), {}))
 
         agent = object.__new__(CoreAgent)
         agent.agent_name = "test"
@@ -2508,9 +2508,9 @@ class TestRunStreamRealExecution:
         max_steps_calls = [c for c in observer_calls if c[1] == TestProcessType.MAX_STEPS_REACHED]
         assert len(max_steps_calls) == 0
 
-    def test_run_stream_retries_empty_final_answer_tool_result(self):
+    def test_run_stream_retries_empty_final_answer_tool_result(self, monkeypatch):
         """An empty final_answer tool result must not end the run successfully."""
-        module = self._load_core_agent_in_isolation()
+        module = core_agent_module
         CoreAgent = module.CoreAgent
 
         class FakeActionOutput:
@@ -2518,9 +2518,28 @@ class TestRunStreamRealExecution:
                 self.output = output
                 self.is_final_answer = is_final_answer
 
-        module.ActionOutput = FakeActionOutput
-        module.FinalAnswerStep = lambda output: SimpleNamespace(output=output)
-        module.handle_agent_output_types = lambda output: output
+        class FakeActionStep:
+            def __init__(self, **kwargs):
+                self.__dict__.update(kwargs)
+
+        class FakeAgentGenerationError(Exception):
+            def __init__(self, message, logger):
+                super().__init__(message)
+
+        class FakeAgentError(Exception):
+            pass
+
+        class FakeAgentExecutionError(FakeAgentError):
+            def __init__(self, message, logger):
+                super().__init__(message)
+
+        monkeypatch.setattr(module, "ActionOutput", FakeActionOutput)
+        monkeypatch.setattr(module, "ActionStep", FakeActionStep)
+        monkeypatch.setattr(module, "AgentError", FakeAgentError)
+        monkeypatch.setattr(module, "AgentExecutionError", FakeAgentExecutionError)
+        monkeypatch.setattr(module, "AgentGenerationError", FakeAgentGenerationError)
+        monkeypatch.setattr(module, "FinalAnswerStep", lambda output: SimpleNamespace(output=output))
+        monkeypatch.setattr(module, "handle_agent_output_types", lambda output: output)
 
         agent = object.__new__(CoreAgent)
         agent.agent_name = "test_agent"
@@ -2555,12 +2574,23 @@ class TestRunStreamRealExecution:
         assert len(agent.memory.steps) == 2
         assert agent.memory.steps[0].error is not None
 
-    def test_run_stream_retries_empty_direct_answer_then_verifies_valid_answer(self):
+    def test_run_stream_retries_empty_direct_answer_then_verifies_valid_answer(self, monkeypatch):
         """An empty direct response is retried before a later valid response is verified."""
-        module = self._load_core_agent_in_isolation()
+        module = core_agent_module
         CoreAgent = module.CoreAgent
-        module.FinalAnswerStep = lambda output: SimpleNamespace(output=output)
-        module.handle_agent_output_types = lambda output: output
+
+        class FakeActionStep:
+            def __init__(self, **kwargs):
+                self.__dict__.update(kwargs)
+
+        class FakeAgentGenerationError(Exception):
+            def __init__(self, message, logger):
+                super().__init__(message)
+
+        monkeypatch.setattr(module, "ActionStep", FakeActionStep)
+        monkeypatch.setattr(module, "AgentGenerationError", FakeAgentGenerationError)
+        monkeypatch.setattr(module, "FinalAnswerStep", lambda output: SimpleNamespace(output=output))
+        monkeypatch.setattr(module, "handle_agent_output_types", lambda output: output)
 
         agent = object.__new__(CoreAgent)
         agent.agent_name = "test_agent"
@@ -2609,6 +2639,50 @@ class TestRunStreamRealExecution:
         assert agent.verification_controller.verify_final_answer.call_args.kwargs[
             "candidate"
         ] == "valid direct answer"
+
+    def test_run_stream_initializes_lazy_planning_state(self, monkeypatch):
+        """Planning-enabled runs reset lazy plan state before executing the first step."""
+        module = core_agent_module
+
+        class FakeActionStep:
+            def __init__(self, **kwargs):
+                self.__dict__.update(kwargs)
+
+        monkeypatch.setattr(module, "ActionStep", FakeActionStep)
+
+        agent = object.__new__(module.CoreAgent)
+        agent.agent_name = "test_agent"
+        agent.name = "test_agent"
+        agent.observer = MagicMock()
+        agent.stop_event = MagicMock()
+        agent.stop_event.is_set.return_value = False
+        agent.step_number = 1
+        agent.memory = MagicMock()
+        agent.memory.steps = []
+        agent.logger = MagicMock()
+        agent.model = MagicMock()
+        agent.final_answer_checks = []
+        agent.enable_planning = True
+        agent.current_plan = "stale plan"
+        agent.current_step_index = 99
+        agent.verification_config = SimpleNamespace(
+            enabled=False,
+            final_verification_enabled=False,
+        )
+        agent._finalize_step = MagicMock()
+        agent._collect_step_metrics = MagicMock()
+        agent._handle_max_steps_reached = MagicMock(return_value="max steps")
+
+        def mock_step_stream(_action_step):
+            if False:
+                yield None
+
+        agent._step_stream = mock_step_stream
+
+        list(agent._run_stream("test task", max_steps=0))
+
+        assert agent.current_plan is None
+        assert agent.current_step_index == 0
 
 
 # ----------------------------------------------------------------------------

--- a/test/sdk/core/agents/test_core_agent.py
+++ b/test/sdk/core/agents/test_core_agent.py
@@ -1837,6 +1837,44 @@ class TestMaxStepsReached:
 class TestRunStreamRealExecution:
     """Tests that actually execute the real _run_stream method for line coverage."""
 
+    class _FakeActionStep:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class _FakeAgentGenerationError(Exception):
+        def __init__(self, message, logger):
+            super().__init__(message)
+
+    @classmethod
+    def _create_canonical_run_agent(cls, monkeypatch, **attributes):
+        monkeypatch.setattr(core_agent_module, "ActionStep", cls._FakeActionStep)
+        monkeypatch.setattr(core_agent_module, "AgentGenerationError", cls._FakeAgentGenerationError)
+        monkeypatch.setattr(core_agent_module, "FinalAnswerStep", lambda output: SimpleNamespace(output=output))
+        monkeypatch.setattr(core_agent_module, "handle_agent_output_types", lambda output: output)
+
+        agent = object.__new__(core_agent_module.CoreAgent)
+        defaults = {
+            "agent_name": "test_agent",
+            "name": "test_agent",
+            "observer": MagicMock(),
+            "stop_event": MagicMock(),
+            "step_number": 1,
+            "memory": MagicMock(),
+            "logger": MagicMock(),
+            "model": MagicMock(),
+            "final_answer_checks": [],
+            "enable_planning": False,
+            "verification_config": SimpleNamespace(enabled=False, final_verification_enabled=False),
+            "_finalize_step": MagicMock(),
+            "_collect_step_metrics": MagicMock(),
+        }
+        defaults.update(attributes)
+        for name, value in defaults.items():
+            setattr(agent, name, value)
+        agent.stop_event.is_set.return_value = False
+        agent.memory.steps = []
+        return agent
+
     @staticmethod
     def _context_runtime_mock(
         *,
@@ -2271,8 +2309,9 @@ class TestRunStreamRealExecution:
         agent.model = MagicMock(return_value=response)
 
         action_step = MagicMock()
+        stream = agent._step_stream(action_step)
         with pytest.raises(Exception, match="empty or whitespace-only output"):
-            next(agent._step_stream(action_step))
+            next(stream)
 
         assert action_step.model_output == "   \n\t"
 
@@ -2511,20 +2550,11 @@ class TestRunStreamRealExecution:
     def test_run_stream_retries_empty_final_answer_tool_result(self, monkeypatch):
         """An empty final_answer tool result must not end the run successfully."""
         module = core_agent_module
-        CoreAgent = module.CoreAgent
 
         class FakeActionOutput:
             def __init__(self, output, is_final_answer):
                 self.output = output
                 self.is_final_answer = is_final_answer
-
-        class FakeActionStep:
-            def __init__(self, **kwargs):
-                self.__dict__.update(kwargs)
-
-        class FakeAgentGenerationError(Exception):
-            def __init__(self, message, logger):
-                super().__init__(message)
 
         class FakeAgentError(Exception):
             pass
@@ -2534,32 +2564,12 @@ class TestRunStreamRealExecution:
                 super().__init__(message)
 
         monkeypatch.setattr(module, "ActionOutput", FakeActionOutput)
-        monkeypatch.setattr(module, "ActionStep", FakeActionStep)
         monkeypatch.setattr(module, "AgentError", FakeAgentError)
         monkeypatch.setattr(module, "AgentExecutionError", FakeAgentExecutionError)
-        monkeypatch.setattr(module, "AgentGenerationError", FakeAgentGenerationError)
-        monkeypatch.setattr(module, "FinalAnswerStep", lambda output: SimpleNamespace(output=output))
-        monkeypatch.setattr(module, "handle_agent_output_types", lambda output: output)
-
-        agent = object.__new__(CoreAgent)
-        agent.agent_name = "test_agent"
-        agent.name = "test_agent"
-        agent.observer = MagicMock()
-        agent.stop_event = MagicMock()
-        agent.stop_event.is_set.return_value = False
-        agent.step_number = 1
-        agent.memory = MagicMock()
-        agent.memory.steps = []
-        agent.logger = MagicMock()
-        agent.model = MagicMock(last_response_diagnostics={"finish_reason": "stop"})
-        agent.final_answer_checks = []
-        agent.enable_planning = False
-        agent.verification_config = SimpleNamespace(
-            enabled=False,
-            final_verification_enabled=False,
+        agent = self._create_canonical_run_agent(
+            monkeypatch,
+            model=MagicMock(last_response_diagnostics={"finish_reason": "stop"}),
         )
-        agent._finalize_step = MagicMock()
-        agent._collect_step_metrics = MagicMock()
 
         outputs = iter(["", "valid answer"])
 
@@ -2577,48 +2587,21 @@ class TestRunStreamRealExecution:
     def test_run_stream_retries_empty_direct_answer_then_verifies_valid_answer(self, monkeypatch):
         """An empty direct response is retried before a later valid response is verified."""
         module = core_agent_module
-        CoreAgent = module.CoreAgent
 
-        class FakeActionStep:
-            def __init__(self, **kwargs):
-                self.__dict__.update(kwargs)
-
-        class FakeAgentGenerationError(Exception):
-            def __init__(self, message, logger):
-                super().__init__(message)
-
-        monkeypatch.setattr(module, "ActionStep", FakeActionStep)
-        monkeypatch.setattr(module, "AgentGenerationError", FakeAgentGenerationError)
-        monkeypatch.setattr(module, "FinalAnswerStep", lambda output: SimpleNamespace(output=output))
-        monkeypatch.setattr(module, "handle_agent_output_types", lambda output: output)
-
-        agent = object.__new__(CoreAgent)
-        agent.agent_name = "test_agent"
-        agent.name = "test_agent"
-        agent.observer = MagicMock()
-        agent.stop_event = MagicMock()
-        agent.stop_event.is_set.return_value = False
-        agent.step_number = 1
-        agent.memory = MagicMock()
-        agent.memory.steps = []
-        agent.logger = MagicMock()
-        agent.model = MagicMock(
-            last_response_diagnostics={"finish_reason": "length"}
-        )
-        agent.final_answer_checks = []
-        agent.enable_planning = False
-        agent.verification_config = SimpleNamespace(
-            enabled=True,
-            final_verification_enabled=True,
-            max_final_rounds=2,
+        agent = self._create_canonical_run_agent(
+            monkeypatch,
+            model=MagicMock(last_response_diagnostics={"finish_reason": "length"}),
+            verification_config=SimpleNamespace(
+                enabled=True,
+                final_verification_enabled=True,
+                max_final_rounds=2,
+            ),
         )
         agent.verification_controller = MagicMock()
         agent.verification_controller.verify_final_answer.return_value = SimpleNamespace(
             passed=True
         )
         agent._build_verification_memory_summary = MagicMock(return_value="summary")
-        agent._finalize_step = MagicMock()
-        agent._collect_step_metrics = MagicMock()
 
         direct_answers = iter([" \n", "valid direct answer"])
 
@@ -2642,35 +2625,9 @@ class TestRunStreamRealExecution:
 
     def test_run_stream_initializes_lazy_planning_state(self, monkeypatch):
         """Planning-enabled runs reset lazy plan state before executing the first step."""
-        module = core_agent_module
-
-        class FakeActionStep:
-            def __init__(self, **kwargs):
-                self.__dict__.update(kwargs)
-
-        monkeypatch.setattr(module, "ActionStep", FakeActionStep)
-
-        agent = object.__new__(module.CoreAgent)
-        agent.agent_name = "test_agent"
-        agent.name = "test_agent"
-        agent.observer = MagicMock()
-        agent.stop_event = MagicMock()
-        agent.stop_event.is_set.return_value = False
-        agent.step_number = 1
-        agent.memory = MagicMock()
-        agent.memory.steps = []
-        agent.logger = MagicMock()
-        agent.model = MagicMock()
-        agent.final_answer_checks = []
-        agent.enable_planning = True
+        agent = self._create_canonical_run_agent(monkeypatch, enable_planning=True)
         agent.current_plan = "stale plan"
         agent.current_step_index = 99
-        agent.verification_config = SimpleNamespace(
-            enabled=False,
-            final_verification_enabled=False,
-        )
-        agent._finalize_step = MagicMock()
-        agent._collect_step_metrics = MagicMock()
         agent._handle_max_steps_reached = MagicMock(return_value="max steps")
 
         def mock_step_stream(_action_step):
@@ -2807,9 +2764,20 @@ class TestHandleMaxStepsReached:
         ]
         assert len(error_calls) >= 1
 
-    def test_handle_max_steps_reached_empty_content_uses_fallback(self, caplog):
+    def test_handle_max_steps_reached_empty_content_uses_fallback(self, caplog, monkeypatch):
         """Empty max-step synthesis returns a visible fallback and records why."""
         agent, _module = self._create_agent_for_handle_max_steps_test()
+
+        class FakeActionStep:
+            def __init__(self, **kwargs):
+                self.__dict__.update(kwargs)
+
+        class FakeAgentMaxStepsError(Exception):
+            def __init__(self, message, logger):
+                super().__init__(message)
+
+        monkeypatch.setattr(core_agent_module, "ActionStep", FakeActionStep)
+        monkeypatch.setattr(core_agent_module, "AgentMaxStepsError", FakeAgentMaxStepsError)
 
         mock_chat_message = MagicMock()
         mock_chat_message.role = "assistant"
@@ -2818,7 +2786,7 @@ class TestHandleMaxStepsReached:
         agent.model = MagicMock(return_value=mock_chat_message)
         agent._finalize_step = MagicMock()
 
-        result = agent._handle_max_steps_reached("original task")
+        result = core_agent_module.CoreAgent._handle_max_steps_reached(agent, "original task")
 
         assert result == (
             "The agent was unable to generate a valid response after reaching "

--- a/test/sdk/core/agents/test_core_agent.py
+++ b/test/sdk/core/agents/test_core_agent.py
@@ -2464,6 +2464,53 @@ class TestRunStreamRealExecution:
         max_steps_calls = [c for c in observer_calls if c[1] == TestProcessType.MAX_STEPS_REACHED]
         assert len(max_steps_calls) == 0
 
+    def test_run_stream_retries_empty_final_answer_tool_result(self):
+        """An empty final_answer tool result must not end the run successfully."""
+        module = self._load_core_agent_in_isolation()
+        CoreAgent = module.CoreAgent
+
+        class FakeActionOutput:
+            def __init__(self, output, is_final_answer):
+                self.output = output
+                self.is_final_answer = is_final_answer
+
+        module.ActionOutput = FakeActionOutput
+        module.FinalAnswerStep = lambda output: SimpleNamespace(output=output)
+        module.handle_agent_output_types = lambda output: output
+
+        agent = object.__new__(CoreAgent)
+        agent.agent_name = "test_agent"
+        agent.name = "test_agent"
+        agent.observer = MagicMock()
+        agent.stop_event = MagicMock()
+        agent.stop_event.is_set.return_value = False
+        agent.step_number = 1
+        agent.memory = MagicMock()
+        agent.memory.steps = []
+        agent.logger = MagicMock()
+        agent.model = MagicMock(last_response_diagnostics={"finish_reason": "stop"})
+        agent.final_answer_checks = []
+        agent.enable_planning = False
+        agent.verification_config = SimpleNamespace(
+            enabled=False,
+            final_verification_enabled=False,
+        )
+        agent._finalize_step = MagicMock()
+        agent._collect_step_metrics = MagicMock()
+
+        outputs = iter(["", "valid answer"])
+
+        def mock_step_stream(_action_step):
+            yield FakeActionOutput(next(outputs), True)
+
+        agent._step_stream = mock_step_stream
+
+        results = list(agent._run_stream("test task", max_steps=2))
+
+        assert results[-1].output == "valid answer"
+        assert len(agent.memory.steps) == 2
+        assert agent.memory.steps[0].error is not None
+
 
 # ----------------------------------------------------------------------------
 # Tests for _handle_max_steps_reached method
@@ -3080,4 +3127,3 @@ def test_run_injects_current_time_when_missing():
 
     assert agent.task.startswith("[Current time:")
     assert "What time is it?" in agent.task
-

--- a/test/sdk/core/agents/test_nexent_agent.py
+++ b/test/sdk/core/agents/test_nexent_agent.py
@@ -1615,7 +1615,7 @@ def test_agent_run_with_observer_success_with_agent_text(nexent_agent_instance, 
     mock_core_agent.observer.add_message.assert_any_call(
         "", ProcessType.TOKEN_COUNT, ANY)
     mock_core_agent.observer.add_message.assert_any_call(
-        "test_agent", ProcessType.FINAL_ANSWER, " content")
+        "test_agent", ProcessType.FINAL_ANSWER, "Final answer with  content")
 
 
 def test_agent_run_with_observer_emits_model_context_window(nexent_agent_instance, mock_core_agent):
@@ -1774,7 +1774,44 @@ def test_agent_run_with_observer_success_with_string_final_answer(nexent_agent_i
     mock_core_agent.observer.add_message.assert_any_call(
         "", ProcessType.TOKEN_COUNT, ANY)
     mock_core_agent.observer.add_message.assert_any_call(
-        "test_agent", ProcessType.FINAL_ANSWER, "")
+        "test_agent", ProcessType.FINAL_ANSWER, "String final answer with ")
+
+
+@pytest.mark.parametrize(
+    ("raw_final_answer", "lang", "expected"),
+    [
+        (
+            "<think>internal reasoning only</think>",
+            "en",
+            "The agent could not generate a valid final response. Please try again or rephrase your request.",
+        ),
+        (
+            "思考：内部推理内容。\n\n",
+            "zh",
+            "智能体未能生成有效的最终回复，请重试或换一种方式描述需求。",
+        ),
+    ],
+)
+def test_agent_run_with_observer_never_emits_empty_final_answer(
+    nexent_agent_instance, mock_core_agent, raw_final_answer, lang, expected
+):
+    """Reasoning cleanup must not terminate a conversation with an empty final answer."""
+    nexent_agent_instance.agent = mock_core_agent
+    mock_core_agent.observer.lang = lang
+    mock_core_agent.stop_event.is_set.return_value = False
+
+    mock_action_step = MagicMock(spec=ActionStep)
+    mock_action_step.timing = MagicMock(duration=1.0)
+    mock_action_step.step_number = 1
+    mock_action_step.error = None
+    mock_action_step.output = raw_final_answer
+    mock_core_agent.run.return_value = [mock_action_step]
+
+    nexent_agent_instance.agent_run_with_observer("test query")
+
+    mock_core_agent.observer.add_message.assert_any_call(
+        "test_agent", ProcessType.FINAL_ANSWER, expected
+    )
 
 
 def test_agent_run_with_observer_with_error_in_step(nexent_agent_instance, mock_core_agent):

--- a/test/sdk/core/models/test_openai_llm.py
+++ b/test/sdk/core/models/test_openai_llm.py
@@ -859,6 +859,49 @@ def test_call_with_reasoning_content_only(openai_model_instance):
             "Final response")
 
 
+def test_call_rejects_reasoning_only_response_and_records_diagnostics(
+    openai_model_instance, caplog
+):
+    """A reasoning stream that exhausts its budget must not become an empty success."""
+    messages = [{"role": "user", "content": [{"text": "Hello"}]}]
+
+    reasoning_chunk = MagicMock()
+    reasoning_chunk.choices = [MagicMock()]
+    reasoning_chunk.choices[0].delta.content = None
+    reasoning_chunk.choices[0].delta.role = "assistant"
+    reasoning_chunk.choices[0].delta.reasoning_content = "Internal reasoning"
+    reasoning_chunk.choices[0].finish_reason = None
+    reasoning_chunk.usage = None
+
+    final_chunk = MagicMock()
+    final_chunk.choices = [MagicMock()]
+    final_chunk.choices[0].delta.content = None
+    final_chunk.choices[0].delta.role = None
+    final_chunk.choices[0].delta.reasoning_content = None
+    final_chunk.choices[0].finish_reason = "length"
+    final_chunk.usage = MagicMock(prompt_tokens=10, completion_tokens=20)
+
+    with patch.object(openai_model_instance, "_prepare_completion_kwargs", return_value={}):
+        openai_model_instance.client.chat.completions.create.return_value = [
+            reasoning_chunk,
+            final_chunk,
+        ]
+
+        with pytest.raises(
+            openai_llm_module.EmptyModelResponseError,
+            match="finish_reason=length",
+        ):
+            openai_model_instance.__call__(messages)
+
+    diagnostics = openai_model_instance.last_response_diagnostics
+    assert diagnostics["finish_reason"] == "length"
+    assert diagnostics["content_char_count"] == 0
+    assert diagnostics["reasoning_chunk_count"] == 1
+    assert diagnostics["reasoning_char_count"] == len("Internal reasoning")
+    assert diagnostics["output_tokens"] == 20
+    assert "event=empty_model_response" in caplog.text
+
+
 def test_call_with_reasoning_content_and_content_together(openai_model_instance):
     """Test __call__ method handles chunks with both reasoning_content and content simultaneously"""
 
@@ -1737,7 +1780,11 @@ def test_provider_adapter_preserves_context_manager_tool_order(openai_model_inst
     openai_model_instance.prompt_cache = {"mode": "openai_automatic", "enabled": True}
 
     mock_chunk = MagicMock()
-    mock_chunk.choices = []
+    mock_chunk.choices = [MagicMock()]
+    mock_chunk.choices[0].delta.content = "ok"
+    mock_chunk.choices[0].delta.role = "assistant"
+    mock_chunk.choices[0].delta.reasoning_content = None
+    mock_chunk.choices[0].finish_reason = "stop"
     mock_chunk.usage = MagicMock(prompt_tokens=1, completion_tokens=1)
     tools = [
         {"type": "function", "function": {"name": "zebra"}},


### PR DESCRIPTION
[Specification Details]
主要修改：
模型流结束后记录 finish_reason、正文/推理 chunk 数、字符数、空 choices、非标准 chunk、token usage。
如果正文为空，抛出 EmptyModelResponseError，不再返回成功的空 ChatMessage。
CoreAgent 拒绝 final_answer("") 和纯空白答案，记录来源后进入下一步重试。
直接模型回答为空时同样不再结束会话。
保留 max-step 和最终 observer 出站兜底。
修正 <think> 正则误删标签前正常答案的问题。
修复了原先 core_agent.py 中 logger.warning 使用未定义 logger 的隐患。
定位问题时可搜索日志：
event=empty_model_response
字段可以判断具体原因：
finish_reason=length 且 reasoning_chunk_count>0：推理耗尽输出预算，没来得及生成正文。
chunk_count=0：Provider 返回空流。
empty_choices_chunk_count 较高：只收到 usage/空 choices。
nonstandard_chunk_count>0：Provider 返回非标准流式协议。
finish_reason=stop 且正文、推理都为空：Provider 异常结束或空响应。
如果模型显式调用空的最终答案，还会记录：
event=empty_final_answer_candidate source=final_answer_tool
[Test Result]
<img width="983" height="986" alt="image" src="https://github.com/user-attachments/assets/cd4e09a9-13de-4426-b706-413a804c2a52" />
