### PR TITLE
🐛 fix think-block cleanup truncating visible text

### DIFF
--- a/backend/utils/str_utils.py
+++ b/backend/utils/str_utils.py
@@ -6,7 +6,7 @@ def remove_think_blocks(text: str) -> str:
     """Remove <think>...</think> blocks including inner content."""
     if not text:
         return text
-    return re.sub(r"(?:<think>)?.*?</think>", "", text, flags=re.DOTALL | re.IGNORECASE)
+    return re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL | re.IGNORECASE)
 
 
 def convert_list_to_string(items: Optional[List[int]]) -> str:

--- a/test/backend/utils/test_str_utils.py
+++ b/test/backend/utils/test_str_utils.py
@@ -19,7 +19,7 @@ class TestStrUtils:
 
     def test_remove_think_blocks_with_closing_tag_only(self):
         """Only closing tag: no opening tag -> no removal"""
-        text = ""
+        text = "The model said: hello </think> world"
         result = remove_think_blocks(text)
         assert result == text  # unchanged
 
@@ -33,7 +33,7 @@ class TestStrUtils:
         """Multiple blocks should all be removed"""
         text = "<think>First thought</think> Normal text <think>Second thought</think>"
         result = remove_think_blocks(text)
-        assert result == ""
+        assert result == " Normal text "
 
     def test_remove_think_blocks_empty_string(self):
         """Empty string"""


### PR DESCRIPTION
## Summary
- require a matched `<think>...</think>` pair before removing content
- preserve visible text before stray closing tags and between multiple think blocks
- correct the focused regression expectations for both cases

## Why
The optional opening tag allowed `.*?</think>` to consume ordinary model output. A malformed provider response containing only `</think>` could therefore silently truncate everything before it.

Fixes #3689.

## Tests
- `python3` focused assertions covering 6 think-block cases
- `python3 -m py_compile backend/utils/str_utils.py test/backend/utils/test_str_utils.py`
- `git diff --check`