### PR TITLE
🐛 Bugfix: Unlock NL2Agent form after prompt updates and stops

### DIFF
--- a/backend/tool_collection/mcp/nl2agent_mcp_tools.py
+++ b/backend/tool_collection/mcp/nl2agent_mcp_tools.py
@@ -1140,7 +1140,7 @@ async def save_agent_draft_fields(
         )
         success = SaveAgentDraftFieldsSuccess.model_validate(result)
         updated_fields = set(success.updated_fields)
-        if updated_fields & _NL2AGENT_FINAL_PROMPT_BATCH:
+        if updated_fields & _NL2AGENT_PROMPT_FIELDS:
             try:
                 await validate_agent_generation_complete_impl(
                     agent_id=resolved_agent_id,

--- a/frontend/app/[locale]/agents/page.tsx
+++ b/frontend/app/[locale]/agents/page.tsx
@@ -137,6 +137,7 @@ function AgentSetupContent() {
     markCompletionSynced,
     markCompletionSyncFailed,
     markGenerationCompleted,
+    markGenerationStopped,
     markPromptGenerationFailed,
     requestConfigFocus,
     resetFlow,
@@ -226,6 +227,11 @@ function AgentSetupContent() {
       markPromptGenerationFailed,
       synchronizeCompletion,
     ]
+  );
+
+  const handleGenerationStopped = useCallback(
+    (agentId: number) => markGenerationStopped(agentId),
+    [markGenerationStopped]
   );
 
   const retryCompletionSync = useCallback(() => {
@@ -335,6 +341,7 @@ function AgentSetupContent() {
                   isNl2AgentUnavailable
                 }
                 onStateEvent={handleStateEvent}
+                onStopped={handleGenerationStopped}
               />
             </div>
           </PanelCard>

--- a/frontend/app/[locale]/newchat/adapter/remote-chat-model-adapter.ts
+++ b/frontend/app/[locale]/newchat/adapter/remote-chat-model-adapter.ts
@@ -259,6 +259,7 @@ interface NexentRunConfig {
   language?: "zh" | "en";
   onNl2SkillEvent?: (event: Nl2SkillStreamEvent) => void;
   onNl2AgentState?: (event: Nl2AgentStateEvent) => void;
+  onNl2AgentStopped?: (agentId: number) => void;
   modelId?: number;
   runtimeMetadata?: Record<string, unknown>;
   runtimeMetadataVersion?: number;
@@ -1486,6 +1487,8 @@ export const remoteChatModelAdapter: ChatModelAdapter = {
       ? numericServerThreadId
       : null;
     let backendStopPromise: Promise<void> | null = null;
+    let abortHandled = false;
+    let userAborted = false;
     const stopBackendConversation = async (conversationId: number) => {
       if (isEphemeralRuntime || backendStopPromise) return;
       backendStopPromise = conversationService
@@ -1500,20 +1503,27 @@ export const remoteChatModelAdapter: ChatModelAdapter = {
       await backendStopPromise;
     };
     const handleAbort = () => {
+      if (abortHandled) return;
+      abortHandled = true;
       const abortReason = abortSignal?.reason as
-        | { detach?: boolean }
-        | undefined;
+        { detach?: boolean } | undefined;
       if (abortReason?.detach) {
         log.log(
           `[ChatModelAdapter] Local stream detached from conversation ${backendConversationId ?? "unknown"}`
         );
         return;
       }
+      userAborted = true;
+      const nl2AgentId = Number(custom?.agentId);
+      if (isNl2Agent && Number.isInteger(nl2AgentId) && nl2AgentId > 0) {
+        custom?.onNl2AgentStopped?.(nl2AgentId);
+      }
       if (backendConversationId !== null) {
         void stopBackendConversation(backendConversationId);
       }
     };
     abortSignal?.addEventListener("abort", handleAbort, { once: true });
+    if (abortSignal?.aborted) handleAbort();
     const cleanupAbortHandler = () => {
       abortSignal?.removeEventListener("abort", handleAbort);
     };
@@ -1583,6 +1593,7 @@ export const remoteChatModelAdapter: ChatModelAdapter = {
         error instanceof Error &&
         (error.name === "AbortError" || error.message === "请求已被取消")
       ) {
+        if (abortSignal?.aborted) handleAbort();
         await backendStopPromise;
         log.log("[ChatModelAdapter] Request aborted by user");
         return;
@@ -1862,7 +1873,7 @@ export const remoteChatModelAdapter: ChatModelAdapter = {
     };
     const deliveredNl2AgentStates = new Set<string>();
     const deliverNl2AgentState = (chunk: SseChunk) => {
-      if (!isNl2Agent) return;
+      if (!isNl2Agent || userAborted) return;
       const event = parseNl2AgentState(chunk.content);
       if (!event) {
         log.warn("[ChatModelAdapter] Ignored invalid nl2a_state payload");

--- a/frontend/app/[locale]/newchat/assistant-ui/nl2agent-chat-panel.tsx
+++ b/frontend/app/[locale]/newchat/assistant-ui/nl2agent-chat-panel.tsx
@@ -33,12 +33,14 @@ export interface Nl2AgentChatPanelProps {
   agentId?: number | null;
   disabled?: boolean;
   onStateEvent?: (event: Nl2AgentStateEvent) => void;
+  onStopped?: (agentId: number) => void;
 }
 
 export const Nl2AgentChatPanel: FC<Nl2AgentChatPanelProps> = ({
   agentId = null,
   disabled = false,
   onStateEvent,
+  onStopped,
 }) => {
   const { t } = useTranslation("common");
   const { modelConfig } = useConfig();
@@ -60,12 +62,13 @@ export const Nl2AgentChatPanel: FC<Nl2AgentChatPanelProps> = ({
               runtimeMode: "nl2agent",
               agentId,
               onNl2AgentState: onStateEvent,
+              onNl2AgentStopped: onStopped,
             },
           },
         });
       },
     }),
-    [agentId, onStateEvent]
+    [agentId, onStateEvent, onStopped]
   );
   const runtime = useLocalRuntime(chatModelAdapter, { adapters });
 

--- a/frontend/contexts/nl2AgentFlow.tsx
+++ b/frontend/contexts/nl2AgentFlow.tsx
@@ -62,6 +62,7 @@ type Nl2AgentFlowAction =
   | { type: "submit_card"; cardKey: string }
   | { type: "resources_bound"; agentId: number }
   | { type: "prompt_generation_failed"; agentId: number; fields: string[] }
+  | { type: "generation_stopped"; agentId: number }
   | {
       type: "request_config_focus";
       agentId: number;
@@ -141,6 +142,18 @@ function reducer(
         completionSyncFailed: false,
         isFormLocked: true,
       };
+    case "generation_stopped":
+      if (state.agentId !== action.agentId) return state;
+      return {
+        ...state,
+        phase: "idle",
+        activeCard: null,
+        failedPromptFields: [],
+        configFocusRequest: null,
+        completionSyncFailed: false,
+        isFormLocked: false,
+        isComposerDisabled: false,
+      };
     case "request_config_focus":
       if (state.agentId !== null && state.agentId !== action.agentId) {
         return state;
@@ -190,6 +203,7 @@ interface Nl2AgentFlowContextValue extends Nl2AgentFlowState {
   submitCard: (key: string) => void;
   markResourcesBound: (agentId: number) => void;
   markPromptGenerationFailed: (agentId: number, fields: string[]) => void;
+  markGenerationStopped: (agentId: number) => void;
   requestConfigFocus: (
     agentId: number,
     target: Nl2AgentConfigFocusTarget
@@ -228,6 +242,10 @@ export const Nl2AgentFlowProvider: FC<PropsWithChildren> = ({ children }) => {
       dispatch({ type: "prompt_generation_failed", agentId, fields }),
     []
   );
+  const markGenerationStopped = useCallback(
+    (agentId: number) => dispatch({ type: "generation_stopped", agentId }),
+    []
+  );
   const requestConfigFocus = useCallback(
     (agentId: number, target: Nl2AgentConfigFocusTarget) =>
       dispatch({ type: "request_config_focus", agentId, target }),
@@ -258,6 +276,7 @@ export const Nl2AgentFlowProvider: FC<PropsWithChildren> = ({ children }) => {
       submitCard,
       markResourcesBound,
       markPromptGenerationFailed,
+      markGenerationStopped,
       requestConfigFocus,
       markGenerationCompleted,
       markCompletionSynced,
@@ -269,6 +288,7 @@ export const Nl2AgentFlowProvider: FC<PropsWithChildren> = ({ children }) => {
       markGenerationCompleted,
       markCompletionSynced,
       markCompletionSyncFailed,
+      markGenerationStopped,
       markPromptGenerationFailed,
       markResourcesBound,
       registerCard,

--- a/test/backend/services/test_mcp_internal_tool_search.py
+++ b/test/backend/services/test_mcp_internal_tool_search.py
@@ -629,6 +629,11 @@ async def test_save_agent_draft_fields_reuses_trusted_context_across_rounds(mock
         "save_agent_draft_fields_impl",
         side_effect=save_impl,
     )
+    validate_complete = mocker.patch.object(
+        nl2agent_service,
+        "validate_agent_generation_complete_impl",
+        new=AsyncMock(),
+    )
     first = await save_agent_draft_fields(1042, {"description": "Updated"})
     second = await save_agent_draft_fields(
         1042,
@@ -645,7 +650,15 @@ async def test_save_agent_draft_fields_reuses_trusted_context_across_rounds(mock
     )["updated_fields"] == ["description"]
     assert json.loads(
         second_state.removeprefix("<nl2a_state>").removesuffix("</nl2a_state>")
-    )["updated_fields"] == ["duty_prompt"]
+    ) == {
+        "event": "agent_generation_completed",
+        "agent_id": 1042,
+    }
+    validate_complete.assert_awaited_once_with(
+        agent_id=1042,
+        tenant_id="tenant-a",
+        user_id="user-a",
+    )
 
 
 @pytest.mark.asyncio
@@ -1214,9 +1227,18 @@ async def test_final_prompt_batch_emits_generation_completed_state(mocker):
             {"example_questions": ["What should I research?"]},
             ["example_questions"],
         ),
+        ({"duty_prompt": "Research the requested topic."}, ["duty_prompt"]),
+        (
+            {"constraint_prompt": "Use reliable sources."},
+            ["constraint_prompt"],
+        ),
+        (
+            {"few_shots_prompt": "Question: Example\nAnswer: Example"},
+            ["few_shots_prompt"],
+        ),
     ],
 )
-async def test_completion_validation_uses_persisted_state_for_flexible_final_saves(
+async def test_completion_validation_uses_persisted_state_for_prompt_saves(
     mocker,
     fields,
     updated_fields,
@@ -1268,8 +1290,15 @@ async def test_completion_validation_uses_persisted_state_for_flexible_final_sav
 
 
 @pytest.mark.asyncio
-async def test_partial_final_prompt_save_remains_saved_when_database_is_incomplete(
-    mocker,
+@pytest.mark.parametrize(
+    ("fields", "updated_fields"),
+    [
+        ({"greeting_message": "Hello"}, ["greeting_message"]),
+        ({"duty_prompt": "Research the requested topic."}, ["duty_prompt"]),
+    ],
+)
+async def test_partial_prompt_save_remains_saved_when_database_is_incomplete(
+    mocker, fields, updated_fields
 ):
     mocker.patch.object(
         nl2agent_mcp_tools_module,
@@ -1288,7 +1317,7 @@ async def test_partial_final_prompt_save_remains_saved_when_database_is_incomple
             "status": "success",
             "agent_id": 42,
             "created": False,
-            "updated_fields": ["greeting_message"],
+            "updated_fields": updated_fields,
         },
     )
     mocker.patch.object(
@@ -1302,11 +1331,11 @@ async def test_partial_final_prompt_save_remains_saved_when_database_is_incomple
         ),
     )
 
-    result_json, state_wrapper = (
-        await save_agent_draft_fields(42, {"greeting_message": "Hello"})
-    ).split("\n", 1)
+    result_json, state_wrapper = (await save_agent_draft_fields(42, fields)).split(
+        "\n", 1
+    )
 
-    assert json.loads(result_json)["updated_fields"] == ["greeting_message"]
+    assert json.loads(result_json)["updated_fields"] == updated_fields
     assert json.loads(
         state_wrapper.removeprefix("<nl2a_state>").removesuffix(
             "</nl2a_state>"
@@ -1314,7 +1343,7 @@ async def test_partial_final_prompt_save_remains_saved_when_database_is_incomple
     ) == {
         "event": "agent_draft_fields_saved",
         "agent_id": 42,
-        "updated_fields": ["greeting_message"],
+        "updated_fields": updated_fields,
     }
 
 


### PR DESCRIPTION
 ## Summary

  Fix two cases where the right-side Agent configuration form could remain locked during the NL2Agent workflow:

  1. NL2Agent completes a single-field Prompt optimization without emitting the generation-completed state.
  2. The user manually stops model generation before the workflow finishes.

  The form and Composer now unlock after either a database-verified Prompt update completion or an explicit user cancellation.

  ## What changed

  ### Unlock after single-field Prompt updates

  - Trigger persisted completion validation after any NL2Agent Prompt field is saved.
  - Support completion detection for individual `duty_prompt`, `constraint_prompt`, `few_shots_prompt`, `greeting_message`, and `example_questions` updates.
  - Emit `agent_generation_completed` only when the authoritative persisted Agent state is complete.
  - Preserve `agent_draft_fields_saved` for partial Prompt updates when the database state is still incomplete.
  - Keep completion validation tenant-scoped and user-scoped through the existing trusted MCP execution path.

  ### Unlock after user cancellation

  - Propagate explicit NL2Agent stream cancellation from the chat adapter to the Agent configuration flow.
  - Add a dedicated `generation_stopped` flow action.
  - Reset the flow to `idle` and clear active cards, failed Prompt fields, pending configuration focus, and completion synchronization errors.
  - Unlock both the right-side Agent configuration form and the chat Composer immediately after cancellation.
  - Keep local stream detachment separate from an explicit user stop.
  - Handle abort events idempotently and prevent duplicate backend stop requests.
  - Ignore late NL2Agent state events after cancellation so delayed SSE messages cannot lock the form again.

  ## Why

  NL2Agent previously performed completion validation only when a limited final Prompt field batch was saved. A single-point Prompt optimization could therefore update the database successfully without emitting `agent_generation_completed`, leaving the frontend flow locked.

  Manual cancellation stopped the backend conversation but did not update the NL2Agent frontend flow state. The form consequently remained locked even though generation had already stopped.

  ## Impact

  - The Agent configuration form unlocks after a successful single-field Prompt optimization when the persisted Agent is complete.
  - Partial Prompt updates remain in the normal saved state and do not report false completion.
  - Explicitly stopping NL2Agent generation unlocks the form and Composer immediately.
  - Late state events after cancellation no longer restore a stale locked state.
  - Existing backend conversation cancellation behavior remains unchanged.
  - Local stream detachment does not incorrectly mark generation as stopped.
  - No public API, SSE payload, or database schema changes are introduced.

  ## Validation

  - Added coverage for completion validation after individual Prompt field saves.
  - Added coverage confirming incomplete persisted Prompt state remains `agent_draft_fields_saved`.
  - Added coverage for trusted context reuse with Prompt completion validation.
  - Focused backend tests passed: 8 passed.
  - `git diff --check origin/develop...HEAD` passed.
  - Frontend tests and builds were not run in this workspace as requested.

  ## Known limitations

  - No authenticated browser end-to-end test was run for the complete Prompt optimization and manual cancellation workflows.

## Screenshots
<img width="1623" height="509" alt="image" src="https://github.com/user-attachments/assets/d46d8244-44b2-4395-b096-18378ed9c2ec" />
