### PR TITLE
🐛 Fix: avoid duplicate stream keyword in evaluator LLM calls

### DIFF
--- a/backend/utils/llm_utils.py
+++ b/backend/utils/llm_utils.py
@@ -135,6 +135,10 @@ def call_llm_for_system_prompt(
                 temperature=0.3,
                 top_p=0.95,
             )
+            # The evaluator consumes the response as a stream. Remove any
+            # construction-time stream value before forcing the call-level
+            # streaming mode, otherwise Python receives duplicate keywords.
+            completion_kwargs.pop("stream", None)
             current_request = llm.client.chat.completions.create(stream=True, **completion_kwargs)
             token_join: List[str] = []
             is_thinking = False

--- a/test/backend/utils/test_llm_utils.py
+++ b/test/backend/utils/test_llm_utils.py
@@ -162,6 +162,35 @@ class TestCallLLMForSystemPrompt:
             timeout_seconds=None,
         )
 
+    def test_call_llm_for_system_prompt_removes_prepared_stream(self, mocker: MockFixture):
+        mock_get_model_by_id = mocker.patch('backend.utils.llm_utils.get_model_by_model_id')
+        mock_adapter = mocker.patch('backend.utils.llm_utils.get_llm_adapter_from_config')
+
+        mock_get_model_by_id.return_value = {
+            "base_url": "http://example.com",
+            "api_key": "fake-key",
+            "model_factory": "qwen",
+        }
+
+        mock_llm_instance = mock_adapter.return_value
+        mock_chunk = MagicMock()
+        mock_chunk.choices = [MagicMock()]
+        mock_chunk.choices[0].delta.content = "Generated prompt"
+        mock_llm_instance.client = MagicMock()
+        mock_llm_instance.client.chat.completions.create.return_value = [mock_chunk]
+        mock_llm_instance._prepare_completion_kwargs.return_value = {
+            "stream": False,
+            "temperature": 0.3,
+        }
+
+        result = call_llm_for_system_prompt(1, "user prompt", "system prompt")
+
+        assert result == "Generated prompt"
+        mock_llm_instance.client.chat.completions.create.assert_called_once_with(
+            stream=True,
+            temperature=0.3,
+        )
+
     def test_call_llm_for_system_prompt_exception(self, mocker: MockFixture):
         from consts.error_code import ErrorCode
         from consts.exceptions import AppException


### PR DESCRIPTION
## Problem

Evaluation requests could fail when the evaluator generated system prompts or processed evaluation cases.

The failure was caused by a duplicated `stream` keyword in the evaluator LLM request.

## Root Cause

The in-process LLM client caching feature was introduced by
[PR #3668](https://github.com/ModelEngine-Group/nexent/pull/3668).

After that change, cached model clients could retain a construction-time
`stream` parameter in the result of `_prepare_completion_kwargs()`.

The normal conversation path was later adapted in
[PR #3695](https://github.com/ModelEngine-Group/nexent/pull/3695) by removing
the stale `stream` value before forcing streaming.

However, the evaluation path was not updated accordingly. It still called:

When completion_kwargs already contained stream=False, Python received
the same keyword twice and raised:
```python
TypeError: got multiple values for keyword argument 'stream'
```
The evaluator then forces streaming by calling:
```python
client.chat.completions.create(
    stream=True,
    **completion_kwargs,
)
```
This passes stream twice and can raise a Python duplicate-keyword error before the request reaches the model.
The normal conversation path already removes the old stream parameter, but the evaluator path did not perform the same adaptation.
Solution
Remove any existing stream value from the prepared completion parameters before forcing evaluator calls to use streaming:
```python
completion_kwargs.pop("stream", None)

current_request = llm.client.chat.completions.create(
    stream=True,
    **completion_kwargs,
)
```
Other completion parameters remain unchanged.
## Validation Screenshots
1. Restart the runtime service and clear the cache
2. On the login screen, start a new conversation using Model A
<img width="1267" height="1142" alt="image" src="https://github.com/user-attachments/assets/fd4f92eb-9e08-4d08-ae3b-ff3e74206303" />

3. Use Model A to run an agent evaluation
<img width="1311" height="457" alt="image" src="https://github.com/user-attachments/assets/bab91b7d-451f-4f23-939d-505bd5794e82" />
