### PR TITLE
fix: restore unlimited tenant storage quota

### DIFF
--- a/frontend/app/[locale]/resource-manage/components/resources/QuotaSettingsModal.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/QuotaSettingsModal.tsx
@@ -117,8 +117,9 @@ export function QuotaSettingsModal({
   const [activeThresholdIndex, setActiveThresholdIndex] = useState<
     number | null
   >(null);
-  // Quota input managed as plain controlled state (not Form field)
-  const [quotaValue, setQuotaValue] = useState<number | null>(null);
+  // An empty string explicitly represents an unlimited hard quota.
+  const [quotaInput, setQuotaInput] = useState("");
+  const quotaValue = quotaInput === "" ? null : Number(quotaInput);
 
   // Fetch current quota config and usage
   const fetchData = useCallback(async () => {
@@ -157,10 +158,10 @@ export function QuotaSettingsModal({
       const quotaBytes = configData.hard_limit_bytes;
       if (quotaBytes && quotaBytes < GB) {
         setUnit("MB");
-        setQuotaValue(Math.round(quotaBytes / MB));
+        setQuotaInput(String(Math.round(quotaBytes / MB)));
       } else {
         setUnit("GB");
-        setQuotaValue(quotaBytes ? Math.round(quotaBytes / GB) : null);
+        setQuotaInput(quotaBytes ? String(Math.round(quotaBytes / GB)) : "");
       }
     } catch (err: any) {
       message.error(err.message || "Failed to load quota settings");
@@ -260,15 +261,25 @@ export function QuotaSettingsModal({
         warning_threshold_pct: values.warning_threshold_pct,
         critical_threshold_pct: values.critical_threshold_pct,
       };
-      // Only include hard limit when user is allowed to change it
+      // Only include hard limit when user is allowed to change it.
+      // The update API intentionally ignores null hard-limit fields, so an
+      // empty input must use the dedicated DELETE endpoint after saving the
+      // warning settings.
       if (canEditHardLimit) {
-        if (unit === "GB") {
-          payload.hard_limit_gb = quotaValue;
+        if (quotaValue == null) {
+          await quotaService.updateTenantQuota(tenantId, payload);
+          await quotaService.deleteTenantQuota(tenantId);
         } else {
-          payload.hard_limit_mb = quotaValue;
+          if (unit === "GB") {
+            payload.hard_limit_gb = quotaValue;
+          } else {
+            payload.hard_limit_mb = quotaValue;
+          }
+          await quotaService.updateTenantQuota(tenantId, payload);
         }
+      } else {
+        await quotaService.updateTenantQuota(tenantId, payload);
       }
-      await quotaService.updateTenantQuota(tenantId, payload);
 
       message.success(
         t("quota.saveSuccess", "Quota settings saved successfully")
@@ -374,16 +385,25 @@ export function QuotaSettingsModal({
           </Space>
         </div>
         <Space>
-          <InputNumber
-            min={0}
-            precision={0}
-            value={quotaValue}
-            onChange={(v) => setQuotaValue(v ?? null)}
-            addonAfter={unit}
-            placeholder={t("quota.unlimited", "Unlimited")}
-            style={{ width: 200 }}
-            disabled={config?.hard_limit_editable === false}
-          />
+          <div className="flex items-stretch">
+            <input
+              style={{ width: 200 }}
+              className="ant-input rounded-r-none"
+              value={quotaInput}
+              onChange={(event) => {
+                const nextValue = event.target.value;
+                if (nextValue === "" || /^\d+$/.test(nextValue)) {
+                  setQuotaInput(nextValue);
+                }
+              }}
+              placeholder={t("quota.unlimited", "Unlimited")}
+              inputMode="numeric"
+              disabled={config?.hard_limit_editable === false}
+            />
+            <span className="flex items-center border border-l-0 border-solid border-[#d9d9d9] rounded-r-md bg-[#fafafa] px-3 text-sm text-[#555]">
+              {unit}
+            </span>
+          </div>
           <Segmented
             options={["GB", "MB"]}
             value={unit}

--- a/frontend/app/[locale]/resource-manage/components/resources/QuotaSettingsModal.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/QuotaSettingsModal.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import {
   Modal,
   Form,
+  Input,
   InputNumber,
   Switch,
   Slider,
@@ -385,10 +386,8 @@ export function QuotaSettingsModal({
           </Space>
         </div>
         <Space>
-          <div className="flex items-stretch">
-            <input
+          <Input
               style={{ width: 200 }}
-              className="ant-input rounded-r-none"
               value={quotaInput}
               onChange={(event) => {
                 const nextValue = event.target.value;
@@ -396,14 +395,11 @@ export function QuotaSettingsModal({
                   setQuotaInput(nextValue);
                 }
               }}
+              addonAfter={unit}
               placeholder={t("quota.unlimited", "Unlimited")}
               inputMode="numeric"
               disabled={config?.hard_limit_editable === false}
             />
-            <span className="flex items-center border border-l-0 border-solid border-[#d9d9d9] rounded-r-md bg-[#fafafa] px-3 text-sm text-[#555]">
-              {unit}
-            </span>
-          </div>
           <Segmented
             options={["GB", "MB"]}
             value={unit}

--- a/frontend/app/[locale]/resource-manage/components/resources/SuQuotaModal.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/SuQuotaModal.tsx
@@ -6,11 +6,10 @@
  * Minimal UI focused on SU's sole responsibility:
  * allocating storage capacity to individual tenants.
  */
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Modal,
-  InputNumber,
   App,
   Descriptions,
   Progress,
@@ -53,8 +52,8 @@ export function SuQuotaModal({
     useState<PlatformQuotaOverview | null>(null);
   const [saving, setSaving] = useState(false);
   const [unit, setUnit] = useState<"GB" | "MB">("GB");
-  const [quotaValue, setQuotaValue] = useState<number | null>(null);
-  const quotaInputIsEmptyRef = useRef(false);
+  const [quotaInput, setQuotaInput] = useState("");
+  const quotaValue = quotaInput === "" ? null : Number(quotaInput);
 
   // Reset local state when modal opens; then load data
   useEffect(() => {
@@ -65,8 +64,7 @@ export function SuQuotaModal({
     setUsageData(null);
     setPlatformOverview(null);
     setUnit("GB");
-    setQuotaValue(null);
-    quotaInputIsEmptyRef.current = false;
+    setQuotaInput("");
 
     let cancelled = false;
     setLoading(true);
@@ -88,10 +86,10 @@ export function SuQuotaModal({
         const currentBytes: number | null = cfg?.hard_limit_bytes ?? null;
         if (currentBytes && currentBytes < GB) {
           setUnit("MB");
-          setQuotaValue(Math.round(currentBytes / MB));
+          setQuotaInput(String(Math.round(currentBytes / MB)));
         } else {
           setUnit("GB");
-          setQuotaValue(currentBytes ? Math.round(currentBytes / GB) : null);
+          setQuotaInput(currentBytes ? String(Math.round(currentBytes / GB)) : "");
         }
       } catch (err: any) {
         if (!cancelled) {
@@ -111,7 +109,7 @@ export function SuQuotaModal({
   const handleSave = async () => {
     try {
       setSaving(true);
-      if (quotaValue == null || quotaInputIsEmptyRef.current) {
+      if (quotaValue == null) {
         // Deleting this config restores the tenant to unlimited without
         // resetting its warning preferences.
         await quotaService.deleteTenantQuota(tenantId!);
@@ -164,20 +162,11 @@ export function SuQuotaModal({
     if (nextUnit === unit) return;
     const valueBytes = quotaValue == null ? null : quotaValue * unitBytes;
     setUnit(nextUnit);
-    setQuotaValue(
+    setQuotaInput(
       valueBytes == null
-        ? null
-        : Math.round(valueBytes / (nextUnit === "GB" ? GB : MB))
+        ? ""
+        : String(Math.round(valueBytes / (nextUnit === "GB" ? GB : MB)))
     );
-  };
-
-  const recordQuotaEmptyOnBlur = (target: EventTarget | null) => {
-    if (
-      target instanceof HTMLInputElement &&
-      target.classList.contains("ant-input-number-input")
-    ) {
-      quotaInputIsEmptyRef.current = target.value === "";
-    }
   };
 
   return (
@@ -247,27 +236,31 @@ export function SuQuotaModal({
               {t("quota.tenantHardLimit", "Tenant Hard Storage Limit")}
             </span>
           </div>
-          <div onBlurCapture={(event) => recordQuotaEmptyOnBlur(event.target)}>
-            <Space>
-              <InputNumber
-                style={{ width: 200 }}
-                value={quotaValue}
-                onChange={(value) => setQuotaValue(value ?? null)}
-                changeOnBlur={false}
-                addonAfter={unit}
-                placeholder={t("quota.unlimited", "Unlimited")}
-                min={quotaValue == null ? undefined : minimumQuota}
-                max={validMaximumQuota}
-                precision={0}
-                size="large"
-              />
-              <Segmented
-                options={["GB", "MB"]}
-                value={unit}
-                onChange={(val) => changeUnit(val as "GB" | "MB")}
-              />
-            </Space>
-          </div>
+          <Space>
+            <div className="flex items-stretch">
+            <input
+              style={{ width: 200 }}
+              className="ant-input rounded-r-none"
+              value={quotaInput}
+              onChange={(event) => {
+                const nextValue = event.target.value;
+                if (nextValue === "" || /^\d+$/.test(nextValue)) {
+                  setQuotaInput(nextValue);
+                }
+              }}
+              placeholder={t("quota.unlimited", "Unlimited")}
+              inputMode="numeric"
+            />
+            <span className="flex items-center border border-l-0 border-solid border-[#d9d9d9] rounded-r-md bg-[#fafafa] px-3 text-sm text-[#555]">
+              {unit}
+            </span>
+            </div>
+            <Segmented
+              options={["GB", "MB"]}
+              value={unit}
+              onChange={(val) => changeUnit(val as "GB" | "MB")}
+            />
+          </Space>
           <div style={{ marginTop: 4, fontSize: 12, color: "#999" }}>
             {platformOverview?.platform_capacity_bytes == null
               ? t(

--- a/frontend/app/[locale]/resource-manage/components/resources/SuQuotaModal.tsx
+++ b/frontend/app/[locale]/resource-manage/components/resources/SuQuotaModal.tsx
@@ -6,7 +6,7 @@
  * Minimal UI focused on SU's sole responsibility:
  * allocating storage capacity to individual tenants.
  */
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Modal,
@@ -54,6 +54,7 @@ export function SuQuotaModal({
   const [saving, setSaving] = useState(false);
   const [unit, setUnit] = useState<"GB" | "MB">("GB");
   const [quotaValue, setQuotaValue] = useState<number | null>(null);
+  const quotaInputIsEmptyRef = useRef(false);
 
   // Reset local state when modal opens; then load data
   useEffect(() => {
@@ -65,6 +66,7 @@ export function SuQuotaModal({
     setPlatformOverview(null);
     setUnit("GB");
     setQuotaValue(null);
+    quotaInputIsEmptyRef.current = false;
 
     let cancelled = false;
     setLoading(true);
@@ -109,10 +111,16 @@ export function SuQuotaModal({
   const handleSave = async () => {
     try {
       setSaving(true);
-      await quotaService.updateTenantQuota(tenantId!, {
-        hard_limit_gb: unit === "GB" ? quotaValue : undefined,
-        hard_limit_mb: unit === "MB" ? quotaValue : undefined,
-      });
+      if (quotaValue == null || quotaInputIsEmptyRef.current) {
+        // Deleting this config restores the tenant to unlimited without
+        // resetting its warning preferences.
+        await quotaService.deleteTenantQuota(tenantId!);
+      } else {
+        await quotaService.updateTenantQuota(tenantId!, {
+          hard_limit_gb: unit === "GB" ? quotaValue : undefined,
+          hard_limit_mb: unit === "MB" ? quotaValue : undefined,
+        });
+      }
       message.success(t("quota.saveSuccess", "Tenant quota updated"));
       onSuccess();
     } catch (err: any) {
@@ -161,6 +169,15 @@ export function SuQuotaModal({
         ? null
         : Math.round(valueBytes / (nextUnit === "GB" ? GB : MB))
     );
+  };
+
+  const recordQuotaEmptyOnBlur = (target: EventTarget | null) => {
+    if (
+      target instanceof HTMLInputElement &&
+      target.classList.contains("ant-input-number-input")
+    ) {
+      quotaInputIsEmptyRef.current = target.value === "";
+    }
   };
 
   return (
@@ -230,24 +247,27 @@ export function SuQuotaModal({
               {t("quota.tenantHardLimit", "Tenant Hard Storage Limit")}
             </span>
           </div>
-          <Space>
-            <InputNumber
-              style={{ width: 200 }}
-              value={quotaValue}
-              onChange={(v) => setQuotaValue(v ?? null)}
-              addonAfter={unit}
-              placeholder={t("quota.unlimited", "Unlimited")}
-              min={minimumQuota}
-              max={validMaximumQuota}
-              precision={0}
-              size="large"
-            />
-            <Segmented
-              options={["GB", "MB"]}
-              value={unit}
-              onChange={(val) => changeUnit(val as "GB" | "MB")}
-            />
-          </Space>
+          <div onBlurCapture={(event) => recordQuotaEmptyOnBlur(event.target)}>
+            <Space>
+              <InputNumber
+                style={{ width: 200 }}
+                value={quotaValue}
+                onChange={(value) => setQuotaValue(value ?? null)}
+                changeOnBlur={false}
+                addonAfter={unit}
+                placeholder={t("quota.unlimited", "Unlimited")}
+                min={quotaValue == null ? undefined : minimumQuota}
+                max={validMaximumQuota}
+                precision={0}
+                size="large"
+              />
+              <Segmented
+                options={["GB", "MB"]}
+                value={unit}
+                onChange={(val) => changeUnit(val as "GB" | "MB")}
+              />
+            </Space>
+          </div>
           <div style={{ marginTop: 4, fontSize: 12, color: "#999" }}>
             {platformOverview?.platform_capacity_bytes == null
               ? t(


### PR DESCRIPTION
## Summary
- Allow a super admin to clear a tenant hard storage quota and restore the unlimited state.
- Preserve numeric quota updates and existing warning settings.
- Avoid the number input restoring the previous value while the user clears it.

## Verification
- Built the production web image successfully.
- Opened the isolated local quota-management page and confirmed the cleared input displays the Unlimited placeholder before saving.
-before:
<img width="847" height="939" alt="image" src="https://github.com/user-attachments/assets/54463d47-d61a-442f-a4e0-935845f3060c" />
once numbers are input by user, the limit cannot reset to "unlimited"
after：
<img width="1016" height="1088" alt="image" src="https://github.com/user-attachments/assets/b04ffbb8-c85f-4dad-80b8-512b9095863e" />
by clearing the input number and saving configuration,  The limit is reset to "unlimited"