### PR TITLE
🐛 Bugfix: Fix NL2Agent tool configuration and form unlock flow

### DIFF
--- a/backend/tool_collection/mcp/nl2agent_mcp_tools.py
+++ b/backend/tool_collection/mcp/nl2agent_mcp_tools.py
@@ -952,7 +952,8 @@ async def save_agent_draft_fields(
             user_id=user_id,
         )
         success = SaveAgentDraftFieldsSuccess.model_validate(result)
-        if set(success.updated_fields) == _NL2AGENT_FINAL_PROMPT_BATCH:
+        updated_fields = set(success.updated_fields)
+        if updated_fields & _NL2AGENT_FINAL_PROMPT_BATCH:
             try:
                 await validate_agent_generation_complete_impl(
                     agent_id=resolved_agent_id,
@@ -960,6 +961,8 @@ async def save_agent_draft_fields(
                     user_id=user_id,
                 )
             except Nl2AgentCompletionError as exc:
+                if not _NL2AGENT_FINAL_PROMPT_BATCH.issubset(updated_fields):
+                    return _serialize_agent_draft_save_result(success)
                 return _serialize_agent_draft_save_result(
                     SaveAgentDraftFieldsError(
                         agent_id=resolved_agent_id,

--- a/frontend/app/[locale]/agents/components/agentConfig/ToolManagement.tsx
+++ b/frontend/app/[locale]/agents/components/agentConfig/ToolManagement.tsx
@@ -12,13 +12,13 @@ import type { Tool, ToolParam } from "@/types/agentConfig";
 import { TOOL_SOURCE_TYPES } from "@/const/agentConfig";
 import ToolConfigModal from "./tool/ToolConfigModal";
 import {
-  TOOLS_REQUIRING_KB_SELECTION,
   TOOLS_REQUIRING_EMBEDDING,
   TOOLS_REQUIRING_IMAGE_UNDERSTANDING,
   TOOLS_REQUIRING_AUDIO_UNDERSTANDING,
   TOOLS_REQUIRING_VIDEO_UNDERSTANDING,
   getToolKbType,
   getToolLabels,
+  mergeCanonicalTool,
 } from "./tool/utils";
 import log from "@/lib/logger";
 
@@ -168,20 +168,7 @@ export default function ToolManagement({
       const configuredTool = configured
         ? { ...tool, ...configured, initParams: configured.initParams }
         : tool;
-      // Backfill fields that may be missing from the stored tool (e.g.
-      // `inputs`, which is required for the tool test panel to enter
-      // parsed mode). The canonical source for these fields is the
-      // tool list returned by /tool/list.
-      const canonical = availableTools.find(
-        (t: any) => parseInt(String(t.id)) === parseInt(tool.id)
-      );
-      const toolToUse = canonical
-        ? {
-            ...configuredTool,
-            ...canonical,
-            initParams: configuredTool.initParams,
-          }
-        : configuredTool;
+      const toolToUse = mergeCanonicalTool(configuredTool, availableTools);
       const merged = await mergeParams(toolToUse);
       setConfigTool(toolToUse);
       setConfigParams(merged);
@@ -395,14 +382,14 @@ function groupToolsBySource(tools: Tool[]): SourceGroup[] {
     SourceKey,
     (typeof SOURCE_META)[SourceKey],
   ][]) {
-    const srcTools = tools.filter((t: any) => t.source === meta.sourceValue);
+    const srcTools = tools.filter((tool) => tool.source === meta.sourceValue);
     if (srcTools.length === 0) continue;
     const catMap = new Map<string, Tool[]>();
     for (const tool of srcTools) {
       const cat =
         key === "mcp"
-          ? (tool as any).usage?.trim() || "toolPool.category.other"
-          : (tool as any).category?.trim() || "toolPool.category.other";
+          ? tool.usage?.trim() || "toolPool.category.other"
+          : tool.category?.trim() || "toolPool.category.other";
       if (!catMap.has(cat)) catMap.set(cat, []);
       catMap.get(cat)!.push(tool);
     }

--- a/frontend/app/[locale]/agents/components/agentConfig/tool/utils.ts
+++ b/frontend/app/[locale]/agents/components/agentConfig/tool/utils.ts
@@ -1,8 +1,33 @@
-// Shared tool helpers used by both ToolManagement and SelectToolsDialog.
+import type { Tool } from "@/types/agentConfig";
+
+// Shared tool helpers used by Agent configuration and NL2Agent resource cards.
+
+export function findCanonicalTool(
+  tools: Tool[],
+  toolId: string | number
+): Tool | undefined {
+  return tools.find((tool) => String(tool.id) === String(toolId));
+}
+
+export function mergeCanonicalTool(tool: Tool, tools: Tool[]): Tool {
+  const canonical = findCanonicalTool(tools, tool.id);
+  if (!canonical) return tool;
+
+  return {
+    ...tool,
+    ...canonical,
+    initParams: tool.initParams,
+  };
+}
 
 export const TOOLS_REQUIRING_KB_SELECTION = [
-  "knowledge_base_search", "dify_search", "datamate_search",
-  "idata_search", "haotian_search", "ragflow_search", "aidp_search",
+  "knowledge_base_search",
+  "dify_search",
+  "datamate_search",
+  "idata_search",
+  "haotian_search",
+  "ragflow_search",
+  "aidp_search",
 ];
 export const TOOLS_REQUIRING_EMBEDDING = ["knowledge_base_search"];
 export const TOOLS_REQUIRING_IMAGE_UNDERSTANDING = ["analyze_image"];
@@ -20,6 +45,6 @@ export function getToolKbType(name: string) {
   return "knowledge_base_search" as const;
 }
 
-export function getToolLabels(tool: any): string[] {
+export function getToolLabels(tool: Tool): string[] {
   return Array.isArray(tool.labels) ? tool.labels : [];
 }

--- a/frontend/app/[locale]/agents/components/agentConfig/tool/utils.ts
+++ b/frontend/app/[locale]/agents/components/agentConfig/tool/utils.ts
@@ -21,13 +21,11 @@ export function mergeCanonicalTool(tool: Tool, tools: Tool[]): Tool {
 }
 
 export const TOOLS_REQUIRING_KB_SELECTION = [
-  "knowledge_base_search",
   "dify_search",
   "datamate_search",
   "idata_search",
   "haotian_search",
   "ragflow_search",
-  "aidp_search",
 ];
 export const TOOLS_REQUIRING_EMBEDDING = ["knowledge_base_search"];
 export const TOOLS_REQUIRING_IMAGE_UNDERSTANDING = ["analyze_image"];

--- a/frontend/app/[locale]/newchat/ui/installed-resource-binding-card.tsx
+++ b/frontend/app/[locale]/newchat/ui/installed-resource-binding-card.tsx
@@ -14,9 +14,14 @@ import { useTranslation } from "react-i18next";
 
 import ToolConfigModal from "../../agents/components/agentConfig/tool/ToolConfigModal";
 import SkillConfigModal from "../../agents/components/agentConfig/skill/SkillConfigModal";
+import {
+  findCanonicalTool,
+  mergeCanonicalTool,
+} from "../../agents/components/agentConfig/tool/utils";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useNl2AgentFlow } from "@/contexts/nl2AgentFlow";
+import { useToolList } from "@/hooks/agent/useToolList";
 import {
   searchAgentInfo,
   updateToolConfig,
@@ -164,7 +169,7 @@ const toPersistedBindings = (
     .filter((item) => item.resource.candidate.resource_type === "tool")
     .map((item) => {
       const toolId = parseResourceId(candidateRef(item), "tool");
-      const canonical = toolCatalog.find((tool) => Number(tool.id) === toolId);
+      const canonical = findCanonicalTool(toolCatalog, toolId);
       return {
         ...canonical,
         id: String(toolId),
@@ -250,6 +255,14 @@ export const InstalledResourceBindingCard: FC<{
   const [summaryError, setSummaryError] = useState<string | null>(null);
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [isSynchronizing, setIsSynchronizing] = useState(false);
+  const hasToolResources = payload.resources.some(
+    (resource) => resource.candidate.resource_type === "tool"
+  );
+  const {
+    availableTools,
+    isFetching: isToolCatalogFetching,
+    isError: isToolCatalogError,
+  } = useToolList({ enabled: hasToolResources });
   const waitForAutosave = useAgentStore((state) => state.waitForIdle);
   const applyPersistedResourceBindings = useAgentStore(
     (state) => state.applyPersistedResourceBindings
@@ -504,18 +517,31 @@ export const InstalledResourceBindingCard: FC<{
   };
 
   const dialogResource = configuringItem?.resource;
-  const toolForDialog: Tool | null =
+  const dialogToolId =
     dialogResource?.candidate.resource_type === "tool"
-      ? {
-          id: String(
-            parseResourceId(dialogResource.candidate.candidate_ref, "tool")
-          ),
-          name: dialogResource.candidate.name,
-          description: dialogResource.candidate.description,
-          source:
-            dialogResource.candidate.source === "LOCAL_TOOL" ? "local" : "mcp",
-          initParams: (configuringItem?.draftParams ?? []) as ToolParam[],
-        }
+      ? parseResourceId(dialogResource.candidate.candidate_ref, "tool")
+      : null;
+  const dialogCanonicalTool =
+    dialogToolId == null
+      ? undefined
+      : findCanonicalTool(availableTools, dialogToolId);
+  const toolForDialog: Tool | null =
+    dialogResource?.candidate.resource_type === "tool" &&
+    dialogToolId != null &&
+    dialogCanonicalTool
+      ? mergeCanonicalTool(
+          {
+            id: String(dialogToolId),
+            name: dialogResource.candidate.name,
+            description: dialogResource.candidate.description,
+            source:
+              dialogResource.candidate.source === "LOCAL_TOOL"
+                ? "local"
+                : "mcp",
+            initParams: (configuringItem?.draftParams ?? []) as ToolParam[],
+          },
+          availableTools
+        )
       : null;
   const skillForDialog: Skill | null =
     dialogResource?.candidate.resource_type === "skill"
@@ -554,6 +580,29 @@ export const InstalledResourceBindingCard: FC<{
         {items.map((item) => {
           const ref = candidateRef(item);
           const bound = item.bindingStatus === "bound";
+          const isToolResource =
+            item.resource.candidate.resource_type === "tool";
+          const toolId = isToolResource
+            ? /^tool:(\d+)$/.exec(ref)?.[1]
+            : undefined;
+          const canonicalTool =
+            toolId == null
+              ? undefined
+              : findCanonicalTool(availableTools, toolId);
+          const isToolCatalogPending =
+            isToolResource && !canonicalTool && isToolCatalogFetching;
+          const isToolUnavailable =
+            isToolResource && !canonicalTool && !isToolCatalogFetching;
+          const configureTitle = isToolCatalogPending
+            ? t("toolPool.loadingTools", "Loading tools...")
+            : isToolResource && isToolCatalogError
+              ? t(
+                  "agentConfig.tools.fetchFailed",
+                  "Failed to fetch tools list, please try again later"
+                )
+              : isToolUnavailable
+                ? t("toolPool.tooltip.unavailableTool", "Tool is unavailable")
+                : t("nl2agent.resourceBinding.configure", "Configure");
           return (
             <div key={ref} className="flex min-w-0 items-start gap-3 px-4 py-3">
               <input
@@ -608,14 +657,24 @@ export const InstalledResourceBindingCard: FC<{
                   type="button"
                   variant="outline"
                   size="icon"
-                  title={t("nl2agent.resourceBinding.configure", "Configure")}
-                  disabled={isLocked || bound || isBinding}
+                  title={configureTitle}
+                  disabled={
+                    isLocked ||
+                    bound ||
+                    isBinding ||
+                    isToolCatalogPending ||
+                    isToolUnavailable
+                  }
                   onClick={() => setConfiguringRef(ref)}
                   className={
                     item.configStatus === "invalid" ? "border-destructive" : ""
                   }
                 >
-                  <Settings2 className="size-4" />
+                  {isToolCatalogPending ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <Settings2 className="size-4" />
+                  )}
                 </Button>
               ) : null}
             </div>

--- a/test/backend/services/test_mcp_internal_tool_search.py
+++ b/test/backend/services/test_mcp_internal_tool_search.py
@@ -828,6 +828,130 @@ async def test_final_prompt_batch_emits_generation_completed_state(mocker):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("fields", "updated_fields"),
+    [
+        (
+            {
+                "constraint_prompt": "Use reliable sources.",
+                "greeting_message": "Hello",
+                "example_questions": ["What should I research?"],
+            },
+            [
+                "constraint_prompt",
+                "greeting_message",
+                "example_questions",
+            ],
+        ),
+        (
+            {"example_questions": ["What should I research?"]},
+            ["example_questions"],
+        ),
+    ],
+)
+async def test_completion_validation_uses_persisted_state_for_flexible_final_saves(
+    mocker,
+    fields,
+    updated_fields,
+):
+    mocker.patch.object(
+        nl2agent_mcp_tools_module,
+        "get_http_request",
+        return_value=SimpleNamespace(headers={"Authorization": "Bearer token"}),
+    )
+    mocker.patch.object(
+        nl2agent_mcp_tools_module,
+        "get_current_user_id",
+        return_value=("user-a", "tenant-a"),
+    )
+    mocker.patch.object(
+        nl2agent_service,
+        "save_agent_draft_fields_impl",
+        return_value={
+            "status": "success",
+            "agent_id": 42,
+            "created": False,
+            "updated_fields": updated_fields,
+        },
+    )
+    validate_complete = mocker.patch.object(
+        nl2agent_service,
+        "validate_agent_generation_complete_impl",
+        new=AsyncMock(),
+    )
+
+    result_json, state_wrapper = (
+        await save_agent_draft_fields(42, fields)
+    ).split("\n", 1)
+
+    assert json.loads(result_json)["updated_fields"] == updated_fields
+    assert json.loads(
+        state_wrapper.removeprefix("<nl2a_state>").removesuffix(
+            "</nl2a_state>"
+        )
+    ) == {
+        "event": "agent_generation_completed",
+        "agent_id": 42,
+    }
+    validate_complete.assert_awaited_once_with(
+        agent_id=42,
+        tenant_id="tenant-a",
+        user_id="user-a",
+    )
+
+
+@pytest.mark.asyncio
+async def test_partial_final_prompt_save_remains_saved_when_database_is_incomplete(
+    mocker,
+):
+    mocker.patch.object(
+        nl2agent_mcp_tools_module,
+        "get_http_request",
+        return_value=SimpleNamespace(headers={"Authorization": "Bearer token"}),
+    )
+    mocker.patch.object(
+        nl2agent_mcp_tools_module,
+        "get_current_user_id",
+        return_value=("user-a", "tenant-a"),
+    )
+    mocker.patch.object(
+        nl2agent_service,
+        "save_agent_draft_fields_impl",
+        return_value={
+            "status": "success",
+            "agent_id": 42,
+            "created": False,
+            "updated_fields": ["greeting_message"],
+        },
+    )
+    mocker.patch.object(
+        nl2agent_service,
+        "validate_agent_generation_complete_impl",
+        new=AsyncMock(
+            side_effect=nl2agent_service.Nl2AgentCompletionError(
+                "prompt_fields_incomplete",
+                ["example_questions"],
+            )
+        ),
+    )
+
+    result_json, state_wrapper = (
+        await save_agent_draft_fields(42, {"greeting_message": "Hello"})
+    ).split("\n", 1)
+
+    assert json.loads(result_json)["updated_fields"] == ["greeting_message"]
+    assert json.loads(
+        state_wrapper.removeprefix("<nl2a_state>").removesuffix(
+            "</nl2a_state>"
+        )
+    ) == {
+        "event": "agent_draft_fields_saved",
+        "agent_id": 42,
+        "updated_fields": ["greeting_message"],
+    }
+
+
+@pytest.mark.asyncio
 async def test_final_prompt_batch_emits_failure_when_database_is_incomplete(mocker):
     mocker.patch.object(
         nl2agent_mcp_tools_module,

--- a/test/backend/services/test_nl2agent_service.py
+++ b/test/backend/services/test_nl2agent_service.py
@@ -1303,6 +1303,15 @@ async def test_create_stream_yields_process_chunks_without_waiting_for_later_out
                 }
             ),
         },
+        {
+            "type": "nl2a_state",
+            "content": json.dumps(
+                {
+                    "event": "agent_generation_completed",
+                    "agent_id": 42,
+                }
+            ),
+        },
         {"type": "final_answer", "content": "plain answer"},
     ]
     release_next = [asyncio.Event() for _ in process_chunks]


### PR DESCRIPTION
## Summary

  Fix two regressions in the NL2Agent configuration workflow:

  1. Tool configuration cards did not reuse the canonical Tool configuration data, so input parameter forms were not rendered before tool testing.
  2. The right-side Agent form could remain locked after generation because `agent_generation_completed` was only emitted for one exact final-field batch shape.

  ## What changed

  ### Reuse canonical Tool configuration

  - Load the canonical Tool catalog in the installed-resource binding card.
  - Merge canonical Tool metadata into NL2Agent resource candidates before opening `ToolConfigModal`.
  - Preserve the draft `initParams` while restoring canonical fields such as `inputs`, schemas, labels, and source metadata.
  - Reuse the same canonical merge helper in the regular Agent Tool configuration flow.
  - Disable Tool configuration while the catalog is loading or when the Tool is no longer available.
  - Use canonical Tool records when synchronizing persisted bindings back to the Agent form.

  ### Restore reliable generation completion events

  - Detect completion whenever a successful save updates either final Prompt field, instead of requiring `updated_fields` to exactly equal `["greeting_message", "example_questions"]`.
  - Validate the authoritative persisted Agent state before emitting `agent_generation_completed`.
  - Support split saves, retries, and saves that combine final Prompt fields with other fields.
  - Keep partial final-field saves as normal `agent_draft_fields_saved` events when the database state is still incomplete.
  - Preserve the existing `prompt_generation_failed` behavior when a complete final batch is submitted but persisted Prompt fields remain incomplete.
  - Extend SSE regression coverage to verify that the completion event is forwarded before the final answer.

  ## Why

  The NL2Agent resource card previously constructed a reduced Tool object from recommendation data. It omitted canonical fields required by `ToolConfigModal` and `ToolTestPanel`, including the Tool input schema. As a result, the input parameter form was not rendered and parameterized
  Tool tests failed.

  The final confirmation card previously unlocked the Agent form directly. After that card was replaced by a plain-text summary, unlocking depended on the trusted `agent_generation_completed` SSE event. Tying that event to one exact save shape caused valid split, retried, or combined
  saves to complete without notifying the frontend, leaving the form locked.

  ## Impact

  - NL2Agent Tool configuration now behaves consistently with the regular Agent Tool configuration flow.
  - Parameter forms are available before Tool testing.
  - The Agent form is unlocked after any database-verified successful generation completion.
  - Completion remains database-backed and can only be emitted through the trusted Tool execution-log side channel.
  - No public API, SSE payload, or database schema changes are introduced.

  ## Validation

  - `170` related Backend and SDK tests passed.
  - `npm run type-check` passed.
  - Targeted Prettier checks passed for all modified frontend files.
  - Targeted Ruff checks passed after excluding pre-existing import-order/import-style findings.
  - `git diff --check origin/develop...HEAD` passed.

  ## Known limitations

  - Targeted ESLint could not start because the current frontend setup does not provide the `eslint.config.*` file required by ESLint 9. This is a repository configuration issue rather than a lint finding in the modified files.
  - No authenticated browser end-to-end test was run for the complete NL2Agent generation workflow.

## Screenshots
<img width="571" height="427" alt="image" src="https://github.com/user-attachments/assets/64085061-bbcc-4af4-a8ee-65684f722ecb" />
