### PR TITLE
test: make dreaming age fixture time-stable

### DIFF
--- a/test/backend/services/test_memory_dreaming_service.py
+++ b/test/backend/services/test_memory_dreaming_service.py
@@ -44,7 +44,7 @@ def test_ac001_ac006_full_run_and_idempotency_key(monkeypatch):
         "agent_id": "a",
         "conversation_id": "conversation-7",
         "content": "Always prefer stable transaction rollback behavior",
-        "create_time": "2026-07-20T09:00:00",
+        "create_time": datetime.utcnow().isoformat(),
         "update_time": "2026-07-23T10:30:00",
         "recall_count": 3,
         "daily_count": 2,


### PR DESCRIPTION
## Summary

- make the Dreaming full-run test fixture use the current UTC time
- prevent the candidate from aging past the production retention cutoff

## Testing

- `PYTHONPATH=backend:sdk ../../nexent/backend/.venv/bin/python -m pytest test/backend/services/test_memory_dreaming_service.py -q`
- 8 passed