### PR TITLE
fix(frontend): 补齐用户组多选框搜索能力并适配 antd6 showSearch 配置

### DIFF
--- a/frontend/app/[locale]/agents/components/agent-deployment.tsx
+++ b/frontend/app/[locale]/agents/components/agent-deployment.tsx
@@ -38,6 +38,7 @@ export default function AgentDeployment() {
           >
             <Select
               mode="multiple"
+              showSearch={{ optionFilterProp: "label" }}
               placeholder={t("agent.deployment.groupIdsPlaceholder")}
               options={groupOptions}
               value={editedAgent.group_ids ?? []}

--- a/frontend/app/[locale]/knowledges/components/document/DocumentList.tsx
+++ b/frontend/app/[locale]/knowledges/components/document/DocumentList.tsx
@@ -672,6 +672,7 @@ const DocumentListContainer = forwardRef<DocumentListRef, DocumentListProps>(
                     <Can permission="kb.groups:update">
                       <Select
                         mode="multiple"
+                        showSearch={{ optionFilterProp: "label" }}
                         value={isGroupSelectDisabled ? [] : selectedGroupIds}
                         onChange={onSelectedGroupIdsChange}
                         style={{

--- a/frontend/app/[locale]/knowledges/components/knowledge/KnowledgeBaseEditModal.tsx
+++ b/frontend/app/[locale]/knowledges/components/knowledge/KnowledgeBaseEditModal.tsx
@@ -228,6 +228,7 @@ export function KnowledgeBaseEditModal({
           >
             <Select
               mode="multiple"
+              showSearch={{ optionFilterProp: "label" }}
               placeholder={
                 isGroupSelectDisabled
                   ? t("knowledgeBase.create.permission.groupPlaceholder")

--- a/frontend/app/[locale]/mcp-space/components/McpServiceDetailModal.tsx
+++ b/frontend/app/[locale]/mcp-space/components/McpServiceDetailModal.tsx
@@ -871,6 +871,7 @@ export default function McpServiceDetailModal({
                 >
                   <Select
                     mode="multiple"
+                    showSearch={{ optionFilterProp: "label" }}
                     placeholder={t("tenantResources.knowledgeBase.groupNames")}
                     disabled={isReadOnly || isApi}
                     value={

--- a/frontend/app/[locale]/mcp-space/components/PublishConfirmModal.tsx
+++ b/frontend/app/[locale]/mcp-space/components/PublishConfirmModal.tsx
@@ -303,6 +303,7 @@ export default function PublishConfirmModal({
           >
             <Select
               mode="multiple"
+              showSearch={{ optionFilterProp: "label" }}
               placeholder={
                 isGroupSelectDisabled
                   ? t("knowledgeBase.create.permission.groupPlaceholder")

--- a/frontend/app/[locale]/mcp-space/components/PublishedServiceDetailModal.tsx
+++ b/frontend/app/[locale]/mcp-space/components/PublishedServiceDetailModal.tsx
@@ -429,6 +429,7 @@ export default function PublishedServiceDetailModal({
                     <Form.Item name="group_ids" className="mb-0">
                       <Select
                         mode="multiple"
+                        showSearch={{ optionFilterProp: "label" }}
                         placeholder={t("tenantResources.knowledgeBase.groupNames")}
                         value={draft.ingroupPermission === "PRIVATE" ? [] : (draft.groupIds ? draft.groupIds.split(",").map(Number) : [])}
                         options={groups.map((g: { group_id: number; group_name: string }) => ({

--- a/frontend/app/[locale]/mcp-space/components/add/local/AddMcpServiceLocalSection.tsx
+++ b/frontend/app/[locale]/mcp-space/components/add/local/AddMcpServiceLocalSection.tsx
@@ -679,6 +679,7 @@ export default function AddMcpServiceLocalSection({
             >
               <Select
                 mode="multiple"
+                showSearch={{ optionFilterProp: "label" }}
                 placeholder={
                   isGroupSelectDisabled
                     ? t("knowledgeBase.create.permission.groupPlaceholder")

--- a/frontend/app/[locale]/resource-manage/components/resources/GroupList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/GroupList.tsx
@@ -379,8 +379,7 @@ export default function GroupList({ tenantId }: { tenantId: string | null }) {
             >
               <Select
                 mode="multiple"
-                showSearch
-                optionFilterProp="label"
+                showSearch={{ optionFilterProp: "label" }}
                 placeholder={t("tenantResources.groups.selectUsers")}
                 options={allUsers.map((user) => ({
                   label: user.username,

--- a/frontend/app/[locale]/resource-manage/components/resources/GroupList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/GroupList.tsx
@@ -379,6 +379,8 @@ export default function GroupList({ tenantId }: { tenantId: string | null }) {
             >
               <Select
                 mode="multiple"
+                showSearch
+                optionFilterProp="label"
                 placeholder={t("tenantResources.groups.selectUsers")}
                 options={allUsers.map((user) => ({
                   label: user.username,

--- a/frontend/app/[locale]/resource-manage/components/resources/InvitationList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/InvitationList.tsx
@@ -644,6 +644,8 @@ export default function InvitationList({
             >
               <Select
                 mode="multiple"
+                showSearch
+                optionFilterProp="label"
                 placeholder={t("tenantResources.invitation.groupNames")}
                 options={groups.map((group) => ({
                   label: group.group_name,

--- a/frontend/app/[locale]/resource-manage/components/resources/InvitationList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/InvitationList.tsx
@@ -644,8 +644,7 @@ export default function InvitationList({
             >
               <Select
                 mode="multiple"
-                showSearch
-                optionFilterProp="label"
+                showSearch={{ optionFilterProp: "label" }}
                 placeholder={t("tenantResources.invitation.groupNames")}
                 options={groups.map((group) => ({
                   label: group.group_name,

--- a/frontend/app/[locale]/resource-manage/components/resources/UserList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/UserList.tsx
@@ -395,8 +395,7 @@ export default function UserList({
           >
             <Select
               mode="multiple"
-              showSearch
-              optionFilterProp="label"
+              showSearch={{ optionFilterProp: "label" }}
               placeholder={t("tenantResources.groups.selectUsers")}
               options={groups.map((g) => ({
                 label: g.group_name,

--- a/frontend/app/[locale]/resource-manage/components/resources/UserList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/UserList.tsx
@@ -395,6 +395,8 @@ export default function UserList({
           >
             <Select
               mode="multiple"
+              showSearch
+              optionFilterProp="label"
               placeholder={t("tenantResources.groups.selectUsers")}
               options={groups.map((g) => ({
                 label: g.group_name,

--- a/frontend/ext_components/aidp/components/AidpUpdateKbModal.tsx
+++ b/frontend/ext_components/aidp/components/AidpUpdateKbModal.tsx
@@ -225,6 +225,7 @@ const AidpUpdateKbModal: React.FC<AidpUpdateKbModalProps> = ({
             >
               <Select
                 mode="multiple"
+                showSearch={{ optionFilterProp: "label" }}
                 placeholder={t("aidpKnowledge.createAccessGroupsPlaceholder")}
                 disabled={ingroupPermission === "PRIVATE"}
                 options={groupOptions}


### PR DESCRIPTION
## 概述
资源管理、知识库、MCP 空间、Agent 配置等多处「用户组/成员」多选下拉框缺少搜索过滤,用户组数量多时只能滚动翻找。本次统一补齐搜索能力,并适配 antd 6 中已废弃的 `optionFilterProp` 写法。

## 问题背景
- 多处 `<Select mode="multiple">` 未配置 `showSearch`,options 来自 `useGroupList(tenantId)` 全量加载,无法键入过滤。
- antd 6 已将顶层 `optionFilterProp` 标记为 `@deprecated`,推荐使用 `showSearch.optionFilterProp`。

## 改动内容
为以下 11 处多选 Select 统一配置 `showSearch={{ optionFilterProp: "label" }}`:

- 资源管理:UserList(编辑用户所属组)、GroupList(编辑组成员)、InvitationList(邀请码关联组)
- 知识库:DocumentList、KnowledgeBaseEditModal、AidpUpdateKbModal
- MCP 空间:AddMcpServiceLocalSection、McpServiceDetailModal、PublishedServiceDetailModal、PublishConfirmModal
- Agent 配置:agent-deployment

数据源均为 `useGroupList(tenantId)`(全量加载),前端过滤可覆盖全部用户组,未改动数据层;仅新增搜索属性,不动任何 `onChange` / `options` / 回填逻辑。

<img width="614" height="451" alt="image" src="https://github.com/user-attachments/assets/6c2c3a22-2ead-4188-8b15-73da73cf2713" />
