### PR TITLE
🐛Fix: localize resource deletion confirmations

### DIFF
--- a/frontend/app/[locale]/resource-manage/components/resources/AgentList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/AgentList.tsx
@@ -7,7 +7,6 @@ import {
   Button,
   App,
   Tooltip,
-  Popconfirm,
   Typography,
   Tag,
   Modal,
@@ -24,6 +23,7 @@ import {
   Clock,
   Eye,
 } from "lucide-react";
+import { useConfirmModal } from "@/hooks/useConfirmModal";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { useAgentList } from "@/hooks/agent/useAgentList";
@@ -63,6 +63,7 @@ type AgentListRow = Pick<
 };
 
 export default function AgentList({ tenantId }: { tenantId: string | null }) {
+  const { confirm } = useConfirmModal();
   const { t } = useTranslation("common");
   const { message } = App.useApp();
   const [form] = Form.useForm();
@@ -506,24 +507,21 @@ export default function AgentList({ tenantId }: { tenantId: string | null }) {
               size="small"
             />
           </Tooltip>
-          <Popconfirm
-            title={t("businessLogic.config.modal.deleteTitle")}
-            description={t("businessLogic.config.modal.deleteContent", {
-              name: record.display_name,
-            })}
-            onConfirm={() => handleDelete(record)}
-            okText={t("common.confirm")}
-            cancelText={t("common.cancel")}
-          >
-            <Tooltip title={t("common.delete")}>
-              <Button
-                type="text"
-                danger
-                icon={<Trash2 className="h-4 w-4" />}
-                size="small"
-              />
-            </Tooltip>
-          </Popconfirm>
+          <Tooltip title={t("common.delete")}>
+            <Button
+              type="text"
+              danger
+              icon={<Trash2 className="h-4 w-4" />}
+              size="small"
+              onClick={() => confirm({
+                title: t("businessLogic.config.modal.deleteTitle"),
+                content: t("businessLogic.config.modal.deleteContent", { name: record.display_name }),
+                okText: t("common.confirm"),
+                cancelText: t("common.cancel"),
+                onOk: () => handleDelete(record),
+              })}
+            />
+          </Tooltip>
         </div>
       ),
     },

--- a/frontend/app/[locale]/resource-manage/components/resources/ApiKeyList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/ApiKeyList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useMemo, useState } from "react";
-import { App, Button, Popconfirm, Table, Tag } from "antd";
+import { App, Button, Table, Tag } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import { RefreshCw, Trash2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -155,35 +155,36 @@ export default function ApiKeyList({ tenantId }: { tenantId: string | null }) {
         width: 100,
         render: (_, record) => (
           <div className="flex items-center gap-1">
-            <Popconfirm
-              title={t("tenantResources.apiKeys.confirmRefresh")}
-              description={t("tenantResources.apiKeys.affectsAll")}
-              onConfirm={() => refreshKey(record)}
-              okText={t("common.confirm")}
-              cancelText={t("common.cancel")}
-            >
-              <Button
-                type="text"
-                size="small"
-                loading={pendingUserId === record.user_id}
-                icon={<RefreshCw className="h-4 w-4" />}
-              />
-            </Popconfirm>
-            <Popconfirm
-              title={t("tenantResources.apiKeys.confirmRevoke")}
-              description={t("tenantResources.apiKeys.affectsAll")}
-              onConfirm={() => revokeKey(record)}
-              okText={t("common.confirm")}
-              cancelText={t("common.cancel")}
-            >
-              <Button
-                type="text"
-                danger
-                size="small"
-                disabled={pendingUserId === record.user_id}
-                icon={<Trash2 className="h-4 w-4" />}
-              />
-            </Popconfirm>
+            <Button
+              type="text"
+              size="small"
+              loading={pendingUserId === record.user_id}
+              icon={<RefreshCw className="h-4 w-4" />}
+              onClick={() => modal.confirm({
+                title: t("tenantResources.apiKeys.confirmRefresh"),
+                content: t("tenantResources.apiKeys.affectsAll"),
+                centered: true,
+                okText: t("common.confirm"),
+                cancelText: t("common.cancel"),
+                onOk: () => refreshKey(record),
+              })}
+            />
+            <Button
+              type="text"
+              danger
+              size="small"
+              disabled={pendingUserId === record.user_id}
+              icon={<Trash2 className="h-4 w-4" />}
+              onClick={() => modal.confirm({
+                title: t("tenantResources.apiKeys.confirmRevoke"),
+                content: t("tenantResources.apiKeys.affectsAll"),
+                centered: true,
+                okText: t("common.confirm"),
+                cancelText: t("common.cancel"),
+                okButtonProps: { danger: true },
+                onOk: () => revokeKey(record),
+              })}
+            />
           </div>
         ),
       },

--- a/frontend/app/[locale]/resource-manage/components/resources/GroupList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/GroupList.tsx
@@ -9,7 +9,6 @@ import {
   Modal,
   Form,
   Input,
-  Popconfirm,
   message,
   Select,
   Tooltip,
@@ -18,6 +17,7 @@ import { Edit, Trash2 } from "lucide-react";
 import { ColumnsType } from "antd/es/table";
 import { useGroupList } from "@/hooks/group/useGroupList";
 import { useUserList } from "@/hooks/user/useUserList";
+import { useConfirmModal } from "@/hooks/useConfirmModal";
 import {
   createGroup,
   updateGroup,
@@ -33,6 +33,7 @@ import {
 import { type User } from "@/services/userService";
 
 export default function GroupList({ tenantId }: { tenantId: string | null }) {
+  const { confirm } = useConfirmModal();
   const { t } = useTranslation("common");
   const queryClient = useQueryClient();
 
@@ -272,23 +273,21 @@ export default function GroupList({ tenantId }: { tenantId: string | null }) {
                 size="small"
               />
             </Tooltip>
-            <Popconfirm
-              title={t("tenantResources.groups.confirmDelete", {
-                name: record.group_name,
-              })}
-              onConfirm={() => handleDelete(record.group_id)}
-              okText={t("common.confirm")}
-              cancelText={t("common.cancel")}
-            >
-              <Tooltip title={t("tenantResources.groups.deleteGroup")}>
-                <Button
-                  type="text"
-                  danger
-                  icon={<Trash2 className="h-4 w-4" />}
-                  size="small"
-                />
-              </Tooltip>
-            </Popconfirm>
+            <Tooltip title={t("tenantResources.groups.deleteGroup")}>
+              <Button
+                type="text"
+                danger
+                icon={<Trash2 className="h-4 w-4" />}
+                size="small"
+                onClick={() => confirm({
+                  title: t("tenantResources.groups.confirmDelete", { name: record.group_name }),
+                  content: "",
+                  okText: t("common.confirm"),
+                  cancelText: t("common.cancel"),
+                  onOk: () => handleDelete(record.group_id),
+                })}
+              />
+            </Tooltip>
           </div>
         ),
       },

--- a/frontend/app/[locale]/resource-manage/components/resources/InvitationList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/InvitationList.tsx
@@ -10,7 +10,6 @@ import {
   Form,
   Input,
   Select,
-  Popconfirm,
   message,
   Tag,
   Pagination,
@@ -23,6 +22,7 @@ import { copyToClipboard } from "@/lib/clipboard";
 import { ColumnsType } from "antd/es/table";
 import { useInvitationList } from "@/hooks/invitation/useInvitationList";
 import { useGroupList } from "@/hooks/group/useGroupList";
+import { useConfirmModal } from "@/hooks/useConfirmModal";
 import { getTenantDefaultGroupId } from "@/services/groupService";
 import {
   createInvitation,
@@ -60,6 +60,7 @@ export default function InvitationList({
   tenantId: string | null;
   refreshKey?: number;
 }) {
+  const { confirm } = useConfirmModal();
   const { t } = useTranslation("common");
   const { user } = useAuthorizationContext();
   const userRole = user?.role;
@@ -408,24 +409,21 @@ export default function InvitationList({
                 size="small"
               />
             </Tooltip>
-            <Popconfirm
-              title={t("tenantResources.invitation.confirmDeleteInvitation", {
-                code: record.invitation_code,
-              })}
-              description={t("common.cannotBeUndone")}
-              onConfirm={() => handleDelete(record.invitation_code)}
-              okText={t("common.confirm")}
-              cancelText={t("common.cancel")}
-            >
-              <Tooltip title={t("tenantResources.invitation.deleteInvitation")}>
-                <Button
-                  type="text"
-                  danger
-                  icon={<Trash2 className="h-4 w-4" />}
-                  size="small"
-                />
-              </Tooltip>
-            </Popconfirm>
+            <Tooltip title={t("tenantResources.invitation.deleteInvitation")}>
+              <Button
+                type="text"
+                danger
+                icon={<Trash2 className="h-4 w-4" />}
+                size="small"
+                onClick={() => confirm({
+                  title: t("tenantResources.invitation.confirmDeleteInvitation", { code: record.invitation_code }),
+                  content: t("common.cannotBeUndone"),
+                  okText: t("common.confirm"),
+                  cancelText: t("common.cancel"),
+                  onOk: () => handleDelete(record.invitation_code),
+                })}
+              />
+            </Tooltip>
           </div>
         ),
       },

--- a/frontend/app/[locale]/resource-manage/components/resources/KnowledgeList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/KnowledgeList.tsx
@@ -4,7 +4,6 @@ import React, { useMemo, useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Table,
-  Popconfirm,
   message,
   Button,
   Input,
@@ -28,6 +27,7 @@ import { MarkdownRenderer } from "@/components/common/markdownRenderer";
 import { useKnowledgeList } from "@/hooks/knowledge/useKnowledgeList";
 import { useGroupList } from "@/hooks/group/useGroupList";
 import { useAuthorization } from "@/hooks/auth/useAuthorization";
+import { useConfirmModal } from "@/hooks/useConfirmModal";
 import knowledgeBaseService from "@/services/knowledgeBaseService";
 import quotaService from "@/services/quotaService";
 import { type KnowledgeBase } from "@/types/knowledgeBase";
@@ -62,6 +62,7 @@ export default function KnowledgeList({
 }: {
   tenantId: string | null;
 }) {
+  const { confirm } = useConfirmModal();
   const { t } = useTranslation("common");
   const [kbView, setKbView] = useState<"shared" | "personal">("shared");
   const { data, isLoading, refetch } = useKnowledgeList(tenantId);
@@ -531,22 +532,23 @@ export default function KnowledgeList({
                 size="small"
               />
             </Tooltip>
-            <Popconfirm
-              title={t("knowledgeBase.modal.deleteConfirm.title")}
-              description={t("common.cannotBeUndone")}
-              onConfirm={() => handleDelete(record.id)}
-              okText={t("common.confirm")}
-              cancelText={t("common.cancel")}
-            >
-              <Tooltip title={t("common.delete")}>
-                <Button
-                  type="text"
-                  danger
-                  icon={<Trash2 className="h-4 w-4" />}
-                  size="small"
-                />
-              </Tooltip>
-            </Popconfirm>
+            <Tooltip title={t("common.delete")}>
+              <Button
+                type="text"
+                danger
+                icon={<Trash2 className="h-4 w-4" />}
+                size="small"
+                onClick={() =>
+                  confirm({
+                    title: t("knowledgeBase.modal.deleteConfirm.title"),
+                    content: t("common.cannotBeUndone"),
+                    okText: t("common.confirm"),
+                    cancelText: t("common.cancel"),
+                    onOk: () => handleDelete(record.id),
+                  })
+                }
+              />
+            </Tooltip>
           </div>
         );
       },

--- a/frontend/app/[locale]/resource-manage/components/resources/McpList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/McpList.tsx
@@ -15,7 +15,6 @@ import {
   App,
   Upload,
   Tabs,
-  Popconfirm,
   Tag,
 } from "antd";
 import {
@@ -603,23 +602,10 @@ export default function McpList({ tenantId }: { tenantId: string | null }) {
                 disabled={actionsLocked}
               />
             </Tooltip>
-            <Popconfirm
-              title={t("mcpConfig.delete.confirmTitle")}
-              description={t("mcpConfig.delete.confirmContent", { name: record.service_name })}
-              onConfirm={() => onDeleteServer(record)}
-              okText={t("common.confirm")}
-              cancelText={t("common.cancel")}
-            >
-              <Tooltip title={t("mcpConfig.serverList.button.delete")}>
-                <Button
-                  type="text"
-                  danger
-                  icon={<Trash2 className="h-4 w-4" />}
-                  size="small"
-                  disabled={actionsLocked}
-                />
-              </Tooltip>
-            </Popconfirm>
+            <Tooltip title={t("mcpConfig.serverList.button.delete")}>
+              <Button type="text" danger icon={<Trash2 className="h-4 w-4" />} size="small" disabled={actionsLocked}
+                onClick={() => confirm({ title: t("mcpConfig.delete.confirmTitle"), content: t("mcpConfig.delete.confirmContent", { name: record.service_name }), onOk: () => onDeleteServer(record) })} />
+            </Tooltip>
           </div>
         );
       },
@@ -697,23 +683,10 @@ export default function McpList({ tenantId }: { tenantId: string | null }) {
               disabled={updatingTools}
             />
           </Tooltip>
-          <Popconfirm
-            title={t("mcpConfig.deleteContainer.confirmTitle")}
-            description={t("mcpConfig.deleteContainer.confirmContent", { name: record.name || record.container_id })}
-            onConfirm={() => onDeleteContainer(record)}
-            okText={t("common.confirm")}
-            cancelText={t("common.cancel")}
-          >
-            <Tooltip title={t("mcpConfig.containerList.button.delete")}>
-              <Button
-                type="text"
-                danger
-                icon={<Trash2 className="h-4 w-4" />}
-                size="small"
-                disabled={actionsLocked}
-              />
-            </Tooltip>
-          </Popconfirm>
+          <Tooltip title={t("mcpConfig.containerList.button.delete")}>
+            <Button type="text" danger icon={<Trash2 className="h-4 w-4" />} size="small" disabled={actionsLocked}
+              onClick={() => confirm({ title: t("mcpConfig.deleteContainer.confirmTitle"), content: t("mcpConfig.deleteContainer.confirmContent", { name: record.name || record.container_id }), onOk: () => onDeleteContainer(record) })} />
+          </Tooltip>
         </div>
       ),
     },
@@ -742,23 +715,10 @@ export default function McpList({ tenantId }: { tenantId: string | null }) {
       width: "20%",
       render: (_: any, record: any) => (
         <div className="flex items-center space-x-2">
-          <Popconfirm
-            title={t("mcpConfig.delete.confirmTitle")}
-            description={t("mcpConfig.delete.confirmContent", { name: record.mcp_service_name })}
-            onConfirm={() => onDeleteOpenapiService(record)}
-            okText={t("common.confirm")}
-            cancelText={t("common.cancel")}
-          >
-            <Tooltip title={t("mcpConfig.serverList.button.delete")}>
-              <Button
-                type="text"
-                danger
-                icon={<Trash2 className="h-4 w-4" />}
-                size="small"
-                disabled={actionsLocked}
-              />
-            </Tooltip>
-          </Popconfirm>
+          <Tooltip title={t("mcpConfig.serverList.button.delete")}>
+            <Button type="text" danger icon={<Trash2 className="h-4 w-4" />} size="small" disabled={actionsLocked}
+              onClick={() => confirm({ title: t("mcpConfig.delete.confirmTitle"), content: t("mcpConfig.delete.confirmContent", { name: record.mcp_service_name }), onOk: () => onDeleteOpenapiService(record) })} />
+          </Tooltip>
         </div>
       ),
     },

--- a/frontend/app/[locale]/resource-manage/components/resources/ModelList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/ModelList.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from "react-i18next";
 import {
   Table,
   Button,
-  Popconfirm,
   message,
   Tag,
   Segmented,
@@ -32,6 +31,7 @@ import { modelService } from "@/services/modelService";
 import { type ModelOption, type ModelType } from "@/types/modelConfig";
 import type { ModelMonitoringItem } from "@/types/monitoring";
 import { MODEL_TYPES } from "@/const/modelConfig";
+import { useConfirmModal } from "@/hooks/useConfirmModal";
 import { ModelAddDialog } from "../../../models/components/model/ModelAddDialog";
 import { ModelEditDialog } from "../../../models/components/model/ModelEditDialog";
 import ModelCapacityCoverageWidget from "./ModelCapacityCoverageWidget";
@@ -46,6 +46,7 @@ interface UnifiedModelRow extends ModelOption {
 
 export default function ModelList({ tenantId }: { tenantId: string | null }) {
   const { t } = useTranslation("common");
+  const { confirm } = useConfirmModal();
 
   const { bareModelIds } = useCapacityCoverage();
 
@@ -474,22 +475,23 @@ export default function ModelList({ tenantId }: { tenantId: string | null }) {
               size="small"
             />
           </Tooltip>
-          <Popconfirm
-            title={t("tenantResources.models.confirmDelete")}
-            description={t("common.cannotBeUndone")}
-            onConfirm={() => handleDelete(record.displayName, record.source)}
-            okText={t("common.confirm")}
-            cancelText={t("common.cancel")}
-          >
-            <Tooltip title={t("tenantResources.models.deleteModel")}>
-              <Button
-                type="text"
-                danger
-                icon={<Trash2 className="h-4 w-4" />}
-                size="small"
-              />
-            </Tooltip>
-          </Popconfirm>
+          <Tooltip title={t("tenantResources.models.deleteModel")}>
+            <Button
+              type="text"
+              danger
+              icon={<Trash2 className="h-4 w-4" />}
+              size="small"
+              onClick={() =>
+                confirm({
+                  title: t("tenantResources.models.confirmDelete"),
+                  content: t("common.cannotBeUndone"),
+                  okText: t("common.confirm"),
+                  cancelText: t("common.cancel"),
+                  onOk: () => handleDelete(record.displayName, record.source),
+                })
+              }
+            />
+          </Tooltip>
         </div>
       ),
     },

--- a/frontend/app/[locale]/resource-manage/components/resources/UserList.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/UserList.tsx
@@ -9,7 +9,6 @@ import {
   Form,
   Input,
   Select,
-  Popconfirm,
   message,
   Tag,
   Tooltip,
@@ -18,6 +17,7 @@ import { Edit, Trash2 } from "lucide-react";
 import { ColumnsType } from "antd/es/table";
 import { useUserList } from "@/hooks/user/useUserList";
 import { useGroupList } from "@/hooks/group/useGroupList";
+import { useConfirmModal } from "@/hooks/useConfirmModal";
 import {
   updateUser,
   deleteUser,
@@ -32,13 +32,8 @@ import {
   type CreateGroupRequest,
 } from "@/services/groupService";
 
-export default function UserList({
-  tenantId,
-  refreshKey,
-}: {
-  tenantId: string | null;
-  refreshKey?: number;
-}) {
+export default function UserList({ tenantId, refreshKey }: { tenantId: string | null; refreshKey?: number }) {
+  const { confirm } = useConfirmModal();
   const { t } = useTranslation("common");
 
   // Pagination state
@@ -260,23 +255,25 @@ export default function UserList({
                 size="small"
               />
             </Tooltip>
-            <Popconfirm
-              title={t("tenantResources.users.confirmDelete", {
-                name: record.username,
-              })}
-              onConfirm={() => handleDelete(record.id)}
-              okText={t("common.confirm")}
-              cancelText={t("common.cancel")}
-            >
-              <Tooltip title={t("tenantResources.users.deleteUser")}>
-                <Button
-                  type="text"
-                  danger
-                  icon={<Trash2 className="h-4 w-4" />}
-                  size="small"
-                />
-              </Tooltip>
-            </Popconfirm>
+            <Tooltip title={t("tenantResources.users.deleteUser")}>
+              <Button
+                type="text"
+                danger
+                icon={<Trash2 className="h-4 w-4" />}
+                size="small"
+                onClick={() =>
+                  confirm({
+                    title: t("tenantResources.users.confirmDelete", {
+                      name: record.username,
+                    }),
+                    content: "",
+                    okText: t("common.confirm"),
+                    cancelText: t("common.cancel"),
+                    onOk: () => handleDelete(record.id),
+                  })
+                }
+              />
+            </Tooltip>
           </div>
         ),
         width: "30%",


### PR DESCRIPTION
## Summary

This PR standardizes destructive-action confirmations across the resource management UI by replacing inline Ant Design `Popconfirm` components with centered confirmation modals.

The update provides a consistent confirmation experience across agents, API keys, groups, invitations, knowledge bases, MCP resources, models, and users.
<img width="1785" height="815" alt="image" src="https://github.com/user-attachments/assets/2248b4c5-865f-477d-912a-6d99056faba6" />
<img width="1399" height="568" alt="image" src="https://github.com/user-attachments/assets/7b8efc3f-f5c0-47f1-b93a-e05870c09a5e" />
<img width="1637" height="874" alt="image" src="https://github.com/user-attachments/assets/6ce1952e-466c-4992-92b3-e059f9b71fd2" />
<img width="1404" height="650" alt="image" src="https://github.com/user-attachments/assets/5bc76ffe-5af4-44b8-9f7d-b4ac150d8c8e" />
<img width="2252" height="766" alt="image" src="https://github.com/user-attachments/assets/a6c59e6f-0c36-46d9-9b98-a315e082041a" />
<img width="2089" height="818" alt="image" src="https://github.com/user-attachments/assets/d631a67b-06d5-4857-a55a-7ef9a92ee4b3" />
<img width="2105" height="798" alt="image" src="https://github.com/user-attachments/assets/d7ec4f01-f11a-4a1c-8deb-fc4d63ca2f1c" />
<img width="2186" height="734" alt="image" src="https://github.com/user-attachments/assets/6a34dc77-69be-400a-bb79-301692edb939" />


## Changes

Replaced `Popconfirm` with confirmation modals in:

- `AgentList.tsx` — Agent deletion
- `ApiKeyList.tsx` — API key refresh and revoke
- `GroupList.tsx` — Group deletion
- `InvitationList.tsx` — Invitation deletion
- `KnowledgeList.tsx` — Knowledge base deletion
- `McpList.tsx` — MCP server, container, and OpenAPI service deletion
- `ModelList.tsx` — Model deletion
- `UserList.tsx` — User deletion


## Verification

- `npm run type-check` passes.
- No backend changes.