### PR TITLE
fix(agentConfigService): 为代理配置参数添加约束校验支持

### DIFF
--- a/frontend/services/agentConfigService.ts
+++ b/frontend/services/agentConfigService.ts
@@ -117,6 +117,14 @@ export const fetchTools = async () => {
           value: param.default,
           description: param.description,
           description_zh: param.description_zh,
+          // Bind Pydantic Field constraints (ge/le/gt/lt/...) so the
+          // config modal can validate non-required numeric params.
+          constraints:
+            param.constraints &&
+            typeof param.constraints === "object" &&
+            Object.keys(param.constraints).length > 0
+              ? param.constraints
+              : undefined,
         };
       }),
     }));


### PR DESCRIPTION
补充绑定Pydantic字段的约束条件，让配置模态框可以正确校验非必填的数值型参数