### PR TITLE
🐛 Fix: avoid duplicate stream keyword in evaluator LLM calls

### DIFF
--- a/backend/utils/llm_utils.py
+++ b/backend/utils/llm_utils.py
@@ -135,6 +135,10 @@ def call_llm_for_system_prompt(
                 temperature=0.3,
                 top_p=0.95,
             )
+            # The evaluator consumes the response as a stream. Remove any
+            # construction-time stream value before forcing the call-level
+            # streaming mode, otherwise Python receives duplicate keywords.
+            completion_kwargs.pop("stream", None)
             current_request = llm.client.chat.completions.create(stream=True, **completion_kwargs)
             token_join: List[str] = []
             is_thinking = False

--- a/test/backend/utils/test_llm_utils.py
+++ b/test/backend/utils/test_llm_utils.py
@@ -162,6 +162,35 @@ class TestCallLLMForSystemPrompt:
             timeout_seconds=None,
         )
 
+    def test_call_llm_for_system_prompt_removes_prepared_stream(self, mocker: MockFixture):
+        mock_get_model_by_id = mocker.patch('backend.utils.llm_utils.get_model_by_model_id')
+        mock_adapter = mocker.patch('backend.utils.llm_utils.get_llm_adapter_from_config')
+
+        mock_get_model_by_id.return_value = {
+            "base_url": "http://example.com",
+            "api_key": "fake-key",
+            "model_factory": "qwen",
+        }
+
+        mock_llm_instance = mock_adapter.return_value
+        mock_chunk = MagicMock()
+        mock_chunk.choices = [MagicMock()]
+        mock_chunk.choices[0].delta.content = "Generated prompt"
+        mock_llm_instance.client = MagicMock()
+        mock_llm_instance.client.chat.completions.create.return_value = [mock_chunk]
+        mock_llm_instance._prepare_completion_kwargs.return_value = {
+            "stream": False,
+            "temperature": 0.3,
+        }
+
+        result = call_llm_for_system_prompt(1, "user prompt", "system prompt")
+
+        assert result == "Generated prompt"
+        mock_llm_instance.client.chat.completions.create.assert_called_once_with(
+            stream=True,
+            temperature=0.3,
+        )
+
     def test_call_llm_for_system_prompt_exception(self, mocker: MockFixture):
         from consts.error_code import ErrorCode
         from consts.exceptions import AppException


### PR DESCRIPTION
## Summary

Backport the evaluator stream compatibility fix from PR #3829 to main without waiting for the next release.

## Problem

The in-process LLM client caching feature introduced reusable model clients. After that change, the evaluator path was not adapted to cached completion parameters.

When _prepare_completion_kwargs() retained a construction-time stream value, the evaluator also passed stream=True, which could result in:

TypeError: got multiple values for keyword argument 'stream'

This affected evaluator-related requests such as AI-generated evaluation sets, AI-generated evaluators, and LLM Judge evaluation calls.

The normal conversation path already removed the stale parameter, but the evaluator path was missing the same compatibility handling.

## Solution

Remove any existing stream value before forcing evaluator requests to use streaming:

completion_kwargs.pop('stream', None)
current_request = llm.client.chat.completions.create(stream=True, **completion_kwargs)

Other completion parameters are preserved unchanged.

## Tests

Added a regression test that simulates a cached client returning stream=False and verifies that the final request contains only stream=True.

## Validation

- Targeted unit tests: 69 passed
- Config, Runtime, and frontend local health checks: passed
- Full unit-test workflow: passed
- Codecov patch coverage: 100%
- Docker build, SonarCloud, and CodeQL checks: passed

## Scope

Only the evaluator compatibility fix and its regression test are included. No API, database schema, or model configuration changes.

## Validation Screenshots

<!-- Add screenshots here -->
<img width="1928" height="1131" alt="7a84c54c-600b-44e6-a962-b9a7ff4eb1ae" src="https://github.com/user-attachments/assets/155d24e1-1579-44d2-b4c9-5ad8427ad830" />

<img width="1706" height="472" alt="046b6ce3-02c4-4297-8b67-a864aaf20b5a" src="https://github.com/user-attachments/assets/606bf147-6b9f-4ea2-a69f-6b4fd1db746c" />
