### PR TITLE
🐛 Fix signed integer list parsing

### DIFF
--- a/backend/utils/str_utils.py
+++ b/backend/utils/str_utils.py
@@ -1,5 +1,8 @@
+import logging
 import re
 from typing import List, Optional
+
+logger = logging.getLogger(__name__)
 
 
 def remove_think_blocks(text: str) -> str:
@@ -36,4 +39,16 @@ def convert_string_to_list(items_str: Optional[str]) -> List[int]:
     """
     if not items_str or items_str.strip() == "":
         return []
-    return [int(item.strip()) for item in items_str.split(",") if item.strip().isdigit()]
+
+    items = []
+    for raw_item in items_str.split(","):
+        item = raw_item.strip()
+        if not item:
+            continue
+        try:
+            items.append(int(item))
+        except ValueError:
+            logger.warning(
+                "convert_string_to_list: dropping non-integer entry %r", item
+            )
+    return items

--- a/test/backend/utils/test_str_utils.py
+++ b/test/backend/utils/test_str_utils.py
@@ -1,5 +1,10 @@
 import pytest
-from backend.utils.str_utils import remove_think_blocks, convert_list_to_string
+
+from backend.utils.str_utils import (
+    convert_list_to_string,
+    convert_string_to_list,
+    remove_think_blocks,
+)
 
 
 class TestStrUtils:
@@ -88,6 +93,23 @@ class TestStrUtils:
         """Zero and negative numbers should be handled correctly"""
         result = convert_list_to_string([0, -1, 5])
         assert result == "0,-1,5"
+
+    def test_convert_string_to_list_round_trips_signed_integers(self):
+        """Serialized signed integers should round-trip without data loss"""
+        serialized = convert_list_to_string([0, -1, 5])
+
+        assert convert_string_to_list(serialized) == [0, -1, 5]
+
+    def test_convert_string_to_list_accepts_whitespace_and_explicit_signs(self):
+        """Whitespace and explicit integer signs should be accepted"""
+        assert convert_string_to_list("  -2, +3, 0  ") == [-2, 3, 0]
+
+    def test_convert_string_to_list_warns_and_keeps_valid_entries(self, caplog):
+        """Malformed entries should be reported without discarding valid values"""
+        result = convert_string_to_list("invalid, 1, , -2")
+
+        assert result == [1, -2]
+        assert "dropping non-integer entry 'invalid'" in caplog.text
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- parse whitespace-trimmed signed integers instead of filtering them with `str.isdigit()`
- warn when malformed non-empty entries are skipped while retaining valid entries
- add regression coverage for signed round-trips and malformed mixed input

## Root cause

`convert_string_to_list` filtered tokens through `str.isdigit()` before conversion. That rejected `-1` and `+1`, even though `convert_list_to_string` can serialize negative integers, and it silently discarded malformed entries.

## Validation

- `uvx --from pytest pytest test/backend/utils/test_str_utils.py -q` (18 passed)
- `uvx ruff check --select E,F,I backend/utils/str_utils.py test/backend/utils/test_str_utils.py`
- `uvx ruff format --check backend/utils/str_utils.py test/backend/utils/test_str_utils.py`
- `python3 -m compileall -q backend/utils/str_utils.py test/backend/utils/test_str_utils.py`
- `git diff --check`

Fixes #3818