### PR TITLE
🐛 Fix incomplete model config handling

### DIFF
--- a/backend/utils/config_utils.py
+++ b/backend/utils/config_utils.py
@@ -45,10 +45,10 @@ def get_env_key(key: str) -> str:
 
 def get_model_name_from_config(model_config: Dict[str, Any]) -> str:
     """Get model name from model id"""
-    if model_config is None:
+    if not model_config:
         return ""
-    model_repo = model_config["model_repo"]
-    model_name = model_config["model_name"]
+    model_repo = model_config.get("model_repo") or ""
+    model_name = model_config.get("model_name") or ""
     if not model_repo:
         return model_name
     return f"{model_repo}/{model_name}"

--- a/test/backend/utils/test_config_utils.py
+++ b/test/backend/utils/test_config_utils.py
@@ -81,6 +81,17 @@ class TestGetEnvKey:
 class TestGetModelNameFromConfig:
     """Test get_model_name_from_config function"""
 
+    @pytest.mark.parametrize(
+        ("config", "expected"),
+        [
+            ({}, ""),
+            ({"model_name": "gpt-4"}, "gpt-4"),
+        ],
+    )
+    def test_get_model_name_from_config_with_incomplete_config(self, config, expected):
+        """Test empty and partial model configurations."""
+        assert get_model_name_from_config(config) == expected
+
     def test_get_model_name_from_config_with_model_repo(self):
         """Test with model repository"""
         config = {"model_repo": "openai", "model_name": "gpt-4"}


### PR DESCRIPTION
## Summary

- return an empty model name for empty configuration mappings
- safely handle partial mappings that omit `model_repo` or `model_name`
- add regression coverage while preserving complete `repo/name` formatting

## Root cause

`TenantConfigManager.get_model_config` can return an empty default mapping for invalid model IDs, but `get_model_name_from_config` indexed both keys directly. That mismatch raised `KeyError` before callers could handle the empty model name.

## Testing

- `python -m pytest test/backend/utils/test_config_utils.py -q` (35 passed)
- `python -m compileall -q backend/utils/config_utils.py test/backend/utils/test_config_utils.py`
- `uvx ruff check --select E9,F63,F7,F82 backend/utils/config_utils.py test/backend/utils/test_config_utils.py`
- `git diff --check`

Fixes #3810