### PR TITLE
🐛 expose conversation ID to browser clients

### DIFF
--- a/backend/apps/app_factory.py
+++ b/backend/apps/app_factory.py
@@ -51,6 +51,7 @@ def create_app(
         allow_credentials=True,
         allow_methods=cors_methods or ["*"],
         allow_headers=["*"],
+        expose_headers=["conversation_id"],
     )
 
     # Register exception handlers

--- a/test/backend/app/test_config_app.py
+++ b/test/backend/app/test_config_app.py
@@ -82,6 +82,7 @@ class TestConfigAppIntegration:
         assert cors_middleware.kwargs.get("allow_credentials") is True
         assert cors_middleware.kwargs.get("allow_methods") == ["*"]
         assert cors_middleware.kwargs.get("allow_headers") == ["*"]
+        assert cors_middleware.kwargs.get("expose_headers") == ["conversation_id"]
 
 
 class TestConfigAppRouterConfiguration:

--- a/test/backend/app/test_northbound_base_app.py
+++ b/test/backend/app/test_northbound_base_app.py
@@ -316,6 +316,7 @@ class TestNorthboundBaseApp(unittest.TestCase):
         self.assertTrue(cors_middleware.kwargs.get("allow_credentials"))
         self.assertEqual(cors_middleware.kwargs.get("allow_methods"), ["GET", "POST", "PUT", "DELETE"])
         self.assertEqual(cors_middleware.kwargs.get("allow_headers"), ["*"])
+        self.assertEqual(cors_middleware.kwargs.get("expose_headers"), ["conversation_id"])
 
     def test_router_inclusion(self):
         """The main northbound router should be included."""


### PR DESCRIPTION
## Summary
- expose the existing `conversation_id` response header through CORS
- cover the shared app factory and northbound app middleware configuration

## Why
The agent endpoints already return `conversation_id`, but browser clients cannot read non-safelisted response headers unless `Access-Control-Expose-Headers` includes it. Static frontends therefore lose the ID even though it is present on the HTTP response.

Fixes #3610.

## Tests
- FastAPI `TestClient` CORS smoke with an `Origin` request and `conversation_id: 42`
- `python3 -m py_compile backend/apps/app_factory.py test/backend/app/test_config_app.py test/backend/app/test_northbound_base_app.py`
- `git diff --check`