### PR TITLE
Bugfix: Preserve Skill frontmatter when renaming during Agent import

### DIFF
--- a/backend/services/skill_service.py
+++ b/backend/services/skill_service.py
@@ -241,22 +241,22 @@ def _replace_skill_frontmatter_name(content: str, new_name: str) -> str:
     if not match:
         raise SkillException("SKILL.md must have YAML frontmatter")
 
-    try:
-        frontmatter = yaml.safe_load(match.group("frontmatter"))
-    except yaml.YAMLError as exc:
-        raise SkillException(f"Invalid SKILL.md frontmatter: {exc}") from exc
-    if not isinstance(frontmatter, dict):
-        raise SkillException("SKILL.md frontmatter must be a mapping")
+    frontmatter = match.group("frontmatter")
+    name_match = re.search(r"(?m)^name[ \t]*:[^\r\n]*(?P<line_end>\r?\n|$)", frontmatter)
+    if not name_match:
+        raise SkillException("SKILL.md frontmatter must contain a name field")
 
-    frontmatter["name"] = new_name
-    yaml_content = yaml.safe_dump(
-        frontmatter,
-        allow_unicode=True,
-        sort_keys=False,
-        default_flow_style=False,
-        width=float("inf"),
+    replacement = f"name: {json.dumps(new_name, ensure_ascii=False)}{name_match.group('line_end')}"
+    updated_frontmatter = (
+        frontmatter[:name_match.start()]
+        + replacement
+        + frontmatter[name_match.end():]
     )
-    return f"---\n{yaml_content}---\n{match.group('body')}"
+    return (
+        content[:match.start("frontmatter")]
+        + updated_frontmatter
+        + content[match.end("frontmatter"):]
+    )
 
 
 def _to_group_id_set(group_ids: Any) -> set[int]:

--- a/test/backend/services/test_skill_service.py
+++ b/test/backend/services/test_skill_service.py
@@ -4691,12 +4691,11 @@ class TestUploadZipFilesWithZipError:
         ("content", "error"),
         [
             ("# No frontmatter", "must have YAML frontmatter"),
-            ("---\n: invalid\n---\nbody", "Invalid SKILL.md frontmatter"),
-            ("---\nplain value\n---\nbody", "frontmatter must be a mapping"),
+            ("---\ndescription: A skill\n---\nbody", "must contain a name field"),
         ],
     )
-    def test_frontmatter_name_replacement_rejects_invalid_frontmatter(self, content, error):
-        """Renaming requires valid mapping-style SKILL.md frontmatter."""
+    def test_frontmatter_name_replacement_requires_name_field(self, content, error):
+        """Renaming requires frontmatter with a top-level name field."""
         with pytest.raises(skill_service.SkillException, match=error):
             skill_service._replace_skill_frontmatter_name(content, "new-skill")
 
@@ -4732,6 +4731,33 @@ class TestUploadZipFilesWithZipError:
             "custom-field": {"enabled": True},
         }
         assert match.group("body") == body
+
+    def test_frontmatter_name_replacement_keeps_legacy_description_unchanged(self):
+        """Renaming must not parse legacy descriptions that contain YAML-like colons."""
+        description = (
+            "Expert code reviewer. Performs detailed analysis using bundled tools to detect "
+            "nested loops, and other code smells. Ideal for: (1) Reviewing pull requests."
+        )
+        content = (
+            "---\n"
+            "name: code_review_expert\n"
+            f"description: {description}\n"
+            "tags:\n"
+            "  - code\n"
+            "---\n"
+            "# Code Review Expert\n"
+        )
+
+        updated = skill_service._replace_skill_frontmatter_name(
+            content,
+            "code_review_expert 副本",
+        )
+
+        assert updated == content.replace(
+            "name: code_review_expert\n",
+            'name: "code_review_expert 副本"\n',
+            1,
+        )
 
     def test_create_zip_with_name_override_extracts_updated_skill_md(self):
         """The ZIP extraction override should prevent the original name from returning."""
@@ -4778,7 +4804,7 @@ class TestUploadZipFilesWithZipError:
 
         assert result["skill_id"] == 42
         override = mock_upload.call_args.kwargs["file_overrides"]["SKILL.md"].decode("utf-8")
-        assert "name: new-skill\n" in override
+        assert 'name: "new-skill"\n' in override
         assert "author: Example Author\n" in override
         assert override.endswith("# Instructions\n\nBody stays unchanged.\n")
 


### PR DESCRIPTION
修复 Agent 导入中重命名 Skill 时因严格解析 frontmatter 导致失败的问题。仅替换顶层 name: 行，保留其他内容、格式和换行不变。
