### PR TITLE
🐛Bugfix: 修复新版对话栏删除对话后的分页、列表显示及滚动条状态异常

### DIFF
--- a/backend/apps/conversation_management_app.py
+++ b/backend/apps/conversation_management_app.py
@@ -13,17 +13,18 @@ from consts.model import (
     OpinionRequest,
     RenameRequest,
 )
-from consts.exceptions import ConversationNotFoundError, ValidationError, TokenExpiredError
-from database.conversation_db import get_conversation_list_page
+from consts.exceptions import ConversationNotFoundError, TokenExpiredError, ValidationError
 from services.conversation_management_service import (
     create_new_conversation,
     delete_conversation_service,
     generate_conversation_title_service,
     get_conversation_history_service,
+    get_message_id_by_index_impl,
     get_sources_service,
+    list_conversations_service,
     rename_conversation_service,
     update_conversation_knowledge_scope_service,
-    update_message_opinion_service, get_message_id_by_index_impl,
+    update_message_opinion_service,
 )
 from utils.auth_utils import get_current_user_id, get_current_user_info
 
@@ -80,7 +81,7 @@ async def list_conversations_endpoint(
         user_id, tenant_id = get_current_user_id(authorization)
         if not user_id:
             raise HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail="Unauthorized access, Please login first")
-        conversations = get_conversation_list_page(
+        conversations = list_conversations_service(
             user_id=user_id,
             today_start_ms=today_start_ms,
             week_start_ms=week_start_ms,

--- a/backend/database/conversation_db.py
+++ b/backend/database/conversation_db.py
@@ -789,6 +789,31 @@ def get_conversation_list(
         return result
 
 
+def _build_conversation_list_page(
+    records: List[Any], metadata_record: Any
+) -> Dict[str, Any]:
+    """Serialize independently queried rows and metadata."""
+    metadata = {
+        'total': int(metadata_record.total or 0) if metadata_record else 0,
+        'today': int(metadata_record.today or 0) if metadata_record else 0,
+        'last_7_days': int(metadata_record.last_7_days or 0) if metadata_record else 0,
+        'older': int(metadata_record.older or 0) if metadata_record else 0,
+    }
+    items = [
+        {
+            'conversation_id': record.conversation_id,
+            'conversation_title': record.conversation_title,
+            'agent_id': record.agent_id,
+            'chat_mode': record.chat_mode or 'execution',
+            'create_time': int(record.create_time),
+            'update_time': int(record.update_time),
+        }
+        for record in records
+        if record.conversation_id is not None
+    ]
+    return {'items': items, 'metadata': metadata}
+
+
 def get_conversation_list_page(
     user_id: str,
     today_start_ms: int,
@@ -796,53 +821,41 @@ def get_conversation_list_page(
     limit: Optional[int] = None,
     offset: int = 0,
 ) -> Dict[str, Any]:
-    """Return one conversation page and its bucket counts in one query."""
+    """Return one ordered conversation page and its bucket counts."""
     with get_db_session() as session:
         created_ms = func.extract('epoch', ConversationRecord.create_time) * 1000
-        stmt = select(
+        filters = (
+            ConversationRecord.delete_flag == 'N',
+            ConversationRecord.created_by == user_id,
+        )
+        metadata_stmt = select(
+            func.count().label('total'),
+            func.count().filter(created_ms >= today_start_ms).label('today'),
+            func.count().filter(
+                created_ms < today_start_ms,
+                created_ms >= week_start_ms,
+            ).label('last_7_days'),
+            func.count().filter(created_ms < week_start_ms).label('older'),
+        ).where(*filters)
+        metadata_record = session.execute(metadata_stmt).one()
+
+        page_stmt = select(
             ConversationRecord.conversation_id,
             ConversationRecord.conversation_title,
             ConversationRecord.agent_id,
             ConversationRecord.chat_mode,
             created_ms.label('create_time'),
             (func.extract('epoch', ConversationRecord.update_time) * 1000).label('update_time'),
-            func.count().over().label('total'),
-            func.count().filter(created_ms >= today_start_ms).over().label('today'),
-            func.count().filter(
-                created_ms < today_start_ms,
-                created_ms >= week_start_ms,
-            ).over().label('last_7_days'),
-            func.count().filter(created_ms < week_start_ms).over().label('older'),
-        ).where(
-            ConversationRecord.delete_flag == 'N',
-            ConversationRecord.created_by == user_id,
-        ).order_by(
+        ).where(*filters).order_by(
             desc(ConversationRecord.create_time),
             desc(ConversationRecord.conversation_id),
         )
         if limit is not None:
-            stmt = stmt.limit(limit)
+            page_stmt = page_stmt.limit(limit)
         if offset:
-            stmt = stmt.offset(offset)
-
-        records = list(session.execute(stmt))
-        metadata = {
-            'total': int(records[0].total or 0) if records else 0,
-            'today': int(records[0].today or 0) if records else 0,
-            'last_7_days': int(records[0].last_7_days or 0) if records else 0,
-            'older': int(records[0].older or 0) if records else 0,
-        }
-        items = []
-        for record in records:
-            items.append({
-                'conversation_id': record.conversation_id,
-                'conversation_title': record.conversation_title,
-                'agent_id': record.agent_id,
-                'chat_mode': record.chat_mode or 'execution',
-                'create_time': int(record.create_time),
-                'update_time': int(record.update_time),
-            })
-        return {'items': items, 'metadata': metadata}
+            page_stmt = page_stmt.offset(offset)
+        records = list(session.execute(page_stmt))
+        return _build_conversation_list_page(records, metadata_record)
 
 
 def update_conversation_agent_id(conversation_id: int, agent_id: int, user_id: Optional[str] = None) -> bool:

--- a/backend/services/conversation_management_service.py
+++ b/backend/services/conversation_management_service.py
@@ -19,6 +19,7 @@ from database.conversation_db import (
     delete_conversation,
     get_conversation,
     get_conversation_history,
+    get_conversation_list_page,
     get_historical_context,
     get_latest_assistant_message,  # noqa: F401 - service boundary re-export
     get_latest_assistant_message_id,
@@ -423,6 +424,23 @@ def get_conversation_service(
         conversation_id=conversation_id,
         user_id=user_id,
         tenant_id=tenant_id,
+    )
+
+
+def list_conversations_service(
+    user_id: str,
+    today_start_ms: int,
+    week_start_ms: int,
+    limit: Optional[int] = None,
+    offset: int = 0,
+) -> Dict[str, Any]:
+    """Return one ordered conversation page and its list metadata."""
+    return get_conversation_list_page(
+        user_id=user_id,
+        today_start_ms=today_start_ms,
+        week_start_ms=week_start_ms,
+        limit=limit,
+        offset=offset,
     )
 
 

--- a/frontend/app/[locale]/chat/components/chatLeftSidebar.tsx
+++ b/frontend/app/[locale]/chat/components/chatLeftSidebar.tsx
@@ -197,15 +197,16 @@ export function ChatSidebar({
     const container = conversationListRef.current;
     if (
       !container ||
+      !hasDownwardUserIntent ||
       !shouldLoadNextConversationPage({
         hasMore: conversationManagement.hasNextPage,
         isLoading: isLoadingNextPageRef.current,
         isNearBottom: isConversationListNearBottom(
-          conversationContentRef.current?.scrollHeight ?? container.scrollHeight,
+          conversationContentRef.current?.scrollHeight ??
+            container.scrollHeight,
           container.scrollTop,
           container.clientHeight
         ),
-        hasDownwardUserIntent,
       })
     ) {
       return;
@@ -249,8 +250,7 @@ export function ChatSidebar({
 
   const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) =>
     requestNextPage(
-      event.isTrusted &&
-        ["ArrowDown", "PageDown", "End"].includes(event.key)
+      event.isTrusted && ["ArrowDown", "PageDown", "End"].includes(event.key)
     );
 
   const handleRenameClick = (conversationId: number, currentTitle: string) => {
@@ -545,10 +545,7 @@ export function ChatSidebar({
         <div className="flex-1" />
 
         <div className="pb-3 flex justify-center">
-          <Tooltip
-            title={t("chat.sidebar.switchToNew")}
-            placement="right"
-          >
+          <Tooltip title={t("chat.sidebar.switchToNew")} placement="right">
             <Button
               type="text"
               size="middle"
@@ -638,17 +635,24 @@ export function ChatSidebar({
                     ref={measurementRowRef}
                     className="flex items-center min-h-10 px-3 py-1"
                   >
-                    <span className="text-base font-normal font-sans">Conversation</span>
+                    <span className="text-base font-normal font-sans">
+                      Conversation
+                    </span>
                   </div>
                   <div
                     ref={measurementSecondRowRef}
                     className="flex items-center min-h-10 px-3 py-1"
                   >
-                    <span className="text-base font-normal font-sans">Conversation</span>
+                    <span className="text-base font-normal font-sans">
+                      Conversation
+                    </span>
                   </div>
                 </div>
               </div>
-              <div ref={conversationContentRef} className="flex flex-col gap-4 pb-4">
+              <div
+                ref={conversationContentRef}
+                className="flex flex-col gap-4 pb-4"
+              >
                 {conversationManagement.conversationList.length > 0 ? (
                   <>
                     {renderConversationList(today, t("chatLeftSidebar.today"))}
@@ -681,12 +685,17 @@ export function ChatSidebar({
                   height: Math.max(
                     0,
                     totalVirtualHeight -
-                      conversationManagement.conversationList.length * rowHeight -
-                      [today, week, older].filter((group) => group.length > 0).length * headerHeight -
+                      conversationManagement.conversationList.length *
+                        rowHeight -
+                      [today, week, older].filter((group) => group.length > 0)
+                        .length *
+                        headerHeight -
                       Math.max(
                         0,
-                        [today, week, older].filter((group) => group.length > 0).length - 1
-                      ) * 16 -
+                        [today, week, older].filter((group) => group.length > 0)
+                          .length - 1
+                      ) *
+                        16 -
                       16
                   ),
                 }}
@@ -712,7 +721,7 @@ export function ChatSidebar({
       <style jsx global>{`
         .ant-layout-sider.chat-left-sidebar,
         .ant-layout-sider.chat-left-sidebar .ant-layout-sider-children {
-          background-color: #F2F8FF !important;
+          background-color: #f2f8ff !important;
         }
 
         .chat-sidebar-title-fade {

--- a/frontend/app/[locale]/newchat/adapter/conversation-thread-list-adapter.tsx
+++ b/frontend/app/[locale]/newchat/adapter/conversation-thread-list-adapter.tsx
@@ -17,7 +17,6 @@ import type {
   RemoteThreadListAdapter,
   ThreadHistoryAdapter,
 } from "@assistant-ui/react";
-
 import {
   CONVERSATION_PAGE_SIZE,
   conversationService,
@@ -27,7 +26,7 @@ import {
   newChatConversationViewport,
 } from "@/lib/conversationViewport";
 import { toMessageCreatedAt } from "@/lib/messageDate";
-
+import { createConversationThreadPageLoader } from "@/lib/conversationThreadPagination";
 import { storageService } from "@/services/storageService";
 import { parseAutomationProposal } from "@/features/agentAutomation/parseProposal";
 import type { ConversationListItem } from "@/types/conversation";
@@ -149,7 +148,8 @@ const toToolSearchItem = (value: unknown) => {
   const item = value as Record<string, unknown>;
   const url = typeof item.url === "string" ? item.url : "";
   const filename = typeof item.filename === "string" ? item.filename : "";
-  const sourceFile = typeof item.source_file === "string" ? item.source_file : "";
+  const sourceFile =
+    typeof item.source_file === "string" ? item.source_file : "";
   const imageMetadata = parseImageMetadata(item.text);
   const resolvedUrl = imageMetadata?.image_url || url;
   const title =
@@ -164,17 +164,24 @@ const toToolSearchItem = (value: unknown) => {
       : typeof item.citeIndex === "number"
         ? item.citeIndex
         : undefined;
-  const toolSign = typeof item.tool_sign === "string" ? item.tool_sign : undefined;
+  const toolSign =
+    typeof item.tool_sign === "string" ? item.tool_sign : undefined;
 
   return resolvedUrl || sourceFile
     ? {
         url: resolvedUrl,
         title,
-        text: imageMetadata ? undefined : typeof item.text === "string" ? item.text : undefined,
-        sourceType: typeof item.source_type === "string" ? item.source_type : undefined,
+        text: imageMetadata
+          ? undefined
+          : typeof item.text === "string"
+            ? item.text
+            : undefined,
+        sourceType:
+          typeof item.source_type === "string" ? item.source_type : undefined,
         filename: filename || undefined,
         sourceFile: sourceFile || imageMetadata?.source_file || undefined,
-        objectName: typeof item.object_name === "string" ? item.object_name : undefined,
+        objectName:
+          typeof item.object_name === "string" ? item.object_name : undefined,
         citeIndex,
         toolSign,
         isImage: Boolean(imageMetadata),
@@ -630,7 +637,7 @@ export class RemoteConversationHistoryAdapter implements ThreadHistoryAdapter {
                     isImage: true,
                     imageKey: imagePart.imageKey,
                   },
-                  part.tool_call_id,
+                  part.tool_call_id
                 );
               }
             }
@@ -1084,11 +1091,9 @@ export class RemoteConversationHistoryAdapter implements ThreadHistoryAdapter {
 const toRemoteThreadMetadata = (
   item: ConversationListItem
 ): RemoteThreadMetadata => {
-  // Prefer the most recent activity timestamp; fall back to the creation time
-  // so the thread list can always group by recency. The timestamp is passed
-  // through the `custom` slot because the installed @assistant-ui/react
-  // (0.14.15) does not yet thread `lastMessageAt` through the runtime state.
-  const timestamp = item.update_time || item.create_time;
+  // The database owns the stable newest-first order. Use the same creation
+  // timestamp for grouping so the frontend never reorders paginated rows.
+  const timestamp = item.create_time;
   return {
     remoteId: String(item.conversation_id),
     status: "regular",
@@ -1104,17 +1109,6 @@ const toRemoteThreadMetadata = (
         }
       : {}),
   };
-};
-
-const parseConversationListOffset = (after: string | undefined): number => {
-  if (after === undefined) return 0;
-
-  const offset = Number(after);
-  return Number.isSafeInteger(offset) &&
-    offset >= 0 &&
-    offset <= Number.MAX_SAFE_INTEGER - CONVERSATION_PAGE_SIZE
-    ? offset
-    : 0;
 };
 
 const createHistoryProvider = (): FC<PropsWithChildren> => {
@@ -1322,33 +1316,24 @@ const waitForServerConversationId = async (
 export const conversationThreadListAdapter: RemoteThreadListAdapter = {
   unstable_Provider: createHistoryProvider(),
 
-  async list({ after } = {}): Promise<RemoteThreadListResponse> {
-    if (after === undefined) {
-      newChatConversationViewport.reset();
-      return { threads: [], nextCursor: "0" };
-    }
-
-    const { todayStartMs, weekStartMs } = getConversationDateBoundaries();
-    const offset = parseConversationListOffset(after);
-    const limit =
-      offset === 0
-        ? newChatConversationViewport.takePageLimit()
-        : CONVERSATION_PAGE_SIZE;
-    const data = await conversationService.getList({
-      offset,
-      limit,
-      todayStartMs,
-      weekStartMs,
-    });
-    newChatConversationViewport.setMetadata(data.metadata);
-    const nextOffset = offset + data.items.length;
-
-    return {
-      threads: data.items.map(toRemoteThreadMetadata),
-      nextCursor:
-        nextOffset < data.metadata.total ? String(nextOffset) : undefined,
-    };
-  },
+  list: createConversationThreadPageLoader({
+    pageSize: CONVERSATION_PAGE_SIZE,
+    takeNextPageSize: newChatConversationViewport.takeNextPageSize,
+    getOffsetAdjustment: newChatConversationViewport.getOffsetAdjustment,
+    commitOffsetAdjustment: newChatConversationViewport.commitOffsetAdjustment,
+    resetPagination: newChatConversationViewport.resetPagination,
+    fetchPage: async ({ offset, limit }) => {
+      const { todayStartMs, weekStartMs } = getConversationDateBoundaries();
+      return conversationService.getList({
+        offset,
+        limit,
+        todayStartMs,
+        weekStartMs,
+      });
+    },
+    mapItem: toRemoteThreadMetadata,
+    onMetadata: newChatConversationViewport.setMetadata,
+  }),
 
   async initialize(_threadId: string): Promise<RemoteThreadInitializeResponse> {
     // Conversation creation is now handled lazily by `POST /api/agent/run`:

--- a/frontend/app/[locale]/newchat/assistant-ui/thread-list.tsx
+++ b/frontend/app/[locale]/newchat/assistant-ui/thread-list.tsx
@@ -5,7 +5,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { Button, message } from "antd";
+import { message } from "antd";
 import { useConfirmModal } from "@/hooks/useConfirmModal";
 import {
   AuiIf,
@@ -27,6 +27,7 @@ import {
   Fragment,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -35,18 +36,18 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import log from "@/lib/logger";
+import { CONVERSATION_PAGE_SIZE } from "@/services/conversationService";
 import type { FC } from "react";
+import { getConversationPageRequest } from "@/lib/conversationLoadPolicy";
+import { runConversationDeletionLifecycle } from "@/lib/conversationThreadPagination";
 import {
-  isConversationListNearBottom,
-  shouldContinueConversationPageLoading,
-  shouldLoadNextConversationPage,
-} from "@/lib/conversationLoadPolicy";
-import { setPendingThreadOperationId } from "../adapter/conversation-thread-list-adapter";
-import {
+  calculateConversationVirtualSpacerHeight,
   calculateConversationViewport,
   getConversationViewportGroupCounts,
+  isConversationLoadedBoundaryReached,
   newChatConversationViewport,
 } from "@/lib/conversationViewport";
+import { setPendingThreadOperationId } from "../adapter/conversation-thread-list-adapter";
 
 // Conversation status indicator component
 const ConversationStatusIndicator: FC<{
@@ -81,6 +82,17 @@ interface ThreadListProps {
   scrollContainerRef: RefObject<HTMLDivElement>;
 }
 
+type DeleteConversation = () => void | Promise<void>;
+type DeleteWithPagination = (
+  deleteConversation: DeleteConversation
+) => Promise<void>;
+type RequestConversationPage = (
+  isScrollRequest: boolean,
+  continueTowardScrollPosition?: boolean
+) => void;
+
+const CONVERSATION_LOAD_THRESHOLD = 80;
+
 export const ThreadList: FC<ThreadListProps> = ({
   generatedTitles,
   scrollContainerRef,
@@ -88,169 +100,253 @@ export const ThreadList: FC<ThreadListProps> = ({
   const { t } = useTranslation();
   const aui = useAui();
   const hasMore = useAuiState((s) => s.threads.hasMore);
+  const isThreadListLoading = useAuiState((s) => s.threads.isLoading);
+  const isLoadingMore = useAuiState((s) => s.threads.isLoadingMore);
   const threadCount = useAuiState((s) => s.threads.threadIds.length);
   const conversationMetadata = useSyncExternalStore(
     newChatConversationViewport.subscribe,
     newChatConversationViewport.getSnapshot,
     newChatConversationViewport.getSnapshot
   );
-  const isLoadingRef = useRef(false);
-  const contentRef = useRef<HTMLDivElement>(null);
+  const loadedItemsRef = useRef<HTMLDivElement>(null);
+  const loadMoreSentinelRef = useRef<HTMLDivElement>(null);
   const measurementRowRef = useRef<HTMLDivElement>(null);
   const measurementHeaderRef = useRef<HTMLDivElement>(null);
-  const touchStartYRef = useRef<number | null>(null);
+  const pageLoadPromiseRef = useRef<Promise<void> | null>(null);
+  const deletionInFlightRef = useRef(false);
+  const requestPageRef = useRef<RequestConversationPage>(() => {});
+  const userScrollIntentRef = useRef(false);
   const previousScrollTopRef = useRef(0);
-  const continueLoadingRef = useRef(false);
-  const paginationStateRef = useRef({ hasMore, threadCount });
-  const [totalVirtualHeight, setTotalVirtualHeight] = useState(0);
-  const [rowHeight, setRowHeight] = useState(36);
-  const [headerHeight, setHeaderHeight] = useState(32);
-  const [renderedHeaderCount, setRenderedHeaderCount] = useState(0);
-  paginationStateRef.current = { hasMore, threadCount };
+  const [virtualSpacerHeight, setVirtualSpacerHeight] = useState(0);
+  const [deletionRevision, setDeletionRevision] = useState(0);
 
-  // Placeholder for completed set - currently not used since status only has completed/running
-  const completedConversations = useMemo(() => new Set<string>(), []);
+  const getLoadedBoundary = useCallback((): number | null => {
+    const container = scrollContainerRef.current;
+    const sentinel = loadMoreSentinelRef.current;
+    if (!container || !sentinel) return null;
 
-  useEffect(() => {
-    if (conversationMetadata?.total === 0) {
-      setTotalVirtualHeight(0);
-      return;
-    }
-    let cancelled = false;
-    void document.fonts.ready.then(() => {
-      requestAnimationFrame(() => {
-        if (cancelled) return;
-        const container = scrollContainerRef.current;
-        const measuredRow = measurementRowRef.current;
-        const measuredHeader = measurementHeaderRef.current;
-        if (!container || !measuredRow || !measuredHeader) return;
-        const nextRowHeight = measuredRow.getBoundingClientRect().height;
-        const nextHeaderHeight = measuredHeader.getBoundingClientRect().height;
-        const viewport = calculateConversationViewport({
-          containerHeight: container.clientHeight,
-          rowHeight: nextRowHeight,
-          groupHeaderHeight: nextHeaderHeight,
-          contentPadding: 16,
-          groupCounts: getConversationViewportGroupCounts(conversationMetadata),
-        });
-        setRowHeight(nextRowHeight);
-        setHeaderHeight(nextHeaderHeight);
-        setTotalVirtualHeight(viewport.totalHeight);
-        if (threadCount > 0 || isLoadingRef.current || !hasMore) return;
-        newChatConversationViewport.resolveInitialLimit(viewport.initialLimit);
-        isLoadingRef.current = true;
-        void aui.threads
-          .loadMore()
-          .catch((error) =>
-            log.error("Failed to load initial conversations", error)
-          )
-          .finally(() => {
-            isLoadingRef.current = false;
-          });
-      });
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [aui, conversationMetadata, hasMore, scrollContainerRef, threadCount]);
-
-  useEffect(() => {
-    setRenderedHeaderCount(
-      contentRef.current?.querySelectorAll(
-        '[data-slot="aui_thread-list-group-label"]'
-      ).length ?? 0
+    return (
+      sentinel.getBoundingClientRect().top -
+      container.getBoundingClientRect().top +
+      container.scrollTop +
+      sentinel.getBoundingClientRect().height
     );
-  }, [threadCount]);
+  }, [scrollContainerRef]);
+
+  const requestPage = useCallback(
+    (isScrollRequest: boolean, continueTowardScrollPosition = false) => {
+      if (deletionInFlightRef.current || pageLoadPromiseRef.current) return;
+
+      const container = scrollContainerRef.current;
+      const measuredRow = measurementRowRef.current;
+      const measuredHeader = measurementHeaderRef.current;
+      if (!container || !measuredRow || !measuredHeader) return;
+
+      const loadedBoundary = getLoadedBoundary();
+      if (
+        isScrollRequest &&
+        (loadedBoundary === null ||
+          !isConversationLoadedBoundaryReached({
+            scrollTop: container.scrollTop,
+            clientHeight: container.clientHeight,
+            loadedBoundary,
+            threshold: CONVERSATION_LOAD_THRESHOLD,
+          }))
+      ) {
+        return;
+      }
+
+      const rowHeight = measuredRow.getBoundingClientRect().height;
+      const viewport = calculateConversationViewport({
+        containerHeight: container.clientHeight,
+        rowHeight,
+        groupHeaderHeight: measuredHeader.getBoundingClientRect().height,
+        contentPadding: 16,
+        groupCounts: getConversationViewportGroupCounts(conversationMetadata),
+      });
+      const isLoading = isThreadListLoading || isLoadingMore;
+      const request =
+        threadCount === 0 && hasMore && !isLoading
+          ? {
+              limit: viewport.initialLimit,
+              reason: "viewport-fill" as const,
+            }
+          : getConversationPageRequest({
+              hasMore,
+              isLoading,
+              clientHeight: container.clientHeight,
+              scrollHeight: loadedBoundary ?? container.scrollHeight,
+              rowHeight,
+              isLoadRequested: isScrollRequest,
+              regularPageSize: CONVERSATION_PAGE_SIZE,
+            });
+      if (!request) return;
+
+      newChatConversationViewport.requestNextPageSize(request.limit);
+      const trackedTask = aui.threads
+        .loadMore()
+        .then(() => {
+          if (continueTowardScrollPosition) {
+            requestAnimationFrame(() => requestPageRef.current(true, true));
+          }
+        })
+        .catch((error) =>
+          log.error(`Failed to load conversations (${request.reason})`, error)
+        )
+        .finally(() => {
+          newChatConversationViewport.clearNextPageSize();
+          if (pageLoadPromiseRef.current === trackedTask) {
+            pageLoadPromiseRef.current = null;
+          }
+        });
+      pageLoadPromiseRef.current = trackedTask;
+    },
+    [
+      aui,
+      conversationMetadata,
+      getLoadedBoundary,
+      hasMore,
+      isLoadingMore,
+      isThreadListLoading,
+      scrollContainerRef,
+      threadCount,
+    ]
+  );
+  requestPageRef.current = requestPage;
+
+  const deleteWithPagination = useCallback<DeleteWithPagination>(
+    async (deleteConversation) => {
+      deletionInFlightRef.current = true;
+
+      try {
+        await runConversationDeletionLifecycle({
+          pendingPageLoad: pageLoadPromiseRef.current,
+          deleteConversation,
+          recordDeletedLoadedItem: () => {
+            newChatConversationViewport.recordDeletedLoadedItem();
+            setDeletionRevision((revision) => revision + 1);
+          },
+        });
+      } finally {
+        newChatConversationViewport.clearNextPageSize();
+        deletionInFlightRef.current = false;
+        requestAnimationFrame(() => requestPageRef.current(false));
+      }
+    },
+    []
+  );
+
+  useLayoutEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    let frame: number | null = null;
+
+    const measureAndFill = () => {
+      frame = null;
+      const measuredRow = measurementRowRef.current;
+      const measuredHeader = measurementHeaderRef.current;
+      const loadedItems = loadedItemsRef.current;
+      if (
+        measuredRow &&
+        measuredHeader &&
+        loadedItems &&
+        conversationMetadata
+      ) {
+        const groupCount = getConversationViewportGroupCounts(
+          conversationMetadata
+        ).filter((count) => count > 0).length;
+        const nextSpacerHeight = calculateConversationVirtualSpacerHeight({
+          totalCount: conversationMetadata.total,
+          pendingDeletionCount:
+            newChatConversationViewport.getOffsetAdjustment(),
+          loadedContentHeight: loadedItems.getBoundingClientRect().height,
+          rowHeight: measuredRow.getBoundingClientRect().height,
+          groupHeaderHeight: measuredHeader.getBoundingClientRect().height,
+          groupCount,
+          contentPadding: 16,
+        });
+        setVirtualSpacerHeight((currentHeight) =>
+          currentHeight === nextSpacerHeight ? currentHeight : nextSpacerHeight
+        );
+      } else {
+        setVirtualSpacerHeight(0);
+      }
+      requestPage(false);
+    };
+    const scheduleMeasurement = () => {
+      if (frame !== null) cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(measureAndFill);
+    };
+
+    // Read layout synchronously after commit. A single animation-frame retry
+    // covers transient zero-sized containers without delaying the page shell.
+    measureAndFill();
+    if (container.clientHeight <= 0) scheduleMeasurement();
+
+    const resizeObserver = new ResizeObserver(scheduleMeasurement);
+    resizeObserver.observe(container);
+    if (loadedItemsRef.current) resizeObserver.observe(loadedItemsRef.current);
+    return () => {
+      resizeObserver.disconnect();
+      if (frame !== null) cancelAnimationFrame(frame);
+    };
+  }, [
+    conversationMetadata,
+    deletionRevision,
+    requestPage,
+    scrollContainerRef,
+    threadCount,
+  ]);
 
   useEffect(() => {
     const container = scrollContainerRef.current;
-    if (!container) return;
-    let cancelled = false;
+    const sentinel = loadMoreSentinelRef.current;
+    if (!container || !sentinel) return;
 
-    const requestNextPage = (hasDownwardUserIntent: boolean) => {
-      if (hasDownwardUserIntent) continueLoadingRef.current = true;
-      const paginationState = paginationStateRef.current;
-      const isNearLoadedBoundary = isConversationListNearBottom(
-        contentRef.current?.scrollHeight ?? container.scrollHeight,
-        container.scrollTop,
-        container.clientHeight
-      );
-      if (
-        !shouldLoadNextConversationPage({
-          hasMore: paginationState.hasMore,
-          isLoading: isLoadingRef.current,
-          isNearBottom: isNearLoadedBoundary,
-          hasDownwardUserIntent: continueLoadingRef.current,
-        })
-      ) {
-        if (!paginationState.hasMore || !isNearLoadedBoundary) {
-          continueLoadingRef.current = false;
-        }
-        return;
+    previousScrollTopRef.current = container.scrollTop;
+    const handleScrollIntent = () => {
+      userScrollIntentRef.current = true;
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (["ArrowDown", "PageDown", "End"].includes(event.key)) {
+        handleScrollIntent();
       }
-      const loadedBefore = paginationState.threadCount;
-      isLoadingRef.current = true;
-      void aui.threads.loadMore().finally(() => {
-        isLoadingRef.current = false;
-        requestAnimationFrame(() => {
-          if (cancelled) return;
-          const latestState = paginationStateRef.current;
-          const shouldContinue = shouldContinueConversationPageLoading({
-            hasMore: latestState.hasMore,
-            loadedBefore,
-            loadedAfter: latestState.threadCount,
-            isNearLoadedBoundary: isConversationListNearBottom(
-              contentRef.current?.scrollHeight ?? container.scrollHeight,
-              container.scrollTop,
-              container.clientHeight
-            ),
-          });
-          continueLoadingRef.current = shouldContinue;
-          if (shouldContinue) requestNextPage(true);
-        });
-      });
     };
-    const handleWheel = (event: WheelEvent) =>
-      requestNextPage(event.isTrusted && event.deltaY > 0);
+    const handleWheel = (event: WheelEvent) => {
+      if (event.deltaY > 0) handleScrollIntent();
+    };
     const handleScroll = (event: Event) => {
-      requestNextPage(
-        event.isTrusted &&
-          container.scrollTop > previousScrollTopRef.current
-      );
+      const isScrollingDown =
+        container.scrollTop > previousScrollTopRef.current;
       previousScrollTopRef.current = container.scrollTop;
+      const hasUserIntent = userScrollIntentRef.current;
+      userScrollIntentRef.current = false;
+      if (event.isTrusted && hasUserIntent && isScrollingDown) {
+        requestPage(true, true);
+      }
     };
-    const handleTouchStart = (event: TouchEvent) => {
-      touchStartYRef.current = event.touches[0]?.clientY ?? null;
-    };
-    const handleTouchMove = (event: TouchEvent) => {
-      const currentY = event.touches[0]?.clientY;
-      const startY = touchStartYRef.current;
-      requestNextPage(
-        event.isTrusted &&
-          currentY !== undefined &&
-          startY !== null &&
-          currentY < startY
-      );
-      touchStartYRef.current = currentY ?? null;
-    };
-    const handleKeyDown = (event: KeyboardEvent) =>
-      requestNextPage(
-        event.isTrusted && ["ArrowDown", "PageDown", "End"].includes(event.key)
-      );
+    container.addEventListener("pointerdown", handleScrollIntent);
     container.addEventListener("wheel", handleWheel, { passive: true });
-    container.addEventListener("scroll", handleScroll, { passive: true });
-    container.addEventListener("touchstart", handleTouchStart, { passive: true });
-    container.addEventListener("touchmove", handleTouchMove, { passive: true });
     container.addEventListener("keydown", handleKeyDown);
+    container.addEventListener("scroll", handleScroll, { passive: true });
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          requestPage(true, false);
+        }
+      },
+      { root: container, threshold: 0 }
+    );
+    observer.observe(sentinel);
     return () => {
-      cancelled = true;
+      observer.disconnect();
+      container.removeEventListener("pointerdown", handleScrollIntent);
       container.removeEventListener("wheel", handleWheel);
-      container.removeEventListener("scroll", handleScroll);
-      container.removeEventListener("touchstart", handleTouchStart);
-      container.removeEventListener("touchmove", handleTouchMove);
       container.removeEventListener("keydown", handleKeyDown);
+      container.removeEventListener("scroll", handleScroll);
     };
-  }, [aui, scrollContainerRef]);
+  }, [requestPage, scrollContainerRef]);
 
   return (
     <div className="flex flex-col p-2">
@@ -271,13 +367,20 @@ export const ThreadList: FC<ThreadListProps> = ({
           {t("chat.threadList.today")}
         </div>
       </div>
-      <div ref={contentRef} className="flex flex-col">
-        <AuiIf condition={(s) => s.threads.isLoading}>
+      <div ref={loadedItemsRef} className="flex flex-col">
+        <AuiIf
+          condition={(s) =>
+            s.threads.isLoading ||
+            (s.threads.threadIds.length === 0 && s.threads.hasMore)
+          }
+        >
           <ThreadListSkeleton />
         </AuiIf>
         <AuiIf
           condition={(s) =>
-            !s.threads.isLoading && s.threads.threadIds.length === 0
+            !s.threads.isLoading &&
+            !s.threads.hasMore &&
+            s.threads.threadIds.length === 0
           }
         >
           <ThreadListEmpty />
@@ -288,23 +391,20 @@ export const ThreadList: FC<ThreadListProps> = ({
           }
         >
           <ThreadListItems
-            completedConversations={completedConversations}
             generatedTitles={generatedTitles}
+            deleteWithPagination={deleteWithPagination}
           />
         </AuiIf>
       </div>
       <div
+        ref={loadMoreSentinelRef}
         aria-hidden="true"
-        className="shrink-0 w-full"
-        style={{
-          height: Math.max(
-            0,
-            totalVirtualHeight -
-              threadCount * rowHeight -
-              renderedHeaderCount * headerHeight -
-              16
-          ),
-        }}
+        className="h-px w-full shrink-0"
+      />
+      <div
+        aria-hidden="true"
+        className="w-full shrink-0"
+        style={{ height: virtualSpacerHeight }}
       />
     </div>
   );
@@ -326,26 +426,28 @@ const ThreadListEmpty: FC = () => {
 };
 
 interface ThreadListItemsProps {
-  completedConversations: Set<string>;
   generatedTitles?: ReadonlyMap<string, string>;
+  deleteWithPagination: DeleteWithPagination;
 }
 
 const ThreadListItems: FC<ThreadListItemsProps> = ({
-  completedConversations,
   generatedTitles,
+  deleteWithPagination,
 }) => {
   const { t } = useTranslation();
 
   const groups = useThreadListGroups();
 
-  const GroupedThreadListItem = useMemo<FC>(
-    () => () => (
-      <ThreadListItem
-        completedConversations={completedConversations}
-        generatedTitles={generatedTitles}
-      />
-    ),
-    [completedConversations, generatedTitles],
+  const GroupedThreadListItem = useCallback(
+    function GroupedThreadListItem() {
+      return (
+        <ThreadListItem
+          generatedTitles={generatedTitles}
+          deleteWithPagination={deleteWithPagination}
+        />
+      );
+    },
+    [deleteWithPagination, generatedTitles]
   );
 
   if (!groups) {
@@ -353,8 +455,8 @@ const ThreadListItems: FC<ThreadListItemsProps> = ({
       <ThreadListPrimitive.Items>
         {() => (
           <ThreadListItem
-            completedConversations={completedConversations}
             generatedTitles={generatedTitles}
+            deleteWithPagination={deleteWithPagination}
           />
         )}
       </ThreadListPrimitive.Items>
@@ -436,14 +538,8 @@ const useThreadListGroups = (): ThreadListGroup[] | null => {
       now.getDate()
     ).getTime();
 
-    const time = (index: number) =>
-      dates[index]?.getTime() ?? Number.MAX_SAFE_INTEGER;
-    const indices = threadIds
-      .map((_, index) => index)
-      .sort((a, b) => time(b) - time(a));
-
     const result: ThreadListGroup[] = [];
-    for (const index of indices) {
+    for (const [index] of threadIds.entries()) {
       const label = dateGroupLabel(dates[index], startOfToday);
       const entry: ThreadListGroupEntry = { id: threadIds[index], index };
       const lastGroup = result[result.length - 1];
@@ -481,32 +577,32 @@ const ThreadListSkeleton: FC = () => {
 };
 
 interface ThreadListItemProps {
-  completedConversations: Set<string>;
   generatedTitles?: ReadonlyMap<string, string>;
+  deleteWithPagination: DeleteWithPagination;
 }
 
 const ThreadListItem: FC<ThreadListItemProps> = ({
-  completedConversations,
   generatedTitles,
+  deleteWithPagination,
 }) => {
   return (
     <ThreadListItemPrimitive.Root className="group/item flex h-9 items-center rounded-lg hover:bg-muted data-[active=true]:bg-muted">
       <ThreadListItemContent
-        completedConversations={completedConversations}
         generatedTitles={generatedTitles}
+        deleteWithPagination={deleteWithPagination}
       />
     </ThreadListItemPrimitive.Root>
   );
 };
 
 interface ThreadListItemContentProps {
-  completedConversations: Set<string>;
   generatedTitles?: ReadonlyMap<string, string>;
+  deleteWithPagination: DeleteWithPagination;
 }
 
 const ThreadListItemContent: FC<ThreadListItemContentProps> = ({
-  completedConversations,
   generatedTitles,
+  deleteWithPagination,
 }) => {
   const aui = useAui();
   const { t } = useTranslation();
@@ -549,8 +645,7 @@ const ThreadListItemContent: FC<ThreadListItemContentProps> = ({
       onOk: async () => {
         setPendingThreadOperationId(thread.id);
         try {
-          await threadListItem.delete();
-          await aui.threads.reload();
+          await deleteWithPagination(() => threadListItem.delete());
         } catch (error) {
           log.error("[ThreadList] Failed to delete thread:", error);
           message.error(t("chatInterface.deleteFailed"));
@@ -560,7 +655,7 @@ const ThreadListItemContent: FC<ThreadListItemContentProps> = ({
         }
       },
     });
-  }, [aui, confirm, t, threadListItem]);
+  }, [confirm, deleteWithPagination, t, thread.id, threadListItem]);
 
   return (
     <>
@@ -574,9 +669,7 @@ const ThreadListItemContent: FC<ThreadListItemContentProps> = ({
         <>
           <ThreadListItemPrimitive.Trigger className="flex min-w-0 flex-1 justify-start px-3 text-left text-sm">
             <div className="flex min-w-0 flex-1 items-center text-left">
-              <ConversationStatusIndicatorWrapper
-                completedConversations={completedConversations}
-              />
+              <ConversationStatusIndicatorWrapper />
               <Tooltip>
                 <TooltipTrigger asChild>
                   <span className="min-w-0 flex-1 truncate text-left">
@@ -623,9 +716,7 @@ const ThreadListItemContent: FC<ThreadListItemContentProps> = ({
 };
 
 // Wrapper to get thread status from adapter and pass to status indicator
-const ConversationStatusIndicatorWrapper: FC<{
-  completedConversations: Set<string>;
-}> = ({ completedConversations }) => {
+const ConversationStatusIndicatorWrapper: FC = () => {
   const aui = useAui();
   const status = aui.threadListItem.getState().status as string;
   const isRunning = status === "running" || status === "streaming";
@@ -667,7 +758,7 @@ const InlineRenameEditor: FC<{
   return (
     <form
       onSubmit={handleSubmit}
-      className="flex min-w-0 flex-1 items-center gap-1 px-3 overflow-hidden"
+      className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden px-3"
     >
       <input
         type="text"
@@ -682,7 +773,7 @@ const InlineRenameEditor: FC<{
           }
         }}
         autoFocus
-        className="shrink min-w-0 flex-1 rounded border border-input px-2 py-1 text-sm outline-none focus:border-ring"
+        className="min-w-0 shrink flex-1 rounded border border-input px-2 py-1 text-sm outline-none focus:border-ring"
       />
       <div className="flex shrink-0 gap-1">
         <button type="submit" className="p-1 hover:bg-accent rounded">

--- a/frontend/hooks/chat/useConversationManagement.ts
+++ b/frontend/hooks/chat/useConversationManagement.ts
@@ -48,14 +48,21 @@ export interface ConversationManagement {
     agentId: number | null
   ) => void;
   handleNewConversation: () => void;
-  handleConversationSelect: (conversation: ConversationListItem) => Promise<void>;
-  updateConversationTitle: (conversationId: number, title: string) => Promise<void>;
+  handleConversationSelect: (
+    conversation: ConversationListItem
+  ) => Promise<void>;
+  updateConversationTitle: (
+    conversationId: number,
+    title: string
+  ) => Promise<void>;
   clearConversationLoadError: (conversationId: number) => void;
   setConversationLoadErrorForId: (
     conversationId: number,
     error: string
   ) => void;
-  setSelectedConversationId: React.Dispatch<React.SetStateAction<number | null>>;
+  setSelectedConversationId: React.Dispatch<
+    React.SetStateAction<number | null>
+  >;
   setConversationTitle: React.Dispatch<React.SetStateAction<string>>;
   setIsNewConversation: React.Dispatch<React.SetStateAction<boolean>>;
 }
@@ -104,9 +111,9 @@ export const useConversationManagement = (): ConversationManagement => {
 
   const conversationList = Array.from(
     new Map(
-      (conversationListQuery.data?.pages.flatMap((page) => page.items) ?? [])
-        .sort((a, b) => b.create_time - a.create_time)
-        .map((conversation) => [conversation.conversation_id, conversation])
+      (
+        conversationListQuery.data?.pages.flatMap((page) => page.items) ?? []
+      ).map((conversation) => [conversation.conversation_id, conversation])
     ).values()
   );
 
@@ -118,15 +125,17 @@ export const useConversationManagement = (): ConversationManagement => {
     }
     return Array.from(
       new Map(
-        (result.data?.pages.flatMap((page) => page.items) ?? [])
-          .sort((a, b) => b.create_time - a.create_time)
-          .map((conversation) => [conversation.conversation_id, conversation])
+        (result.data?.pages.flatMap((page) => page.items) ?? []).map(
+          (conversation) => [conversation.conversation_id, conversation]
+        )
       ).values()
     );
   };
 
   const invalidateConversationList = () => {
-    void queryClient.invalidateQueries({ queryKey: CONVERSATION_LIST_QUERY_KEY });
+    void queryClient.invalidateQueries({
+      queryKey: CONVERSATION_LIST_QUERY_KEY,
+    });
   };
 
   const fetchNextPage = async (): Promise<void> => {

--- a/frontend/lib/conversationLoadPolicy.ts
+++ b/frontend/lib/conversationLoadPolicy.ts
@@ -2,16 +2,11 @@ interface ConversationLoadState {
   hasMore: boolean;
   isLoading: boolean;
   isNearBottom: boolean;
-  hasDownwardUserIntent: boolean;
 }
 
 export const shouldLoadNextConversationPage = (
   state: ConversationLoadState
-): boolean =>
-  state.hasMore &&
-  !state.isLoading &&
-  state.isNearBottom &&
-  state.hasDownwardUserIntent;
+): boolean => state.hasMore && !state.isLoading && state.isNearBottom;
 
 export const isConversationListNearBottom = (
   scrollHeight: number,
@@ -20,16 +15,70 @@ export const isConversationListNearBottom = (
   threshold = 80
 ): boolean => scrollHeight - scrollTop - clientHeight <= threshold;
 
-interface ConversationPageContinuationState {
+interface ConversationScrollRequestState {
   hasMore: boolean;
-  loadedBefore: number;
-  loadedAfter: number;
-  isNearLoadedBoundary: boolean;
+  isLoading: boolean;
+  scrollHeight: number;
+  scrollTop: number;
+  clientHeight: number;
+  hasUserIntent: boolean;
+  isScrollingDown: boolean;
 }
 
-export const shouldContinueConversationPageLoading = (
-  state: ConversationPageContinuationState
+export const shouldRequestConversationPageFromScroll = (
+  state: ConversationScrollRequestState
 ): boolean =>
-  state.hasMore &&
-  state.loadedAfter > state.loadedBefore &&
-  state.isNearLoadedBoundary;
+  state.hasUserIntent &&
+  state.isScrollingDown &&
+  shouldLoadNextConversationPage({
+    hasMore: state.hasMore,
+    isLoading: state.isLoading,
+    isNearBottom: isConversationListNearBottom(
+      state.scrollHeight,
+      state.scrollTop,
+      state.clientHeight
+    ),
+  });
+
+interface ConversationPageRequestState {
+  hasMore: boolean;
+  isLoading: boolean;
+  clientHeight: number;
+  scrollHeight: number;
+  rowHeight: number;
+  isLoadRequested: boolean;
+  regularPageSize: number;
+}
+
+export interface ConversationPageRequest {
+  limit: number;
+  reason: "viewport-fill" | "scroll";
+}
+
+export const getConversationPageRequest = (
+  state: ConversationPageRequestState
+): ConversationPageRequest | null => {
+  if (
+    !state.hasMore ||
+    state.isLoading ||
+    state.clientHeight <= 0 ||
+    state.rowHeight <= 0
+  ) {
+    return null;
+  }
+
+  if (state.scrollHeight <= state.clientHeight) {
+    const missingHeight = state.clientHeight - state.scrollHeight;
+    return {
+      limit: Math.min(100, Math.ceil(missingHeight / state.rowHeight) + 1),
+      reason: "viewport-fill",
+    };
+  }
+
+  return state.isLoadRequested
+    ? {
+        limit: Math.max(1, state.regularPageSize),
+        reason: "scroll",
+      }
+    : null;
+};

--- a/frontend/lib/conversationThreadPagination.ts
+++ b/frontend/lib/conversationThreadPagination.ts
@@ -1,0 +1,103 @@
+export interface ConversationPage<
+  TItem,
+  TMetadata extends { total: number } = { total: number },
+> {
+  items: TItem[];
+  metadata: TMetadata;
+}
+
+interface ConversationThreadPageLoaderOptions<
+  TItem,
+  TThread,
+  TMetadata extends { total: number },
+> {
+  pageSize: number;
+  takeNextPageSize: (fallback: number) => number;
+  getOffsetAdjustment: () => number;
+  commitOffsetAdjustment: (count: number) => void;
+  resetPagination: () => void;
+  fetchPage: (params: {
+    offset: number;
+    limit: number;
+  }) => Promise<ConversationPage<TItem, TMetadata>>;
+  mapItem: (item: TItem) => TThread;
+  onMetadata: (metadata: TMetadata) => void;
+}
+
+interface ConversationThreadPageOptions {
+  after?: string;
+}
+
+export interface ConversationThreadPage<TThread> {
+  threads: TThread[];
+  nextCursor?: string;
+}
+
+interface ConversationDeletionLifecycleOptions {
+  pendingPageLoad: Promise<void> | null;
+  deleteConversation: () => void | Promise<void>;
+  recordDeletedLoadedItem: () => void;
+}
+
+export const runConversationDeletionLifecycle = async ({
+  pendingPageLoad,
+  deleteConversation,
+  recordDeletedLoadedItem,
+}: ConversationDeletionLifecycleOptions): Promise<void> => {
+  await pendingPageLoad;
+  await deleteConversation();
+  recordDeletedLoadedItem();
+};
+
+const parseOffset = (after: string | undefined, pageSize: number): number => {
+  if (after === undefined) return 0;
+
+  const offset = Number(after);
+  return Number.isSafeInteger(offset) &&
+    offset >= 0 &&
+    offset <= Number.MAX_SAFE_INTEGER - pageSize
+    ? offset
+    : 0;
+};
+
+export const createConversationThreadPageLoader = <
+  TItem,
+  TThread,
+  TMetadata extends { total: number } = { total: number },
+>({
+  pageSize,
+  takeNextPageSize,
+  getOffsetAdjustment,
+  commitOffsetAdjustment,
+  resetPagination,
+  fetchPage,
+  mapItem,
+  onMetadata,
+}: ConversationThreadPageLoaderOptions<TItem, TThread, TMetadata>) => {
+  return async ({ after }: ConversationThreadPageOptions = {}): Promise<
+    ConversationThreadPage<TThread>
+  > => {
+    // assistant-ui starts loading before the sidebar has committed and can be
+    // measured. Bootstrap the runtime without fetching so the mounted list can
+    // choose a first-page size from the real viewport in the same frame.
+    if (after === undefined) {
+      resetPagination();
+      return { threads: [], nextCursor: "0" };
+    }
+
+    const limit = takeNextPageSize(pageSize);
+    const requestedOffset = parseOffset(after, limit);
+    const offsetAdjustment = Math.min(requestedOffset, getOffsetAdjustment());
+    const offset = requestedOffset - offsetAdjustment;
+    const data = await fetchPage({ offset, limit });
+    commitOffsetAdjustment(offsetAdjustment);
+    onMetadata(data.metadata);
+    const nextOffset = offset + data.items.length;
+
+    return {
+      threads: data.items.map(mapItem),
+      nextCursor:
+        nextOffset < data.metadata.total ? String(nextOffset) : undefined,
+    };
+  };
+};

--- a/frontend/lib/conversationViewport.ts
+++ b/frontend/lib/conversationViewport.ts
@@ -64,7 +64,7 @@ export const calculateConversationViewport = (
     for (let index = 0; index < count; index += 1) {
       usedHeight += rowHeight;
       rows += 1;
-      if (usedHeight >= containerHeight) {
+      if (usedHeight > containerHeight) {
         return { initialLimit: Math.min(100, rows), totalHeight };
       }
     }
@@ -86,30 +86,96 @@ export const getConversationDateBoundaries = (): {
   return { todayStartMs, weekStartMs: todayStartMs - 7 * 86_400_000 };
 };
 
+interface ConversationVirtualSpacerInput {
+  totalCount: number;
+  pendingDeletionCount: number;
+  loadedContentHeight: number;
+  rowHeight: number;
+  groupHeaderHeight: number;
+  groupCount: number;
+  contentPadding: number;
+}
+
+export const calculateConversationVirtualSpacerHeight = (
+  input: ConversationVirtualSpacerInput
+): number => {
+  const remainingTotal = Math.max(
+    0,
+    Math.floor(input.totalCount) - Math.floor(input.pendingDeletionCount)
+  );
+  const estimatedTotalHeight =
+    remainingTotal * Math.max(0, input.rowHeight) +
+    Math.max(0, Math.floor(input.groupCount)) *
+      Math.max(0, input.groupHeaderHeight) +
+    Math.max(0, input.contentPadding);
+
+  return Math.max(
+    0,
+    estimatedTotalHeight -
+      Math.max(0, input.contentPadding) -
+      Math.max(0, input.loadedContentHeight)
+  );
+};
+
+interface ConversationLoadedBoundaryInput {
+  scrollTop: number;
+  clientHeight: number;
+  loadedBoundary: number;
+  threshold?: number;
+}
+
+export const isConversationLoadedBoundaryReached = (
+  input: ConversationLoadedBoundaryInput
+): boolean =>
+  input.scrollTop + input.clientHeight >=
+  input.loadedBoundary - Math.max(0, input.threshold ?? 0);
+
 export class ConversationViewportCoordinator {
+  private nextPageSize: number | null = null;
+  private pendingOffsetAdjustment = 0;
   private metadata: ConversationListMetadata | null = null;
-  private initialLimit: number | null = null;
   private listeners = new Set<() => void>();
 
-  private notify(): void {
-    this.listeners.forEach((listener) => listener());
+  requestNextPageSize(pageSize: number): void {
+    this.nextPageSize = this.normalizePageSize(pageSize);
   }
 
-  setMetadata(metadata: ConversationListMetadata): void {
+  takeNextPageSize = (fallback: number): number => {
+    const pageSize = this.nextPageSize ?? this.normalizePageSize(fallback);
+    this.nextPageSize = null;
+    return pageSize;
+  };
+
+  clearNextPageSize(): void {
+    this.nextPageSize = null;
+  }
+
+  recordDeletedLoadedItem(): void {
+    this.pendingOffsetAdjustment += 1;
+  }
+
+  getOffsetAdjustment = (): number => this.pendingOffsetAdjustment;
+
+  commitOffsetAdjustment = (count: number): void => {
+    this.pendingOffsetAdjustment = Math.max(
+      0,
+      this.pendingOffsetAdjustment - Math.max(0, Math.floor(count))
+    );
+  };
+
+  resetPagination = (): void => {
+    this.nextPageSize = null;
+    this.pendingOffsetAdjustment = 0;
+    if (this.metadata !== null) {
+      this.metadata = null;
+      this.notify();
+    }
+  };
+
+  setMetadata = (metadata: ConversationListMetadata): void => {
     this.metadata = metadata;
-    this.initialLimit = null;
     this.notify();
-  }
-
-  reset(): void {
-    this.metadata = null;
-    this.initialLimit = null;
-    this.notify();
-  }
-
-  getMetadata(): ConversationListMetadata | null {
-    return this.metadata;
-  }
+  };
 
   getSnapshot = (): ConversationListMetadata | null => this.metadata;
 
@@ -118,14 +184,12 @@ export class ConversationViewportCoordinator {
     return () => this.listeners.delete(listener);
   };
 
-  resolveInitialLimit(limit: number): void {
-    this.initialLimit = Math.max(1, Math.ceil(limit));
+  private notify(): void {
+    this.listeners.forEach((listener) => listener());
   }
 
-  takePageLimit(): number {
-    const limit = this.initialLimit ?? DEFAULT_CONVERSATION_PAGE_SIZE;
-    this.initialLimit = null;
-    return limit;
+  private normalizePageSize(pageSize: number): number {
+    return Math.min(100, Math.max(1, Math.ceil(pageSize)));
   }
 }
 

--- a/frontend/tests/conversationLoadPolicy.test.ts
+++ b/frontend/tests/conversationLoadPolicy.test.ts
@@ -2,54 +2,144 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  getConversationPageRequest,
   isConversationListNearBottom,
-  shouldContinueConversationPageLoading,
+  shouldRequestConversationPageFromScroll,
   shouldLoadNextConversationPage,
-  // @ts-expect-error -- Node's built-in TypeScript runner needs the extension.
+  // @ts-expect-error Node's test runner loads the TypeScript source directly.
 } from "../lib/conversationLoadPolicy.ts";
 
-test("does not load without downward user intent", () => {
+test("requests only the rows missing from an underfilled viewport", () => {
+  assert.deepEqual(
+    getConversationPageRequest({
+      hasMore: true,
+      isLoading: false,
+      clientHeight: 600,
+      scrollHeight: 420,
+      rowHeight: 36,
+      isLoadRequested: false,
+      regularPageSize: 20,
+    }),
+    { limit: 6, reason: "viewport-fill" }
+  );
+});
+
+test("loads one overflow row when content exactly fills the viewport", () => {
+  assert.deepEqual(
+    getConversationPageRequest({
+      hasMore: true,
+      isLoading: false,
+      clientHeight: 600,
+      scrollHeight: 600,
+      rowHeight: 36,
+      isLoadRequested: false,
+      regularPageSize: 20,
+    }),
+    { limit: 1, reason: "viewport-fill" }
+  );
+});
+
+test("uses the regular page size for an explicit user pagination request", () => {
+  assert.deepEqual(
+    getConversationPageRequest({
+      hasMore: true,
+      isLoading: false,
+      clientHeight: 600,
+      scrollHeight: 1200,
+      rowHeight: 36,
+      isLoadRequested: true,
+      regularPageSize: 20,
+    }),
+    { limit: 20, reason: "scroll" }
+  );
+});
+
+test("does not preload a second page when the initial overflow row is below the viewport", () => {
+  assert.equal(
+    getConversationPageRequest({
+      hasMore: true,
+      isLoading: false,
+      clientHeight: 600,
+      scrollHeight: 636,
+      rowHeight: 36,
+      isLoadRequested: false,
+      regularPageSize: 20,
+    }),
+    null
+  );
+});
+
+test("does not request while loading, exhausted, or away from the sentinel", () => {
+  const base = {
+    hasMore: true,
+    isLoading: false,
+    clientHeight: 600,
+    scrollHeight: 1200,
+    rowHeight: 36,
+    isLoadRequested: false,
+    regularPageSize: 20,
+  };
+
+  assert.equal(getConversationPageRequest({ ...base, isLoading: true }), null);
+  assert.equal(getConversationPageRequest({ ...base, hasMore: false }), null);
+  assert.equal(getConversationPageRequest(base), null);
+});
+
+test("legacy scroll guards remain stable", () => {
+  assert.equal(isConversationListNearBottom(1000, 720, 200), true);
   assert.equal(
     shouldLoadNextConversationPage({
       hasMore: true,
       isLoading: false,
       isNearBottom: true,
-      hasDownwardUserIntent: false,
     }),
+    true
+  );
+});
+
+test("small viewports request the next page when scrolling near the post-delete bottom", () => {
+  const state = {
+    hasMore: true,
+    isLoading: false,
+    scrollHeight: 720,
+    scrollTop: 280,
+    clientHeight: 360,
+    hasUserIntent: true,
+    isScrollingDown: true,
+  };
+
+  assert.equal(shouldRequestConversationPageFromScroll(state), true);
+  assert.equal(
+    shouldRequestConversationPageFromScroll({ ...state, scrollTop: 100 }),
+    false
+  );
+  assert.equal(
+    shouldRequestConversationPageFromScroll({ ...state, isLoading: true }),
+    false
+  );
+  assert.equal(
+    shouldRequestConversationPageFromScroll({ ...state, hasMore: false }),
     false
   );
 });
 
-test("loads once downward user intent reaches the bottom", () => {
-  assert.equal(
-    shouldLoadNextConversationPage({
-      hasMore: true,
-      isLoading: false,
-      isNearBottom: true,
-      hasDownwardUserIntent: true,
-    }),
-    true
-  );
-  assert.equal(isConversationListNearBottom(1000, 700, 220), true);
-  assert.equal(isConversationListNearBottom(1000, 600, 220), false);
-});
+test("does not treat layout changes or upward scrolling as pagination intent", () => {
+  const state = {
+    hasMore: true,
+    isLoading: false,
+    scrollHeight: 720,
+    scrollTop: 280,
+    clientHeight: 360,
+    hasUserIntent: false,
+    isScrollingDown: true,
+  };
 
-test("continues loading after a scrollbar jump only while pages make progress", () => {
+  assert.equal(shouldRequestConversationPageFromScroll(state), false);
   assert.equal(
-    shouldContinueConversationPageLoading({
-      hasMore: true,
-      loadedBefore: 20,
-      loadedAfter: 40,
-      isNearLoadedBoundary: true,
-    }),
-    true
-  );
-  assert.equal(
-    shouldContinueConversationPageLoading({
-      hasMore: true,
-      loadedBefore: 40,
-      loadedAfter: 40,
-      isNearLoadedBoundary: true,
+    shouldRequestConversationPageFromScroll({
+      ...state,
+      hasUserIntent: true,
+      isScrollingDown: false,
     }),
     false
   );

--- a/frontend/tests/conversationThreadPagination.test.ts
+++ b/frontend/tests/conversationThreadPagination.test.ts
@@ -1,0 +1,272 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+// @ts-expect-error Node's test runner loads the TypeScript source directly.
+import { createConversationThreadPageLoader } from "../lib/conversationThreadPagination.ts";
+// @ts-expect-error Node's test runner loads the TypeScript source directly.
+import { runConversationDeletionLifecycle } from "../lib/conversationThreadPagination.ts";
+import {
+  calculateConversationVirtualSpacerHeight,
+  calculateConversationViewport,
+  ConversationViewportCoordinator,
+  // @ts-expect-error Node's test runner loads the TypeScript source directly.
+} from "../lib/conversationViewport.ts";
+
+interface Item {
+  id: string;
+}
+
+interface TestMetadata {
+  total: number;
+  today: number;
+  last_7_days: number;
+  older: number;
+}
+
+const createItems = (count: number): Item[] =>
+  Array.from({ length: count }, (_, index) => ({ id: String(index + 1) }));
+
+const createLoaderHarness = (initialItems: Item[], pageSize = 20) => {
+  let items = initialItems;
+  const calls: Array<{ offset: number; limit: number }> = [];
+  const coordinator = new ConversationViewportCoordinator();
+  const loader = createConversationThreadPageLoader<Item, string, TestMetadata>(
+    {
+      pageSize,
+      takeNextPageSize: coordinator.takeNextPageSize,
+      getOffsetAdjustment: coordinator.getOffsetAdjustment,
+      commitOffsetAdjustment: coordinator.commitOffsetAdjustment,
+      resetPagination: coordinator.resetPagination,
+      fetchPage: async (params) => {
+        calls.push(params);
+        return {
+          items: items.slice(params.offset, params.offset + params.limit),
+          metadata: {
+            total: items.length,
+            today: items.length,
+            last_7_days: 0,
+            older: 0,
+          },
+        };
+      },
+      mapItem: (item) => item.id,
+      onMetadata: coordinator.setMetadata,
+    }
+  );
+
+  return {
+    calls,
+    coordinator,
+    loader,
+    deleteItem(id: string) {
+      items = items.filter((item) => item.id !== id);
+    },
+  };
+};
+
+test("successful deletion updates pagination state after the final page is loaded", async () => {
+  const events: string[] = [];
+  const coordinator = new ConversationViewportCoordinator();
+
+  await runConversationDeletionLifecycle({
+    pendingPageLoad: Promise.resolve().then(() => {
+      events.push("page-loaded");
+    }),
+    deleteConversation: async () => {
+      events.push("deleted");
+    },
+    recordDeletedLoadedItem: () => {
+      coordinator.recordDeletedLoadedItem();
+      events.push("pagination-updated");
+    },
+  });
+
+  assert.deepEqual(events, ["page-loaded", "deleted", "pagination-updated"]);
+  assert.equal(coordinator.getOffsetAdjustment(), 1);
+  assert.equal(
+    calculateConversationVirtualSpacerHeight({
+      totalCount: 5,
+      pendingDeletionCount: coordinator.getOffsetAdjustment(),
+      loadedContentHeight: 4 * 36 + 32,
+      rowHeight: 36,
+      groupHeaderHeight: 32,
+      groupCount: 1,
+      contentPadding: 16,
+    }),
+    0
+  );
+});
+
+test("failed deletion does not update pagination state", async () => {
+  let recordedDeletion = false;
+
+  await assert.rejects(
+    runConversationDeletionLifecycle({
+      pendingPageLoad: null,
+      deleteConversation: async () => {
+        throw new Error("delete failed");
+      },
+      recordDeletedLoadedItem: () => {
+        recordedDeletion = true;
+      },
+    }),
+    /delete failed/
+  );
+
+  assert.equal(recordedDeletion, false);
+});
+
+test("bootstrap waits for viewport measurement before fetching the first page", async () => {
+  const harness = createLoaderHarness(createItems(8), 3);
+
+  assert.deepEqual(await harness.loader(), {
+    threads: [],
+    nextCursor: "0",
+  });
+  assert.deepEqual(harness.calls, []);
+
+  harness.coordinator.requestNextPageSize(5);
+  assert.deepEqual(await harness.loader({ after: "0" }), {
+    threads: ["1", "2", "3", "4", "5"],
+    nextCursor: "5",
+  });
+  assert.deepEqual(harness.calls, [{ offset: 0, limit: 5 }]);
+});
+
+test("later pages use the actual cursor and a one-shot requested size", async () => {
+  const harness = createLoaderHarness(createItems(10), 3);
+  await harness.loader();
+
+  harness.coordinator.requestNextPageSize(2);
+  const first = await harness.loader({ after: "0" });
+  harness.coordinator.requestNextPageSize(4);
+  const second = await harness.loader({ after: first.nextCursor });
+  const third = await harness.loader({ after: second.nextCursor });
+
+  assert.deepEqual(first.threads, ["1", "2"]);
+  assert.deepEqual(second.threads, ["3", "4", "5", "6"]);
+  assert.deepEqual(third.threads, ["7", "8", "9"]);
+  assert.deepEqual(harness.calls, [
+    { offset: 0, limit: 2 },
+    { offset: 2, limit: 4 },
+    { offset: 6, limit: 3 },
+  ]);
+});
+
+test("small-window deletion preserves loaded pages and corrects the next offset", async () => {
+  const harness = createLoaderHarness(createItems(46));
+  const visibleThreads: string[] = [];
+  const measuredViewport = calculateConversationViewport({
+    containerHeight: 540,
+    rowHeight: 36,
+    groupHeaderHeight: 32,
+    contentPadding: 16,
+    groupCounts: [46, 0, 0],
+  });
+
+  // Runtime bootstrap happens before the sidebar DOM exists. The mounted
+  // sidebar then measures the small viewport and requests its real first page.
+  await harness.loader();
+  harness.coordinator.requestNextPageSize(measuredViewport.initialLimit);
+  let page = await harness.loader({ after: "0" });
+  visibleThreads.push(...page.threads);
+  page = await harness.loader({ after: page.nextCursor });
+  visibleThreads.push(...page.threads);
+
+  assert.equal(visibleThreads.length, 34);
+  assert.equal(page.nextCursor, "34");
+
+  // assistant-ui removes the item optimistically. Resizing must not reload or
+  // discard the other loaded rows; only the deleted row leaves the list.
+  harness.deleteItem("4");
+  visibleThreads.splice(visibleThreads.indexOf("4"), 1);
+  harness.coordinator.recordDeletedLoadedItem();
+
+  assert.equal(visibleThreads.length, 33);
+  assert.equal(harness.calls.length, 2);
+
+  const finalPage = await harness.loader({ after: page.nextCursor });
+  visibleThreads.push(...finalPage.threads);
+
+  assert.deepEqual(harness.calls.at(-1), { offset: 33, limit: 20 });
+  assert.equal(finalPage.nextCursor, undefined);
+  assert.deepEqual(
+    visibleThreads,
+    createItems(46)
+      .filter((item) => item.id !== "4")
+      .map((item) => item.id)
+  );
+  assert.equal(new Set(visibleThreads).size, 45);
+});
+
+test("multiple successful deletions are applied to the next page once", async () => {
+  const harness = createLoaderHarness(createItems(60));
+  await harness.loader();
+  harness.coordinator.requestNextPageSize(20);
+  const first = await harness.loader({ after: "0" });
+
+  harness.deleteItem("2");
+  harness.deleteItem("8");
+  harness.coordinator.recordDeletedLoadedItem();
+  harness.coordinator.recordDeletedLoadedItem();
+
+  const second = await harness.loader({ after: first.nextCursor });
+  const third = await harness.loader({ after: second.nextCursor });
+
+  assert.deepEqual(harness.calls, [
+    { offset: 0, limit: 20 },
+    { offset: 18, limit: 20 },
+    { offset: 38, limit: 20 },
+  ]);
+  assert.equal(harness.coordinator.getOffsetAdjustment(), 0);
+  assert.equal(third.nextCursor, undefined);
+});
+
+test("a failed page request retains the deletion offset for retry", async () => {
+  const coordinator = new ConversationViewportCoordinator();
+  let attempts = 0;
+  const calls: Array<{ offset: number; limit: number }> = [];
+  const loader = createConversationThreadPageLoader<Item, string>({
+    pageSize: 20,
+    takeNextPageSize: coordinator.takeNextPageSize,
+    getOffsetAdjustment: coordinator.getOffsetAdjustment,
+    commitOffsetAdjustment: coordinator.commitOffsetAdjustment,
+    resetPagination: coordinator.resetPagination,
+    fetchPage: async (params) => {
+      calls.push(params);
+      attempts += 1;
+      if (attempts === 1) throw new Error("temporary failure");
+      return { items: [{ id: "20" }], metadata: { total: 20 } };
+    },
+    mapItem: (item) => item.id,
+    onMetadata: () => undefined,
+  });
+
+  coordinator.recordDeletedLoadedItem();
+  await assert.rejects(loader({ after: "20" }), /temporary failure/);
+  assert.equal(coordinator.getOffsetAdjustment(), 1);
+
+  assert.deepEqual(await loader({ after: "20" }), {
+    threads: ["20"],
+    nextCursor: undefined,
+  });
+  assert.deepEqual(calls, [
+    { offset: 19, limit: 20 },
+    { offset: 19, limit: 20 },
+  ]);
+  assert.equal(coordinator.getOffsetAdjustment(), 0);
+});
+
+test("invalid cursors restart from offset zero without consuming deletion state", async () => {
+  const harness = createLoaderHarness([], 20);
+  harness.coordinator.recordDeletedLoadedItem();
+
+  await harness.loader({ after: "invalid" });
+  await harness.loader({ after: String(Number.MAX_SAFE_INTEGER) });
+
+  assert.deepEqual(harness.calls, [
+    { offset: 0, limit: 20 },
+    { offset: 0, limit: 20 },
+  ]);
+  assert.equal(harness.coordinator.getOffsetAdjustment(), 1);
+});

--- a/frontend/tests/conversationViewport.test.ts
+++ b/frontend/tests/conversationViewport.test.ts
@@ -2,73 +2,176 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  calculateConversationVirtualSpacerHeight,
   calculateConversationViewport,
   ConversationViewportCoordinator,
   getConversationViewportGroupCounts,
-  // @ts-expect-error -- Node requires the extension for this standalone test.
+  isConversationLoadedBoundaryReached,
+  // @ts-expect-error Node's test runner loads the TypeScript source directly.
 } from "../lib/conversationViewport.ts";
 
-test("requests enough rows to fill the viewport before metadata is loaded", () => {
-  const groupCounts = getConversationViewportGroupCounts();
-  const result = calculateConversationViewport({
-    containerHeight: 500,
-    rowHeight: 40,
-    groupHeaderHeight: 28,
-    groupGap: 16,
+test("keeps the native scroll height stable before and after pagination", () => {
+  const cases = [
+    { clientHeight: 505, loadedCount: 13 },
+    { clientHeight: 1067, loadedCount: 29 },
+  ];
+
+  for (const { clientHeight, loadedCount } of cases) {
+    const loadedContentHeight = loadedCount * 36 + 2 * 32;
+    const spacerHeight = calculateConversationVirtualSpacerHeight({
+      totalCount: 37,
+      pendingDeletionCount: 0,
+      loadedContentHeight,
+      rowHeight: 36,
+      groupHeaderHeight: 32,
+      groupCount: 2,
+      contentPadding: 16,
+    });
+    const initialScrollHeight = 16 + loadedContentHeight + 1 + spacerHeight;
+    const fullyLoadedScrollHeight = 16 + (37 * 36 + 2 * 32) + 1;
+
+    assert.equal(initialScrollHeight, fullyLoadedScrollHeight);
+    assert.ok(initialScrollHeight > clientHeight);
+  }
+});
+
+test("keeps virtual height continuous after deleting a loaded conversation", () => {
+  const loadedContentHeightAfterDelete = 28 * 36 + 2 * 32;
+  const spacerHeight = calculateConversationVirtualSpacerHeight({
+    totalCount: 37,
+    pendingDeletionCount: 1,
+    loadedContentHeight: loadedContentHeightAfterDelete,
+    rowHeight: 36,
+    groupHeaderHeight: 32,
+    groupCount: 2,
     contentPadding: 16,
-    groupCounts,
   });
 
-  assert.deepEqual(groupCounts, [100, 0, 0]);
-  assert.equal(result.initialLimit, 12);
-});
-
-test("calculates the exact initial rows and total virtual height", () => {
-  const result = calculateConversationViewport({
-    containerHeight: 500,
-    rowHeight: 40,
-    groupHeaderHeight: 28,
-    groupGap: 16,
-    groupCounts: [3, 7, 20],
-  });
-
-  assert.equal(result.initialLimit, 11);
-  assert.equal(result.totalHeight, 30 * 40 + 3 * 28 + 2 * 16);
-});
-
-test("falls back to 20 when DOM measurements are invalid", () => {
+  assert.equal(spacerHeight, 8 * 36);
   assert.equal(
-    calculateConversationViewport({
-      containerHeight: 0,
-      rowHeight: 0,
-      groupHeaderHeight: 0,
-      groupCounts: [30, 0, 0],
-    }).initialLimit,
-    20
+    16 + loadedContentHeightAfterDelete + 1 + spacerHeight,
+    16 + (36 * 36 + 2 * 32) + 1
   );
 });
 
-test("publishes metadata and consumes the dynamic first-page limit once", () => {
+test("loads against the real loaded-content boundary, not the virtual tail", () => {
+  assert.equal(
+    isConversationLoadedBoundaryReached({
+      scrollTop: 0,
+      clientHeight: 505,
+      loadedBoundary: 549,
+    }),
+    false
+  );
+  assert.equal(
+    isConversationLoadedBoundaryReached({
+      scrollTop: 44,
+      clientHeight: 505,
+      loadedBoundary: 549,
+    }),
+    true
+  );
+  assert.equal(
+    isConversationLoadedBoundaryReached({
+      scrollTop: 44,
+      clientHeight: 505,
+      loadedBoundary: 1269,
+    }),
+    false
+  );
+});
+
+test("calculates rows from data-source group counts and includes overflow", () => {
+  assert.deepEqual(
+    calculateConversationViewport({
+      containerHeight: 188,
+      rowHeight: 36,
+      groupHeaderHeight: 24,
+      contentPadding: 16,
+      groupCounts: [2, 3, 5],
+    }),
+    { initialLimit: 4, totalHeight: 448 }
+  );
+});
+
+test("measured first-page size follows small and large viewport heights", () => {
+  for (const containerHeight of [360, 900]) {
+    const viewport = calculateConversationViewport({
+      containerHeight,
+      rowHeight: 36,
+      groupHeaderHeight: 32,
+      contentPadding: 16,
+      groupCounts: [100, 0, 0],
+    });
+    const renderedHeight = 16 + 32 + viewport.initialLimit * 36;
+
+    assert.ok(renderedHeight > containerHeight);
+    assert.ok(renderedHeight - 36 <= containerHeight);
+  }
+});
+
+test("uses metadata counts without reordering conversations in memory", () => {
+  assert.deepEqual(
+    getConversationViewportGroupCounts({
+      total: 8,
+      today: 2,
+      last_7_days: 3,
+      older: 3,
+    }),
+    [2, 3, 3]
+  );
+});
+
+test("coordinator consumes measured page sizes once", () => {
+  const coordinator = new ConversationViewportCoordinator();
+  coordinator.requestNextPageSize(6.1);
+  assert.equal(coordinator.takeNextPageSize(20), 7);
+  assert.equal(coordinator.takeNextPageSize(20), 20);
+
+  coordinator.requestNextPageSize(5);
+  coordinator.clearNextPageSize();
+  assert.equal(coordinator.takeNextPageSize(20), 20);
+});
+
+test("coordinator publishes metadata without changing pagination state", () => {
   const coordinator = new ConversationViewportCoordinator();
   let notifications = 0;
   const unsubscribe = coordinator.subscribe(() => {
     notifications += 1;
   });
+  const metadata = {
+    total: 3,
+    today: 1,
+    last_7_days: 1,
+    older: 1,
+  };
 
-  coordinator.setMetadata({
-    total: 35,
-    today: 5,
-    last_7_days: 10,
-    older: 20,
-  });
-  coordinator.resolveInitialLimit(29);
+  coordinator.setMetadata(metadata);
 
+  assert.equal(coordinator.getSnapshot(), metadata);
   assert.equal(notifications, 1);
-  assert.equal(coordinator.getSnapshot()?.total, 35);
-  assert.equal(coordinator.takePageLimit(), 29);
-  assert.equal(coordinator.takePageLimit(), 20);
-  coordinator.reset();
-  assert.equal(coordinator.getSnapshot(), null);
-  assert.equal(notifications, 2);
   unsubscribe();
+});
+
+test("reset clears transient pagination state and published metadata", () => {
+  const coordinator = new ConversationViewportCoordinator();
+  let notifications = 0;
+  coordinator.subscribe(() => {
+    notifications += 1;
+  });
+
+  coordinator.requestNextPageSize(7);
+  coordinator.recordDeletedLoadedItem();
+  coordinator.setMetadata({
+    total: 3,
+    today: 3,
+    last_7_days: 0,
+    older: 0,
+  });
+  coordinator.resetPagination();
+
+  assert.equal(coordinator.getSnapshot(), null);
+  assert.equal(coordinator.getOffsetAdjustment(), 0);
+  assert.equal(coordinator.takeNextPageSize(20), 20);
+  assert.equal(notifications, 2);
 });

--- a/test/backend/app/test_conversation_management_app.py
+++ b/test/backend/app/test_conversation_management_app.py
@@ -61,7 +61,7 @@ def conversation_mocks():
     """Provide fresh mocks for each conversation management test"""
     with patch('backend.apps.conversation_management_app.get_current_user_id') as mock_get_current_user_id, \
             patch('backend.apps.conversation_management_app.create_new_conversation') as mock_create_new_conv, \
-            patch('backend.apps.conversation_management_app.get_conversation_list_page') as mock_get_conv_list, \
+            patch('backend.apps.conversation_management_app.list_conversations_service') as mock_get_conv_list, \
             patch('backend.apps.conversation_management_app.rename_conversation_service') as mock_rename_conv, \
             patch('backend.apps.conversation_management_app.logging') as mock_logging, \
             patch('backend.apps.conversation_management_app.delete_conversation_service') as mock_delete_conv, \

--- a/test/backend/database/test_conversation_db.py
+++ b/test/backend/database/test_conversation_db.py
@@ -1554,7 +1554,7 @@ def test_get_conversation_list_applies_offset_without_limit(monkeypatch, mock_se
     session.execute.assert_called_once_with(stmt)
 
 
-def test_get_conversation_list_page_returns_rows_and_metadata_from_one_query(
+def test_get_conversation_list_page_returns_rows_and_metadata(
     monkeypatch, mock_session_ctx
 ):
     session, ctx = mock_session_ctx
@@ -1576,7 +1576,14 @@ def test_get_conversation_list_page_returns_rows_and_metadata_from_one_query(
         "return_value",
         ComparableTimestamp(),
     )
-    session.execute.return_value = [
+    metadata_result = MagicMock()
+    metadata_result.one.return_value = types.SimpleNamespace(
+        total=30,
+        today=3,
+        last_7_days=7,
+        older=20,
+    )
+    page_records = [
         types.SimpleNamespace(
             conversation_id=2,
             conversation_title="Second",
@@ -1584,12 +1591,9 @@ def test_get_conversation_list_page_returns_rows_and_metadata_from_one_query(
             chat_mode="execution",
             create_time=2000,
             update_time=2100,
-            total=30,
-            today=3,
-            last_7_days=7,
-            older=20,
         )
     ]
+    session.execute.side_effect = [metadata_result, page_records]
     monkeypatch.setattr("backend.database.conversation_db.get_db_session", lambda: ctx)
 
     result = get_conversation_list_page(
@@ -1613,7 +1617,7 @@ def test_get_conversation_list_page_returns_rows_and_metadata_from_one_query(
         ],
         "metadata": {"total": 30, "today": 3, "last_7_days": 7, "older": 20},
     }
-    session.execute.assert_called_once()
+    assert session.execute.call_count == 2
 
 
 def test_get_conversation_list_page_supports_unpaginated_empty_result(
@@ -1638,7 +1642,14 @@ def test_get_conversation_list_page_supports_unpaginated_empty_result(
         "return_value",
         ComparableTimestamp(),
     )
-    session.execute.return_value = []
+    metadata_result = MagicMock()
+    metadata_result.one.return_value = types.SimpleNamespace(
+        total=0,
+        today=0,
+        last_7_days=0,
+        older=0,
+    )
+    session.execute.side_effect = [metadata_result, []]
     monkeypatch.setattr("backend.database.conversation_db.get_db_session", lambda: ctx)
 
     result = get_conversation_list_page(
@@ -1651,7 +1662,55 @@ def test_get_conversation_list_page_supports_unpaginated_empty_result(
         "items": [],
         "metadata": {"total": 0, "today": 0, "last_7_days": 0, "older": 0},
     }
-    session.execute.assert_called_once()
+    assert session.execute.call_count == 2
+
+
+def test_get_conversation_list_page_preserves_metadata_when_page_is_empty(
+    monkeypatch, mock_session_ctx
+):
+    """An offset past the last row must not make a non-empty dataset look empty."""
+    session, ctx = mock_session_ctx
+
+    class ComparableTimestamp:
+        def label(self, _name):
+            return self
+
+        def __ge__(self, _value):
+            return MagicMock()
+
+        def __lt__(self, _value):
+            return MagicMock()
+
+    from backend.database import conversation_db
+
+    monkeypatch.setattr(
+        conversation_db.func.extract.return_value.__mul__,
+        "return_value",
+        ComparableTimestamp(),
+    )
+    metadata_result = MagicMock()
+    metadata_result.one.return_value = types.SimpleNamespace(
+        total=3,
+        today=1,
+        last_7_days=1,
+        older=1,
+    )
+    session.execute.side_effect = [metadata_result, []]
+    monkeypatch.setattr("backend.database.conversation_db.get_db_session", lambda: ctx)
+
+    result = get_conversation_list_page(
+        "user-1",
+        today_start_ms=2000,
+        week_start_ms=1000,
+        limit=20,
+        offset=20,
+    )
+
+    assert result == {
+        "items": [],
+        "metadata": {"total": 3, "today": 1, "last_7_days": 1, "older": 1},
+    }
+    assert session.execute.call_count == 2
 
 
 def test_update_conversation_agent_id_success(monkeypatch, mock_session_ctx):

--- a/test/backend/services/test_conversation_management_service.py
+++ b/test/backend/services/test_conversation_management_service.py
@@ -207,6 +207,7 @@ from backend.services.conversation_management_service import (
         update_conversation_title,
         create_new_conversation,
         get_conversation_service,
+        list_conversations_service,
         rename_conversation_service,
         delete_conversation_service,
         get_conversation_history_service,
@@ -216,6 +217,34 @@ from backend.services.conversation_management_service import (
         update_conversation_chat_mode_service,
         update_message_opinion_service,
         get_message_id_by_index_impl
+    )
+
+
+@patch('backend.services.conversation_management_service.get_conversation_list_page')
+def test_list_conversations_service_forwards_explicit_page_parameters(
+    mock_get_conversation_list_page,
+):
+    page = {
+        "items": [{"conversation_id": 123}],
+        "metadata": {"total": 1, "today": 1, "last_7_days": 0, "older": 0},
+    }
+    mock_get_conversation_list_page.return_value = page
+
+    result = list_conversations_service(
+        user_id="test_user_id",
+        today_start_ms=2000,
+        week_start_ms=1000,
+        limit=20,
+        offset=0,
+    )
+
+    assert result == page
+    mock_get_conversation_list_page.assert_called_once_with(
+        user_id="test_user_id",
+        today_start_ms=2000,
+        week_start_ms=1000,
+        limit=20,
+        offset=0,
     )
 
 


### PR DESCRIPTION
## 问题背景
新版对话栏已经支持根据窗口高度按需加载对话：
- 页面初始化时根据对话栏真实高度计算首屏数量。
- 用户向下滚动时继续分页加载。
- 大、小尺寸窗口使用不同的首屏加载数量。
但删除对话后存在以下问题：
1. 删除已加载的对话后，后续分页请求仍使用删除前的 offset，可能跳过尚未加载的对话。
2. 删除后重新加载列表会丢失已经加载的分页，页面只剩下能够填满当前对话栏的对话。
3. 当最后一页已经全部加载，即 hasMore=false 时，删除操作没有更新分页状态。
4. 虚拟滚动高度仍然按照删除前的对话总数计算，导致：
   - 滚动条长度没有变化。
   - 对话栏底部残留一条对话高度的空白区域。
5. 页面初始化时，滚动条需要用户滚动后才能显示正确长度。
## 根因分析
问题主要来自分页状态、删除生命周期和滚动高度之间没有统一更新：
- 删除后直接重新加载对话列表，导致 assistant-ui 清空之前已经加载的分页数据。
- offset 分页没有考虑已加载范围内发生的删除，后续请求可能跳过一条数据。
- 删除状态更新受 hasMore 限制：
  - 当仍有下一页时会登记删除。
  - 当全部分页已经加载时不会登记删除。
- 虚拟滚动高度依赖服务端返回的总数，但删除成功后没有立即扣除本地已删除数量。
- 删除操作、React 列表提交和高度测量之间存在生命周期时序差异，可能在删除状态登记前完成一次错误的高度测量。
## 解决方法
1. 根据真实对话栏高度加载首屏
2. 保留删除前已经加载的分页
3. 修正删除后的分页 offset
4. 统一成功删除的生命周期
5. 实时更新滚动条和列表高度
6. 区分用户滚动和布局变化
## 新增测试
`frontend/tests/conversationThreadPagination.test.ts`
`frontend/tests/conversationViewport.test.ts`
`frontend/tests/conversationLoadPolicy.test.ts`