### PR TITLE
fix: correct Dreaming permission migration

### DIFF
--- a/deploy/sql/migrations/v2.5.0_0813_versioned_markdown_long_term_memory.sql
+++ b/deploy/sql/migrations/v2.5.0_0813_versioned_markdown_long_term_memory.sql
@@ -1,48 +1,5 @@
 -- Final pre-production Dreaming schema. This file is the only Dreaming migration.
--- Upgrade unpublished intermediate schemas before the complete CREATE definitions.
--- On a fresh installation none of these tables exist, so this block performs no ALTERs.
-DO $$ BEGIN
-    IF to_regclass('nexent.memory_dreaming_audit_t') IS NOT NULL THEN
-        ALTER TABLE nexent.memory_dreaming_audit_t
-            ADD COLUMN IF NOT EXISTS lock_owner VARCHAR(100),
-            ADD COLUMN IF NOT EXISTS lock_until TIMESTAMP,
-            ADD COLUMN IF NOT EXISTS published_version_id BIGINT,
-            ADD COLUMN IF NOT EXISTS reason VARCHAR(100);
-        IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'nexent'
-            AND table_name = 'memory_dreaming_audit_t' AND column_name = 'result_json') THEN
-            ALTER TABLE nexent.memory_dreaming_audit_t
-                ADD COLUMN IF NOT EXISTS decisions JSONB NOT NULL DEFAULT '[]'::jsonb;
-            UPDATE nexent.memory_dreaming_audit_t
-            SET decisions = COALESCE(result_json -> 'decisions', '[]'::jsonb),
-                published_version_id = CASE
-                    WHEN result_json #>> '{version,version_id}' ~ '^[0-9]+$'
-                    THEN (result_json #>> '{version,version_id}')::BIGINT ELSE NULL END,
-                reason = result_json ->> 'reason'
-            WHERE result_json IS NOT NULL;
-            ALTER TABLE nexent.memory_dreaming_audit_t DROP COLUMN result_json;
-        END IF;
-        ALTER TABLE nexent.memory_dreaming_audit_t ALTER COLUMN agent_id SET DEFAULT '';
-    END IF;
-
-    IF to_regclass('nexent.memory_dreaming_schedule_t') IS NOT NULL THEN
-        IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'nexent'
-            AND table_name = 'memory_dreaming_schedule_t' AND column_name = 'compression_max_attempts')
-           AND NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'nexent'
-            AND table_name = 'memory_dreaming_schedule_t' AND column_name = 'summarization_max_attempts') THEN
-            ALTER TABLE nexent.memory_dreaming_schedule_t
-                RENAME COLUMN compression_max_attempts TO summarization_max_attempts;
-        END IF;
-        ALTER TABLE nexent.memory_dreaming_schedule_t
-            ADD COLUMN IF NOT EXISTS min_score DOUBLE PRECISION,
-            ADD COLUMN IF NOT EXISTS min_recall_count INTEGER,
-            ADD COLUMN IF NOT EXISTS min_unique_queries INTEGER,
-            ADD COLUMN IF NOT EXISTS source_limit INTEGER,
-            ADD COLUMN IF NOT EXISTS long_term_max_chars INTEGER,
-            ADD COLUMN IF NOT EXISTS summarization_max_attempts INTEGER;
-        ALTER TABLE nexent.memory_dreaming_schedule_t ALTER COLUMN agent_id SET DEFAULT '';
-    END IF;
-
-END $$;
+-- All tables introduced here are created directly with their final definitions.
 
 CREATE TABLE IF NOT EXISTS nexent.memory_dreaming_audit_t (
     run_id BIGSERIAL PRIMARY KEY, tenant_id VARCHAR(100) NOT NULL,
@@ -73,32 +30,6 @@ CREATE TABLE IF NOT EXISTS nexent.memory_dreaming_decision_t (
 );
 CREATE INDEX IF NOT EXISTS idx_memory_dreaming_decision_memory
     ON nexent.memory_dreaming_decision_t (memory_id);
-
--- Expand decisions written by unpublished intermediate schemas, then remove their JSON columns.
-DO $$ BEGIN
-    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'nexent'
-        AND table_name = 'memory_dreaming_audit_t' AND column_name = 'decisions') THEN
-        INSERT INTO nexent.memory_dreaming_decision_t (
-            run_id, decision_order, memory_id, score, noise, signal_count, context_diversity,
-            evidence_ids, event, reason, archive_suggested
-        )
-        SELECT audit.run_id, item.ordinality - 1,
-            CASE WHEN item.value ->> 'memory_id' ~ '^[0-9]+$' THEN (item.value ->> 'memory_id')::BIGINT ELSE 0 END,
-            CASE WHEN item.value ->> 'score' ~ '^-?[0-9]+([.][0-9]+)?$' THEN (item.value ->> 'score')::DOUBLE PRECISION ELSE 0 END,
-            COALESCE((item.value ->> 'noise')::BOOLEAN, FALSE),
-            COALESCE((item.value ->> 'signal_count')::INTEGER, 0),
-            COALESCE((item.value ->> 'context_diversity')::INTEGER, 0),
-            ARRAY(SELECT jsonb_array_elements_text(COALESCE(item.value -> 'evidence_ids', '[]'::jsonb))),
-            COALESCE(item.value ->> 'event', 'DEFER'), LEFT(COALESCE(item.value ->> 'reason', ''), 100),
-            COALESCE((item.value ->> 'archive_suggested')::BOOLEAN, FALSE)
-        FROM nexent.memory_dreaming_audit_t audit
-        CROSS JOIN LATERAL jsonb_array_elements(COALESCE(audit.decisions, '[]'::jsonb))
-            WITH ORDINALITY AS item(value, ordinality)
-        ON CONFLICT (run_id, decision_order) DO NOTHING;
-        ALTER TABLE nexent.memory_dreaming_audit_t DROP COLUMN decisions;
-    END IF;
-
-END $$;
 
 CREATE TABLE IF NOT EXISTS nexent.memory_dreaming_schedule_t (
     schedule_id BIGSERIAL PRIMARY KEY, tenant_id VARCHAR(100) NOT NULL, user_id VARCHAR(100) NOT NULL,
@@ -167,12 +98,12 @@ CREATE UNIQUE INDEX IF NOT EXISTS uq_memory_long_term_run
 INSERT INTO nexent.role_permission_t (
     role_permission_id, user_role, permission_category, permission_type, permission_subtype
 ) VALUES
-    (1004, 'SU', 'RESOURCE', 'DREAMING', 'VIEW_TENANT'),
-    (1005, 'SU', 'RESOURCE', 'DREAMING', 'EDIT_TENANT'),
-    (1116, 'ADMIN', 'RESOURCE', 'DREAMING', 'VIEW_TENANT'),
-    (1117, 'ADMIN', 'RESOURCE', 'DREAMING', 'EDIT_TENANT'),
-    (1514, 'ASSET_OWNER', 'RESOURCE', 'DREAMING', 'VIEW_TENANT'),
-    (1515, 'ASSET_OWNER', 'RESOURCE', 'DREAMING', 'EDIT_TENANT')
+    (224, 'SU', 'RESOURCE', 'DREAMING', 'VIEW_TENANT'),
+    (225, 'SU', 'RESOURCE', 'DREAMING', 'EDIT_TENANT'),
+    (222, 'ADMIN', 'RESOURCE', 'DREAMING', 'VIEW_TENANT'),
+    (223, 'ADMIN', 'RESOURCE', 'DREAMING', 'EDIT_TENANT'),
+    (226, 'ASSET_OWNER', 'RESOURCE', 'DREAMING', 'VIEW_TENANT'),
+    (227, 'ASSET_OWNER', 'RESOURCE', 'DREAMING', 'EDIT_TENANT')
 ON CONFLICT (role_permission_id) DO UPDATE SET
     user_role = EXCLUDED.user_role, permission_category = EXCLUDED.permission_category,
     permission_type = EXCLUDED.permission_type, permission_subtype = EXCLUDED.permission_subtype;

--- a/test/backend/database/test_memory_dreaming_schema.py
+++ b/test/backend/database/test_memory_dreaming_schema.py
@@ -1,6 +1,5 @@
+import re
 from pathlib import Path
-
-from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 
 from database.db_models import (
     MemoryDreamingAudit,
@@ -9,6 +8,7 @@ from database.db_models import (
     MemoryLongTermVersion,
     TableBase,
 )
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 
 
 def test_final_orm_contract_has_only_shared_long_term_versions():
@@ -50,9 +50,20 @@ def test_final_migration_is_the_only_dreaming_schema_source():
     assert not list(migrations.glob("v2.4.0_*dreaming*.sql"))
     assert not list(migrations.glob("v2.5.0_072*_*dreaming*.sql"))
     assert "current_phase = 'compression'" not in final
-    assert "DROP COLUMN result_json" in final
-    assert "ALTER TABLE nexent.memory_dreaming_audit_t DROP COLUMN decisions" in final
+    assert "result_json" not in final
+    assert "compression_max_attempts" not in final
     assert "CREATE TABLE IF NOT EXISTS nexent.memory_dreaming_decision_t" in final
     assert "ON DELETE CASCADE" in final
     assert "published_version_id BIGINT" in final
     assert "reason VARCHAR(100)" in final
+
+    created_tables = re.findall(
+        r"CREATE TABLE IF NOT EXISTS nexent\.(\w+)", final, flags=re.IGNORECASE
+    )
+    assert created_tables
+    for table_name in created_tables:
+        assert not re.search(
+            rf"ALTER TABLE\s+(?:ONLY\s+)?nexent\.{re.escape(table_name)}\b",
+            final,
+            flags=re.IGNORECASE,
+        )

--- a/test/backend/database/test_memory_dreaming_schema.py
+++ b/test/backend/database/test_memory_dreaming_schema.py
@@ -67,3 +67,24 @@ def test_final_migration_is_the_only_dreaming_schema_source():
             final,
             flags=re.IGNORECASE,
         )
+
+
+def test_final_migration_upgrades_v24_without_intermediate_v25_schema():
+    root = Path(__file__).resolve().parents[3]
+    migrations = root / "deploy/sql/migrations"
+    v24 = (migrations / "v2.4_merged_migrations.sql").read_text()
+    final = (migrations / "v2.5.0_0813_versioned_markdown_long_term_memory.sql").read_text()
+
+    assert "CREATE TABLE IF NOT EXISTS nexent.memory_records_t" in v24
+    for table_name in (
+        "memory_dreaming_audit_t",
+        "memory_dreaming_decision_t",
+        "memory_dreaming_schedule_t",
+        "memory_long_term_version_t",
+    ):
+        assert f"nexent.{table_name}" not in v24
+
+    assert "DELETE FROM nexent.memory_records_t WHERE layer IN ('tenant', 'user')" in final
+    assert "ALTER TABLE nexent.memory_records_t" in final
+    assert "result_json" not in final
+    assert "compression_max_attempts" not in final


### PR DESCRIPTION
## What changed

- move all six Dreaming resource permissions to IDs `222`–`227`, below the navigation-permission range
- preserve role permission ID `1514` for `ASSET_OWNER / LEFT_NAV_MENU /users`
- simplify the unreleased 2.5.0 Dreaming migration so tables introduced by the file are created directly with their final definitions
- add a schema regression assertion that rejects `ALTER TABLE` statements targeting tables created by the same migration
- add an explicit compatibility-boundary test: preserve upgrades for the formal 2.4 schema while ignoring only unpublished 2.5 draft schemas

## Why

The Dreaming migration reused navigation-range IDs. In particular, its `ON CONFLICT` update changed permission `1514` from the ASSET_OWNER `/users` route into `DREAMING:VIEW_TENANT`, removing the route permission. The migration also contained compatibility ALTER/backfill logic for unpublished intermediate 2.5 schemas despite being the final pre-production schema source. Compatibility with the formal 2.4 schema remains required and is preserved through the existing `memory_records_t` data and constraint migration.

## Impact

Dreaming permissions keep the same roles and semantic capabilities. ASSET_OWNER regains the `/users` route permission while retaining `DREAMING:VIEW_TENANT` and `DREAMING:EDIT_TENANT` through IDs `226` and `227`. Backend and SDK permission checks are unaffected because they query semantic permission fields rather than numeric IDs.

## Validation

- 101 focused Dreaming tests passed; 3 schema/compatibility tests passed
- Ruff passed for the changed test
- `git diff --check` passed
- real PostgreSQL fresh-schema migration and idempotent reapplication passed
- verified six Dreaming permissions at IDs `222`–`227` and route `1514` preserved as `/users`
- authenticated local config-service checks passed: ASSET_OWNER user info exposed `/users` plus both Dreaming capabilities; same-tenant Dreaming view/edit returned 200; missing-permission and cross-tenant requests returned 404
