### PR TITLE
🐛 reject failed stopword downloads

### DIFF
--- a/sdk/nexent/core/nlp/stopwords.py
+++ b/sdk/nexent/core/nlp/stopwords.py
@@ -13,6 +13,7 @@ def download_stopwords(url: str, save_path: str) -> bool:
     try:
         logger.info(f"Downloading stopwords: {url}")
         response = requests.get(url, timeout=10)
+        response.raise_for_status()
         response.encoding = 'utf-8'
         with open(save_path, 'w', encoding='utf-8') as f:
             f.write(response.text)

--- a/test/sdk/core/nlp/test_stopwords.py
+++ b/test/sdk/core/nlp/test_stopwords.py
@@ -1,0 +1,29 @@
+import importlib.util
+from pathlib import Path
+from unittest.mock import Mock
+
+import requests
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[4] / "sdk" / "nexent" / "core" / "nlp" / "stopwords.py"
+)
+SPEC = importlib.util.spec_from_file_location("nexent_stopwords", MODULE_PATH)
+assert SPEC and SPEC.loader
+stopwords = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(stopwords)
+
+
+def test_download_stopwords_rejects_http_error(monkeypatch, tmp_path):
+    response = Mock(text="Not Found")
+    response.raise_for_status.side_effect = requests.HTTPError("404 Client Error")
+    get = Mock(return_value=response)
+    monkeypatch.setattr(stopwords.requests, "get", get)
+    target = tmp_path / "stopwords.txt"
+
+    assert (
+        stopwords.download_stopwords("https://example.com/missing", str(target))
+        is False
+    )
+    assert not target.exists()
+    response.raise_for_status.assert_called_once_with()


### PR DESCRIPTION
## Summary

- reject non-success HTTP responses before writing the stopword file
- avoid treating a short 404/500 response body as a valid stopword list
- add a focused regression test that verifies an HTTP error returns `False` and leaves no file

## Validation

- direct fail-before/pass-after mocked HTTP reproduction
- `pytest -q test/sdk/core/nlp/test_stopwords.py` — 1 passed
- Ruff check and format check on both changed files
- `git diff --cached --check`
