### PR TITLE
🐛 preserve IPv6 brackets in A2A base URLs

### DIFF
--- a/backend/database/a2a_agent_db.py
+++ b/backend/database/a2a_agent_db.py
@@ -41,9 +41,12 @@ def _extract_base_url(url: str) -> str:
     """
     from urllib.parse import urlparse
     parsed = urlparse(url)
+    hostname = parsed.hostname or ""
+    if ":" in hostname:
+        hostname = f"[{hostname}]"
     if parsed.port:
-        return f"{parsed.scheme}://{parsed.hostname}:{parsed.port}"
-    return f"{parsed.scheme}://{parsed.hostname}"
+        return f"{parsed.scheme}://{hostname}:{parsed.port}"
+    return f"{parsed.scheme}://{hostname}"
 
 # Standard human-readable protocol label
 PROTOCOL_HTTP_JSON = "HTTP+JSON"

--- a/test/backend/database/test_a2a_agent_db.py
+++ b/test/backend/database/test_a2a_agent_db.py
@@ -484,6 +484,13 @@ def artifact():
 # Tests: Helper Functions
 # ===========================================================================
 
+class TestExtractBaseUrl:
+    def test_preserves_ipv6_brackets(self):
+        url = "https://[2001:db8::7]:8443/.well-known/agent-card.json"
+
+        assert a2a_db._extract_base_url(url) == "https://[2001:db8::7]:8443"
+
+
 class TestGenerateTaskId:
     def test_prefix(self):
         assert a2a_db._generate_task_id().startswith('task_')


### PR DESCRIPTION
## What this PR does

A2A agent discovery derives a service base URL from the agent-card URL. Python URL parsing removes the brackets required around IPv6 literals, so https://[2001:db8::7]:8443/.well-known/agent-card.json was persisted as the invalid URL https://2001:db8::7:8443.

This change restores brackets when the parsed hostname is an IPv6 literal while preserving the existing behavior for hostnames, ports, paths, and user-info removal.

## Validation

- focused pytest: 1 passed, 135 deselected
- focused Ruff fatal-error rules: passed
- Python syntax compilation: passed
- git diff --check: passed