### PR TITLE
🐛 Fix: support Chinese evaluation reports and validate AI evaluation scene descriptions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 # Python
 **/.venv/
-**/.venv-*/
 **/__pycache__/
 **/*.pyc
 **/*.pyo

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 # Python
 **/.venv/
+**/.venv-*/
 **/__pycache__/
 **/*.pyc
 **/*.pyo

--- a/backend/utils/font_utils.py
+++ b/backend/utils/font_utils.py
@@ -28,6 +28,7 @@ def _find_cjk_font_path() -> Optional[str]:
         "C:/Windows/Fonts/simsun.ttc",
         # Linux / macOS
         os.path.expanduser("~/.fonts/NotoSansSC.ttf"),
+        "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
         "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
     ]
     for fp in candidates:
@@ -86,11 +87,15 @@ def setup_matplotlib_cjk() -> str:
 def setup_reportlab_cjk() -> str:
     """Register a CJK font with reportlab and return the PDF font name.
 
-    Returns ``"CJK"`` on success, ``"Helvetica"`` on failure.
+    Returns ``"CJK"`` when a TrueType font can be embedded.  Debian's
+    ``fonts-noto-cjk`` package provides CFF-based TTC files, which ReportLab's
+    ``TTFont`` cannot embed, so fall back to ReportLab's built-in Chinese CID
+    font before using Helvetica as a last resort.
     """
+    from reportlab.pdfbase import pdfmetrics
+
     fp = get_cjk_font_path()
     if fp:
-        from reportlab.pdfbase import pdfmetrics
         from reportlab.pdfbase.ttfonts import TTFont
         try:
             pdfmetrics.registerFont(TTFont("CJK", fp))
@@ -98,4 +103,13 @@ def setup_reportlab_cjk() -> str:
             return "CJK"
         except Exception as exc:
             logger.warning("Failed to register reportlab CJK font: %s", exc)
+
+    try:
+        from reportlab.pdfbase.cidfonts import UnicodeCIDFont
+
+        pdfmetrics.registerFont(UnicodeCIDFont("STSong-Light"))
+        logger.warning("Using ReportLab built-in STSong-Light CID font for CJK PDF text")
+        return "STSong-Light"
+    except Exception as exc:
+        logger.warning("Failed to register ReportLab CJK CID fallback: %s", exc)
     return "Helvetica"

--- a/backend/utils/font_utils.py
+++ b/backend/utils/font_utils.py
@@ -8,6 +8,8 @@ results so fonts are registered once per process lifetime.
 
 import logging
 import os
+import shutil
+import subprocess
 from typing import Optional
 
 
@@ -18,15 +20,65 @@ _CACHED_FONT_PATH: Optional[str] = None   # path to CJK .ttf file, or "" if not 
 _CACHED_FONT_NAME: Optional[str] = None   # matplotlib family name, or "" if fallback
 
 
+def _find_cjk_font_with_fontconfig() -> Optional[str]:
+    """Resolve a Chinese font through Linux fontconfig.
+
+    ``fc-match`` returns the best font for a font pattern and language.  The
+    family and language fields are checked as well as the file path so a
+    generic western fallback is not mistaken for a usable CJK font.
+    """
+    fc_match = shutil.which("fc-match")
+    if not fc_match:
+        logger.debug("fontconfig fc-match is unavailable")
+        return None
+
+    try:
+        result = subprocess.run(
+            [
+                fc_match,
+                "-f",
+                "%{family}\\t%{lang}\\t%{file}\\n",
+                "sans-serif:lang=zh-cn",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        logger.debug("fontconfig CJK lookup failed: %s", exc)
+        return None
+
+    for line in result.stdout.splitlines():
+        family, separator, remainder = line.partition("\t")
+        if not separator:
+            continue
+        lang, separator, font_path = remainder.partition("\t")
+        if not separator or not font_path:
+            continue
+        family_lang = f"{family} {lang}".lower()
+        if "zh" not in family_lang and "cjk" not in family_lang:
+            logger.debug("fontconfig returned non-CJK fallback: %s", line)
+            continue
+        if os.path.exists(font_path) and os.path.getsize(font_path) > 1000:
+            logger.debug("fontconfig resolved CJK font: %s → %s", family, font_path)
+            return font_path
+    return None
+
+
 def _find_cjk_font_path() -> Optional[str]:
-    """Return the filesystem path to an available CJK font, or ``None``."""
+    """Return an available Linux CJK font path, or ``None``.
+
+    fontconfig is the primary discovery mechanism.  The explicit paths are
+    retained only as a compatibility fallback for minimal environments where
+    the command is unavailable or its cache is not usable yet.
+    """
+    font_path = _find_cjk_font_with_fontconfig()
+    if font_path:
+        return font_path
+
     candidates = [
-        # Windows
-        "C:/Windows/Fonts/msyh.ttc",
-        "C:/Windows/Fonts/msyhbd.ttc",
-        "C:/Windows/Fonts/simhei.ttf",
-        "C:/Windows/Fonts/simsun.ttc",
-        # Linux / macOS
+        # Linux fallback paths
         os.path.expanduser("~/.fonts/NotoSansSC.ttf"),
         "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
         "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",

--- a/deploy/images/dockerfiles/main/Dockerfile
+++ b/deploy/images/dockerfiles/main/Dockerfile
@@ -29,7 +29,9 @@ RUN --mount=type=cache,id=nexent-main-apt-cache-${TARGETARCH},target=/var/cache/
         postgresql-client \
         fontconfig \
         fonts-noto-cjk && \
-    fc-cache -fv
+    fc-cache -fv && \
+    command -v fc-match >/dev/null 2>&1 && \
+    fc-match --version >/dev/null 2>&1
 
 FROM base AS builder
 ARG MIRROR

--- a/deploy/images/dockerfiles/main/Dockerfile
+++ b/deploy/images/dockerfiles/main/Dockerfile
@@ -23,7 +23,13 @@ RUN --mount=type=cache,id=nexent-main-apt-cache-${TARGETARCH},target=/var/cache/
                 "$apt_source"; \
         done; \
     fi && \
-    apt-get update && apt-get install -y --no-install-recommends curl postgresql-client
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl \
+        postgresql-client \
+        fontconfig \
+        fonts-noto-cjk && \
+    fc-cache -fv
 
 FROM base AS builder
 ARG MIRROR

--- a/deploy/images/dockerfiles/main/Dockerfile
+++ b/deploy/images/dockerfiles/main/Dockerfile
@@ -29,9 +29,7 @@ RUN --mount=type=cache,id=nexent-main-apt-cache-${TARGETARCH},target=/var/cache/
         postgresql-client \
         fontconfig \
         fonts-noto-cjk && \
-    fc-cache -fv && \
-    command -v fc-match >/dev/null 2>&1 && \
-    fc-match --version >/dev/null 2>&1
+    fc-cache -f
 
 FROM base AS builder
 ARG MIRROR

--- a/frontend/app/[locale]/evaluation/page.tsx
+++ b/frontend/app/[locale]/evaluation/page.tsx
@@ -2013,6 +2013,7 @@ function SetsTab() {
     return true;
   };
   const [genDesc, setGenDesc] = useState("");
+  const [genDescError, setGenDescError] = useState<string | null>(null);
   const [genCount, setGenCount] = useState(10);
   const [genSetModel, setGenSetModel] = useState<number | undefined>(undefined);
   const [busy, setBusy] = useState(false);
@@ -2780,6 +2781,7 @@ function SetsTab() {
         open={genD}
         onClose={() => {
           setGenD(false);
+          setGenDescError(null);
           setGenTargetSetId(undefined);
           setGenSetName("");
           setGenSetDesc("");
@@ -2865,7 +2867,10 @@ function SetsTab() {
               title={
                 <Flex gap={6} align="center">
                   <Zap className="size-4" />
-                  <Text>{t("agentEvaluation.genSceneDescTitle")}</Text>
+                  <Text>
+                    {t("agentEvaluation.genSceneDescTitle")}{" "}
+                    <Text type="danger">*</Text>
+                  </Text>
                 </Flex>
               }
             >
@@ -2877,9 +2882,20 @@ function SetsTab() {
                   rows={3}
                   maxLength={1000}
                   value={genDesc}
-                  onChange={(e) => setGenDesc(e.target.value)}
+                  status={genDescError ? "error" : undefined}
+                  onChange={(e) => {
+                    setGenDesc(e.target.value);
+                    if (genDescError && e.target.value.trim()) {
+                      setGenDescError(null);
+                    }
+                  }}
                   placeholder={t("agentEvaluation.genSceneDescPlaceholder")}
                 />
+                {genDescError && (
+                  <Text type="danger" className="text-xs">
+                    {genDescError}
+                  </Text>
+                )}
               </Flex>
             </Card>
             <Card
@@ -3029,7 +3045,10 @@ function SetsTab() {
                 loading={busy}
                 style={{ marginTop: 18 }}
                 onClick={async () => {
-                  if (!genDesc.trim()) return;
+                  if (!genDesc.trim()) {
+                    setGenDescError(t("agentEvaluation.genSceneDescRequired"));
+                    return;
+                  }
                   if (!genSetModel) {
                     message.warning(t("agentEvaluation.selectGenModel"));
                     return;
@@ -3084,6 +3103,7 @@ function SetsTab() {
                     if (d?.data?.evaluation_set_id) {
                       setGenD(false);
                       setGenDesc("");
+                      setGenDescError(null);
                       setGenAgentId(undefined);
                       setGenFiles([]);
                       setGenSetName("");

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -4702,6 +4702,7 @@
   "agentEvaluation.genSetNameHint": "2-64 characters",
   "agentEvaluation.genSetNameAutoHint": "Auto-use existing set name",
   "agentEvaluation.genSceneDescHint": "Describe the scenarios and test focus you want to cover. AI will generate test cases based on this.",
+  "agentEvaluation.genSceneDescRequired": "Please enter a scene description",
   "agentEvaluation.genSceneDescPlaceholder": "e.g., Cover return, replacement, complaint, and logistics tracking for customer service scenarios",
   "agentEvaluation.genSelectExistingSet": "Select existing set to append cases",
   "agentEvaluation.genExistingSetHint": "Select an existing evaluation set to append cases, or leave empty and enter a name below to create a new set",

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -4716,6 +4716,7 @@
   "agentEvaluation.genSetNameHint": "2-64个字符",
   "agentEvaluation.genSetNameAutoHint": "自动使用已有评测集名称",
   "agentEvaluation.genSceneDescHint": "描述想要覆盖的场景和测试重点，AI 将据此生成测试用例。",
+  "agentEvaluation.genSceneDescRequired": "请输入场景描述",
   "agentEvaluation.genSceneDescPlaceholder": "例如：覆盖客服场景的退货、换货、投诉、物流查询",
   "agentEvaluation.genSelectExistingSet": "选择已有评测集追加用例",
   "agentEvaluation.genExistingSetHint": "选择已有评测集追加用例，留空则下方输入名称创建新评测集",

--- a/test/backend/utils/test_font_utils.py
+++ b/test/backend/utils/test_font_utils.py
@@ -80,6 +80,38 @@ class TestFindCjkFontPath:
             "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc"
         )
 
+    def test_fontconfig_failure_falls_back_to_candidates(self, monkeypatch):
+        monkeypatch.setattr(font_utils.shutil, "which", lambda _name: "/usr/bin/fc-match")
+
+        def _raise(*_args, **_kwargs):
+            raise OSError("fc-match unavailable")
+
+        monkeypatch.setattr(font_utils.subprocess, "run", _raise)
+        monkeypatch.setattr(font_utils.os.path, "exists", lambda _path: False)
+
+        assert font_utils._find_cjk_font_path() is None
+
+    def test_ignores_invalid_or_non_cjk_fontconfig_results(self, monkeypatch):
+        monkeypatch.setattr(font_utils.shutil, "which", lambda _name: "/usr/bin/fc-match")
+        monkeypatch.setattr(
+            font_utils.subprocess,
+            "run",
+            lambda *_args, **_kwargs: SimpleNamespace(
+                stdout="malformed\nNoto Sans CJK SC\t\nDejaVu Sans\ten\t/foo.ttf\n"
+            ),
+        )
+        monkeypatch.setattr(font_utils.os.path, "exists", lambda _path: False)
+
+        assert font_utils._find_cjk_font_path() is None
+
+    def test_uses_explicit_linux_path_when_fontconfig_has_no_result(self, monkeypatch):
+        monkeypatch.setattr(font_utils, "_find_cjk_font_with_fontconfig", lambda: None)
+        expected = "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc"
+        monkeypatch.setattr(font_utils.os.path, "exists", lambda path: path == expected)
+        monkeypatch.setattr(font_utils.os.path, "getsize", lambda _path: 2001)
+
+        assert font_utils._find_cjk_font_path() == expected
+
     def test_returns_real_font_when_present(self):
         fp = font_utils._find_cjk_font_path()
         assert fp is None or (Path(fp).exists() and Path(fp).stat().st_size > 1000)
@@ -156,3 +188,10 @@ class TestSetupReportlabCjk:
         _pdfmetrics, _ttfonts, cidfonts = _install_reportlab_stub()
         assert font_utils.setup_reportlab_cjk() == "STSong-Light"
         cidfonts.UnicodeCIDFont.assert_called_once_with("STSong-Light")
+
+    @patch("font_utils.get_cjk_font_path", return_value=None)
+    def test_cid_fallback_error_returns_helvetica(self, _fp):
+        _pdfmetrics, _ttfonts, cidfonts = _install_reportlab_stub()
+        cidfonts.UnicodeCIDFont.side_effect = RuntimeError("no CID font")
+
+        assert font_utils.setup_reportlab_cjk() == "Helvetica"

--- a/test/backend/utils/test_font_utils.py
+++ b/test/backend/utils/test_font_utils.py
@@ -50,14 +50,17 @@ def _install_reportlab_stub(register_side_effect=None):
     pdfmetrics = MagicMock()
     pdfmetrics.registerFont.side_effect = register_side_effect
     ttfonts = MagicMock()
+    cidfonts = MagicMock()
     rl = MagicMock()
     rl.pdfbase.pdfmetrics = pdfmetrics
     rl.pdfbase.ttfonts = ttfonts
+    rl.pdfbase.cidfonts = cidfonts
     sys.modules["reportlab"] = rl
     sys.modules["reportlab.pdfbase"] = rl.pdfbase
     sys.modules["reportlab.pdfbase.pdfmetrics"] = pdfmetrics
     sys.modules["reportlab.pdfbase.ttfonts"] = ttfonts
-    return pdfmetrics, ttfonts
+    sys.modules["reportlab.pdfbase.cidfonts"] = cidfonts
+    return pdfmetrics, ttfonts, cidfonts
 
 
 class TestFindCjkFontPath:
@@ -120,15 +123,20 @@ class TestSetupMatplotlibCjk:
 class TestSetupReportlabCjk:
     @patch("font_utils.get_cjk_font_path", return_value="C:/x.ttf")
     def test_registers_and_returns_cjk(self, _fp):
-        pdfmetrics, ttfonts = _install_reportlab_stub()
+        pdfmetrics, ttfonts, _cidfonts = _install_reportlab_stub()
         assert font_utils.setup_reportlab_cjk() == "CJK"
         pdfmetrics.registerFont.assert_called_once_with(ttfonts.TTFont("CJK", "C:/x.ttf"))
 
     @patch("font_utils.get_cjk_font_path", return_value="C:/x.ttf")
-    def test_register_error_returns_helvetica(self, _fp):
-        _install_reportlab_stub(register_side_effect=RuntimeError("no"))
-        assert font_utils.setup_reportlab_cjk() == "Helvetica"
+    def test_register_error_uses_cid_fallback(self, _fp):
+        pdfmetrics, _ttfonts, cidfonts = _install_reportlab_stub(
+            register_side_effect=[RuntimeError("no"), None]
+        )
+        assert font_utils.setup_reportlab_cjk() == "STSong-Light"
+        assert pdfmetrics.registerFont.call_args_list[1].args == (cidfonts.UnicodeCIDFont("STSong-Light"),)
 
     @patch("font_utils.get_cjk_font_path", return_value=None)
-    def test_no_font_returns_helvetica(self, _fp):
-        assert font_utils.setup_reportlab_cjk() == "Helvetica"
+    def test_no_font_uses_cid_fallback(self, _fp):
+        _pdfmetrics, _ttfonts, cidfonts = _install_reportlab_stub()
+        assert font_utils.setup_reportlab_cjk() == "STSong-Light"
+        cidfonts.UnicodeCIDFont.assert_called_once_with("STSong-Light")

--- a/test/backend/utils/test_font_utils.py
+++ b/test/backend/utils/test_font_utils.py
@@ -64,6 +64,22 @@ def _install_reportlab_stub(register_side_effect=None):
 
 
 class TestFindCjkFontPath:
+    def test_prefers_linux_fontconfig_result(self, monkeypatch):
+        monkeypatch.setattr(font_utils.shutil, "which", lambda _name: "/usr/bin/fc-match")
+        monkeypatch.setattr(
+            font_utils.subprocess,
+            "run",
+            lambda *_args, **_kwargs: SimpleNamespace(
+                stdout="Noto Sans CJK SC\tzh-cn|zh-tw\t/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc\n"
+            ),
+        )
+        monkeypatch.setattr(font_utils.os.path, "exists", lambda _path: True)
+        monkeypatch.setattr(font_utils.os.path, "getsize", lambda _path: 2001)
+
+        assert font_utils._find_cjk_font_path() == (
+            "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc"
+        )
+
     def test_returns_real_font_when_present(self):
         fp = font_utils._find_cjk_font_path()
         assert fp is None or (Path(fp).exists() and Path(fp).stat().st_size > 1000)


### PR DESCRIPTION
## Summary

This PR fixes two issues:

1. Chinese characters in downloaded agent evaluation reports were rendered as garbled blocks.
2. The AI-generated evaluation set form allowed an empty scene description. Clicking **Confirm** then produced no feedback.

## Changes

### 1. Chinese font support

- Install `fontconfig` and `fonts-noto-cjk` in the image during the build stage.
- Run `fc-cache -f` to refresh the fontconfig cache.
- Use `fc-match` to dynamically locate the installed Linux CJK font.
- Use the discovered Noto CJK font for Matplotlib charts.
- Use ReportLab's built-in `STSong-Light` CID font as a fallback for PDF body text because ReportLab cannot directly embed CFF-based TTC fonts.
- No font download is performed at runtime.

### 2. Scene description validation

- Mark the scene description field as required.
- Display a validation message when the field is empty.
- Prevent submission until a non-empty scene description is provided.
- Clear the validation message after the user enters valid content.
- Keep the behavior consistent with validation patterns used on other pages.

## Testing and Verification

After building the Docker image locally, pull it up in Docker Desktop to check.
<img width="1750" height="1272" alt="81b36bf3-31f4-444f-867c-2eee7f9458ca" src="https://github.com/user-attachments/assets/f4abd8d3-cfb7-453d-bfc8-631df63c9831" />

When generating evaluation sets with AI, 'Scene Description' is a required field for validation
<img width="907" height="1087" alt="img_v3_0214v_86610da0-72b0-408a-9f71-6098f1cafd6g" src="https://github.com/user-attachments/assets/042c8667-5925-40e3-a835-3f4405d0d7f5" />
