### PR TITLE
fix(frontend): reorder displayed citation indexes

### DIFF
--- a/frontend/app/[locale]/newchat/ui/cite-marker.tsx
+++ b/frontend/app/[locale]/newchat/ui/cite-marker.tsx
@@ -12,7 +12,10 @@ import { cn } from "@/lib/utils";
 export interface CiteMarkerProps {
   /** The raw citekey from the markdown, e.g. "b1", "a1", "1" */
   citekey: string;
-  citeIndex: number;
+  /** The index displayed to the user, ordered by first appearance. */
+  displayIndex: number;
+  /** The original index used to resolve the source data. */
+  sourceIndex: number;
   url?: string;
   title: string;
   text?: string;
@@ -97,7 +100,8 @@ function CitationPreview({ text }: { text: string }) {
 
 const CiteMarkerImpl = ({
   citekey,
-  citeIndex,
+  displayIndex,
+  sourceIndex,
   url,
   title,
   text,
@@ -111,12 +115,15 @@ const CiteMarkerImpl = ({
         <TooltipTrigger asChild>
           <button
             type="button"
+            data-citation-key={citekey}
+            data-citation-source-index={sourceIndex}
+            data-citation-display-index={displayIndex}
             onClick={onClick}
             disabled={!onClick}
             aria-label={
               loading
-                ? `Source ${citeIndex} is loading`
-                : `Open source ${citeIndex}: ${title}`
+                ? `Source ${displayIndex} is loading`
+                : `Open source ${displayIndex}: ${title}`
             }
             className={cn(
               "mx-0.5 inline-flex items-center justify-center rounded bg-primary/10 px-1 align-baseline font-normal leading-normal text-primary transition-colors",
@@ -126,7 +133,7 @@ const CiteMarkerImpl = ({
               className,
             )}
           >
-            [{citeIndex}]
+            [{displayIndex}]
           </button>
         </TooltipTrigger>
         <TooltipContent side="top" className="max-w-sm px-3 py-2">

--- a/frontend/app/[locale]/newchat/ui/markdown-text.tsx
+++ b/frontend/app/[locale]/newchat/ui/markdown-text.tsx
@@ -10,7 +10,7 @@ import {
   useIsMarkdownCodeBlock,
 } from "@assistant-ui/react-markdown";
 import { useAuiState } from "@assistant-ui/react";
-import { type FC, memo, useState } from "react";
+import { type FC, memo, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import remarkGfm from "remark-gfm";
@@ -107,6 +107,25 @@ function getCiteIndex(citekey: string): number | undefined {
   return Number.isNaN(citeIndex) ? undefined : citeIndex;
 }
 
+function buildCitationDisplayIndexMap(
+  content: readonly MessageSourcePart[]
+): Map<string, number> {
+  const displayIndexMap = new Map<string, number>();
+
+  for (const part of content) {
+    if (part.type !== "text" || typeof part.text !== "string") continue;
+
+    for (const match of part.text.matchAll(/\[\[([^\]]+)\]\]/g)) {
+      const citekey = match[1];
+      if (!displayIndexMap.has(citekey)) {
+        displayIndexMap.set(citekey, displayIndexMap.size + 1);
+      }
+    }
+  }
+
+  return displayIndexMap;
+}
+
 function toPanelSource(source: SearchSource): PanelSourceItem {
   return {
     sourceType:
@@ -142,7 +161,9 @@ const CiteComponent: FC<
   const citeIndex = getCiteIndex(citekey);
   const messageSources = resolveCiteSources(messageId, content);
   const source = messageSources.find((item) => item.citeIndex === citeIndex);
-  const resolvedCiteIndex = source?.citeIndex ?? citeIndex ?? 0;
+  const sourceIndex = source?.citeIndex ?? citeIndex ?? 0;
+  const citationDisplayIndexMap = buildCitationDisplayIndexMap(content);
+  const displayIndex = citationDisplayIndexMap.get(citekey) ?? sourceIndex;
   const panelItems = messageSources.map(toPanelSource);
   const sources = panelItems.filter((item) => !item.isImage);
   const images = panelItems.filter((item) => item.isImage);
@@ -150,9 +171,10 @@ const CiteComponent: FC<
   return (
     <CiteMarker
       citekey={citekey}
-      citeIndex={resolvedCiteIndex}
+      displayIndex={displayIndex}
+      sourceIndex={sourceIndex}
       url={source?.url}
-      title={source?.title ?? `Source ${resolvedCiteIndex}`}
+      title={source?.title ?? `Source ${sourceIndex}`}
       text={source?.text}
       loading={!source}
       onClick={
@@ -174,6 +196,10 @@ const CiteComponent: FC<
 // Wrapper component that safely renders MarkdownTextPrimitive
 // Guards against rendering for non-text parts or when text is not a valid string
 const MarkdownTextImpl = () => {
+  const messageId = useAuiState((s) => s.message.id as string | undefined);
+  const content = useAuiState(
+    (s) => s.message.content as readonly MessageSourcePart[]
+  );
   // Check if we have a valid text part context using useAuiState
   const isValidTextPart = useAuiState((s) => {
     const part = s.part;
@@ -184,23 +210,42 @@ const MarkdownTextImpl = () => {
       part.text.length > 0
     );
   });
+  const citationDisplayIndexMap = useMemo(
+    () => buildCitationDisplayIndexMap(content),
+    [content]
+  );
+  const citationIndexMapAttribute = useMemo(
+    () => JSON.stringify(Object.fromEntries(citationDisplayIndexMap)),
+    [citationDisplayIndexMap]
+  );
+
+  useEffect(() => {
+    if (citationDisplayIndexMap.size === 0) return;
+
+    console.info("[Nexent] Citation display index mapping", {
+      messageId,
+      citationIndexMap: Object.fromEntries(citationDisplayIndexMap),
+    });
+  }, [citationDisplayIndexMap, messageId]);
 
   if (!isValidTextPart) {
     return null;
   }
 
   return (
-    <MarkdownTextPrimitive
-      remarkPlugins={[remarkGfm, remarkCite]}
-      urlTransform={markdownUrlTransform}
-      className="aui-md"
-      components={defaultComponents}
-      componentsByLanguage={{
-        mermaid: {
-          SyntaxHighlighter: MermaidDiagram,
-        },
-      }}
-    />
+    <div data-citation-index-map={citationIndexMapAttribute}>
+      <MarkdownTextPrimitive
+        remarkPlugins={[remarkGfm, remarkCite]}
+        urlTransform={markdownUrlTransform}
+        className="aui-md"
+        components={defaultComponents}
+        componentsByLanguage={{
+          mermaid: {
+            SyntaxHighlighter: MermaidDiagram,
+          },
+        }}
+      />
+    </div>
   );
 };
 

--- a/frontend/components/common/markdownRenderer.tsx
+++ b/frontend/components/common/markdownRenderer.tsx
@@ -67,6 +67,12 @@ interface ParsedMarkdownHeading extends MarkdownHeading {
   offset: number;
 }
 
+interface CitationReference {
+  key: string;
+  toolSign: string;
+  sourceIndex: number;
+}
+
 // Simple in-memory cache to avoid refetching the same S3 object multiple times
 const s3MediaCache = new Map<string, string>();
 const mediaObjectUrlCache = new Map<string, string>();
@@ -229,6 +235,49 @@ export const extractMarkdownHeadings = (content: string): MarkdownHeading[] => {
     level,
     text,
   }));
+};
+
+const parseCitationReference = (value: string): CitationReference | null => {
+  const toolSign = value.charAt(0);
+  const sourceIndex = Number.parseInt(value.slice(1), 10);
+
+  if (!toolSign || Number.isNaN(sourceIndex)) {
+    return null;
+  }
+
+  return {
+    key: `${toolSign}${sourceIndex}`,
+    toolSign,
+    sourceIndex,
+  };
+};
+
+const buildCitationDisplayIndexMap = (
+  content: string,
+  searchResults: SearchResult[]
+): Map<string, number> => {
+  const validCitationKeys = new Set(
+    searchResults
+      .filter((result) => result.tool_sign && typeof result.cite_index === "number")
+      .map((result) => `${result.tool_sign}${result.cite_index}`)
+  );
+  const displayIndexMap = new Map<string, number>();
+  const citationPattern = /\[\[([^\]]+)\]\]/g;
+
+  for (const match of content.matchAll(citationPattern)) {
+    const reference = parseCitationReference(match[1]);
+    if (
+      !reference ||
+      !validCitationKeys.has(reference.key) ||
+      displayIndexMap.has(reference.key)
+    ) {
+      continue;
+    }
+
+    displayIndexMap.set(reference.key, displayIndexMap.size + 1);
+  }
+
+  return displayIndexMap;
 };
 
 const getSessionCachedValue = (key: string): string | null => {
@@ -560,13 +609,19 @@ const getBackgroundColor = (toolSign: string) => {
 // Replace the original LinkIcon component
 const CitationBadge = ({
   toolSign,
-  citeIndex,
+  sourceIndex,
+  displayIndex,
 }: {
   toolSign: string;
-  citeIndex: number;
+  sourceIndex: number;
+  displayIndex: number;
 }) => (
   <span
     className="ds-markdown-cite"
+    data-citation-key={`${toolSign}${sourceIndex}`}
+    data-citation-tool-sign={toolSign}
+    data-citation-source-index={sourceIndex}
+    data-citation-display-index={displayIndex}
     style={{
       verticalAlign: "middle",
       fontVariant: "tabular-nums",
@@ -588,17 +643,19 @@ const CitationBadge = ({
       top: "-2px",
     }}
   >
-    {citeIndex}
+    {displayIndex}
   </span>
 );
 
 // Modified HoverableText component
 const HoverableText = ({
   text,
+  displayIndex,
   searchResults,
   onCitationHover,
 }: {
   text: string;
+  displayIndex: number;
   searchResults?: SearchResult[];
   onCitationHover?: () => void;
 }) => {
@@ -760,7 +817,11 @@ const HoverableText = ({
             style={{ zIndex: isOpen ? 1000 : "auto" }}
           >
             <span className="inline-flex items-center cursor-pointer transition-colors">
-              <CitationBadge toolSign={toolSign} citeIndex={citeIndex} />
+              <CitationBadge
+                toolSign={toolSign}
+                sourceIndex={citeIndex}
+                displayIndex={displayIndex}
+              />
             </span>
           </span>
         </TooltipTrigger>
@@ -1111,6 +1172,17 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
     () => extractParsedMarkdownHeadings(content),
     [content]
   );
+  const citationDisplayIndexMap = React.useMemo(
+    () => buildCitationDisplayIndexMap(processedContent, searchResults),
+    [processedContent, searchResults]
+  );
+  const citationIndexMapAttribute = React.useMemo(() => {
+    if (citationDisplayIndexMap.size === 0) {
+      return undefined;
+    }
+
+    return JSON.stringify(Object.fromEntries(citationDisplayIndexMap));
+  }, [citationDisplayIndexMap]);
   let renderedHeadingIndex = 0;
 
   const renderCodeFallback = (text: string, key?: React.Key) => (
@@ -1203,20 +1275,18 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
           const match = part.match(/^\[\[([^\]]+)\]\]$/);
           if (match) {
             const innerText = match[1];
-
-            const toolSign = innerText.charAt(0);
-            const citeIndex = parseInt(innerText.slice(1));
-            const hasMatch = searchResults?.some(
-              (result) =>
-                result.tool_sign === toolSign && result.cite_index === citeIndex
-            );
+            const reference = parseCitationReference(innerText);
+            const displayIndex = reference
+              ? citationDisplayIndexMap.get(reference.key)
+              : undefined;
 
             // Only show citation icon when matching search result is found
-            if (hasMatch) {
+            if (displayIndex !== undefined) {
               return (
                 <HoverableText
                   key={index}
                   text={innerText}
+                  displayIndex={displayIndex}
                   searchResults={searchResults}
                   onCitationHover={onCitationHover}
                 />
@@ -1361,7 +1431,10 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
 
   return (
     <>
-      <div className={`markdown-body ${className || ""}`}>
+      <div
+        className={`markdown-body ${className || ""}`}
+        data-citation-index-map={citationIndexMapAttribute}
+      >
         <MarkdownErrorBoundary rawContent={processedContent}>
           <ReactMarkdown
             remarkPlugins={


### PR DESCRIPTION
## Summary
- renumber displayed citations by first valid appearance while preserving source lookup keys
- keep numbering global across search tools and stable for repeated references
- expose per-badge and answer-level citation mappings through production-visible data attributes

## Validation
- `npm run type-check`
- mock browser assertions: disordered references, duplicate/invalid references, mixed tools, and no valid citation (4/4 passed)
- Docker-based Nexent end-to-end verification using the current branch and the built-in knowledge-base service
- `git diff --check`

## Nexent conversation UI end-to-end verification

The final UI verification used a locally deployed Nexent speed-mode environment built from this branch. It exercised the production knowledge-base upload, indexing, Agent configuration, retrieval, and conversation UI instead of injecting mock conversation data.

Test data and indexing:
- Created the `PR3739 Frontend Verified KB` knowledge base from the Nexent web UI.
- Uploaded six Markdown files (`indexed-1.md` through `indexed-6.md`) one at a time through the frontend.
- Each file contains a unique verification token (`CITATION-1` through `CITATION-6`).
- Nexent's built-in data-processing service completed indexing for all six files: 6 documents, 6 chunks, all shown as ready.
- Verified through the frontend document preview that the retained source file and its content are accessible.

Agent and conversation:
- Bound `PR3739 Frontend Verified KB` to the `PR3739 引用顺序验证 Agent` through the Agent configuration UI and published a new version.
- Started a real conversation and instructed the Agent to retrieve all six sources and answer in semantic order: `CITATION-4, CITATION-5, CITATION-6, CITATION-1, CITATION-2, CITATION-3`.
- The knowledge-base tool returned the underlying source indexes in the order `3, 6, 5, 2, 4, 1`.

Browser assertions:
- Visible citation sequence: `1, 2, 3, 4, 5, 6`.
- Per-badge source-to-display mapping: `3→1, 6→2, 5→3, 2→4, 4→5, 1→6`.
- Answer-level mapping attribute: `{"a3":1,"a6":2,"a5":3,"a2":4,"a4":5,"a1":6}`.
- The browser console contains the `[Nexent] Citation display index mapping` diagnostic log.
- Citation badges open the production source panel and show the six frontend-uploaded documents and their indexed content.

The Docker-based Nexent end-to-end verification passed.

## Nexent conversation UI screenshot

<img width="2656" height="1506" alt="image" src="https://github.com/user-attachments/assets/000fdf69-861a-4fb9-a5b1-2a8620e8ed13" />
<img width="2656" height="1506" alt="image" src="https://github.com/user-attachments/assets/891fca6b-6883-4ae6-8b39-ef333103a392" />
