### PR TITLE
fix: update tests for merged v2.5.0 migrations

### DIFF
--- a/test/backend/database/test_conversation_knowledge_scope_migration.py
+++ b/test/backend/database/test_conversation_knowledge_scope_migration.py
@@ -1,13 +1,23 @@
 from pathlib import Path
 
 
-MIGRATION = Path(
-    "deploy/sql/migrations/v2.5.0_0806_add_conversation_knowledge_scope.sql"
+MERGED_MIGRATION = Path("deploy/sql/migrations/v2.5.0_merged_migrations.sql")
+KNOWLEDGE_SCOPE_SOURCE_MARKER = (
+    "-- Source migration: v2.5.0_0806_add_conversation_knowledge_scope.sql"
 )
 
 
+def _read_conversation_knowledge_scope_migration() -> str:
+    merged = MERGED_MIGRATION.read_text(encoding="utf-8")
+    assert KNOWLEDGE_SCOPE_SOURCE_MARKER in merged
+    knowledge_scope_and_later = merged.split(KNOWLEDGE_SCOPE_SOURCE_MARKER, maxsplit=1)[1]
+    next_source_marker = "\n-- Source migration:"
+    assert next_source_marker in knowledge_scope_and_later
+    return knowledge_scope_and_later.split(next_source_marker, maxsplit=1)[0]
+
+
 def test_conversation_knowledge_scope_migration_is_repeatable():
-    sql = MIGRATION.read_text(encoding="utf-8")
+    sql = _read_conversation_knowledge_scope_migration()
 
     assert "SET search_path TO nexent, public" in sql
     assert "ADD COLUMN IF NOT EXISTS knowledge_scope JSONB" in sql

--- a/test/backend/database/test_memory_dreaming_postgres_integration.py
+++ b/test/backend/database/test_memory_dreaming_postgres_integration.py
@@ -18,6 +18,20 @@ pytestmark = pytest.mark.skipif(
     reason="set RUN_POSTGRES_INTEGRATION=1 with local PostgreSQL env",
 )
 
+DREAMING_SOURCE_MARKER = (
+    "-- Source migration: v2.5.0_0813_versioned_markdown_long_term_memory.sql"
+)
+
+
+def _read_dreaming_migration() -> str:
+    root = Path(__file__).resolve().parents[3]
+    merged = (root / "deploy/sql/migrations/v2.5.0_merged_migrations.sql").read_text()
+    assert DREAMING_SOURCE_MARKER in merged
+    dreaming_and_later = merged.split(DREAMING_SOURCE_MARKER, maxsplit=1)[1]
+    next_source_marker = "\n-- Source migration:"
+    assert next_source_marker in dreaming_and_later
+    return dreaming_and_later.split(next_source_marker, maxsplit=1)[0]
+
 
 def _connect():
     return psycopg2.connect(
@@ -181,10 +195,7 @@ def test_ac010_real_postgres_evidence_types_round_trip_through_orm():
 
 def test_ac075_real_postgres_upgrades_json_decisions_and_is_repeatable():
     connection = _connect()
-    migration = (
-        Path(__file__).resolve().parents[3]
-        / "deploy/sql/migrations/v2.5.0_0813_versioned_markdown_long_term_memory.sql"
-    ).read_text()
+    migration = _read_dreaming_migration()
     try:
         with connection.cursor() as cursor:
             cursor.execute(

--- a/test/backend/database/test_memory_dreaming_schema.py
+++ b/test/backend/database/test_memory_dreaming_schema.py
@@ -11,6 +11,20 @@ from database.db_models import (
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 
 
+DREAMING_SOURCE_MARKER = (
+    "-- Source migration: v2.5.0_0813_versioned_markdown_long_term_memory.sql"
+)
+
+
+def _read_dreaming_migration(root: Path) -> str:
+    merged = (root / "deploy/sql/migrations/v2.5.0_merged_migrations.sql").read_text()
+    assert DREAMING_SOURCE_MARKER in merged
+    dreaming_and_later = merged.split(DREAMING_SOURCE_MARKER, maxsplit=1)[1]
+    next_source_marker = "\n-- Source migration:"
+    assert next_source_marker in dreaming_and_later
+    return dreaming_and_later.split(next_source_marker, maxsplit=1)[0]
+
+
 def test_final_orm_contract_has_only_shared_long_term_versions():
     assert MemoryDreamingAudit.__tablename__ == "memory_dreaming_audit_t"
     assert MemoryDreamingDecision.__tablename__ == "memory_dreaming_decision_t"
@@ -36,7 +50,7 @@ def test_final_orm_contract_has_only_shared_long_term_versions():
 def test_final_migration_is_the_only_dreaming_schema_source():
     root = Path(__file__).resolve().parents[3]
     migrations = root / "deploy/sql/migrations"
-    final = (migrations / "v2.5.0_0813_versioned_markdown_long_term_memory.sql").read_text()
+    final = _read_dreaming_migration(root)
     init_sql = (root / "deploy/sql/init.sql").read_text()
     for token in (
         "memory_dreaming_audit_t", "memory_dreaming_decision_t", "memory_dreaming_schedule_t",
@@ -73,7 +87,7 @@ def test_final_migration_upgrades_v24_without_intermediate_v25_schema():
     root = Path(__file__).resolve().parents[3]
     migrations = root / "deploy/sql/migrations"
     v24 = (migrations / "v2.4_merged_migrations.sql").read_text()
-    final = (migrations / "v2.5.0_0813_versioned_markdown_long_term_memory.sql").read_text()
+    final = _read_dreaming_migration(root)
 
     assert "CREATE TABLE IF NOT EXISTS nexent.memory_records_t" in v24
     for table_name in (


### PR DESCRIPTION
## Summary
- update Dreaming schema tests to read SQL from v2.5.0_merged_migrations.sql
- extract only the original Dreaming source section so schema assertions and the opt-in PostgreSQL test remain correctly scoped
- update the conversation knowledge-scope migration test to extract its source section from the same merged migration
- keep the existing schema, repeatability, upgrade-boundary, and init.sql isolation assertions unchanged

## Root cause
The v2.5.0 release migration consolidation removed the standalone Dreaming and conversation knowledge-scope SQL files, while their unit tests continued to read the deleted paths.

## Testing
- focused migration tests: 5 passed, 4 opt-in PostgreSQL tests skipped by the existing RUN_POSTGRES_INTEGRATION gate
- Ruff passed for all changed test files
- git diff --check passed
- repository test-path audit found no remaining tests that read deleted standalone v2.5.0 migration files
- GitHub full test job passed in 8m38s
- Analyze, CodeQL, and SonarCloud checks passed

## Environment note
The dedicated Multipass runtime could not start because host snapd.apparmor is not enabled. The focused internal tests ran with the repository existing Python 3.11 environment; the complete GitHub CI suite subsequently passed.