### PR TITLE
Dc/fix/tool default value ranges 20260819

### DIFF
--- a/backend/consts/tool_param_constraints.py
+++ b/backend/consts/tool_param_constraints.py
@@ -1,0 +1,44 @@
+"""
+Numeric range constraints for local tool parameters.
+
+Keyed by tool name; each entry is {param_name: (type, min, max)} where
+min/max may be None to indicate an unbounded side. These are enforced on
+the backend (service layer) before persisting tool configuration, while the
+SDK constructors apply the same normalization at runtime as a defense-in-depth
+fallback for legacy/errored data.
+
+Keep in sync with the matching ``Field(...)`` declarations in the SDK tools
+under ``sdk/nexent/core/tools/``.
+"""
+
+TOOL_PARAM_RANGE_CONSTRAINTS = {
+    "knowledge_base_search": {"top_k": ("int", 1, 100)},
+    "dify_search": {"top_k": ("int", 1, 100)},
+    "datamate_search": {
+        "top_k": ("int", 1, 100),
+        "threshold": ("float", 0.0, 1.0),
+        "kb_page": ("int", 1, None),
+        "kb_page_size": ("int", 1, 100),
+    },
+    "haotian_search": {
+        "top_k": ("int", 1, 100),
+        "keyword_weight": ("float", 0.0, 1.0),
+        "vector_weight": ("float", 0.0, 1.0),
+    },
+    "ragflow_search": {
+        "top_k": ("int", 1, 100),
+        "similarity_threshold": ("float", 0.0, 1.0),
+        "vector_similarity_weight": ("float", 0.0, 1.0),
+    },
+    "idata_search": {
+        "top_k": ("int", 1, 100),
+        "similarity_threshold": ("float", None, 1.0),
+        "keyword_similarity_weight": ("float", 0.0, 1.0),
+        "vector_similarity_weight": ("float", 0.0, 1.0),
+    },
+    "tavily_search": {"max_results": ("int", 1, 100)},
+    "exa_search": {"max_results": ("int", 1, 100)},
+    "linkup_search": {"max_results": ("int", 1, 100)},
+    "terminal": {"ssh_port": ("int", 1, 65535)},
+    "get_email": {"timeout": ("int", 1, None)},
+}

--- a/backend/services/tool_configuration_service.py
+++ b/backend/services/tool_configuration_service.py
@@ -405,28 +405,30 @@ def _get_tool_name(tool_id: int) -> Optional[str]:
     return tools[0].get("name") if tools else None
 
 
+def _coerce_param_value(
+    tool_name: str, param_name: str, value_type: str, raw_value: Any
+) -> float:
+    """Coerce a raw parameter value to float, enforcing int-ness when declared."""
+    try:
+        numeric_value = float(raw_value)
+    except (TypeError, ValueError):
+        raise ValidationError(f"{tool_name} {param_name} must be a valid {value_type}")
+    if value_type == "int" and not numeric_value.is_integer():
+        raise ValidationError(f"{tool_name} {param_name} must be an integer")
+    return numeric_value
+
+
 def _validate_tool_param_ranges(tool_name: Optional[str], params: Dict[str, Any]):
     """Validate numeric parameter ranges against the tool's declared constraints."""
     constraints = TOOL_PARAM_RANGE_CONSTRAINTS.get(tool_name or "")
     if not constraints:
         return
     for param_name, (value_type, min_value, max_value) in constraints.items():
-        if param_name not in params:
-            continue
-        raw_value = params[param_name]
+        raw_value = params.get(param_name)
         # None means "not configured"; the DB layer drops it and the SDK falls back to its default.
         if raw_value is None:
             continue
-        try:
-            if value_type == "int":
-                numeric_value = float(raw_value)
-                if not numeric_value.is_integer():
-                    raise ValidationError(f"{tool_name} {param_name} must be an integer")
-                numeric_value = int(numeric_value)
-            else:
-                numeric_value = float(raw_value)
-        except (TypeError, ValueError):
-            raise ValidationError(f"{tool_name} {param_name} must be a valid {value_type}")
+        numeric_value = _coerce_param_value(tool_name, param_name, value_type, raw_value)
         if min_value is not None and numeric_value < min_value:
             raise ValidationError(f"{tool_name} {param_name} must be >= {min_value}")
         if max_value is not None and numeric_value > max_value:

--- a/backend/services/tool_configuration_service.py
+++ b/backend/services/tool_configuration_service.py
@@ -23,6 +23,7 @@ from consts.const import (
 from consts.exceptions import MCPConnectionError, NotFoundException, ToolExecutionException, ValidationError
 from consts.model import ToolInstanceInfoRequest, ToolInfo, ToolSourceEnum, ToolValidateRequest
 from consts.tool_labels import SYSTEM_MANAGED_TOOL_NAMES
+from consts.tool_param_constraints import TOOL_PARAM_RANGE_CONSTRAINTS
 from database.outer_api_tool_db import (
     upsert_openapi_service,
     query_openapi_services_by_tenant,
@@ -394,6 +395,44 @@ def search_tool_info_impl(
         }
 
 
+def _get_tool_name(tool_id: int) -> Optional[str]:
+    """Resolve a tool's canonical name from the DB.
+
+    The DB ``ag_tool_info_t.name`` value matches the SDK tool ``name`` attribute,
+    which is exactly the key used by ``TOOL_PARAM_RANGE_CONSTRAINTS``.
+    """
+    tools = query_tools_by_ids([tool_id])
+    return tools[0].get("name") if tools else None
+
+
+def _validate_tool_param_ranges(tool_name: Optional[str], params: Dict[str, Any]):
+    """Validate numeric parameter ranges against the tool's declared constraints."""
+    constraints = TOOL_PARAM_RANGE_CONSTRAINTS.get(tool_name or "")
+    if not constraints:
+        return
+    for param_name, (value_type, min_value, max_value) in constraints.items():
+        if param_name not in params:
+            continue
+        raw_value = params[param_name]
+        # None means "not configured"; the DB layer drops it and the SDK falls back to its default.
+        if raw_value is None:
+            continue
+        try:
+            if value_type == "int":
+                numeric_value = float(raw_value)
+                if not numeric_value.is_integer():
+                    raise ValidationError(f"{tool_name} {param_name} must be an integer")
+                numeric_value = int(numeric_value)
+            else:
+                numeric_value = float(raw_value)
+        except (TypeError, ValueError):
+            raise ValidationError(f"{tool_name} {param_name} must be a valid {value_type}")
+        if min_value is not None and numeric_value < min_value:
+            raise ValidationError(f"{tool_name} {param_name} must be >= {min_value}")
+        if max_value is not None and numeric_value > max_value:
+            raise ValidationError(f"{tool_name} {param_name} must be <= {max_value}")
+
+
 def update_tool_info_impl(tool_info: ToolInstanceInfoRequest, tenant_id: str, user_id: str):
     """
     Update tool configuration information
@@ -456,6 +495,11 @@ def update_tool_info_impl(tool_info: ToolInstanceInfoRequest, tenant_id: str, us
                 ]
                 params["kds_list"] = list(dict.fromkeys(hidden_existing + visible_submitted))
         tool_info.params = params
+
+    _validate_tool_param_ranges(
+        _get_tool_name(tool_info.tool_id),
+        dict(tool_info.params or {}),
+    )
 
     tool_instance = create_or_update_tool_by_tool_info(
         tool_info, tenant_id, user_id, version_no=version_no)

--- a/frontend/app/[locale]/agents/components/agentConfig/tool/ToolConfigModal.tsx
+++ b/frontend/app/[locale]/agents/components/agentConfig/tool/ToolConfigModal.tsx
@@ -1,4 +1,4 @@
-﻿"use client";
+"use client";
 
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
@@ -28,6 +28,7 @@ import { useAgentConfigStore } from "@/stores/agentConfigStore";
 import { CloseOutlined } from "@ant-design/icons";
 
 import { TOOL_PARAM_TYPES, getToolParamOptions } from "@/const/agentConfig";
+import { getToolParamConstraint } from "@/const/toolParamConstraints";
 import { ToolParam, Tool } from "@/types/agentConfig";
 import { KnowledgeBase } from "@/types/knowledgeBase";
 import ToolTestPanel from "./ToolTestPanel";
@@ -2030,7 +2031,8 @@ export default function ToolConfigModal({
       }
 
       switch (param.type) {
-        case TOOL_PARAM_TYPES.NUMBER:
+        case TOOL_PARAM_TYPES.NUMBER: {
+          const constraint = getToolParamConstraint(tool.name, param.name);
           return (
             <InputNumber
               placeholder={t("toolConfig.input.string.placeholder", {
@@ -2039,8 +2041,12 @@ export default function ToolConfigModal({
                   param.description_zh
                 ),
               })}
+              min={constraint?.min ?? undefined}
+              max={constraint?.max ?? undefined}
+              precision={constraint?.type === "int" ? 0 : undefined}
             />
           );
+        }
 
         case TOOL_PARAM_TYPES.BOOLEAN:
           return <Switch />;

--- a/frontend/const/toolParamConstraints.ts
+++ b/frontend/const/toolParamConstraints.ts
@@ -1,0 +1,82 @@
+// ========== Tool Parameter Range Constraints ==========
+//
+// Numeric range constraints for local tool parameters, mirroring the backend
+// table in ``backend/consts/tool_param_constraints.py``.
+//
+// Keyed by tool name; each entry maps a param name to { type, min, max }.
+// min/max use `null` to indicate an unbounded side.
+//
+// Keep in sync with the matching ``Field(...)`` declarations in the SDK tools
+// under ``sdk/nexent/core/tools/`` and the backend constraint table.
+
+export type ToolParamConstraintType = "int" | "float";
+
+export interface ToolParamConstraint {
+  type: ToolParamConstraintType;
+  min: number | null;
+  max: number | null;
+}
+
+export type ToolParamRangeConstraints = Record<
+  string,
+  Record<string, ToolParamConstraint>
+>;
+
+export const TOOL_PARAM_RANGE_CONSTRAINTS: ToolParamRangeConstraints = {
+  knowledge_base_search: {
+    top_k: { type: "int", min: 1, max: 100 },
+  },
+  dify_search: {
+    top_k: { type: "int", min: 1, max: 100 },
+  },
+  datamate_search: {
+    top_k: { type: "int", min: 1, max: 100 },
+    threshold: { type: "float", min: 0, max: 1 },
+    kb_page: { type: "int", min: 1, max: null },
+    kb_page_size: { type: "int", min: 1, max: 100 },
+  },
+  haotian_search: {
+    top_k: { type: "int", min: 1, max: 100 },
+    keyword_weight: { type: "float", min: 0, max: 1 },
+    vector_weight: { type: "float", min: 0, max: 1 },
+  },
+  ragflow_search: {
+    top_k: { type: "int", min: 1, max: 100 },
+    similarity_threshold: { type: "float", min: 0, max: 1 },
+    vector_similarity_weight: { type: "float", min: 0, max: 1 },
+  },
+  idata_search: {
+    top_k: { type: "int", min: 1, max: 100 },
+    similarity_threshold: { type: "float", min: null, max: 1 },
+    keyword_similarity_weight: { type: "float", min: 0, max: 1 },
+    vector_similarity_weight: { type: "float", min: 0, max: 1 },
+  },
+  tavily_search: {
+    max_results: { type: "int", min: 1, max: 100 },
+  },
+  exa_search: {
+    max_results: { type: "int", min: 1, max: 100 },
+  },
+  linkup_search: {
+    max_results: { type: "int", min: 1, max: 100 },
+  },
+  terminal: {
+    ssh_port: { type: "int", min: 1, max: 65535 },
+  },
+  get_email: {
+    timeout: { type: "int", min: 1, max: null },
+  },
+};
+
+/**
+ * Get the range constraint for a specific tool and parameter.
+ * Returns undefined when no constraint is declared.
+ */
+export function getToolParamConstraint(
+  toolName: string,
+  paramName: string
+): ToolParamConstraint | undefined {
+  const toolConstraints = TOOL_PARAM_RANGE_CONSTRAINTS[toolName];
+  if (!toolConstraints) return undefined;
+  return toolConstraints[paramName];
+}

--- a/frontend/hooks/agent/useSaveGuard.ts
+++ b/frontend/hooks/agent/useSaveGuard.ts
@@ -11,6 +11,7 @@ import {
   searchAgentInfo,
 } from "@/services/agentConfigService";
 import { Agent } from "@/types/agentConfig";
+import { getToolParamConstraint } from "@/const/toolParamConstraints";
 import log from "@/lib/logger";
 
 /**
@@ -55,6 +56,35 @@ function isValueCompatibleWithType(
       // we already filtered those above.
       return true;
   }
+}
+
+/**
+ * Check a numeric value against the declared range constraint for a
+ * tool parameter. Returns true when no constraint is declared.
+ */
+function isValueWithinRange(
+  value: unknown,
+  toolName: string,
+  paramName: string
+): boolean {
+  const constraint = getToolParamConstraint(toolName, paramName);
+  if (!constraint) return true;
+
+  const numericValue =
+    typeof value === "string" ? Number(value.trim()) : (value as number);
+  if (typeof numericValue !== "number" || !Number.isFinite(numericValue)) {
+    return false;
+  }
+  if (constraint.type === "int" && !Number.isInteger(numericValue)) {
+    return false;
+  }
+  if (constraint.min !== null && numericValue < constraint.min) {
+    return false;
+  }
+  if (constraint.max !== null && numericValue > constraint.max) {
+    return false;
+  }
+  return true;
 }
 
 /**
@@ -103,6 +133,9 @@ async function batchUpdateToolConfigs(
             param.type &&
             !isValueCompatibleWithType(param.value, param.type)
           ) {
+            return acc;
+          }
+          if (!isValueWithinRange(param.value, tool.name, param.name)) {
             return acc;
           }
           acc[param.name] = param.value;

--- a/sdk/nexent/core/tools/datamate_search_tool.py
+++ b/sdk/nexent/core/tools/datamate_search_tool.py
@@ -83,9 +83,9 @@ class DataMateSearchTool(Tool):
         observer: MessageObserver = Field(
             description="Message observer", default=None, exclude=True),
         top_k: int = Field(
-            description="Default maximum number of search results to return", default=3),
+            description="Default maximum number of search results to return", default=3, ge=1, le=100),
         threshold: float = Field(
-            description="Default similarity threshold for search results", default=0.2),
+            description="Default similarity threshold for search results", default=0.2, ge=0.0, le=1.0),
         rerank: bool = Field(
             description="Whether to enable reranking for search results",
             default=False,
@@ -127,8 +127,8 @@ class DataMateSearchTool(Tool):
         self.use_https = parsed_url["use_https"]
         self.server_base_url = parsed_url["base_url"]
         self.index_names = [] if index_names is None else index_names
-        self.top_k = top_k
-        self.threshold = threshold
+        self.top_k = max(1, min(int(top_k or 3), 100))
+        self.threshold = max(0.0, min(float(threshold if threshold is not None else 0.2), 1.0))
         self.rerank = rerank
         self.rerank_model_name = rerank_model_name
         self.rerank_model = rerank_model
@@ -146,8 +146,8 @@ class DataMateSearchTool(Tool):
             verify_ssl=self.verify_ssl if self.use_https else True
         )
 
-        self.kb_page = kb_page
-        self.kb_page_size = kb_page_size
+        self.kb_page = max(1, int(kb_page or 1))
+        self.kb_page_size = max(1, min(int(kb_page_size or 20), 100))
         self.observer = observer
 
         self.record_ops = 1  # To record serial number

--- a/sdk/nexent/core/tools/dify_search_tool.py
+++ b/sdk/nexent/core/tools/dify_search_tool.py
@@ -72,7 +72,7 @@ class DifySearchTool(Tool):
         dataset_ids: str = Field(
             description="JSON string array of Dify dataset IDs"),
         top_k: int = Field(
-            description="Maximum number of search results per dataset", default=3),
+            description="Maximum number of search results per dataset", default=3, ge=1, le=100),
         search_method: str = Field(
             description="Search method: keyword_search, semantic_search, full_text_search, hybrid_search",
             default="semantic_search",
@@ -132,7 +132,7 @@ class DifySearchTool(Tool):
 
         self.server_url = server_url.rstrip("/")
         self.api_key = api_key
-        self.top_k = top_k
+        self.top_k = max(1, min(int(top_k or 3), 100))
         self.search_method = search_method
         self.observer = observer
         self.rerank = rerank

--- a/sdk/nexent/core/tools/exa_search_tool.py
+++ b/sdk/nexent/core/tools/exa_search_tool.py
@@ -51,7 +51,7 @@ class ExaSearchTool(Tool):
 
     def __init__(self, exa_api_key:str=Field(description="EXA API key"),
                  observer: MessageObserver=Field(description="Message observer", default=None, exclude=True),
-                 max_results:int=Field(description="Maximum number of search results", default=3),
+                 max_results:int=Field(description="Maximum number of search results", default=3, ge=1, le=100),
                  image_filter: bool = Field(description="Whether to enable image filtering", default=True)
      ):
 
@@ -59,7 +59,7 @@ class ExaSearchTool(Tool):
 
         self.observer = observer
         self.exa = Exa(api_key=exa_api_key)
-        self.max_results = max_results
+        self.max_results = max(1, min(int(max_results or 3), 100))
         self.image_filter = image_filter
         self.record_ops = 1  # Used to record sequence number
 

--- a/sdk/nexent/core/tools/get_email_tool.py
+++ b/sdk/nexent/core/tools/get_email_tool.py
@@ -78,14 +78,14 @@ class GetEmailTool(Tool):
                  username: str=Field(description="IMAP Server Username"), 
                  password: str=Field(description="IMAP Server Password"), 
                  use_ssl: bool=Field(description="Use SSL", default=True),
-                 timeout: int = Field(description="Timeout", default=30)):
+                 timeout: int = Field(description="Timeout", default=30, ge=1)):
         super().__init__()
         self.imap_server = imap_server
         self.imap_port = imap_port
         self.username = username
         self.password = password
         self.use_ssl = use_ssl
-        self.timeout = timeout
+        self.timeout = max(1, int(timeout or 30))
 
     def _decode_subject(self, subject):
         """Decode email subject, fallback to utf-8 or latin1 for unknown encodings"""

--- a/sdk/nexent/core/tools/haotian_search_tool.py
+++ b/sdk/nexent/core/tools/haotian_search_tool.py
@@ -110,7 +110,7 @@ class HaotianSearchTool(Tool):
         dataset_ids: Any = Field(
             description="Selected dataset ids (JSON string array or list)"
         ),
-        top_k: int = Field(description="Maximum number of search results", default=3),
+        top_k: int = Field(description="Maximum number of search results", default=3, ge=1, le=100),
         search_method: str = Field(
             description="Search method",
             default="keyword_search",
@@ -127,8 +127,8 @@ class HaotianSearchTool(Tool):
             description="Reranking model name",
             default="",
         ),
-        keyword_weight: float = Field(description="Keyword weight", default=0.1),
-        vector_weight: float = Field(description="Vector weight", default=0.3),
+        keyword_weight: float = Field(description="Keyword weight", default=0.1, ge=0.0, le=1.0),
+        vector_weight: float = Field(description="Vector weight", default=0.3, ge=0.0, le=1.0),
         embedding_provider_name: str = Field(
             description="Embedding provider name",
             default="",
@@ -168,13 +168,13 @@ class HaotianSearchTool(Tool):
         self.authorization = authorization.strip()
 
         self.dataset_ids = self._parse_dataset_ids(dataset_ids)
-        self.top_k = top_k
+        self.top_k = max(1, min(int(top_k or 3), 100))
         self.search_method = search_method
         self.reranking_enable = reranking_enable
         self.reranking_provider_name = reranking_provider_name
         self.reranking_model_name = reranking_model_name
-        self.keyword_weight = keyword_weight
-        self.vector_weight = vector_weight
+        self.keyword_weight = max(0.0, min(float(keyword_weight if keyword_weight is not None else 0.1), 1.0))
+        self.vector_weight = max(0.0, min(float(vector_weight if vector_weight is not None else 0.3), 1.0))
         self.embedding_provider_name = embedding_provider_name
         self.embedding_model_name = embedding_model_name
         self.score_threshold_enabled = score_threshold_enabled

--- a/sdk/nexent/core/tools/idata_search_tool.py
+++ b/sdk/nexent/core/tools/idata_search_tool.py
@@ -45,13 +45,13 @@ class IdataSearchTool(Tool):
             description="JSON string array of iData knowledge base IDs"),
         rerank_model_id: str = Field(description="Rerank model ID"),
         top_k: int = Field(
-            description="Maximum number of search results", default=10),
+            description="Maximum number of search results", default=10, ge=1, le=100),
         similarity_threshold: float = Field(
-            description="Rerank similarity threshold score", default=-10.0),
+            description="Rerank similarity threshold score", default=-10.0, le=1.0),
         keyword_similarity_weight: float = Field(
-            description="Keyword similarity weight", default=0.10),
+            description="Keyword similarity weight", default=0.10, ge=0.0, le=1.0),
         vector_similarity_weight: float = Field(
-            description="Vector similarity weight", default=0.3),
+            description="Vector similarity weight", default=0.3, ge=0.0, le=1.0),
         observer: MessageObserver = Field(
             description="Message observer", default=None, exclude=True),
     ):
@@ -120,10 +120,10 @@ class IdataSearchTool(Tool):
         self.user_id = user_id
         self.knowledge_space_id = knowledge_space_id
         self.rerank_model_id = rerank_model_id
-        self.top_k = top_k
-        self.similarity_threshold = similarity_threshold
-        self.keyword_similarity_weight = keyword_similarity_weight
-        self.vector_similarity_weight = vector_similarity_weight
+        self.top_k = max(1, min(int(top_k or 10), 100))
+        self.similarity_threshold = min(float(similarity_threshold if similarity_threshold is not None else -10.0), 1.0)
+        self.keyword_similarity_weight = max(0.0, min(float(keyword_similarity_weight if keyword_similarity_weight is not None else 0.10), 1.0))
+        self.vector_similarity_weight = max(0.0, min(float(vector_similarity_weight if vector_similarity_weight is not None else 0.3), 1.0))
         self.observer = observer
 
         # Cache HTTP client for reuse (uses shared HttpClientManager internally)

--- a/sdk/nexent/core/tools/knowledge_base_search_tool.py
+++ b/sdk/nexent/core/tools/knowledge_base_search_tool.py
@@ -85,7 +85,7 @@ class KnowledgeBaseSearchTool(Tool):
     def __init__(
         self,
         top_k: int = Field(
-            description="Maximum number of search results", default=3
+            description="Maximum number of search results", default=3, ge=1, le=100
         ),
         index_names: List[str] = Field(
             description="The list of index names to search"
@@ -139,7 +139,7 @@ class KnowledgeBaseSearchTool(Tool):
             ValueError: If language is not supported
         """
         super().__init__()
-        self.top_k = top_k
+        self.top_k = max(1, min(int(_unwrap_field_info(top_k) or 3), 100))
         self.observer = observer
         self.vdb_core = vdb_core
         self.index_names = [] if index_names is None else index_names
@@ -195,12 +195,7 @@ class KnowledgeBaseSearchTool(Tool):
         Returns:
             List of actual index_names for ES queries
         """
-        display_map = self.display_name_to_index_map
-        if isinstance(display_map, FieldInfo):
-            if display_map.default_factory is not None:
-                display_map = display_map.default_factory()
-            else:
-                display_map = display_map.default
+        display_map = _unwrap_field_info(self.display_name_to_index_map)
         if not display_map:
             return names
 
@@ -283,18 +278,8 @@ class KnowledgeBaseSearchTool(Tool):
         # Compute effective top_k for initial search:
         # When rerank is enabled, retrieve more candidates to allow rerank to select the best ones.
         # Note: smolagents Tool may not expand Field defaults, so use getattr with FieldInfo fallback.
-        effective_top_k = self.top_k
-        is_rerank = self.rerank
-        if isinstance(effective_top_k, FieldInfo):
-            if effective_top_k.default_factory is not None:
-                effective_top_k = effective_top_k.default_factory()
-            else:
-                effective_top_k = effective_top_k.default
-        if isinstance(is_rerank, FieldInfo):
-            if is_rerank.default_factory is not None:
-                is_rerank = is_rerank.default_factory()
-            else:
-                is_rerank = is_rerank.default
+        effective_top_k = _unwrap_field_info(self.top_k)
+        is_rerank = _unwrap_field_info(self.rerank)
         if is_rerank:
             effective_top_k = effective_top_k * RERANK_OVERSEARCH_MULTIPLIER
 

--- a/sdk/nexent/core/tools/linkup_search_tool.py
+++ b/sdk/nexent/core/tools/linkup_search_tool.py
@@ -51,13 +51,13 @@ class LinkupSearchTool(Tool):
         self,
         linkup_api_key: str = Field(description="Linkup API key"),
         observer: MessageObserver = Field(description="Message observer", default=None, exclude=True),
-        max_results: int = Field(description="Maximum number of search results", default=3),
+        max_results: int = Field(description="Maximum number of search results", default=3, ge=1, le=100),
         image_filter: bool = Field(description="Whether to enable image filtering", default=True)
     ):
         super().__init__()
         self.observer = observer
         self.client = LinkupClient(api_key=linkup_api_key)
-        self.max_results = max_results
+        self.max_results = max(1, min(int(max_results or 3), 100))
         self.record_ops = 1
         self.image_filter = image_filter
         self.data_process_service = os.getenv("DATA_PROCESS_SERVICE")

--- a/sdk/nexent/core/tools/ragflow_search_tool.py
+++ b/sdk/nexent/core/tools/ragflow_search_tool.py
@@ -106,12 +106,12 @@ class RAGFlowSearchTool(Tool):
         server_url: str = Field(description="RAGFlow API base URL (e.g., 'http://localhost:9380')"),
         api_key: str = Field(description="RAGFlow API key"),
         dataset_ids: str = Field(description="JSON string array of RAGFlow dataset IDs", default="[]"),
-        top_k: int = Field(description="Maximum number of search results to return to the LLM", default=3),
+        top_k: int = Field(description="Maximum number of search results to return to the LLM", default=3, ge=1, le=100),
         similarity_threshold: float = Field(
-            description="Minimum similarity score threshold for results", default=0.2
+            description="Minimum similarity score threshold for results", default=0.2, ge=0.0, le=1.0
         ),
         vector_similarity_weight: float = Field(
-            description="Weight of vector similarity in hybrid search (0.0-1.0)", default=0.3
+            description="Weight of vector similarity in hybrid search (0.0-1.0)", default=0.3, ge=0.0, le=1.0
         ),
         keyword: bool = Field(description="Whether to enable keyword search in hybrid mode", default=False),
         highlight: bool = Field(description="Whether to enable highlight in search results", default=True),
@@ -156,9 +156,9 @@ class RAGFlowSearchTool(Tool):
 
         self.server_url = server_url.rstrip("/")
         self.api_key = api_key
-        self.top_k = top_k
-        self.similarity_threshold = similarity_threshold
-        self.vector_similarity_weight = vector_similarity_weight
+        self.top_k = max(1, min(int(top_k or 3), 100))
+        self.similarity_threshold = max(0.0, min(float(similarity_threshold if similarity_threshold is not None else 0.2), 1.0))
+        self.vector_similarity_weight = max(0.0, min(float(vector_similarity_weight if vector_similarity_weight is not None else 0.3), 1.0))
         self.keyword = keyword
         self.highlight = highlight
         self.observer = observer

--- a/sdk/nexent/core/tools/tavily_search_tool.py
+++ b/sdk/nexent/core/tools/tavily_search_tool.py
@@ -50,7 +50,7 @@ class TavilySearchTool(Tool):
 
     def __init__(self, tavily_api_key:str=Field(description="Tavily API key"),
                  observer: MessageObserver=Field(description="Message observer", default=None, exclude=True),
-                 max_results:int=Field(description="Maximum number of search results", default=3),
+                 max_results:int=Field(description="Maximum number of search results", default=3, ge=1, le=100),
                  image_filter: bool = Field(description="Whether to enable image filtering", default=True)
      ):
 
@@ -58,7 +58,7 @@ class TavilySearchTool(Tool):
 
         self.observer = observer
         self.tavily = TavilyClient(api_key=tavily_api_key)
-        self.max_results = max_results
+        self.max_results = max(1, min(int(max_results or 3), 100))
         self.image_filter = image_filter
         self.record_ops = 1  # Used to record sequence number
         

--- a/sdk/nexent/core/tools/terminal_tool.py
+++ b/sdk/nexent/core/tools/terminal_tool.py
@@ -77,7 +77,7 @@ class TerminalTool(Tool):
                  init_path: str = Field(description="Initial workspace path", default="~"),
                  observer: MessageObserver = Field(description="Message observer", default=None, exclude=True),
                  ssh_host: str = Field(description="SSH host", default="nexent-openssh-server"),
-                 ssh_port: int = Field(description="SSH port", default=22),
+                 ssh_port: int = Field(description="SSH port", default=22, ge=1, le=65535),
                  ssh_user: str = Field(description="SSH username"),
                  password: str = Field(description="SSH password")):
         """Initialize the TerminalTool.
@@ -104,7 +104,7 @@ class TerminalTool(Tool):
 
         self.observer = observer
         self.ssh_host = ssh_host
-        self.ssh_port = ssh_port
+        self.ssh_port = max(1, min(int(ssh_port or 22), 65535))
         self.ssh_user = ssh_user
         self.password = password
 


### PR DESCRIPTION
## 标题

修复工具参数非法值传入的漏洞：SDK 运行时兜底 + 后端入库校验 + 前端拦截

## 背景

工具参数（如 `top_k`、`ssh_port`、`threshold` 等）在「前端表单 → 后端入库 → 运行时注入 SDK」的整条链路上均缺少范围校验。当参数被清空或填入非法值时，会以 `None`/越界值/非整数的形态流入底层：

- rerank 开启时 `top_k=None` 触发 `None * multiplier` 的 `TypeError`；
- 关闭 rerank 时 `top_k=None` 透传为 ES 的 `"size": null`，返回 400；
- 其它工具同样存在 payload 中 null 导致下游服务 400 的问题（见 `uploads/RevisionPlan/tool-default-value-ranges/`）。

根因是三层防线全部缺失：SDK 构造器不兜底、后端 Service 层不校验、前端只做类型检查不做范围限制。

## 改动内容

### 1. SDK 层（运行时兜底）

- `knowledge_base_search_tool.py`：
  - 抽取 `_unwrap_field_info` 工具函数，统一解包 smolagents 未展开的 `FieldInfo`；
  - 新增 `DEFAULT_TOP_K` 常量，`top_k` 的 `Field` 增加 `ge=1, le=100`；
  - `__init__` 中对 `top_k` 做 `max(1, min(int(...), 100))` 钳制。
- 其余 10 个工具（dify/datamate/haotian/ragflow/idata/tavily/exa/linkup/terminal/get_email）：
  - 参数 `Field` 声明补充 `ge`/`le` 约束；
  - `__init__` 中统一做 `None` 兜底 + 范围钳制（int 用 `max(1, min(...))`，float 权重用 `[0,1]` 钳制，`0.0` 用 `is not None` 判断避免误判）。

### 2. 后端 Service 层（入库前拦截）

- 新增约束表 `consts/tool_param_constraints.py`，按 `工具名 → 参数名 → (type, min, max)` 声明范围；
- `tool_configuration_service.py`：
  - 新增 `_get_tool_name`（从 DB 取工具名，直接对应约束表 key）；
  - 新增 `_validate_tool_param_ranges`（类型 + 范围校验，非法抛 `ValidationError`）；
  - 在 `update_tool_info_impl` 中入库前调用校验。

### 3. 前端（第一道防线）

- 新增约束表 `const/toolParamConstraints.ts`（与后端数据一致）+ `getToolParamConstraint` 查询函数；
- `useSaveGuard.ts`：新增 `isValueWithinRange`，保存前丢弃超范围/非整数值；
- `ToolConfigModal.tsx`：数字输入框绑定 `min`/`max`/`precision`。

## 设计要点

- **双层防护**：SDK 构造器兜底历史脏数据，后端 Service 层拦截新脏数据，前端提前拦截改善体验。
- **约束单一事实来源**：前后端各持一份约束表（暂未打通数据库下发），数据需保持同步（已在注释中标注对应关系）。
- **`None` 语义**：后端校验对 `None` 跳过（入库层会过滤 `None` 键，SDK 有默认值兜底），避免误拦「未配置」状态。
- **float 边界**：权重参数用 `is not None` 判断，避免 `0.0` 被当作 false 误判。


## 验证方式

- SDK：`top_k=None/0/负数/小数/越界` 均安全回退或钳制，不再抛 `TypeError`/ES 400。
- 后端：非法参数经 `/tool/update` 被 `ValidationError` 拦截，返回 400。
- 前端：输入框受 min/max 限制，保存时非法值被丢弃。