### PR TITLE
feat(northbound): add tenant-admin-only create-user endpoint

### DIFF
--- a/backend/apps/northbound_base_app.py
+++ b/backend/apps/northbound_base_app.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from apps.app_factory import create_app
 from .northbound_app import router as northbound_router
 from .northbound_knowledge_app import router as northbound_knowledge_router
+from .northbound_user_app import router as northbound_user_router
 
 
 class A2AServerSettings(BaseModel):
@@ -51,6 +52,7 @@ northbound_app = create_app(
 
 northbound_app.include_router(northbound_router)
 northbound_app.include_router(northbound_knowledge_router)
+northbound_app.include_router(northbound_user_router)
 
 
 # =============================================================================

--- a/backend/apps/northbound_user_app.py
+++ b/backend/apps/northbound_user_app.py
@@ -1,0 +1,151 @@
+"""
+Northbound API for tenant user provisioning.
+
+Exposes ``POST /nb/v1/users`` which lets a **tenant administrator** create a user
+in their own tenant. Authentication reuses the northbound Bearer API key; the
+caller must additionally hold the ``ADMIN`` role inside the resolved tenant.
+"""
+import logging
+from http import HTTPStatus
+from typing import Annotated, Optional
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+
+from database.user_tenant_db import get_user_role_by_tenant
+from services.user_management_service import create_user_as_tenant_admin
+from consts.exceptions import (
+    AppException,
+    TenantResourceLimitError,
+    UserRegistrationException,
+)
+
+from .northbound_app import _get_northbound_context
+
+logger = logging.getLogger("northbound_user_app")
+
+router = APIRouter(prefix="/nb/v1", tags=["northbound"])
+
+__all__ = ["router"]
+
+TENANT_ADMIN_ROLE = "ADMIN"
+
+# Mirrors services.user_management_service.ADMIN_CREATABLE_ROLES. Declared here
+# so the OpenAPI schema documents the accepted values without importing the
+# service package's runtime dependencies into the route module.
+ALLOWED_USER_ROLES = ("USER", "DEV", "ADMIN")
+
+
+class CreateUserRequest(BaseModel):
+    """Payload for creating a user through the northbound API."""
+
+    model_config = {"extra": "forbid"}
+
+    email: Annotated[EmailStr, Field(description="Email address of the new user")]
+    initial_password: Annotated[
+        str,
+        Field(
+            min_length=8,
+            description="Initial password: at least 8 characters with uppercase, lowercase and digit",
+        ),
+    ]
+    name: Annotated[
+        Optional[str], Field(default=None, description="Display name of the new user")
+    ]
+    role: Annotated[
+        str,
+        Field(
+            default="USER",
+            description=f"Role assigned to the new user. One of {', '.join(ALLOWED_USER_ROLES)}",
+        ),
+    ]
+
+
+class CreateUserResponse(BaseModel):
+    """Summary of the newly created user."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    user_id: str
+    user_email: EmailStr
+    user_role: str
+    tenant_id: str
+
+
+async def _require_tenant_admin_context(request: Request):
+    """Resolve the northbound context and ensure the caller is a tenant admin.
+
+    The caller must hold the ``ADMIN`` role *within the tenant resolved from the
+    API key*. A missing tenant relationship (no role row) is also rejected, and
+    platform super administrators (``SU``) are intentionally not exempted.
+    """
+    ctx = await _get_northbound_context(request)
+    try:
+        user_role = get_user_role_by_tenant(ctx.user_id, ctx.tenant_id)
+    except Exception:
+        logger.exception("Failed to resolve caller role for tenant admin check")
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail="Failed to verify caller permissions",
+        )
+
+    if (user_role or "").upper() != TENANT_ADMIN_ROLE:
+        logger.warning(
+            "Rejected northbound user creation: user=%s role=%s tenant=%s",
+            ctx.user_id,
+            user_role or "<none>",
+            ctx.tenant_id,
+        )
+        raise HTTPException(
+            status_code=HTTPStatus.FORBIDDEN,
+            detail="This endpoint is restricted to tenant administrators.",
+        )
+    return ctx
+
+
+@router.post(
+    "/users",
+    response_model=CreateUserResponse,
+    status_code=HTTPStatus.CREATED,
+    summary="Create a user in the caller's tenant (tenant admin only)",
+)
+async def create_user(payload: CreateUserRequest, request: Request):
+    """Create a user belonging to the caller's tenant.
+
+    Restricted to tenant administrators: the API key must resolve to a user whose
+    role inside the resolved tenant is ``ADMIN``.
+
+    The new user is provisioned with the supplied initial password and is
+    immediately usable (email pre-confirmed). Emails are globally unique, so an
+    address registered elsewhere is rejected with ``409``.
+    """
+    ctx = await _require_tenant_admin_context(request)
+
+    try:
+        created = await create_user_as_tenant_admin(
+            tenant_id=ctx.tenant_id,
+            email=payload.email,
+            initial_password=payload.initial_password,
+            created_by=ctx.user_id,
+            name=payload.name,
+            role=payload.role,
+        )
+    except HTTPException:
+        raise
+    except AppException as exc:
+        raise HTTPException(status_code=exc.http_status, detail=exc.message)
+    except TenantResourceLimitError as exc:
+        # Must precede ValueError: TenantResourceLimitError subclasses it.
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=str(exc))
+    except UserRegistrationException as exc:
+        raise HTTPException(status_code=HTTPStatus.CONFLICT, detail=str(exc))
+    except ValueError as exc:
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=str(exc))
+    except Exception:
+        logger.exception("Failed to create user via northbound API")
+        raise HTTPException(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            detail="Failed to create user",
+        )
+
+    return CreateUserResponse(**created)

--- a/backend/services/user_management_service.py
+++ b/backend/services/user_management_service.py
@@ -51,6 +51,7 @@ from database.group_db import query_group_ids_by_user
 from database.client import as_dict, get_db_session
 from database.db_models import RolePermission
 from services.invitation_service import use_invitation_code, check_invitation_available, get_invitation_by_code
+from services.oauth_service import find_supabase_user_id_by_email
 from services.group_service import add_user_to_groups
 from services.tool_configuration_service import init_tool_list_for_tenant
 from services.skill_service import init_skill_list_for_tenant
@@ -668,3 +669,117 @@ async def update_password(user_id: str, old_password: str, new_password: str) ->
         logging.error(
             f"Failed to update password for user {user_id}: {str(exc)}")
         raise
+
+
+# -----------------------------
+# Northbound user provisioning
+# -----------------------------
+
+# Roles a tenant administrator is allowed to assign through the northbound API.
+# "SU" (platform super administrator) is deliberately excluded: a partner-facing
+# endpoint must never become a privilege-escalation path.
+ADMIN_CREATABLE_ROLES = ("USER", "DEV", "ADMIN")
+
+# Substrings Supabase GoTrue uses when a user already exists. Only used to
+# classify the narrow TOCTOU window between the pre-check and create_user.
+_SUPABASE_DUPLICATE_MARKERS = (
+    "already registered",
+    "already exists",
+    "already been registered",
+    "duplicate",
+    "user_already_exists",
+)
+
+
+def _looks_like_duplicate_user_error(exc: Exception) -> bool:
+    """Whether a Supabase error indicates the email is already taken."""
+    message = str(exc).lower()
+    return any(marker in message for marker in _SUPABASE_DUPLICATE_MARKERS)
+
+
+async def create_user_as_tenant_admin(
+    tenant_id: str,
+    email: EmailStr,
+    initial_password: str,
+    created_by: str,
+    name: Optional[str] = None,
+    role: str = "USER",
+) -> Dict[str, Any]:
+    """Create a user in ``tenant_id`` on behalf of a tenant administrator.
+
+    Unlike :func:`signup_user_with_invitation`, this does not consume an
+    invitation code: the caller's own administrator role (checked by the
+    caller) authorises the creation, and the new user always lands in
+    ``tenant_id``.
+
+    Raises:
+        ValueError: ``role`` is not in :data:`ADMIN_CREATABLE_ROLES`.
+        AppException: password does not meet the strength requirements.
+        UserRegistrationException: the email is already registered.
+        RuntimeError: the Supabase admin client is unavailable.
+    """
+    normalized_role = (role or "").strip().upper()
+    if normalized_role not in ADMIN_CREATABLE_ROLES:
+        raise ValueError(
+            f"Unsupported role '{role}'. Allowed roles: {', '.join(ADMIN_CREATABLE_ROLES)}"
+        )
+
+    if not validate_password_strength(initial_password):
+        raise AppException(
+            ErrorCode.PROFILE_PASSWORD_WEAK,
+            "Password must be at least 8 characters with uppercase, lowercase, and digit.",
+        )
+
+    admin_client = get_supabase_admin_client()
+    if not admin_client:
+        logging.error("Supabase admin client unavailable, cannot create user")
+        raise RuntimeError("Supabase admin client not available")
+
+    # Global (not per-tenant) uniqueness: Supabase Auth treats one email as one
+    # user across the whole project, so reusing an address elsewhere is refused
+    # instead of silently attaching a second tenant to the same login.
+    if find_supabase_user_id_by_email(admin_client, email):
+        raise UserRegistrationException(f"Email {email} is already registered")
+
+    user_metadata = {"full_name": name} if name else {}
+    try:
+        create_resp = admin_client.auth.admin.create_user({
+            "email": str(email),
+            "password": initial_password,
+            "email_confirm": True,
+            "user_metadata": user_metadata,
+        })
+    except Exception as exc:
+        # Pre-check above already covers the common case; this only classifies
+        # the race where a concurrent request registered the same email first.
+        if _looks_like_duplicate_user_error(exc):
+            raise UserRegistrationException(f"Email {email} is already registered")
+        logging.error(f"Supabase admin create_user failed for {email}: {str(exc)}")
+        raise
+
+    new_user = getattr(create_resp, "user", None)
+    if not new_user:
+        logging.error("Supabase admin create_user returned no user object")
+        raise UserRegistrationException(
+            "Registration service is temporarily unavailable, please try again later"
+        )
+
+    user_id = new_user.id
+    insert_user_tenant(
+        user_id=user_id,
+        tenant_id=tenant_id,
+        user_role=normalized_role,
+        user_email=str(email),
+        created_by=created_by,
+    )
+
+    logging.info(
+        f"User {email} created by tenant admin {created_by} "
+        f"in tenant {tenant_id} with role {normalized_role}"
+    )
+    return {
+        "user_id": user_id,
+        "user_email": str(email),
+        "user_role": normalized_role,
+        "tenant_id": tenant_id,
+    }

--- a/openspec/nb-create-user-tenant-admin/design.md
+++ b/openspec/nb-create-user-tenant-admin/design.md
@@ -1,0 +1,290 @@
+# 北向创建用户接口（仅租户管理员）— 设计文档
+
+> 变更名：`nb-create-user-tenant-admin`
+> 流程模式：Full
+> 关联 Issue：https://github.com/ModelEngine-Group/nexent/issues/3822
+> 关联 proposal：`openspec/nb-create-user-tenant-admin/proposal.md`
+> 基准代码：`origin/develop` @ `86d75923d`
+
+## 1. 方案概述
+
+- **业务背景**：北向 API 缺少用户管理端点，租户管理员只能通过邀请码间接开通账号。
+- **需求目标**：提供 `POST /nb/v1/users`，租户管理员可直接创建本租户用户。
+- **需求范围**：新增 1 个北向 app 文件、1 个服务函数、2 处测试，并注册路由；不触碰既有注册流程。
+
+整体做法：新增独立北向 app `backend/apps/northbound_user_app.py`，复用既有
+`_get_northbound_context` 解析 API Key，再用 `get_user_role_by_tenant` 校验调用者在本租户
+为 `ADMIN`（否则 403）；新用户走 Supabase Admin 创建（`email_confirm=True`）+ `insert_user_tenant`
+写入租户关系。
+
+## 2. 功能需求
+
+### 2.1 核心功能
+
+- **创建用户**
+  服务函数 `create_user_as_tenant_admin()` 依次完成：角色白名单校验 → 密码强度校验 →
+  邮箱存在预检 → `auth.admin.create_user` → `insert_user_tenant` → 返回新用户摘要。
+- **权限门禁**
+  `_require_tenant_admin_context(request)`：先取 `ctx`，再查角色，非 `ADMIN` 抛 403。
+
+### 2.2 流程描述
+
+```plantuml
+@startuml
+participant "调用方" as C
+participant "northbound_user_app" as A
+participant "northbound_app\n(_get_northbound_context)" as N
+participant "user_tenant_db" as D
+participant "user_management_service" as S
+participant "Supabase Admin" as SB
+
+C -> A: POST /nb/v1/users\nBearer <api_key>
+A -> N: 解析 API Key
+N --> A: ctx.user_id / ctx.tenant_id  (失败 -> 401)
+A -> D: get_user_role_by_tenant(user_id, tenant_id)
+D --> A: role  (无行 -> "")
+alt role != "ADMIN"
+  A --> C: 403 Forbidden
+else role == "ADMIN"
+  A -> S: create_user_as_tenant_admin(...)
+  S -> S: 角色白名单校验 (SU/未知 -> ValueError)
+  S -> S: validate_password_strength (弱 -> AppException 400)
+  S -> SB: list_users 预检邮箱
+  SB --> S: 命中 -> UserRegistrationException
+  S -> SB: auth.admin.create_user(email_confirm=True)
+  SB --> S: user.id
+  S -> D: insert_user_tenant(user_id, tenant_id, role, email, created_by)
+  D --> S: 关系行 (超限额 -> TenantResourceLimitError)
+  S --> A: {user_id, user_email, user_role, tenant_id}
+  A --> C: 201 Created
+end
+@enduml
+```
+
+### 2.3 权限设计
+
+- **角色清单**：`SU` / `ADMIN` / `DEV` / `USER`（`backend/database/user_tenant_db.py` 约定）
+- **权限矩阵**：见 `proposal.md` §5.2
+- **SOD 矩阵**：创建者与被创建者可以是同一人（自管理场景允许）；
+  不允许创建 `SU`，避免北向接口成为平台级提权入口 —— 这是本设计唯一的 SOD 硬约束。
+
+## 3. 非功能需求
+
+### 3.1 性能要求
+邮箱预检走 Supabase `list_users` 分页扫描（每页 100）。用户量大时为 O(n/100) 次调用，
+是本端点主要开销。本期不做缓存（避免引入一致性问题），如成为瓶颈再优化为按邮箱直查。
+
+### 3.2 安全要求
+- 角色白名单显式排除 `SU` 与未知值
+- 密码不入日志、不入响应
+- Supabase 服务角色密钥只经 `get_supabase_admin_client()` 获取
+
+### 3.3 兼容性要求
+- 纯新增：不改既有端点、不改既有注册流程、不改数据表结构
+
+### 3.4 依赖的外部要求
+- 部署需配置 `SERVICE_ROLE_KEY`（否则 `get_supabase_admin_client()` 返回 None → 500）
+
+## 4. 约束与依赖
+
+### 4.1 技术约束
+
+- **邮箱唯一性是全局的**：Supabase Auth 按邮箱全局唯一，因此"邮箱已被其他租户占用"
+  也只能拒绝（409），不能挂到本租户。这是比"租户内唯一"更严格的语义。
+- **legacy 异常没有全局 handler**（关键）：
+  `backend/apps/app_factory.py:189` 的通用 `Exception` handler 只处理
+  `AppException` / `NexentCapabilityError`，其余一律 500。因此
+  `TenantResourceLimitError`、`UserRegistrationException`、`ValueError`
+  **必须在端点层显式映射**为 HTTPException，不能依赖全局转换。
+- **循环依赖**：`user_management_service` 复用 `oauth_service.find_supabase_user_id_by_email`
+  时使用函数内惰性 import（与 `oauth_service.py:444` 惰性 import `get_supabase_admin_client` 同风格）。
+
+### 4.2 外部依赖
+- Supabase GoTrue Admin API（`auth.admin.create_user` / `auth.admin.list_users`）
+- PostgreSQL `user_tenant_t`
+
+## 5. IT 方案设计
+
+### 5.1 用例设计
+
+```plantuml
+@startuml
+actor "租户管理员" as Admin
+actor "租户普通用户" as User
+rectangle "北向 API" {
+  usecase "创建本租户用户" as UC1
+  usecase "北向知识库/文件能力" as UC2
+}
+Admin --> UC1
+User --> UC1 : <<拒绝 403>>
+Admin --> UC2
+@enduml
+```
+
+### 5.2 实体设计
+无新增实体。复用 `UserTenant`（`backend/database/db_models.py`）与 Supabase Auth 用户。
+
+### 5.3 数据库设计
+无 DDL 变更。`insert_user_tenant` 已承载全部写入与限额校验。
+
+### 5.4 类设计
+
+```plantuml
+@startuml
+class CreateUserRequest {
+  +email: EmailStr
+  +initial_password: str
+  +name: Optional[str]
+  +role: str = "USER"
+}
+class CreateUserResponse {
+  +user_id: str
+  +user_email: str
+  +user_role: str
+  +tenant_id: str
+}
+class "northbound_user_app" as App {
+  -_require_tenant_admin_context(request)
+  +create_user(payload, request)
+}
+class "user_management_service" as Svc {
+  +create_user_as_tenant_admin(...)
+}
+App ..> CreateUserRequest
+App ..> CreateUserResponse
+App ..> Svc
+@enduml
+```
+
+### 5.5 时序图设计
+见 §2.2。
+
+### 5.6 API 设计
+
+```yaml
+paths:
+  /nb/v1/users:
+    post:
+      tags: [northbound]
+      summary: Create a user in the caller's tenant (tenant admin only)
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email, initial_password]
+              properties:
+                email:
+                  type: string
+                  format: email
+                initial_password:
+                  type: string
+                  description: ">=8 chars with upper, lower and digit"
+                name:
+                  type: string
+                  nullable: true
+                role:
+                  type: string
+                  enum: [USER, DEV, ADMIN]
+                  default: USER
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  user_id: { type: string }
+                  user_email: { type: string, format: email }
+                  user_role: { type: string }
+                  tenant_id: { type: string }
+        '400': { description: Weak password / invalid role / tenant quota exceeded }
+        '401': { description: Invalid or missing API key }
+        '403': { description: Caller is not a tenant administrator }
+        '409': { description: Email already registered }
+        '422': { description: Request validation error }
+        '500': { description: Internal error }
+```
+
+> 说明：FastAPI 由路由 + Pydantic 模型自动生成 `/openapi.json`，无需手写 swagger 文件。
+
+## 6. 其他设计
+
+### 6.1 端点路径与路由注册
+
+- 新建 `APIRouter(prefix="/nb/v1", tags=["northbound"])`，端点路径 `/users`，
+  最终产出 `POST /nb/v1/users`（无尾部斜杠，避免 307 重定向）。
+  与 `northbound_app.py:62` 的主 router 同前缀、不同路径，FastAPI 允许且不冲突。
+- 在 `backend/apps/northbound_base_app.py` 追加 import 与 `include_router`，
+  与现有 `northbound_router` / `northbound_knowledge_router` 并列（该文件第 18-19、52-53 行）。
+
+### 6.2 服务函数签名
+
+```python
+async def create_user_as_tenant_admin(
+    tenant_id: str,
+    email: EmailStr,
+    initial_password: str,
+    created_by: str,
+    name: Optional[str] = None,
+    role: str = "USER",
+) -> Dict[str, Any]:
+```
+
+处理顺序与异常：
+
+| 步骤 | 失败异常 | 端点映射 |
+| ---- | -------- | -------- |
+| 角色白名单归一化（大写、去空格） | `ValueError`（`SU` 或未知值） | 400 |
+| `validate_password_strength` | `AppException(ErrorCode.PROFILE_PASSWORD_WEAK)` | 400（由 `AppException` handler 自动映射） |
+| 邮箱预检 `find_supabase_user_id_by_email` | `UserRegistrationException` | 409 |
+| `get_supabase_admin_client()` 返回空 | `RuntimeError` | 500 |
+| `auth.admin.create_user` 返回无 user | `UserRegistrationException` | 409 |
+| `insert_user_tenant` 超限额 | `TenantResourceLimitError` | 400 |
+| 其它 | — | 500 |
+
+### 6.3 为什么不用 `_require_asset_owner_context`
+
+`backend/apps/northbound_knowledge_app.py:45` 的 `_require_asset_owner_context` 语义是
+"调用者必须属于资产所有者租户"（`ctx.tenant_id == ASSET_OWNER_TENANT_ID`），
+与本需求"租户内角色为 ADMIN"不同，故新写 `_require_tenant_admin_context`。
+
+## 7. 涉及文件
+
+| 文件 | 操作 | 说明 |
+| ---- | ---- | ---- |
+| `backend/apps/northbound_user_app.py` | 新增 | router、`CreateUserRequest`/`CreateUserResponse`、`_require_tenant_admin_context`、`POST /users` 与错误映射 |
+| `backend/apps/northbound_base_app.py` | 修改 | 追加 import + `include_router`（2 行） |
+| `backend/services/user_management_service.py` | 修改 | 新增 `create_user_as_tenant_admin` |
+| `test/backend/app/test_northbound_user_app.py` | 新增 | 端点层单测（参考 `test_northbound_knowledge_app.py` 的 `sys.modules` 打桩风格） |
+| `test/backend/services/test_user_management_service.py` | 修改 | 追加服务层单测 |
+
+## 8. 风险 & 缓解
+
+| 风险 | 影响 | 缓解 |
+| ---- | ---- | ---- |
+| `SERVICE_ROLE_KEY` 未配置 | `get_supabase_admin_client()` 返回 None，全部请求 500 | 显式判空抛 `RuntimeError`，日志可定位；与既有 `oauth_service.py:449` 处理一致 |
+| 邮箱预检与创建之间的竞态（TOCTOU） | 并发同邮箱可能穿过预检 | Supabase 唯一约束兜底，异常统一映射 409，语义幂等可接受 |
+| 邮箱预检为 O(n/100) 分页扫描 | 用户量大时延迟升高 | 本期接受；后续可换按邮箱直查 |
+| 管理员数超限 | 创建 `ADMIN` 失败 | `insert_user_tenant` 内建 `MAX_ADMINS_PER_TENANT` 校验 → 400 |
+| 测试拉入重量级依赖链 | 单测启动失败 | 用 `sys.modules` 打桩 `apps.northbound_app` 等模块，与既有北向测试同风格 |
+
+## 9. 附录
+
+### 9.1 原始需求描述
+
+> 提供北向创建用户接口，只有租户管理员才能调用此接口
+
+### 9.2 参考资料
+
+- `backend/apps/northbound_app.py:83` `_get_northbound_context`
+- `backend/apps/northbound_knowledge_app.py:38,45` 北向 app 风格参考
+- `backend/apps/app_factory.py:70-209` 异常 handler 注册
+- `backend/database/user_tenant_db.py:77,159` `get_user_role_by_tenant` / `insert_user_tenant`
+- `backend/services/user_management_service.py:595` `validate_password_strength`
+- `backend/services/oauth_service.py:371,459` 邮箱预检与 admin 创建范式
+- `backend/utils/auth_utils.py:300` `get_supabase_admin_client`

--- a/openspec/nb-create-user-tenant-admin/proposal.md
+++ b/openspec/nb-create-user-tenant-admin/proposal.md
@@ -1,0 +1,188 @@
+# 北向创建用户接口（仅租户管理员可调用）— 需求分析文档
+
+> 变更名：`nb-create-user-tenant-admin`
+> 流程模式：Full
+> 目标仓：`ModelEngine-Group/nexent`（远端默认分支 `develop`）
+> 关联 Issue：https://github.com/ModelEngine-Group/nexent/issues/3822
+> 目标分支：`feat-nb-create-user-tenant-admin`（基于 `origin/develop` @ `86d75923d`）
+
+## 1. 需求概述
+
+### 1.1 业务背景
+
+nexent 当前创建用户只有一条路径：带邀请码的自注册
+（`backend/services/user_management_service.py:155` `signup_user_with_invitation`）。
+
+北向（Northbound）API 侧已有知识库、文件、A2A 等能力
+（`backend/apps/northbound_app.py` / `northbound_knowledge_app.py` / `northbound_base_app.py`），
+但**缺少用户管理类端点**。在集成 / 运营场景下，租户管理员需要直接为用户开通账号
+（指定邮箱 + 初始密码），而不必先生成并分发邀请码。
+
+### 1.2 需求目标
+
+新增一个北向 HTTP 端点，允许**租户管理员**创建归属于本租户的用户。
+
+### 1.3 需求范围
+
+**包含：**
+- 新增北向端点 `POST /nb/v1/users`
+- 复用既有北向 API Key 鉴权解析调用者身份
+- 权限门禁：仅租户管理员可调用
+- 管理员指定初始密码，经既有密码强度校验
+- 新用户落到调用者所在租户
+- 邮箱冲突检测
+- 单元测试 + OpenAPI 文档自动生成
+
+**不包含：**
+- 不修改邀请码自注册流程
+- 不做批量创建 / Excel 导入
+- 不支持跨租户创建（新用户只能落在调用者本租户）
+- 不发激活 / 通知邮件
+- 不做租户工具 / 技能列表初始化（见 §8 待确认事项 2）
+
+## 2. 功能描述
+
+### 2.1 核心功能点
+
+| 功能点 | 优先级 | 描述 |
+| ------ | ------ | ---- |
+| 北向创建用户端点 | 高 | `POST /nb/v1/users`，Bearer API Key 鉴权 |
+| 租户管理员权限门禁 | 高 | 调用者在本租户 `user_role == "ADMIN"`，否则 403 |
+| 初始密码强度校验 | 高 | 复用 `validate_password_strength`，不满足返回 400 |
+| 角色白名单 | 中 | 可选指定 `USER` / `DEV` / `ADMIN`，默认 `USER`，拒绝 `SU` |
+| 邮箱冲突检测 | 高 | 邮箱已被注册返回 409 |
+| OpenAPI 文档 | 低 | FastAPI 由路由与 Pydantic 模型自动生成，无需手写 |
+
+### 2.2 业务流程
+
+1. 调用方携带 `Authorization: Bearer <northbound_api_key>` 请求 `POST /nb/v1/users`
+2. `_get_northbound_context` 解析 API Key → `ctx.user_id` / `ctx.tenant_id`；失败 → 401
+3. `get_user_role_by_tenant(ctx.user_id, ctx.tenant_id)` 查询调用者角色；非 `ADMIN` → 403
+4. Pydantic 校验请求体；不合法 → 422
+5. 服务层：角色白名单校验 → 密码强度校验 → 邮箱存在预检 → 创建 Supabase 用户 → 写入租户关系
+6. 返回 `201 { user_id, user_email, user_role, tenant_id }`
+
+### 2.3 输入/输出
+
+| 输入 | 来源 | 输出 | 描述 |
+| ---- | ---- | ---- | ---- |
+| `Authorization` 头 | 调用方 | 401 / 继续 | 北向 API Key（Bearer） |
+| `email` | 请求体 | — | 必填，`EmailStr` |
+| `initial_password` | 请求体 | — | 必填，≥8 位且含大小写字母与数字 |
+| `name` | 请求体 | — | 可选，写入 Supabase `user_metadata.full_name` |
+| `role` | 请求体 | — | 可选，默认 `USER`，白名单 `USER`/`DEV`/`ADMIN` |
+| — | 系统 | 201 + 用户摘要 | 创建成功 |
+| — | 系统 | 403 / 400 / 409 / 500 | 各类失败 |
+
+## 3. 非功能需求
+
+### 3.1 性能要求
+
+- 响应时间：单次创建无强约束；邮箱预检走 Supabase 分页 `list_users`，用户量大时该调用是主要开销
+- 并发数：租户用户数上限由 `MAX_USERS_PER_TENANT` 兜底，本端点不额外限流
+
+### 3.2 安全要求
+
+- **最小权限**：只有本租户 `ADMIN` 可调用；`SU`（平台超管）不放宽，也不允许被创建
+- **不提权**：角色白名单显式排除 `SU`，避免北向接口成为提权入口
+- **密码处理**：密码仅用于创建，不写日志、不出现在任何响应中
+- **凭证**：Supabase 服务角色密钥只经 `get_supabase_admin_client()` 获取，不硬编码
+- **审计**：`insert_user_tenant(created_by=...)` 记录创建者
+
+### 3.3 兼容性要求
+
+- 不改动既有邀请码自注册流程与既有北向端点
+- 新增端点走 `/nb/v1` 前缀，与既有北向端点风格一致
+
+## 4. 约束条件
+
+### 4.1 技术约束
+
+- 角色枚举由数据层决定：`SU` / `ADMIN` / `DEV` / `USER`
+- 邮箱唯一性由 Supabase Auth 全局保证（一个邮箱 = 一个 Supabase 用户），
+  因此邮箱唯一范围是**全局**而非"租户内"
+- `insert_user_tenant` 内建 `_validate_user_tenant_limit`，自动执行
+  `MAX_USERS_PER_TENANT` / `MAX_ADMINS_PER_TENANT` 硬限额
+
+### 4.2 外部依赖
+
+| 依赖项 | 说明 |
+| ------ | ---- |
+| Supabase Auth Admin API | `auth.admin.create_user` / `list_users`，依赖 `SERVICE_ROLE_KEY` |
+| PostgreSQL（`user_tenant_t`） | 租户关系写入，由 `database.user_tenant_db` 封装 |
+
+## 5. 角色与权限
+
+### 5.1 角色清单
+
+| 角色 | 描述 |
+| ---- | ---- |
+| `SU` | 平台超级管理员，全局唯一性受限（`MAX_SUPER_ADMIN_COUNT`） |
+| `ADMIN` | 租户管理员，本接口的目标调用者 |
+| `DEV` | 开发者 |
+| `USER` | 普通用户，新用户默认角色 |
+
+### 5.2 权限矩阵
+
+| 调用者角色 | 可创建 `USER` | 可创建 `DEV` | 可创建 `ADMIN` | 可创建 `SU` |
+| ---------- | ------------- | ------------ | -------------- | ----------- |
+| `ADMIN`（本租户） | ✅ | ✅ | ✅（受管理员数上限） | ❌ 400 |
+| `DEV` / `USER`（本租户） | ❌ 403 | ❌ 403 | ❌ 403 | ❌ 403 |
+| `SU` | ❌ 403 | ❌ 403 | ❌ 403 | ❌ 403 |
+| 无有效 API Key | ❌ 401 | ❌ 401 | ❌ 401 | ❌ 401 |
+
+> 说明：需求原文为"只有租户管理员才能调用"，故 `SU` 不享受豁免；`SU` 走平台自有通道。
+
+## 6. 需求拆分
+
+### 6.1 特性清单（FE）
+
+| FE 编号 | 特性名称 | 优先级 |
+| ------- | -------- | ------ |
+| FE1 | 北向创建用户端点 + API Key 鉴权 | 高 |
+| FE2 | 租户管理员权限门禁 | 高 |
+| FE3 | 用户创建服务（密码强度 / 角色白名单 / 邮箱冲突） | 高 |
+| FE4 | 单元测试与错误码映射 | 中 |
+
+### 6.2 UserStory 清单（US）
+
+| US 编号 | UserStory | 验收标准 |
+| ------- | --------- | -------- |
+| US1 | 作为租户管理员，我要通过北向 API 直接创建用户 | 携带管理员 API Key 调用返回 201，返回新用户 `user_id`/`user_email`/`user_role`/`tenant_id` |
+| US2 | 作为系统，我要阻止非管理员创建用户 | 非 `ADMIN` 调用返回 403，且不产生任何用户 |
+| US3 | 作为系统，我要保证弱密码不能通过 | 不满足强度要求返回 400，且不产生任何用户 |
+| US4 | 作为系统，我要阻止重复邮箱 | 邮箱已注册返回 409，且不产生任何用户 |
+| US5 | 作为系统，我要阻止通过本接口提权 | 请求 `role=SU` 或未知角色返回 400 |
+
+## 7. 验收标准
+
+- [ ] `POST /nb/v1/users` 可通过北向 API Key 访问，并出现在 `/openapi.json`
+- [ ] 非租户管理员调用返回 `403`
+- [ ] 租户管理员可创建归属本租户的用户
+- [ ] 弱密码返回 `400`；重复邮箱返回 `409`；非法角色返回 `400`
+- [ ] 密码由 Supabase Auth 哈希存储，初始密码不出现在日志与响应中
+- [ ] 单元测试覆盖：管理员成功 / 非管理员 403 / 弱密码 400 / 邮箱冲突 409 / 角色白名单拒绝
+- [ ] 新增测试全部通过，且既有 `test_user_management_service.py` 不回归
+
+## 8. 待确认事项
+
+| 序号 | 问题 | 状态 | 备注 |
+| ---- | ---- | ---- | ---- |
+| 1 | 邮箱全局唯一 vs 租户内唯一 | 已确认：全局唯一 | Supabase Auth 决定，冲突即 409 |
+| 2 | 创建后是否初始化租户工具 / 技能列表 | 已确认：不初始化 | `init_tool_list_for_tenant` 等按租户幂等，与单用户创建无必然关联 |
+| 3 | 是否需要通知邮件 | 已确认：不需要 | 本仓无现成邮件通道 |
+| 4 | `SU` 是否可调用 / 可被创建 | 已确认：均不允许 | 需求限定"只有租户管理员" |
+
+## 9. 附录
+
+### 9.1 原始需求描述
+
+> 提供北向创建用户接口，只有租户管理员才能调用此接口
+
+### 9.2 参考资料
+
+- 既有北向端点：`backend/apps/northbound_app.py`、`backend/apps/northbound_knowledge_app.py`
+- 既有注册流程：`backend/services/user_management_service.py:155`
+- 租户关系数据层：`backend/database/user_tenant_db.py`
+- 异常与错误码：`backend/consts/exceptions.py`、`backend/consts/error_code.py`
+- Issue：https://github.com/ModelEngine-Group/nexent/issues/3822

--- a/openspec/nb-create-user-tenant-admin/tasks.md
+++ b/openspec/nb-create-user-tenant-admin/tasks.md
@@ -1,0 +1,175 @@
+# Task 计划 — 北向创建用户接口（仅租户管理员可调用）
+
+> 变更名：`nb-create-user-tenant-admin`
+> 流程模式：Full
+> 基准分支：`feat-nb-create-user-tenant-admin`（基于 `origin/develop` @ `86d75923d`）
+
+## 基本信息
+
+| 项目 | 内容 |
+| ---- | ---- |
+| 需求单号 | Issue https://github.com/ModelEngine-Group/nexent/issues/3822 |
+| 需求分析文档 | `openspec/nb-create-user-tenant-admin/proposal.md` |
+| 设计文档 | `openspec/nb-create-user-tenant-admin/design.md` |
+| 创建时间 | 2026-08-31 |
+
+## Task 清单
+
+| ID | 标题 | 描述 | 优先级 | 预估工时 | 依赖 | 状态 |
+| ---- | ---- | ---- | ------ | -------- | ---- | ---- |
+| TASK-001 | 新增服务层 `create_user_as_tenant_admin` | 在 `user_management_service.py` 新增创建用户的服务函数：角色白名单 → 密码强度 → 邮箱预检 → Supabase admin 创建 → `insert_user_tenant` | 高 | 0.5d | - | 已完成 |
+| TASK-002 | 新增北向 app 与端点 | 新增 `backend/apps/northbound_user_app.py`：请求/响应模型、`_require_tenant_admin_context`、`POST /nb/v1/users` 及错误映射 | 高 | 0.5d | TASK-001 | 已完成 |
+| TASK-003 | 注册路由 | 在 `northbound_base_app.py` 追加 import 与 `include_router` | 高 | 0.1d | TASK-002 | 已完成 |
+| TASK-004 | 服务层单测 | 追加 `TestCreateUserAsTenantAdmin`：成功路径、弱密码、邮箱已存在、角色白名单拒绝（`SU`/未知）、admin client 不可用 | 高 | 0.5d | TASK-001 | 已完成 |
+| TASK-005 | 端点层单测 | 新增 `test/backend/app/test_northbound_user_app.py`：管理员 201、非管理员 403、缺租户角色行 403、弱密码 400、非法角色 400、邮箱冲突 409、参数校验 422、DB 异常 500 | 高 | 0.5d | TASK-002 | 已完成 |
+| TASK-006 | 运行验证 | 跑新增测试 + 既有 `test_user_management_service.py` 回归；冒烟校验 `POST /nb/v1/users` 已注册 | 高 | 0.3d | TASK-003, TASK-004, TASK-005 | 已完成 |
+| TASK-007 | 提交本轮交付 commit | 一轮 AI 编码交付一次 commit，`Refs #3822` | 高 | 0.1d | TASK-006 | 已完成 |
+
+## Task 详情
+
+### TASK-001：新增服务层 `create_user_as_tenant_admin`
+
+**描述**：
+在 `backend/services/user_management_service.py` 新增：
+
+```python
+async def create_user_as_tenant_admin(
+    tenant_id: str,
+    email: EmailStr,
+    initial_password: str,
+    created_by: str,
+    name: Optional[str] = None,
+    role: str = "USER",
+) -> Dict[str, Any]:
+```
+
+- 角色归一化后校验白名单 `{USER, DEV, ADMIN}`，`SU` 与未知值抛 `ValueError`
+- `validate_password_strength` 不通过抛 `AppException(ErrorCode.PROFILE_PASSWORD_WEAK, ...)`
+- 惰性 import `find_supabase_user_id_by_email` 做邮箱预检，命中抛 `UserRegistrationException`
+- `get_supabase_admin_client()` 为空抛 `RuntimeError`
+- `auth.admin.create_user({email, password, email_confirm: True, user_metadata})`
+- `insert_user_tenant(user_id, tenant_id, role, email, created_by=created_by)`
+- 返回 `{user_id, user_email, user_role, tenant_id}`
+
+**验收标准**：
+- [ ] 函数存在且可被单独调用
+- [ ] 密码不进入任何日志语句
+- [ ] 异常类型与设计文档 §6.2 表格一致
+
+**备注**：
+- 复用文件顶部已有 import：`get_supabase_admin_client`、`validate_password_strength` 同文件定义
+
+---
+
+### TASK-002：新增北向 app 与端点
+
+**描述**：
+新增 `backend/apps/northbound_user_app.py`：
+- `router = APIRouter(prefix="/nb/v1", tags=["northbound"])`
+- `CreateUserRequest`（`EmailStr`、`initial_password`、`name?`、`role?` 默认 `USER`）
+- `CreateUserResponse`（`user_id`、`user_email`、`user_role`、`tenant_id`）
+- `_require_tenant_admin_context(request)`：`_get_northbound_context` → `get_user_role_by_tenant` → 非 `ADMIN` 抛 403
+- `POST /users`，`status_code=201`，按设计文档 §6.2 表格映射异常
+
+**验收标准**：
+- [ ] 端点路径精确为 `/nb/v1/users`
+- [ ] 非管理员返回 403，且未调用服务层
+- [ ] 401/403/400/409/422/500 均有对应分支
+
+**备注**：
+- 风格对齐 `northbound_knowledge_app.py`（`HTTPStatus` 常量、`logger`、docstring 说明受限范围）
+
+---
+
+### TASK-003：注册路由
+
+**描述**：
+在 `backend/apps/northbound_base_app.py` 追加：
+```python
+from .northbound_user_app import router as northbound_user_router
+...
+northbound_app.include_router(northbound_user_router)
+```
+
+**验收标准**：
+- [ ] 仅追加必要行，不改动既有逻辑
+- [ ] 冒烟校验 `POST /nb/v1/users` 出现在 `app.routes`
+
+**备注**：
+- FastAPI `include_router` 是惰性路由解析，`app.routes` 在 include 后即包含；端点单测用 `TestClient` 验证
+
+---
+
+### TASK-004：服务层单测
+
+**描述**：
+在 `test/backend/services/test_user_management_service.py` 追加 `TestCreateUserAsTenantAdmin`。
+
+**验收标准**：
+- [ ] 成功路径（默认 USER、显式 ADMIN）
+- [ ] 弱密码 → `AppException` 且 `error_code == PROFILE_PASSWORD_WEAK`
+- [ ] 邮箱已存在 → `UserRegistrationException`
+- [ ] `role=SU` / 未知角色 → `ValueError`
+- [ ] admin client 不可用 → `RuntimeError`
+- [ ] `create_user` 返回无 user → `UserRegistrationException`
+
+**备注**：
+- 用 `sys.modules` 打桩，避免拉入重量级依赖链
+
+---
+
+### TASK-005：端点层单测
+
+**描述**：
+新增 `test/backend/app/test_northbound_user_app.py`，用 `TestClient` 打桩 `_get_northbound_context` 与 `get_user_role_by_tenant`。
+
+**验收标准**：
+- [ ] 管理员 → 201 且响应字段齐全
+- [ ] 非 ADMIN → 403；缺租户角色行（返回 `""`）→ 403
+- [ ] 弱密码 → 400；非法 role → 400
+- [ ] 邮箱冲突 → 409
+- [ ] 缺字段 / 非法邮箱 → 422
+- [ ] DB 查询异常 → 500
+
+**备注**：
+- 参考 `test/backend/app/test_northbound_knowledge_app.py` 的打桩风格
+
+---
+
+### TASK-006：运行验证
+
+**描述**：
+- 跑 `test/backend/services/test_user_management_service.py`（含新增）
+- 跑 `test/backend/app/test_northbound_user_app.py`
+- 冒烟：导入 `northbound_user_app.router`，确认 `POST /nb/v1/users` 已注册
+
+**验收标准**：
+- [ ] 新增测试全绿
+- [ ] 既有测试无回归
+
+---
+
+### TASK-007：提交本轮交付 commit
+
+**描述**：
+一轮 AI 编码交付 = 一次 commit；spec 三件套需 `git add -f`（`.gitignore` 第 63 行屏蔽 `openspec/`）。
+
+**验收标准**：
+- [ ] commit message 符合规范（type(scope): summary，含 `Refs #3822`、`Co-authored-by`、`Generated-by`）
+- [ ] `openspec/` 下三个文件已随 commit 提交
+
+---
+
+## 优先级定义
+
+| 优先级 | 说明 |
+| ------ | ---- |
+| 高 | 必须完成，影响主线 |
+| 中 | 重要，可以延后 |
+| 低 | 可选，非关键路径 |
+
+## 依赖关系处理
+
+1. 独立任务：无依赖，可并行执行
+2. 顺序依赖：TASK-002 → TASK-003；TASK-001 → TASK-004
+3. 阻塞依赖：TASK-006 需 TASK-003/004/005 全部完成

--- a/test/backend/app/test_northbound_user_app.py
+++ b/test/backend/app/test_northbound_user_app.py
@@ -1,0 +1,339 @@
+"""
+Unit tests for northbound_user_app tenant-admin user creation endpoint.
+
+The northbound app package pulls in the whole backend runtime (supabase,
+sqlalchemy, redis ...), so the collaborators are stubbed through ``sys.modules``
+before the module under test is imported. This mirrors the setup used by
+``test_northbound_knowledge_app.py``.
+"""
+import os
+import sys
+import types
+from dataclasses import dataclass
+from http import HTTPStatus
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+backend_dir = os.path.abspath(os.path.join(current_dir, "../../../backend"))
+if backend_dir not in sys.path:
+    sys.path.insert(0, backend_dir)
+
+
+@dataclass
+class NorthboundContext:
+    request_id: str
+    tenant_id: str
+    user_id: str
+    authorization: str
+    token_id: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Stub the collaborators
+# ---------------------------------------------------------------------------
+services_pkg = types.ModuleType("services")
+services_pkg.__path__ = [os.path.join(backend_dir, "services")]
+sys.modules["services"] = services_pkg
+
+northbound_service_module = types.ModuleType("services.northbound_service")
+northbound_service_module.NorthboundContext = NorthboundContext
+sys.modules["services.northbound_service"] = northbound_service_module
+
+user_management_service_module = types.ModuleType("services.user_management_service")
+user_management_service_module.create_user_as_tenant_admin = AsyncMock()
+user_management_service_module.ADMIN_CREATABLE_ROLES = ("USER", "DEV", "ADMIN")
+sys.modules["services.user_management_service"] = user_management_service_module
+
+database_pkg = types.ModuleType("database")
+database_pkg.__path__ = [os.path.join(backend_dir, "database")]
+sys.modules["database"] = database_pkg
+
+user_tenant_db_module = types.ModuleType("database.user_tenant_db")
+user_tenant_db_module.get_user_role_by_tenant = MagicMock(return_value="ADMIN")
+sys.modules["database.user_tenant_db"] = user_tenant_db_module
+
+# consts.exceptions only depends on the stdlib, so load the real module and
+# keep the genuine ErrorCode -> HTTP status mapping under test.
+consts_pkg = types.ModuleType("consts")
+consts_pkg.__path__ = [os.path.join(backend_dir, "consts")]
+sys.modules["consts"] = consts_pkg
+
+northbound_app_module = types.ModuleType("apps.northbound_app")
+northbound_app_module._get_northbound_context = AsyncMock()
+sys.modules["apps.northbound_app"] = northbound_app_module
+
+from apps.northbound_user_app import router  # noqa: E402
+from consts.error_code import ErrorCode  # noqa: E402
+from consts.exceptions import (  # noqa: E402
+    AppException,
+    TenantResourceLimitError,
+    UserRegistrationException,
+)
+
+TENANT_ID = "tenant-1"
+ADMIN_USER_ID = "admin-user-1"
+NEW_USER_EMAIL = "new.user@example.com"
+VALID_PASSWORD = "Passw0rd1"
+
+CREATE_URL = "/nb/v1/users"
+
+
+def make_ctx(user_id: str = ADMIN_USER_ID, tenant_id: str = TENANT_ID) -> NorthboundContext:
+    return NorthboundContext(
+        request_id="req-1",
+        tenant_id=tenant_id,
+        user_id=user_id,
+        authorization="Bearer nb-api-key",
+    )
+
+
+def success_payload(role: str = "USER", email: str = NEW_USER_EMAIL):
+    return {
+        "user_id": "new-user-1",
+        "user_email": email,
+        "user_role": role,
+        "tenant_id": TENANT_ID,
+    }
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_collaborators():
+    """Give every test a clean ADMIN caller and a successful service call."""
+    role_mock = user_tenant_db_module.get_user_role_by_tenant
+    role_mock.reset_mock()
+    role_mock.side_effect = None
+    role_mock.return_value = "ADMIN"
+
+    create_mock = user_management_service_module.create_user_as_tenant_admin
+    create_mock.reset_mock()
+    create_mock.side_effect = None
+    create_mock.return_value = success_payload()
+
+    with patch(
+        "apps.northbound_user_app._get_northbound_context", new_callable=AsyncMock
+    ) as ctx_mock:
+        ctx_mock.return_value = make_ctx()
+        yield ctx_mock
+
+
+class TestTenantAdminGate:
+    """Only the ADMIN role inside the resolved tenant may create users."""
+
+    @pytest.mark.parametrize("role", ["USER", "DEV", "SU", "OWNER"])
+    def test_non_admin_roles_rejected(self, client, role):
+        user_tenant_db_module.get_user_role_by_tenant.return_value = role
+
+        response = client.post(
+            CREATE_URL, json={"email": NEW_USER_EMAIL, "initial_password": VALID_PASSWORD}
+        )
+
+        assert response.status_code == HTTPStatus.FORBIDDEN
+        assert "tenant administrator" in response.json()["detail"]
+        user_management_service_module.create_user_as_tenant_admin.assert_not_called()
+
+    def test_absent_role_rejected(self, client):
+        """A caller with no tenant relationship has no role and is rejected."""
+        user_tenant_db_module.get_user_role_by_tenant.return_value = None
+
+        response = client.post(
+            CREATE_URL, json={"email": NEW_USER_EMAIL, "initial_password": VALID_PASSWORD}
+        )
+
+        assert response.status_code == HTTPStatus.FORBIDDEN
+        user_management_service_module.create_user_as_tenant_admin.assert_not_called()
+
+    @pytest.mark.parametrize("role", ["ADMIN", "admin", "Admin"])
+    def test_admin_role_allowed_regardless_of_case(self, client, role):
+        user_tenant_db_module.get_user_role_by_tenant.return_value = role
+
+        response = client.post(
+            CREATE_URL, json={"email": NEW_USER_EMAIL, "initial_password": VALID_PASSWORD}
+        )
+
+        assert response.status_code == HTTPStatus.CREATED
+
+    def test_role_resolved_against_caller_tenant(self, client):
+        response = client.post(
+            CREATE_URL, json={"email": NEW_USER_EMAIL, "initial_password": VALID_PASSWORD}
+        )
+
+        assert response.status_code == HTTPStatus.CREATED
+        user_tenant_db_module.get_user_role_by_tenant.assert_called_once_with(
+            ADMIN_USER_ID, TENANT_ID
+        )
+
+    def test_role_lookup_failure_returns_500(self, client):
+        user_tenant_db_module.get_user_role_by_tenant.side_effect = RuntimeError("db down")
+
+        response = client.post(
+            CREATE_URL, json={"email": NEW_USER_EMAIL, "initial_password": VALID_PASSWORD}
+        )
+
+        assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        user_management_service_module.create_user_as_tenant_admin.assert_not_called()
+
+
+class TestCreateUser:
+    def test_creates_user_with_default_role(self, client):
+        response = client.post(
+            CREATE_URL, json={"email": NEW_USER_EMAIL, "initial_password": VALID_PASSWORD}
+        )
+
+        assert response.status_code == HTTPStatus.CREATED
+        assert response.json() == success_payload(role="USER")
+        user_management_service_module.create_user_as_tenant_admin.assert_awaited_once_with(
+            tenant_id=TENANT_ID,
+            email=NEW_USER_EMAIL,
+            initial_password=VALID_PASSWORD,
+            created_by=ADMIN_USER_ID,
+            name=None,
+            role="USER",
+        )
+
+    def test_creates_user_with_explicit_role_and_name(self, client):
+        user_management_service_module.create_user_as_tenant_admin.return_value = (
+            success_payload(role="DEV")
+        )
+
+        response = client.post(
+            CREATE_URL,
+            json={
+                "email": NEW_USER_EMAIL,
+                "initial_password": VALID_PASSWORD,
+                "name": "New User",
+                "role": "DEV",
+            },
+        )
+
+        assert response.status_code == HTTPStatus.CREATED
+        assert response.json()["user_role"] == "DEV"
+        user_management_service_module.create_user_as_tenant_admin.assert_awaited_once_with(
+            tenant_id=TENANT_ID,
+            email=NEW_USER_EMAIL,
+            initial_password=VALID_PASSWORD,
+            created_by=ADMIN_USER_ID,
+            name="New User",
+            role="DEV",
+        )
+
+    def test_response_is_mapped_from_service_result(self, client):
+        user_management_service_module.create_user_as_tenant_admin.return_value = {
+            "user_id": "another-user",
+            "user_email": "another@example.com",
+            "user_role": "ADMIN",
+            "tenant_id": TENANT_ID,
+        }
+
+        response = client.post(
+            CREATE_URL,
+            json={
+                "email": "another@example.com",
+                "initial_password": VALID_PASSWORD,
+                "role": "ADMIN",
+            },
+        )
+
+        assert response.status_code == HTTPStatus.CREATED
+        assert response.json() == {
+            "user_id": "another-user",
+            "user_email": "another@example.com",
+            "user_role": "ADMIN",
+            "tenant_id": TENANT_ID,
+        }
+
+    def test_weak_password_returns_400(self, client):
+        user_management_service_module.create_user_as_tenant_admin.side_effect = AppException(
+            ErrorCode.PROFILE_PASSWORD_WEAK, "Password must be stronger."
+        )
+
+        response = client.post(
+            CREATE_URL, json={"email": NEW_USER_EMAIL, "initial_password": "password"}
+        )
+
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert response.json()["detail"] == "Password must be stronger."
+
+    def test_duplicate_email_returns_409(self, client):
+        user_management_service_module.create_user_as_tenant_admin.side_effect = (
+            UserRegistrationException(f"Email {NEW_USER_EMAIL} is already registered")
+        )
+
+        response = client.post(
+            CREATE_URL, json={"email": NEW_USER_EMAIL, "initial_password": VALID_PASSWORD}
+        )
+
+        assert response.status_code == HTTPStatus.CONFLICT
+
+    def test_tenant_resource_limit_returns_400(self, client):
+        """TenantResourceLimitError is a ValueError subclass and must stay 400."""
+        user_management_service_module.create_user_as_tenant_admin.side_effect = (
+            TenantResourceLimitError("Maximum number of administrators reached")
+        )
+
+        response = client.post(
+            CREATE_URL,
+            json={
+                "email": NEW_USER_EMAIL,
+                "initial_password": VALID_PASSWORD,
+                "role": "ADMIN",
+            },
+        )
+
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert "administrators" in response.json()["detail"]
+
+    def test_unsupported_role_returns_400(self, client):
+        user_management_service_module.create_user_as_tenant_admin.side_effect = ValueError(
+            "Unsupported role 'SU'. Allowed roles: USER, DEV, ADMIN"
+        )
+
+        response = client.post(
+            CREATE_URL,
+            json={"email": NEW_USER_EMAIL, "initial_password": VALID_PASSWORD, "role": "SU"},
+        )
+
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert "Unsupported role" in response.json()["detail"]
+
+    def test_unexpected_error_returns_500(self, client):
+        user_management_service_module.create_user_as_tenant_admin.side_effect = RuntimeError(
+            "supabase exploded"
+        )
+
+        response = client.post(
+            CREATE_URL, json={"email": NEW_USER_EMAIL, "initial_password": VALID_PASSWORD}
+        )
+
+        assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR
+        assert response.json()["detail"] == "Failed to create user"
+
+
+class TestRequestValidation:
+    """Pydantic guards run before the permission check."""
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"email": "not-an-email", "initial_password": VALID_PASSWORD},
+            {"email": NEW_USER_EMAIL, "initial_password": "short"},
+            {"email": NEW_USER_EMAIL},
+            {"email": NEW_USER_EMAIL, "initial_password": VALID_PASSWORD, "unexpected": 1},
+        ],
+    )
+    def test_invalid_payload_returns_422(self, client, payload):
+        response = client.post(CREATE_URL, json=payload)
+
+        assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+        user_tenant_db_module.get_user_role_by_tenant.assert_not_called()
+        user_management_service_module.create_user_as_tenant_admin.assert_not_called()

--- a/test/backend/services/test_user_management_service.py
+++ b/test/backend/services/test_user_management_service.py
@@ -34,6 +34,7 @@ sys.modules['services.invitation_service'] = MagicMock()
 sys.modules['services.group_service'] = MagicMock()
 sys.modules['services.tool_configuration_service'] = MagicMock()
 sys.modules['services.skill_service'] = MagicMock()
+sys.modules['services.oauth_service'] = MagicMock()
 
 asset_owner_visibility_mock = types.ModuleType('services.asset_owner_visibility')
 asset_owner_visibility_mock.filter_accessible_routes_for_asset_owner_feature = lambda routes: routes
@@ -48,6 +49,7 @@ from consts.exceptions import (
     UnauthorizedError,
     AppException,
     ValidationError,
+    TenantResourceLimitError,
 )
 from consts.error_code import ErrorCode
 from consts.const import (
@@ -94,7 +96,9 @@ with patch('backend.database.client.MinioClient', return_value=minio_client_mock
         refresh_user_token,
         get_session_by_authorization,
         get_user_info,
-        format_role_permissions
+        format_role_permissions,
+        create_user_as_tenant_admin,
+        ADMIN_CREATABLE_ROLES,
     )
 
 
@@ -2062,6 +2066,270 @@ class TestAdditionalUserManagementCoverage(unittest.IsolatedAsyncioTestCase):
         from backend.services import user_management_service as ums
 
         self.assertEqual(kwargs["headers"], {"apikey": ums.SUPABASE_KEY})
+
+
+class TestCreateUserAsTenantAdmin(unittest.IsolatedAsyncioTestCase):
+    """Test create_user_as_tenant_admin (northbound tenant-admin provisioning)."""
+
+    TENANT_ID = "tenant-1"
+    ADMIN_ID = "admin-user-1"
+    EMAIL = "new.user@example.com"
+    PASSWORD = "Passw0rd1"
+
+    def _admin_client(self, user_id="new-user-1"):
+        client = MagicMock()
+        create_response = MagicMock()
+        create_response.user = MagicMock()
+        create_response.user.id = user_id
+        client.auth.admin.create_user.return_value = create_response
+        return client
+
+    @patch("backend.services.user_management_service.insert_user_tenant")
+    @patch("backend.services.user_management_service.find_supabase_user_id_by_email")
+    @patch("backend.services.user_management_service.get_supabase_admin_client")
+    @patch("backend.services.user_management_service.validate_password_strength")
+    async def test_creates_user_with_default_role(
+        self, mock_password_ok, mock_get_admin, mock_find_user, mock_insert
+    ):
+        mock_password_ok.return_value = True
+        mock_get_admin.return_value = self._admin_client()
+        mock_find_user.return_value = None
+
+        result = await create_user_as_tenant_admin(
+            tenant_id=self.TENANT_ID,
+            email=self.EMAIL,
+            initial_password=self.PASSWORD,
+            created_by=self.ADMIN_ID,
+        )
+
+        self.assertEqual(
+            result,
+            {
+                "user_id": "new-user-1",
+                "user_email": self.EMAIL,
+                "user_role": "USER",
+                "tenant_id": self.TENANT_ID,
+            },
+        )
+        mock_insert.assert_called_once_with(
+            user_id="new-user-1",
+            tenant_id=self.TENANT_ID,
+            user_role="USER",
+            user_email=self.EMAIL,
+            created_by=self.ADMIN_ID,
+        )
+
+    @patch("backend.services.user_management_service.insert_user_tenant")
+    @patch("backend.services.user_management_service.find_supabase_user_id_by_email")
+    @patch("backend.services.user_management_service.get_supabase_admin_client")
+    @patch("backend.services.user_management_service.validate_password_strength")
+    async def test_create_user_payload_pre_confirms_email_and_carries_name(
+        self, mock_password_ok, mock_get_admin, mock_find_user, mock_insert
+    ):
+        mock_password_ok.return_value = True
+        client = self._admin_client()
+        mock_get_admin.return_value = client
+        mock_find_user.return_value = None
+
+        await create_user_as_tenant_admin(
+            tenant_id=self.TENANT_ID,
+            email=self.EMAIL,
+            initial_password=self.PASSWORD,
+            created_by=self.ADMIN_ID,
+            name="New User",
+            role="dev",
+        )
+
+        client.auth.admin.create_user.assert_called_once_with(
+            {
+                "email": self.EMAIL,
+                "password": self.PASSWORD,
+                "email_confirm": True,
+                "user_metadata": {"full_name": "New User"},
+            }
+        )
+        # Role is normalised before it reaches the database.
+        self.assertEqual(mock_insert.call_args.kwargs["user_role"], "DEV")
+
+    @patch("backend.services.user_management_service.insert_user_tenant")
+    @patch("backend.services.user_management_service.find_supabase_user_id_by_email")
+    @patch("backend.services.user_management_service.get_supabase_admin_client")
+    @patch("backend.services.user_management_service.validate_password_strength")
+    async def test_allowed_roles_are_normalised(
+        self, mock_password_ok, mock_get_admin, mock_find_user, mock_insert
+    ):
+        mock_password_ok.return_value = True
+        mock_get_admin.return_value = self._admin_client()
+        mock_find_user.return_value = None
+
+        for role, expected in [("user", "USER"), ("DEV", "DEV"), (" admin ", "ADMIN")]:
+            mock_insert.reset_mock()
+            await create_user_as_tenant_admin(
+                tenant_id=self.TENANT_ID,
+                email=self.EMAIL,
+                initial_password=self.PASSWORD,
+                created_by=self.ADMIN_ID,
+                role=role,
+            )
+            self.assertEqual(mock_insert.call_args.kwargs["user_role"], expected)
+
+    @patch("backend.services.user_management_service.insert_user_tenant")
+    @patch("backend.services.user_management_service.find_supabase_user_id_by_email")
+    @patch("backend.services.user_management_service.get_supabase_admin_client")
+    @patch("backend.services.user_management_service.validate_password_strength")
+    async def test_rejected_roles_raise_value_error(
+        self, mock_password_ok, mock_get_admin, mock_find_user, mock_insert
+    ):
+        mock_password_ok.return_value = True
+        mock_get_admin.return_value = self._admin_client()
+        mock_find_user.return_value = None
+
+        for role in ["SU", "SUPER_ADMIN", "OWNER", "", None]:
+            with self.assertRaises(ValueError):
+                await create_user_as_tenant_admin(
+                    tenant_id=self.TENANT_ID,
+                    email=self.EMAIL,
+                    initial_password=self.PASSWORD,
+                    created_by=self.ADMIN_ID,
+                    role=role,
+                )
+
+        mock_insert.assert_not_called()
+
+    @patch("backend.services.user_management_service.insert_user_tenant")
+    @patch("backend.services.user_management_service.find_supabase_user_id_by_email")
+    @patch("backend.services.user_management_service.get_supabase_admin_client")
+    @patch("backend.services.user_management_service.validate_password_strength")
+    async def test_weak_password_raises_app_exception(
+        self, mock_password_ok, mock_get_admin, mock_find_user, mock_insert
+    ):
+        mock_password_ok.return_value = False
+        mock_get_admin.return_value = self._admin_client()
+        mock_find_user.return_value = None
+
+        with self.assertRaises(AppException) as ctx:
+            await create_user_as_tenant_admin(
+                tenant_id=self.TENANT_ID,
+                email=self.EMAIL,
+                initial_password="password",
+                created_by=self.ADMIN_ID,
+            )
+
+        self.assertEqual(ctx.exception.error_code, ErrorCode.PROFILE_PASSWORD_WEAK)
+        self.assertEqual(ctx.exception.http_status, 400)
+        mock_insert.assert_not_called()
+
+    @patch("backend.services.user_management_service.insert_user_tenant")
+    @patch("backend.services.user_management_service.find_supabase_user_id_by_email")
+    @patch("backend.services.user_management_service.get_supabase_admin_client")
+    @patch("backend.services.user_management_service.validate_password_strength")
+    async def test_existing_email_raises_registration_exception(
+        self, mock_password_ok, mock_get_admin, mock_find_user, mock_insert
+    ):
+        mock_password_ok.return_value = True
+        mock_get_admin.return_value = self._admin_client()
+        mock_find_user.return_value = "already-registered-user"
+
+        with self.assertRaises(UserRegistrationException):
+            await create_user_as_tenant_admin(
+                tenant_id=self.TENANT_ID,
+                email=self.EMAIL,
+                initial_password=self.PASSWORD,
+                created_by=self.ADMIN_ID,
+            )
+
+        mock_insert.assert_not_called()
+
+    @patch("backend.services.user_management_service.insert_user_tenant")
+    @patch("backend.services.user_management_service.find_supabase_user_id_by_email")
+    @patch("backend.services.user_management_service.get_supabase_admin_client")
+    @patch("backend.services.user_management_service.validate_password_strength")
+    async def test_duplicate_race_maps_to_registration_exception(
+        self, mock_password_ok, mock_get_admin, mock_find_user, mock_insert
+    ):
+        """A concurrent registration surfaces as a Supabase error, not a 500."""
+        mock_password_ok.return_value = True
+        client = self._admin_client()
+        client.auth.admin.create_user.side_effect = RuntimeError(
+            "User already registered"
+        )
+        mock_get_admin.return_value = client
+        mock_find_user.return_value = None
+
+        with self.assertRaises(UserRegistrationException):
+            await create_user_as_tenant_admin(
+                tenant_id=self.TENANT_ID,
+                email=self.EMAIL,
+                initial_password=self.PASSWORD,
+                created_by=self.ADMIN_ID,
+            )
+
+        mock_insert.assert_not_called()
+
+    @patch("backend.services.user_management_service.insert_user_tenant")
+    @patch("backend.services.user_management_service.find_supabase_user_id_by_email")
+    @patch("backend.services.user_management_service.get_supabase_admin_client")
+    @patch("backend.services.user_management_service.validate_password_strength")
+    async def test_unrelated_supabase_error_is_reraised(
+        self, mock_password_ok, mock_get_admin, mock_find_user, mock_insert
+    ):
+        mock_password_ok.return_value = True
+        client = self._admin_client()
+        client.auth.admin.create_user.side_effect = RuntimeError("network down")
+        mock_get_admin.return_value = client
+        mock_find_user.return_value = None
+
+        with self.assertRaises(RuntimeError):
+            await create_user_as_tenant_admin(
+                tenant_id=self.TENANT_ID,
+                email=self.EMAIL,
+                initial_password=self.PASSWORD,
+                created_by=self.ADMIN_ID,
+            )
+
+    @patch("backend.services.user_management_service.insert_user_tenant")
+    @patch("backend.services.user_management_service.find_supabase_user_id_by_email")
+    @patch("backend.services.user_management_service.get_supabase_admin_client")
+    @patch("backend.services.user_management_service.validate_password_strength")
+    async def test_missing_admin_client_raises_runtime_error(
+        self, mock_password_ok, mock_get_admin, mock_find_user, mock_insert
+    ):
+        mock_password_ok.return_value = True
+        mock_get_admin.return_value = None
+
+        with self.assertRaises(RuntimeError):
+            await create_user_as_tenant_admin(
+                tenant_id=self.TENANT_ID,
+                email=self.EMAIL,
+                initial_password=self.PASSWORD,
+                created_by=self.ADMIN_ID,
+            )
+
+    @patch("backend.services.user_management_service.insert_user_tenant")
+    @patch("backend.services.user_management_service.find_supabase_user_id_by_email")
+    @patch("backend.services.user_management_service.get_supabase_admin_client")
+    @patch("backend.services.user_management_service.validate_password_strength")
+    async def test_tenant_quota_error_propagates(
+        self, mock_password_ok, mock_get_admin, mock_find_user, mock_insert
+    ):
+        """Tenant limits are enforced by insert_user_tenant and must not be swallowed."""
+        mock_password_ok.return_value = True
+        mock_get_admin.return_value = self._admin_client()
+        mock_find_user.return_value = None
+        mock_insert.side_effect = TenantResourceLimitError("admin limit reached")
+
+        with self.assertRaises(TenantResourceLimitError):
+            await create_user_as_tenant_admin(
+                tenant_id=self.TENANT_ID,
+                email=self.EMAIL,
+                initial_password=self.PASSWORD,
+                created_by=self.ADMIN_ID,
+                role="ADMIN",
+            )
+
+    async def test_admin_creatable_roles_excludes_super_admin(self):
+        self.assertEqual(ADMIN_CREATABLE_ROLES, ("USER", "DEV", "ADMIN"))
+        self.assertNotIn("SU", ADMIN_CREATABLE_ROLES)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Add a northbound API endpoint `POST /nb/v1/users` that lets a **tenant administrator** create a user in their own tenant.

- Caller must hold `user_role == ADMIN` in the resolved tenant (`_get_northbound_context` + `get_user_role_by_tenant`), otherwise `403 Forbidden` — the service layer is never reached.
- `role` is restricted to an allow-list `USER` / `DEV` / `ADMIN`; `SU` (platform super admin) and unknown roles are rejected (`400`).
- `initial_password` is enforced via the existing `validate_password_strength` (`400` on weak password).
- The Supabase admin client creates the auth user with `email_confirm: True` and links it to the tenant via `insert_user_tenant`.
- An email already registered in **any** tenant is rejected with `409`.
- No side effects beyond account creation (no tool/skill list init, no notification email).

## Changes

- `backend/services/user_management_service.py`: new `create_user_as_tenant_admin(...)`.
- `backend/apps/northbound_user_app.py`: new router + `POST /users` + `_require_tenant_admin_context` 403 gate.
- `backend/apps/northbound_base_app.py`: register `northbound_user_router`.
- `openspec/nb-create-user-tenant-admin/`: proposal / design / tasks (Full mode spec).

## Test plan

- `test/backend/app/test_northbound_user_app.py` (22 cases): admin → 201; non-admin / missing role row → 403; weak password / invalid role → 400; duplicate email → 409; missing field / bad email → 422; DB error → 500.
- `test/backend/services/test_user_management_service.py` (+11 cases): success path, weak password, duplicate email, role allow-list, admin client unavailable.
- Combined run: 122 passed; regression vs `origin/develop` shows no new failures.

Fixes #3822

🤖 Generated with WorkBuddy
