### PR TITLE
Recover interrupted tasks on service startup

### DIFF
--- a/backend/apps/app_factory.py
+++ b/backend/apps/app_factory.py
@@ -22,6 +22,7 @@ def create_app(
     cors_origins: list = None,
     cors_methods: list = None,
     enable_monitoring: bool = True,
+    lifespan=None,
 ) -> FastAPI:
     """
     Create a FastAPI application with common configurations.
@@ -34,6 +35,7 @@ def create_app(
         cors_origins: List of allowed CORS origins (default: ["*"])
         cors_methods: List of allowed CORS methods (default: ["*"])
         enable_monitoring: Whether to enable monitoring
+        lifespan: Optional FastAPI lifespan context manager
 
     Returns:
         Configured FastAPI application
@@ -42,7 +44,8 @@ def create_app(
         title=title,
         description=description,
         version=version,
-        root_path=root_path
+        root_path=root_path,
+        lifespan=lifespan,
     )
 
     # Add CORS middleware

--- a/backend/apps/config_app.py
+++ b/backend/apps/config_app.py
@@ -1,4 +1,6 @@
+import asyncio
 import logging
+from contextlib import asynccontextmanager
 
 from apps.app_factory import create_app
 from apps.agent_app import agent_config_router as agent_router
@@ -56,14 +58,20 @@ from consts.const import (
 )
 from services.prompt_template_service import sync_system_default_prompt_template
 
-# Create logger instance
 logger = logging.getLogger("base_app")
 
-# Create FastAPI app with common configurations
-app = create_app(title="Nexent Config API", description="Configuration APIs")
+async def recover_config_tasks_on_startup():
+    from services.evaluation_maintenance import start as start_eval_maintenance
+    from services.startup_recovery_service import (
+        recover_config_tasks,
+        schedule_interrupted_upload_cleanup,
+    )
+
+    await asyncio.to_thread(recover_config_tasks)
+    start_eval_maintenance()
+    await schedule_interrupted_upload_cleanup()
 
 
-@app.on_event("startup")
 async def sync_default_prompt_template_on_startup():
     """Sync defaults and validate enabled external service configuration."""
     if ENABLE_AIDP_KNOWLEDGE and (not AIDP_SERVER_URL or not AIDP_API_KEY):
@@ -78,16 +86,34 @@ async def sync_default_prompt_template_on_startup():
         logger.error(f"Failed to sync system default prompt template: {str(exc)}")
 
 
-@app.on_event("startup")
 async def start_dreaming_scheduler():
     from services.memory_dreaming_scheduler import dreaming_scheduler
     await dreaming_scheduler.start()
 
 
-@app.on_event("shutdown")
 async def stop_dreaming_scheduler():
     from services.memory_dreaming_scheduler import dreaming_scheduler
     await dreaming_scheduler.stop()
+
+
+@asynccontextmanager
+async def config_lifespan(_app):
+    await recover_config_tasks_on_startup()
+    await sync_default_prompt_template_on_startup()
+    await start_dreaming_scheduler()
+    try:
+        yield
+    finally:
+        # Preserve the scheduler's existing graceful shutdown behavior. Task
+        # state recovery remains exclusively in the startup path above.
+        await stop_dreaming_scheduler()
+
+
+app = create_app(
+    title="Nexent Config API",
+    description="Configuration APIs",
+    lifespan=config_lifespan,
+)
 
 
 app.include_router(model_manager_router)

--- a/backend/apps/config_app.py
+++ b/backend/apps/config_app.py
@@ -56,6 +56,7 @@ from consts.const import (
     ENABLE_AIDP_KNOWLEDGE,
     IS_SPEED_MODE,
 )
+from consts.task_recovery import CONFIG_SERVICE_NAME
 from services.prompt_template_service import sync_system_default_prompt_template
 
 logger = logging.getLogger("base_app")
@@ -69,7 +70,7 @@ async def recover_config_tasks_on_startup():
 
     await asyncio.to_thread(recover_config_tasks)
     start_eval_maintenance()
-    await schedule_interrupted_upload_cleanup()
+    await schedule_interrupted_upload_cleanup(CONFIG_SERVICE_NAME)
 
 
 async def sync_default_prompt_template_on_startup():

--- a/backend/apps/file_management_app.py
+++ b/backend/apps/file_management_app.py
@@ -22,6 +22,7 @@ from consts.exceptions import (
     UnsupportedFileTypeException,
 )
 from consts.model import ProcessParams
+from consts.task_recovery import CONFIG_SERVICE_NAME
 from services.file_management_service import (
     check_file_access,
     delete_file_impl,
@@ -137,6 +138,7 @@ async def upload_files(
             index_name,
             user_id,
             uploader_tenant_id=tenant_id,
+            upload_owner_service=CONFIG_SERVICE_NAME,
         )
         errors, uploaded_file_paths, uploaded_filenames = upload_result
         quota_status = getattr(upload_result, "quota_status", None)

--- a/backend/apps/northbound_base_app.py
+++ b/backend/apps/northbound_base_app.py
@@ -3,10 +3,12 @@ Northbound API with A2A support.
 
 This module combines northbound app with A2A server endpoints.
 """
+import asyncio
 import base64
 import hashlib
 import json
 import logging
+from contextlib import asynccontextmanager
 from typing import Annotated, Any, Dict
 from http import HTTPStatus
 
@@ -40,13 +42,29 @@ from database import a2a_agent_db
 
 logger = logging.getLogger("northbound_base_app")
 
-# Create FastAPI app with common configurations
+async def recover_northbound_tasks_on_startup():
+    from services.startup_recovery_service import (
+        recover_northbound_tasks,
+        schedule_interrupted_upload_cleanup,
+    )
+
+    await asyncio.to_thread(recover_northbound_tasks)
+    await schedule_interrupted_upload_cleanup()
+
+
+@asynccontextmanager
+async def northbound_lifespan(_app):
+    await recover_northbound_tasks_on_startup()
+    yield
+
+
 northbound_app = create_app(
     title="Nexent Northbound API",
     description="Northbound APIs for partners",
     version="1.0.0",
     cors_methods=["GET", "POST", "PUT", "DELETE"],
-    enable_monitoring=False  # Disable monitoring for northbound API if not needed
+    enable_monitoring=False,  # Disable monitoring if not needed
+    lifespan=northbound_lifespan,
 )
 
 northbound_app.include_router(northbound_router)

--- a/backend/apps/northbound_base_app.py
+++ b/backend/apps/northbound_base_app.py
@@ -17,6 +17,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, ConfigDict, Field
 
 from apps.app_factory import create_app
+from consts.task_recovery import NORTHBOUND_SERVICE_NAME
 from .northbound_app import router as northbound_router
 from .northbound_knowledge_app import router as northbound_knowledge_router
 
@@ -49,7 +50,7 @@ async def recover_northbound_tasks_on_startup():
     )
 
     await asyncio.to_thread(recover_northbound_tasks)
-    await schedule_interrupted_upload_cleanup()
+    await schedule_interrupted_upload_cleanup(NORTHBOUND_SERVICE_NAME)
 
 
 @asynccontextmanager

--- a/backend/apps/northbound_knowledge_app.py
+++ b/backend/apps/northbound_knowledge_app.py
@@ -12,6 +12,7 @@ from consts.exceptions import (
     UnauthorizedError,
 )
 from consts.model import HybridSearchRequest, ProcessParams
+from consts.task_recovery import NORTHBOUND_SERVICE_NAME
 from database.knowledge_db import get_index_name_by_knowledge_name
 from services.file_management_service import (
     upload_files_impl,
@@ -460,7 +461,13 @@ async def upload_files(
             )
 
         errors, uploaded_file_paths, uploaded_filenames = await upload_files_impl(
-            destination, file, None, index_name, ctx.user_id, uploader_tenant_id=ctx.tenant_id
+            destination,
+            file,
+            None,
+            index_name,
+            ctx.user_id,
+            uploader_tenant_id=ctx.tenant_id,
+            upload_owner_service=NORTHBOUND_SERVICE_NAME,
         )
 
         if uploaded_file_paths:

--- a/backend/apps/runtime_app.py
+++ b/backend/apps/runtime_app.py
@@ -1,4 +1,6 @@
+import asyncio
 import logging
+from contextlib import asynccontextmanager
 
 from apps.app_factory import create_app
 from apps.agent_app import agent_runtime_router as agent_router
@@ -11,13 +13,39 @@ from apps.file_management_app import file_management_runtime_router as file_mana
 from apps.skill_app import skill_creator_router
 from middleware.exception_handler import ExceptionHandlerMiddleware
 
-# Create logger instance
 logger = logging.getLogger("runtime_app")
 
-# Create FastAPI app with common configurations
-app = create_app(title="Nexent Runtime API", description="Runtime APIs")
+async def start_agent_automation_scheduler():
+    from services.agent_automation.scheduler import agent_automation_scheduler
+    from services.startup_recovery_service import recover_runtime_tasks
+    from services.workspace_cleanup_service import cleanup_orphaned_agent_workspaces
 
-# Add global exception handler middleware
+    await asyncio.to_thread(recover_runtime_tasks)
+    cleanup_orphaned_agent_workspaces()
+    await agent_automation_scheduler.start()
+
+
+async def stop_agent_automation_scheduler():
+    from services.agent_automation.scheduler import agent_automation_scheduler
+
+    await agent_automation_scheduler.stop()
+
+
+@asynccontextmanager
+async def runtime_lifespan(_app):
+    await start_agent_automation_scheduler()
+    try:
+        yield
+    finally:
+        await stop_agent_automation_scheduler()
+
+
+app = create_app(
+    title="Nexent Runtime API",
+    description="Runtime APIs",
+    lifespan=runtime_lifespan,
+)
+
 app.add_middleware(ExceptionHandlerMiddleware)
 
 app.include_router(agent_router)
@@ -29,19 +57,3 @@ app.include_router(conversation_share_router)
 app.include_router(file_management_router)
 app.include_router(voice_router)
 app.include_router(skill_creator_router)
-
-
-@app.on_event("startup")
-async def start_agent_automation_scheduler():
-    from services.agent_automation.scheduler import agent_automation_scheduler
-    from services.workspace_cleanup_service import cleanup_orphaned_agent_workspaces
-
-    cleanup_orphaned_agent_workspaces()
-    await agent_automation_scheduler.start()
-
-
-@app.on_event("shutdown")
-async def stop_agent_automation_scheduler():
-    from services.agent_automation.scheduler import agent_automation_scheduler
-
-    await agent_automation_scheduler.stop()

--- a/backend/config_service.py
+++ b/backend/config_service.py
@@ -14,17 +14,12 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from apps.config_app import app
-from services.evaluation_maintenance import start as start_eval_maintenance
 from utils.logging_utils import configure_elasticsearch_logging, configure_logging
 
 
 configure_logging(logging.INFO)
 configure_elasticsearch_logging()
 logger = logging.getLogger("config_service")
-
-# Start background maintenance scheduler (reap stale runs + aged cleanup)
-start_eval_maintenance()
-
 
 if __name__ == "__main__":
     logger.info("Starting server initialization...")

--- a/backend/consts/task_recovery.py
+++ b/backend/consts/task_recovery.py
@@ -1,0 +1,4 @@
+"""Stable service identifiers used by startup task recovery."""
+
+CONFIG_SERVICE_NAME = "nexent-config"
+NORTHBOUND_SERVICE_NAME = "nexent-northbound"

--- a/backend/data_process_service.py
+++ b/backend/data_process_service.py
@@ -577,7 +577,14 @@ except Exception as e_exec:
         logger.info(f"📋 Effective service config: {self.config}")
         
         for service_name, start_func, config_key in services:
-            if self.config.get(config_key, True):
+            service_enabled = self.config.get(config_key, True)
+            if service_name == "Ray Cluster":
+                # Redis must be available for cancellation markers, while
+                # recovery must finish before Ray or Celery can consume work.
+                from services.startup_recovery_service import recover_data_process_tasks
+
+                recover_data_process_tasks()
+            if service_enabled:
                 enabled_count += 1
                 logger.info(f"Starting {service_name}...")
                 if start_func():

--- a/backend/database/a2a_agent_db.py
+++ b/backend/database/a2a_agent_db.py
@@ -1483,6 +1483,32 @@ def update_task_state(
         return True
 
 
+def fail_active_tasks_on_startup() -> int:
+    """Move A2A work owned by the previous northbound process to FAILED."""
+    now = datetime.now(timezone.utc)
+    with _get_db_session() as session:
+        result = session.query(A2ATask).filter(
+            A2ATask.task_state.in_(
+                ("TASK_STATE_SUBMITTED", "TASK_STATE_WORKING")
+            )
+        ).update(
+            {
+                "task_state": "TASK_STATE_FAILED",
+                "state_timestamp": now,
+                "result_data": {
+                    "error": {
+                        "code": "CONTAINER_RESTARTED",
+                        "message": "Northbound service restarted before the task completed",
+                    }
+                },
+                "completed_at": now,
+                "update_time": now,
+            },
+            synchronize_session=False,
+        )
+        return int(result or 0)
+
+
 def list_tasks(
     endpoint_id: Optional[str] = None,
     caller_user_id: Optional[str] = None,

--- a/backend/database/agent_automation_db.py
+++ b/backend/database/agent_automation_db.py
@@ -620,27 +620,39 @@ def renew_task_lock(task_id: int, lock_owner: str, lease_seconds: float) -> bool
 
 
 def recover_orphaned_runs() -> int:
-    """Finish runs whose task no longer has a live scheduler lease.
+    """Finish runs that were executing when the single runtime stopped.
 
-    This is safe to run on every replica startup because a live lease is never
-    modified. Due tasks are retried after their expired lease is reclaimed.
+    Queued runs are intentionally preserved so the existing scheduler can
+    consume work that never began. The deployment currently supports a single
+    runtime replica, therefore every persisted RUNNING row belongs to the
+    previous process even when its lease has not expired yet.
     """
     sql = text("""
-        UPDATE nexent.agent_automation_run_t AS run
+        UPDATE nexent.agent_automation_run_t
         SET status = 'TIMEOUT',
             error_code = 'AUTOMATION_LEASE_EXPIRED',
             error_message = 'The scheduler stopped before the run completed.',
             finished_at = now(),
             update_time = now()
-        FROM nexent.agent_automation_task_t AS task
-        WHERE run.task_id = task.task_id
-          AND run.delete_flag = 'N'
-          AND run.trigger_type = 'SCHEDULED'
-          AND run.status IN ('QUEUED', 'RUNNING')
-          AND (task.lock_until IS NULL OR task.lock_until < now())
+        WHERE delete_flag = 'N'
+          AND status = 'RUNNING'
     """)
     with get_db_session() as session:
         result = session.execute(sql)
+        return result.rowcount or 0
+
+
+def release_all_task_locks() -> int:
+    """Release scheduler leases owned by the previous single runtime."""
+    with get_db_session() as session:
+        result = session.execute(
+            update(AgentAutomationTask)
+            .where(
+                AgentAutomationTask.delete_flag == "N",
+                AgentAutomationTask.lock_owner.is_not(None),
+            )
+            .values(lock_owner=None, lock_until=None, update_time=_utcnow())
+        )
         return result.rowcount or 0
 
 

--- a/backend/database/agent_evaluation_db.py
+++ b/backend/database/agent_evaluation_db.py
@@ -772,24 +772,124 @@ def reap_stale_runs(tenant_id: str, timeout_minutes: int = 10) -> int:
             )
             .all()
         )
-        for (eid,) in stale:
-            session.query(AgentEvaluation).filter(
-                AgentEvaluation.agent_evaluation_id == eid,
-                AgentEvaluation.tenant_id == tenant_id,
+        stale_ids = [eid for (eid,) in stale]
+        if stale_ids:
+            error_message = "Server restarted — evaluation was interrupted"
+            session.query(AgentEvaluationCase).filter(
+                AgentEvaluationCase.agent_evaluation_id.in_(stale_ids),
+                AgentEvaluationCase.tenant_id == tenant_id,
+                AgentEvaluationCase.status.in_(("PENDING", "RUNNING")),
             ).update(
                 {
-                    "status": EvalRunStatus.FAILED,
-                    "error_message": "Server restarted — evaluation was interrupted",
+                    "status": "FAILED",
+                    "error_message": error_message,
+                    "update_time": datetime.now(timezone.utc),
                 },
                 synchronize_session=False,
             )
-            count += 1
+            session.query(AgentEvaluation).filter(
+                AgentEvaluation.agent_evaluation_id.in_(stale_ids),
+                AgentEvaluation.tenant_id == tenant_id,
+                AgentEvaluation.status == EvalRunStatus.RUNNING,
+            ).update(
+                {
+                    "status": EvalRunStatus.FAILED,
+                    "error_message": error_message,
+                    "update_time": datetime.now(timezone.utc),
+                },
+                synchronize_session=False,
+            )
+            count = len(stale_ids)
         session.commit()
     if count:
         logger.info(
             "Reaped %d stale RUNNING evaluations for tenant %s", count, tenant_id
         )
     return count
+
+
+def list_evaluation_tenant_ids() -> list[str]:
+    """Return tenants that currently own running evaluation work."""
+    with get_db_session() as session:
+        rows = (
+            session.query(AgentEvaluation.tenant_id)
+            .filter(
+                AgentEvaluation.status == EvalRunStatus.RUNNING,
+                AgentEvaluation.delete_flag == "N",
+            )
+            .distinct()
+            .all()
+        )
+        return [str(tenant_id) for (tenant_id,) in rows if tenant_id is not None]
+
+
+def fail_interrupted_no_set_runs_on_startup() -> int:
+    """Fail no-set setup work that cannot be resumed after config restart.
+
+    Regular pending runs already have a durable evaluation set and can be
+    redispatched by evaluation maintenance. A no-set run with set ID ``0`` is
+    still generating its temporary cases in process memory, so it has no
+    durable continuation point.
+    """
+    with get_db_session() as session:
+        pending_ids = [
+            evaluation_id
+            for (evaluation_id,) in session.query(
+                AgentEvaluation.agent_evaluation_id
+            )
+            .filter(
+                AgentEvaluation.status == EvalRunStatus.PENDING,
+                AgentEvaluation.evaluation_set_id == 0,
+                AgentEvaluation.delete_flag == "N",
+            )
+            .all()
+        ]
+        if not pending_ids:
+            return 0
+
+        error_message = "Server restarted before evaluation execution started"
+        update_time = datetime.now(timezone.utc)
+        session.query(AgentEvaluationCase).filter(
+            AgentEvaluationCase.agent_evaluation_id.in_(pending_ids),
+            AgentEvaluationCase.status == "PENDING",
+        ).update(
+            {
+                "status": "FAILED",
+                "error_message": error_message,
+                "update_time": update_time,
+            },
+            synchronize_session=False,
+        )
+        session.query(AgentEvaluation).filter(
+            AgentEvaluation.agent_evaluation_id.in_(pending_ids),
+            AgentEvaluation.status == EvalRunStatus.PENDING,
+            AgentEvaluation.delete_flag == "N",
+        ).update(
+            {
+                "status": EvalRunStatus.FAILED,
+                "error_message": error_message,
+                "update_time": update_time,
+            },
+            synchronize_session=False,
+        )
+        session.commit()
+        return len(pending_ids)
+
+
+def list_dispatchable_pending_runs() -> list[dict[str, Any]]:
+    """Return pending evaluations that already have a durable case set."""
+    with get_db_session() as session:
+        rows = (
+            session.query(AgentEvaluation)
+            .filter(
+                AgentEvaluation.status == EvalRunStatus.PENDING,
+                AgentEvaluation.evaluation_set_id > 0,
+                AgentEvaluation.delete_flag == "N",
+            )
+            .order_by(AgentEvaluation.create_time.asc())
+            .all()
+        )
+        return [as_dict(row) for row in rows]
 
 
 def count_active_runs(tenant_id: str) -> int:

--- a/backend/database/conversation_db.py
+++ b/backend/database/conversation_db.py
@@ -518,6 +518,53 @@ def update_conversation_message_status(message_id: int, status: str,
         )
 
 
+def fail_streaming_assistant_messages() -> List[Dict[str, Any]]:
+    """Mark assistant messages left streaming by a stopped runtime as failed.
+
+    Returns the affected runtime identities so the caller can finish the
+    corresponding short-lived Redis state with the existing runtime-state API.
+    The conditional update makes repeated startup recovery idempotent.
+    """
+    with get_db_session() as session:
+        rows = (
+            session.query(
+                ConversationMessage.message_id,
+                ConversationMessage.conversation_id,
+                ConversationMessage.created_by,
+            )
+            .filter(
+                ConversationMessage.message_role == "assistant",
+                ConversationMessage.status == "streaming",
+                ConversationMessage.delete_flag == "N",
+            )
+            .with_for_update()
+            .all()
+        )
+        if not rows:
+            return []
+
+        message_ids = [int(row.message_id) for row in rows]
+        session.query(ConversationMessage).filter(
+            ConversationMessage.message_id.in_(message_ids),
+            ConversationMessage.status == "streaming",
+            ConversationMessage.delete_flag == "N",
+        ).update(
+            {
+                "status": "failed",
+                "update_time": func.current_timestamp(),
+            },
+            synchronize_session=False,
+        )
+        return [
+            {
+                "message_id": int(row.message_id),
+                "conversation_id": int(row.conversation_id),
+                "user_id": row.created_by,
+            }
+            for row in rows
+        ]
+
+
 def update_conversation_message_content(message_id: int, content: str,
                                          user_id: Optional[str] = None) -> None:
     """

--- a/backend/database/db_models.py
+++ b/backend/database/db_models.py
@@ -888,6 +888,14 @@ class KnowledgeFileLifecycle(TableBase):
             "object_name",
         ),
         Index(
+            "idx_knowledge_file_lifecycle_upload_recovery",
+            "upload_owner_service",
+            "create_time",
+            postgresql_where=text(
+                "delete_flag = 'N' AND status = 'UPLOADING'"
+            ),
+        ),
+        Index(
             "uq_knowledge_file_lifecycle_active_identity",
             "tenant_id",
             "index_name",
@@ -912,6 +920,11 @@ class KnowledgeFileLifecycle(TableBase):
         doc="Effective filename used by processing and displayed to users",
     )
     file_size = Column(BigInteger, nullable=True, doc="Uploaded file size in bytes")
+    upload_owner_service = Column(
+        String(32),
+        nullable=True,
+        doc="Service that owns recovery of an in-progress upload",
+    )
     uploaded_at = Column(TIMESTAMP(timezone=False), nullable=True, doc="Successful MinIO upload time")
     completed_at = Column(TIMESTAMP(timezone=False), nullable=True, doc="Successful ES indexing time")
     status = Column(

--- a/backend/database/evaluation_set_db.py
+++ b/backend/database/evaluation_set_db.py
@@ -6,7 +6,7 @@ from sqlalchemy import or_
 from consts.error_code import ErrorCode
 from consts.exceptions import AppException
 from database.client import as_dict, get_db_session
-from database.db_models import EvaluationSet, EvaluationSetCase
+from database.db_models import AgentEvaluation, EvaluationSet, EvaluationSetCase
 
 
 logger = logging.getLogger(__name__)
@@ -264,6 +264,137 @@ def hard_delete_evaluation_set(evaluation_set_id: int, tenant_id: str) -> int:
         )
         session.commit()
     return deleted
+
+
+def recover_interrupted_generations() -> int:
+    """Fail interrupted AI generations and remove only their appended cases.
+
+    ``case_count`` is updated only when generation completes, so it is the
+    durable pre-generation baseline. Generated rows are append-only; keeping
+    the oldest baseline rows avoids adding a new generation-attempt column.
+    """
+    with get_db_session() as session:
+        sets = (
+            session.query(EvaluationSet)
+            .filter(
+                EvaluationSet.generation_status == "GENERATING",
+                EvaluationSet.delete_flag == "N",
+            )
+            .with_for_update()
+            .all()
+        )
+        for evaluation_set in sets:
+            case_rows = (
+                session.query(EvaluationSetCase.evaluation_set_case_id)
+                .filter(
+                    EvaluationSetCase.evaluation_set_id
+                    == evaluation_set.evaluation_set_id,
+                    EvaluationSetCase.tenant_id == evaluation_set.tenant_id,
+                    EvaluationSetCase.delete_flag == "N",
+                )
+                .order_by(EvaluationSetCase.evaluation_set_case_id.asc())
+                .all()
+            )
+            baseline_count = max(0, int(evaluation_set.case_count or 0))
+            appended_ids = [case_id for (case_id,) in case_rows[baseline_count:]]
+            if appended_ids:
+                session.query(EvaluationSetCase).filter(
+                    EvaluationSetCase.evaluation_set_case_id.in_(appended_ids)
+                ).delete(synchronize_session=False)
+            evaluation_set.generation_status = "FAILED"
+            evaluation_set.generation_progress = 0
+        return len(sets)
+
+
+def cleanup_orphaned_virtual_evaluation_sets() -> int:
+    """Delete no-set evaluation data that was never linked to a run."""
+    with get_db_session() as session:
+        referenced_set_ids = session.query(AgentEvaluation.evaluation_set_id).filter(
+            AgentEvaluation.delete_flag == "N"
+        )
+        orphan_rows = (
+            session.query(EvaluationSet.evaluation_set_id, EvaluationSet.tenant_id)
+            .filter(
+                EvaluationSet.source_filename == "__no_set_virtual__",
+                EvaluationSet.delete_flag == "N",
+                ~EvaluationSet.evaluation_set_id.in_(referenced_set_ids),
+            )
+            .all()
+        )
+        orphan_ids = [set_id for set_id, _ in orphan_rows]
+        if orphan_ids:
+            session.query(EvaluationSetCase).filter(
+                EvaluationSetCase.evaluation_set_id.in_(orphan_ids)
+            ).delete(synchronize_session=False)
+            session.query(EvaluationSet).filter(
+                EvaluationSet.evaluation_set_id.in_(orphan_ids)
+            ).delete(synchronize_session=False)
+        return len(orphan_ids)
+
+
+def materialize_virtual_evaluation_set_for_run(
+    *,
+    tenant_id: str,
+    name: str,
+    cases: list[dict[str, Any]],
+    created_by: str,
+    agent_evaluation_id: int,
+) -> int:
+    """Atomically create a no-set dataset and attach it to a pending run."""
+    with get_db_session() as session:
+        run = (
+            session.query(AgentEvaluation)
+            .filter(
+                AgentEvaluation.agent_evaluation_id == agent_evaluation_id,
+                AgentEvaluation.tenant_id == tenant_id,
+                AgentEvaluation.status == "PENDING",
+                AgentEvaluation.delete_flag == "N",
+            )
+            .with_for_update()
+            .first()
+        )
+        if run is None:
+            raise AppException(
+                ErrorCode.COMMON_RESOURCE_NOT_FOUND,
+                "Pending agent evaluation not found",
+            )
+
+        evaluation_set = EvaluationSet(
+            tenant_id=tenant_id,
+            name=name,
+            description=None,
+            source_filename="__no_set_virtual__",
+            case_count=len(cases),
+            generation_status="DONE",
+            generation_progress=100,
+            created_by=created_by,
+            updated_by=created_by,
+            delete_flag="N",
+        )
+        session.add(evaluation_set)
+        session.flush()
+
+        for index, case in enumerate(cases):
+            session.add(
+                EvaluationSetCase(
+                    tenant_id=tenant_id,
+                    evaluation_set_id=evaluation_set.evaluation_set_id,
+                    inputs=case["inputs"],
+                    label=case["label"],
+                    order_no=int(case.get("order_no", index)),
+                    session_id=case.get("session_id"),
+                    turn_order=int(case.get("turn_order", 0)),
+                    created_by=created_by,
+                    updated_by=created_by,
+                    delete_flag="N",
+                )
+            )
+
+        run.evaluation_set_id = evaluation_set.evaluation_set_id
+        run.progress_total = len(cases)
+        run.updated_by = created_by
+        session.flush()
+        return int(evaluation_set.evaluation_set_id)
 
 
 def list_case_turn_orders_by_session(

--- a/backend/database/knowledge_file_lifecycle_db.py
+++ b/backend/database/knowledge_file_lifecycle_db.py
@@ -38,6 +38,7 @@ def create_file_record(
     bucket_name: Optional[str] = None,
     object_name: Optional[str] = None,
     file_size: Optional[int] = None,
+    upload_owner_service: Optional[str] = None,
     status: str = "UPLOADING",
     stage: str = "UPLOAD",
     created_by: Optional[str] = None,
@@ -52,6 +53,7 @@ def create_file_record(
         bucket_name=bucket_name,
         object_name=object_name,
         file_size=file_size,
+        upload_owner_service=upload_owner_service,
         status=status,
         stage=stage,
         created_by=created_by,
@@ -82,6 +84,7 @@ def create_file_records(records: Iterable[Dict[str, Any]]) -> List[Dict[str, Any
                 bucket_name=record.get("bucket_name"),
                 object_name=record.get("object_name"),
                 file_size=record.get("file_size"),
+                upload_owner_service=record.get("upload_owner_service"),
                 status=record.get("status", "UPLOADING"),
                 stage=record.get("stage", "UPLOAD"),
                 created_by=record.get("created_by"),
@@ -180,14 +183,21 @@ def fail_interrupted_file_tasks() -> List[Dict[str, Any]]:
         return recovered
 
 
-def list_uploading_files_created_before(cutoff: datetime) -> List[Dict[str, Any]]:
-    """Return upload placeholders created before a container startup cutoff."""
+def list_uploading_files_created_before(
+    cutoff: datetime,
+    upload_owner_service: str,
+) -> List[Dict[str, Any]]:
+    """Return old uploads owned by the service that is being restarted."""
+    if not upload_owner_service:
+        raise ValueError("upload_owner_service is required for upload recovery")
+
     with get_db_session() as session:
         rows = (
             session.query(KnowledgeFileLifecycle)
             .filter(
                 KnowledgeFileLifecycle.status == "UPLOADING",
                 KnowledgeFileLifecycle.delete_flag == "N",
+                KnowledgeFileLifecycle.upload_owner_service == upload_owner_service,
                 KnowledgeFileLifecycle.create_time < cutoff,
             )
             .order_by(KnowledgeFileLifecycle.create_time.asc())

--- a/backend/database/knowledge_file_lifecycle_db.py
+++ b/backend/database/knowledge_file_lifecycle_db.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional
 from uuid import uuid4
+
+from sqlalchemy import and_, or_
 
 from .client import as_dict, get_db_session
 from .db_models import KnowledgeFileLifecycle
@@ -138,6 +141,59 @@ def list_file_records(
         if not include_hidden:
             query = query.filter(KnowledgeFileLifecycle.status.notin_(HIDDEN_STATUSES))
         return [as_dict(row) for row in query.order_by(KnowledgeFileLifecycle.create_time.asc()).all()]
+
+
+def fail_interrupted_file_tasks() -> List[Dict[str, Any]]:
+    """Fail ingestion stages that had actually started before worker restart.
+
+    FORWARDING without a forward task ID is still queued behind a completed
+    process task and is intentionally left for the existing Celery chain.
+    """
+    with get_db_session() as session:
+        rows = (
+            session.query(KnowledgeFileLifecycle)
+            .filter(
+                KnowledgeFileLifecycle.delete_flag == "N",
+                or_(
+                    KnowledgeFileLifecycle.status == "PROCESSING",
+                    and_(
+                        KnowledgeFileLifecycle.status == "FORWARDING",
+                        KnowledgeFileLifecycle.forward_task_id.is_not(None),
+                    ),
+                ),
+            )
+            .with_for_update()
+            .all()
+        )
+        recovered = []
+        failed_at = datetime.utcnow()
+        for row in rows:
+            recovered.append(as_dict(row))
+            row.status = "FAILED"
+            row.error_code = "CONTAINER_RESTARTED"
+            row.error_message = "Data-process service restarted before the task completed"
+            row.error_stage = row.stage or (
+                "FORWARD" if row.forward_task_id else "PROCESS"
+            )
+            row.failed_at = failed_at
+            row.version = int(row.version or 0) + 1
+        return recovered
+
+
+def list_uploading_files_created_before(cutoff: datetime) -> List[Dict[str, Any]]:
+    """Return upload placeholders created before a container startup cutoff."""
+    with get_db_session() as session:
+        rows = (
+            session.query(KnowledgeFileLifecycle)
+            .filter(
+                KnowledgeFileLifecycle.status == "UPLOADING",
+                KnowledgeFileLifecycle.delete_flag == "N",
+                KnowledgeFileLifecycle.create_time < cutoff,
+            )
+            .order_by(KnowledgeFileLifecycle.create_time.asc())
+            .all()
+        )
+        return [as_dict(row) for row in rows]
 
 
 def transition_file_record(

--- a/backend/database/memory_dreaming_db.py
+++ b/backend/database/memory_dreaming_db.py
@@ -507,12 +507,14 @@ def release_lease(run_id: int, owner_id: str) -> bool:
         return released is not None
 
 
-def recover_stale() -> int:
+def recover_stale(include_unexpired: bool = False) -> int:
     """Reap runs whose lease expired without completion.
 
     Marks them as failed and clears lock fields so they can be retried.
-    Safe to call on every worker startup.
+    ``include_unexpired`` is used by the single-replica startup path, where all
+    RUNNING rows necessarily belong to the previous process.
     """
+    lease_filter = "" if include_unexpired else "AND lock_until < now()"
     sql = text("""
         UPDATE nexent.memory_dreaming_audit_t
         SET status = 'failed',
@@ -522,9 +524,9 @@ def recover_stale() -> int:
             finished_at = now(),
             update_time = now()
         WHERE status = 'running'
-          AND lock_until < now()
+          {lease_filter}
           AND delete_flag = 'N'
-    """)
+    """.format(lease_filter=lease_filter))
     with get_db_session() as session:
         result = session.execute(sql)
         return result.rowcount or 0

--- a/backend/database/model_management_db.py
+++ b/backend/database/model_management_db.py
@@ -87,6 +87,23 @@ def update_model_record(
         return result.rowcount > 0
 
 
+def fail_detecting_models_on_startup() -> int:
+    """Finish connectivity checks interrupted by a config-service restart."""
+    with get_db_session() as session:
+        result = session.execute(
+            update(ModelRecord)
+            .where(
+                ModelRecord.connect_status == "detecting",
+                ModelRecord.delete_flag == "N",
+            )
+            .values(
+                connect_status="unavailable",
+                update_time=func.current_timestamp(),
+            )
+        )
+        return int(result.rowcount or 0)
+
+
 def delete_model_record(model_id: int, user_id: str, tenant_id: str) -> bool:
     """
     Delete a model record (soft delete) and update the update timestamp

--- a/backend/services/agent_automation/scheduler.py
+++ b/backend/services/agent_automation/scheduler.py
@@ -37,7 +37,7 @@ class AgentAutomationLeaseStore:
     async def recover(self) -> None:
         recovery_time = _utcnow()
         await asyncio.to_thread(agent_automation_db.recover_orphaned_runs)
-        await asyncio.to_thread(agent_automation_db.release_expired_locks)
+        await asyncio.to_thread(agent_automation_db.release_all_task_locks)
         self._recovery_time = recovery_time
 
     async def claim_due(

--- a/backend/services/agent_evaluation_service.py
+++ b/backend/services/agent_evaluation_service.py
@@ -53,12 +53,10 @@ from database.agent_evaluation_db import (
     update_agent_evaluation_status,
 )
 from database.client import get_db_session
-from database.db_models import AgentEvaluation, ModelRecord
+from database.db_models import ModelRecord
 from database.evaluation_set_db import (
-    create_evaluation_set,
     get_evaluation_set_cases_all,
-    insert_evaluation_set_cases,
-    update_evaluation_set_case_count,
+    materialize_virtual_evaluation_set_for_run,
 )
 from database.evaluator_db import get_evaluator
 from services.agent_service import prepare_agent_run
@@ -1636,28 +1634,16 @@ def _setup_no_set_and_execute(
         # Create virtual evaluation set
         timestamp = datetime.now().strftime("%m-%d %H:%M")
         set_name = f"[No-Set] {timestamp}-{uuid.uuid4().hex[:4]}"
-        set_meta = create_evaluation_set(
-            tenant_id=tenant_id,
-            name=set_name,
-            description=None,
-            source_filename="__no_set_virtual__",
-            created_by=user_id,
-        )
-        evaluation_set_id = set_meta["evaluation_set_id"]
-
-        # Insert cases
         cases = [
             {"inputs": {"query": q.strip()}, "label": {"answer": ""}, "order_no": i}
             for i, q in enumerate(queries)
         ]
-        insert_evaluation_set_cases(
+        evaluation_set_id = materialize_virtual_evaluation_set_for_run(
             tenant_id=tenant_id,
-            evaluation_set_id=evaluation_set_id,
+            name=set_name,
             cases=cases,
             created_by=user_id,
-        )
-        update_evaluation_set_case_count(
-            evaluation_set_id, len(cases), updated_by=user_id
+            agent_evaluation_id=agent_evaluation_id,
         )
         set_cases = get_evaluation_set_cases_all(
             evaluation_set_id=evaluation_set_id, tenant_id=tenant_id
@@ -1670,21 +1656,6 @@ def _setup_no_set_and_execute(
             set_cases=set_cases,
             created_by=user_id,
         )
-
-        # Update the run with correct evaluation_set_id and total
-        with get_db_session() as session:
-            session.query(AgentEvaluation).filter(
-                AgentEvaluation.agent_evaluation_id == agent_evaluation_id,
-                AgentEvaluation.tenant_id == tenant_id,
-            ).update(
-                {
-                    "evaluation_set_id": evaluation_set_id,
-                    "progress_total": len(cases),
-                    "status": EvalRunStatus.PENDING,
-                },
-                synchronize_session=False,
-            )
-            session.commit()
 
         # Execute in the runtime process, which owns the shared workspace
         # volume mounted by the sandbox container.

--- a/backend/services/evaluation_maintenance.py
+++ b/backend/services/evaluation_maintenance.py
@@ -6,7 +6,11 @@ import logging
 import threading
 import time
 
-from database.agent_evaluation_db import cleanup_aged_evaluations, reap_stale_runs
+from database.agent_evaluation_db import (
+    cleanup_aged_evaluations,
+    list_dispatchable_pending_runs,
+    reap_stale_runs,
+)
 from database.client import get_db_session
 from database.db_models import AgentEvaluation
 
@@ -32,12 +36,47 @@ def _run_tenant_task(tenants, task, log_template, warn_label):
             logger.warning("%s failed for tenant %s: %s", warn_label, tid, exc)
 
 
+def _dispatch_pending_runs(runs):
+    """Resume durable pending runs through the existing runtime dispatcher."""
+    if not runs:
+        return
+
+    from services.runtime_proxy_service import dispatch_agent_evaluation_run
+
+    for run in runs:
+        run_id = run.get("agent_evaluation_id")
+        tenant_id = run.get("tenant_id")
+        user_id = run.get("created_by")
+        if not run_id or not tenant_id or not user_id:
+            logger.warning(
+                "Cannot redispatch pending evaluation %s without tenant and creator",
+                run_id,
+            )
+            continue
+        try:
+            dispatch_agent_evaluation_run(
+                agent_evaluation_id=int(run_id),
+                user_id=str(user_id),
+                tenant_id=str(tenant_id),
+            )
+        except Exception as exc:
+            # Keep the row PENDING. The next maintenance pass can use the same
+            # idempotent runtime claim once the runtime service is available.
+            logger.warning(
+                "Pending evaluation dispatch failed for run %s: %s",
+                run_id,
+                exc,
+            )
+
+
 def _run_loop():
     """Maintenance loop: periodically reap stale runs and cleanup aged data."""
     last_cleanup = 0.0
     while _running:
         try:
             now = time.time()
+            _dispatch_pending_runs(list_dispatchable_pending_runs())
+
             # Reap stale RUNNING tasks every STALE_CHECK_INTERVAL
             time.sleep(STALE_CHECK_INTERVAL)
 

--- a/backend/services/file_management_service.py
+++ b/backend/services/file_management_service.py
@@ -380,6 +380,7 @@ async def upload_files_impl(
     index_name: Optional[str] = None,
     user_id: Optional[str] = None,
     uploader_tenant_id: Optional[str] = None,
+    upload_owner_service: Optional[str] = None,
 ) -> tuple:
     """
     Upload files to local storage or MinIO based on destination.
@@ -391,6 +392,7 @@ async def upload_files_impl(
         index_name: Knowledge base index for conflict resolution
         user_id: User ID for attachment path isolation
         uploader_tenant_id: Uploader tenant ID (ASSET_OWNER uses dedicated prefix)
+        upload_owner_service: Service responsible for recovering interrupted uploads
 
     Returns:
         UploadFilesResult: Three-item tuple-compatible result with quota metadata
@@ -444,6 +446,7 @@ async def upload_files_impl(
                     "bucket_name": storage_context.bucket_name,
                     "object_name": planned_object_name,
                     "file_size": getattr(upload, "size", None),
+                    "upload_owner_service": upload_owner_service,
                     "status": "UPLOADING",
                     "stage": "UPLOAD",
                     "created_by": user_id,

--- a/backend/services/memory_dreaming_scheduler.py
+++ b/backend/services/memory_dreaming_scheduler.py
@@ -28,7 +28,7 @@ class DreamingLeaseStore:
         return memory_dreaming_db.claim_queued(owner_id, lease_seconds)
 
     async def recover(self) -> None:
-        await asyncio.to_thread(memory_dreaming_db.recover_stale)
+        await asyncio.to_thread(memory_dreaming_db.recover_stale, True)
 
     async def claim_due(
         self,

--- a/backend/services/startup_recovery_service.py
+++ b/backend/services/startup_recovery_service.py
@@ -103,8 +103,8 @@ def recover_northbound_tasks() -> dict[str, int]:
     return result
 
 
-def fail_interrupted_uploads(cutoff: datetime) -> int:
-    """Fail uploads that predate a safe startup cutoff and remove partial objects."""
+def fail_interrupted_uploads(cutoff: datetime, upload_owner_service: str) -> int:
+    """Fail old uploads owned by a restarted service and remove partial objects."""
     from database.attachment_db import delete_file
     from database.client import minio_client
     from database.knowledge_file_lifecycle_db import (
@@ -113,7 +113,10 @@ def fail_interrupted_uploads(cutoff: datetime) -> int:
     )
 
     failed = 0
-    for record in list_uploading_files_created_before(cutoff):
+    for record in list_uploading_files_created_before(
+        cutoff,
+        upload_owner_service,
+    ):
         claimed = transition_file_record(
             record["file_id"],
             status="FAILED",
@@ -162,15 +165,23 @@ def fail_interrupted_uploads(cutoff: datetime) -> int:
     return failed
 
 
-async def schedule_interrupted_upload_cleanup() -> None:
-    """Clean old uploads now, then recheck pre-start rows after the grace period."""
+async def schedule_interrupted_upload_cleanup(upload_owner_service: str) -> None:
+    """Clean this service's old uploads now and again after the grace period."""
     startup_time = datetime.utcnow()
     immediate_cutoff = startup_time - timedelta(seconds=UPLOAD_RECOVERY_GRACE_SECONDS)
-    await asyncio.to_thread(fail_interrupted_uploads, immediate_cutoff)
+    await asyncio.to_thread(
+        fail_interrupted_uploads,
+        immediate_cutoff,
+        upload_owner_service,
+    )
 
     async def _delayed_cleanup() -> None:
         await asyncio.sleep(UPLOAD_RECOVERY_GRACE_SECONDS)
-        await asyncio.to_thread(fail_interrupted_uploads, startup_time)
+        await asyncio.to_thread(
+            fail_interrupted_uploads,
+            startup_time,
+            upload_owner_service,
+        )
 
     task = asyncio.create_task(_delayed_cleanup())
     _upload_cleanup_tasks.add(task)

--- a/backend/services/startup_recovery_service.py
+++ b/backend/services/startup_recovery_service.py
@@ -1,0 +1,177 @@
+"""Container startup recovery for durable task states."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta
+
+logger = logging.getLogger(__name__)
+
+UPLOAD_RECOVERY_GRACE_SECONDS = 30 * 60
+_upload_cleanup_tasks: set[asyncio.Task] = set()
+
+
+def recover_runtime_tasks() -> dict[str, int]:
+    """Fail work that was owned by the previous runtime process."""
+    from database.agent_automation_db import (
+        recover_orphaned_runs,
+        release_all_task_locks,
+    )
+    from database.agent_evaluation_db import (
+        list_evaluation_tenant_ids,
+        reap_stale_runs,
+    )
+    from database.conversation_db import fail_streaming_assistant_messages
+    from services.runtime_state_service import runtime_state_service
+
+    messages = fail_streaming_assistant_messages()
+    for message in messages:
+        user_id = message.get("user_id")
+        if user_id:
+            runtime_state_service.mark_run_finished(
+                str(user_id), int(message["conversation_id"]), "failed"
+            )
+            runtime_state_service.mark_stream_completed(
+                str(user_id), int(message["conversation_id"]), "failed"
+            )
+
+    evaluations = 0
+    for tenant_id in list_evaluation_tenant_ids():
+        evaluations += reap_stale_runs(tenant_id, timeout_minutes=0)
+
+    result = {
+        "conversation_messages": len(messages),
+        "agent_evaluations": evaluations,
+        "automation_runs": recover_orphaned_runs(),
+        "automation_locks": release_all_task_locks(),
+    }
+    logger.info("Runtime startup recovery completed: %s", result)
+    return result
+
+
+def recover_config_tasks() -> dict[str, int]:
+    """Fail config-owned background work lost during process restart."""
+    from database.agent_evaluation_db import fail_interrupted_no_set_runs_on_startup
+    from database.evaluation_set_db import (
+        cleanup_orphaned_virtual_evaluation_sets,
+        recover_interrupted_generations,
+    )
+    from database.model_management_db import fail_detecting_models_on_startup
+    from database.memory_dreaming_db import recover_stale
+
+    result = {
+        "agent_evaluation_setups": fail_interrupted_no_set_runs_on_startup(),
+        "evaluation_set_generations": recover_interrupted_generations(),
+        "orphaned_virtual_sets": cleanup_orphaned_virtual_evaluation_sets(),
+        "model_connectivity_checks": fail_detecting_models_on_startup(),
+        "dreaming_runs": recover_stale(include_unexpired=True),
+    }
+    logger.info("Config startup recovery completed: %s", result)
+    return result
+
+
+def recover_data_process_tasks() -> dict[str, int]:
+    """Fail tasks that had started in the previous data-process worker set."""
+    from database.knowledge_file_lifecycle_db import fail_interrupted_file_tasks
+    from services.redis_service import get_redis_service
+
+    records = fail_interrupted_file_tasks()
+    task_ids = {
+        str(task_id)
+        for record in records
+        for task_id in (
+            record.get("process_task_id"),
+            record.get("forward_task_id"),
+            record.get("parent_task_id"),
+        )
+        if task_id
+    }
+    redis_service = get_redis_service()
+    canceled = sum(redis_service.mark_task_cancelled(task_id) for task_id in task_ids)
+    result = {"knowledge_files": len(records), "cancel_markers": int(canceled)}
+    logger.info("Data-process startup recovery completed: %s", result)
+    return result
+
+
+def recover_northbound_tasks() -> dict[str, int]:
+    """Fail protocol tasks owned by the previous northbound process."""
+    from database.a2a_agent_db import fail_active_tasks_on_startup
+
+    result = {"a2a_tasks": fail_active_tasks_on_startup()}
+    logger.info("Northbound startup recovery completed: %s", result)
+    return result
+
+
+def fail_interrupted_uploads(cutoff: datetime) -> int:
+    """Fail uploads that predate a safe startup cutoff and remove partial objects."""
+    from database.attachment_db import delete_file
+    from database.client import minio_client
+    from database.knowledge_file_lifecycle_db import (
+        list_uploading_files_created_before,
+        transition_file_record,
+    )
+
+    failed = 0
+    for record in list_uploading_files_created_before(cutoff):
+        claimed = transition_file_record(
+            record["file_id"],
+            status="FAILED",
+            stage="UPLOAD",
+            expected_statuses=("UPLOADING",),
+            expected_version=record.get("version"),
+            error_code="CONTAINER_RESTARTED",
+            error_message="Upload was interrupted by a service restart",
+            error_stage="UPLOAD",
+            failed_at=datetime.utcnow(),
+        )
+        if not claimed:
+            continue
+
+        failed += 1
+        object_name = record.get("object_name")
+        bucket_name = record.get("bucket_name")
+        try:
+            if object_name:
+                delete_result = delete_file(object_name, bucket_name)
+                if not delete_result.get("success") and minio_client.file_exists(
+                    object_name, bucket_name
+                ):
+                    raise RuntimeError(
+                        delete_result.get("error") or "Failed to delete upload object"
+                    )
+        except Exception as exc:
+            logger.warning(
+                "Interrupted upload cleanup failed for file_id=%s: %s",
+                record["file_id"],
+                exc,
+            )
+            transition_file_record(
+                record["file_id"],
+                status="FAILED",
+                stage="UPLOAD_RECOVERY",
+                expected_statuses=("FAILED",),
+                expected_version=claimed.get("version"),
+                error_code="UPLOAD_RECOVERY_FAILED",
+                error_message=str(exc),
+                error_stage="UPLOAD_RECOVERY",
+                failed_at=datetime.utcnow(),
+            )
+    if failed:
+        logger.info("Failed %d interrupted uploads created before %s", failed, cutoff)
+    return failed
+
+
+async def schedule_interrupted_upload_cleanup() -> None:
+    """Clean old uploads now, then recheck pre-start rows after the grace period."""
+    startup_time = datetime.utcnow()
+    immediate_cutoff = startup_time - timedelta(seconds=UPLOAD_RECOVERY_GRACE_SECONDS)
+    await asyncio.to_thread(fail_interrupted_uploads, immediate_cutoff)
+
+    async def _delayed_cleanup() -> None:
+        await asyncio.sleep(UPLOAD_RECOVERY_GRACE_SECONDS)
+        await asyncio.to_thread(fail_interrupted_uploads, startup_time)
+
+    task = asyncio.create_task(_delayed_cleanup())
+    _upload_cleanup_tasks.add(task)
+    task.add_done_callback(_upload_cleanup_tasks.discard)

--- a/deploy/k8s/helm/nexent/README.md
+++ b/deploy/k8s/helm/nexent/README.md
@@ -98,6 +98,8 @@ When `--persistence-mode local` is used, Nexent renders static PVs with `hostPat
 
 Config, Runtime, and Northbound use `/health/live` startup probes, while Web probes `/`, before their liveness and readiness probes become active. Each service waits 30 seconds before its first startup check; the following probe budget is five minutes (`periodSeconds: 5`, `failureThreshold: 60`) so cold starts and Python imports do not trigger a premature liveness restart. Operators can override each delay independently, for example with `--set nexent-runtime.probes.startup.initialDelaySeconds=60`.
 
+Config, Runtime, Northbound, and Data Process are intentionally single-replica workloads and use the Kubernetes `Recreate` deployment strategy. Their startup paths mark in-process work left by the previous container as failed, so an old and a new Pod must never overlap. Helm rendering fails if any of these services is scaled above one replica or configured with another strategy. Upgrading one of these services therefore causes a short interruption while Kubernetes stops the old Pod and starts its replacement; stateless services such as Web keep their existing scaling behavior.
+
 ## Deploy Options
 
 | Option | Description | Values |

--- a/deploy/k8s/helm/nexent/charts/nexent-config/templates/deployment.yaml
+++ b/deploy/k8s/helm/nexent/charts/nexent-config/templates/deployment.yaml
@@ -1,3 +1,9 @@
+{{- if ne (int .Values.replicaCount) 1 -}}
+{{- fail "nexent-config must remain single-replica for startup task recovery" -}}
+{{- end -}}
+{{- if ne .Values.strategy.type "Recreate" -}}
+{{- fail "nexent-config strategy.type must be Recreate for startup task recovery" -}}
+{{- end -}}
 {{- $global := default dict .Values.global -}}
 {{- $sqlFileNames := default dict $global.sqlFileNames -}}
 {{- $sharedStorage := default dict $global.sharedStorage -}}

--- a/deploy/k8s/helm/nexent/charts/nexent-config/values.yaml
+++ b/deploy/k8s/helm/nexent/charts/nexent-config/values.yaml
@@ -1,10 +1,7 @@
 replicaCount: 1
 
 strategy:
-  type: RollingUpdate
-  rollingUpdate:
-    maxSurge: 1
-    maxUnavailable: 0
+  type: Recreate
 
 images:
   backend:

--- a/deploy/k8s/helm/nexent/charts/nexent-data-process/templates/deployment.yaml
+++ b/deploy/k8s/helm/nexent/charts/nexent-data-process/templates/deployment.yaml
@@ -1,3 +1,9 @@
+{{- if ne (int .Values.replicaCount) 1 -}}
+{{- fail "nexent-data-process must remain single-replica for startup task recovery" -}}
+{{- end -}}
+{{- if ne .Values.strategy.type "Recreate" -}}
+{{- fail "nexent-data-process strategy.type must be Recreate for startup task recovery" -}}
+{{- end -}}
 {{- $global := default dict .Values.global -}}
 {{- $sqlFileNames := default dict $global.sqlFileNames -}}
 {{- $sharedStorage := default dict $global.sharedStorage -}}
@@ -13,6 +19,8 @@ metadata:
     "helm.sh/hook-weight": "20"
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+{{ toYaml .Values.strategy | indent 4 }}
   selector:
     matchLabels:
       app: nexent-data-process

--- a/deploy/k8s/helm/nexent/charts/nexent-data-process/values.yaml
+++ b/deploy/k8s/helm/nexent/charts/nexent-data-process/values.yaml
@@ -1,5 +1,8 @@
 replicaCount: 1
 
+strategy:
+  type: Recreate
+
 images:
   dataProcess:
     repository: nexent/nexent-data-process

--- a/deploy/k8s/helm/nexent/charts/nexent-northbound/templates/deployment.yaml
+++ b/deploy/k8s/helm/nexent/charts/nexent-northbound/templates/deployment.yaml
@@ -1,3 +1,9 @@
+{{- if ne (int .Values.replicaCount) 1 -}}
+{{- fail "nexent-northbound must remain single-replica for startup task recovery" -}}
+{{- end -}}
+{{- if ne .Values.strategy.type "Recreate" -}}
+{{- fail "nexent-northbound strategy.type must be Recreate for startup task recovery" -}}
+{{- end -}}
 {{- $global := default dict .Values.global -}}
 {{- $sqlFileNames := default dict $global.sqlFileNames -}}
 {{- $sharedStorage := default dict $global.sharedStorage -}}

--- a/deploy/k8s/helm/nexent/charts/nexent-northbound/values.yaml
+++ b/deploy/k8s/helm/nexent/charts/nexent-northbound/values.yaml
@@ -1,10 +1,7 @@
 replicaCount: 1
 
 strategy:
-  type: RollingUpdate
-  rollingUpdate:
-    maxSurge: 1
-    maxUnavailable: 0
+  type: Recreate
 
 images:
   backend:

--- a/deploy/k8s/helm/nexent/charts/nexent-runtime/templates/deployment.yaml
+++ b/deploy/k8s/helm/nexent/charts/nexent-runtime/templates/deployment.yaml
@@ -1,3 +1,9 @@
+{{- if ne (int .Values.replicaCount) 1 -}}
+{{- fail "nexent-runtime must remain single-replica for startup task recovery" -}}
+{{- end -}}
+{{- if ne .Values.strategy.type "Recreate" -}}
+{{- fail "nexent-runtime strategy.type must be Recreate for startup task recovery" -}}
+{{- end -}}
 {{- $global := default dict .Values.global -}}
 {{- $sqlFileNames := default dict $global.sqlFileNames -}}
 {{- $sharedStorage := default dict $global.sharedStorage -}}

--- a/deploy/k8s/helm/nexent/charts/nexent-runtime/values.yaml
+++ b/deploy/k8s/helm/nexent/charts/nexent-runtime/values.yaml
@@ -1,10 +1,7 @@
 replicaCount: 1
 
 strategy:
-  type: RollingUpdate
-  rollingUpdate:
-    maxSurge: 1
-    maxUnavailable: 0
+  type: Recreate
 
 images:
   backend:

--- a/deploy/sql/migrations/v2.5.1_upload_owner_service.sql
+++ b/deploy/sql/migrations/v2.5.1_upload_owner_service.sql
@@ -1,0 +1,11 @@
+-- Scope interrupted-upload recovery to the service that created the upload.
+
+ALTER TABLE nexent.knowledge_file_lifecycle_t
+    ADD COLUMN IF NOT EXISTS upload_owner_service VARCHAR(32);
+
+COMMENT ON COLUMN nexent.knowledge_file_lifecycle_t.upload_owner_service IS
+    'Service responsible for recovering an in-progress upload';
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_file_lifecycle_upload_recovery
+    ON nexent.knowledge_file_lifecycle_t (upload_owner_service, create_time)
+    WHERE delete_flag = 'N' AND status = 'UPLOADING';

--- a/test/backend/app/test_app_factory.py
+++ b/test/backend/app/test_app_factory.py
@@ -4,8 +4,9 @@ Unit tests for app_factory module.
 Tests the create_app function and register_exception_handlers function
 for FastAPI application factory with common configurations and exception handlers.
 """
-import sys
 import os
+import sys
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
@@ -101,6 +102,15 @@ class TestCreateApp:
         assert app.description == "Full description"
         assert app.version == "3.0.0"
         assert app.root_path == "/v3"
+
+    def test_create_app_uses_lifespan_context(self):
+        @asynccontextmanager
+        async def lifespan(_app):
+            yield
+
+        app = create_app(lifespan=lifespan)
+
+        assert app.router.lifespan_context is lifespan
 
 
 class TestRegisterExceptionHandlers:
@@ -929,4 +939,3 @@ class TestGenericHandlerAppExceptionDelegation:
             "message": "Session expired, please log in again",
             "code": "TOKEN_EXPIRED",
         }
-

--- a/test/backend/app/test_config_app.py
+++ b/test/backend/app/test_config_app.py
@@ -8,9 +8,10 @@ This test file focuses on testing config_app by importing it from the app_factor
 module and verifying the app structure without triggering all the complex router
 dependencies.
 """
+import asyncio
 import atexit
 import importlib.util
-from unittest.mock import patch, Mock, MagicMock
+from unittest.mock import AsyncMock, patch, Mock, MagicMock
 import os
 from pathlib import Path
 import sys
@@ -89,8 +90,9 @@ class TestConfigAppRouterConfiguration:
 
     def test_config_app_registers_api_key_routes(self, monkeypatch):
         class RecordingApp:
-            def __init__(self):
+            def __init__(self, lifespan=None):
                 self.included_routers = []
+                self.lifespan = lifespan
 
             def on_event(self, _event):
                 return lambda handler: handler
@@ -99,7 +101,9 @@ class TestConfigAppRouterConfiguration:
                 self.included_routers.append(router)
 
         app_factory_module = types.ModuleType("apps.app_factory")
-        app_factory_module.create_app = lambda **_: RecordingApp()
+        app_factory_module.create_app = (
+            lambda **kwargs: RecordingApp(kwargs.get("lifespan"))
+        )
         monkeypatch.setitem(sys.modules, "apps.app_factory", app_factory_module)
 
         api_key_router = APIRouter(prefix="/api-keys")
@@ -189,6 +193,66 @@ class TestConfigAppRouterConfiguration:
             "/api-keys",
             "/api-keys/refresh",
         }
+
+        recover_config_tasks = MagicMock()
+        schedule_upload_cleanup = AsyncMock()
+        startup_recovery_module = types.ModuleType(
+            "services.startup_recovery_service"
+        )
+        startup_recovery_module.recover_config_tasks = recover_config_tasks
+        startup_recovery_module.schedule_interrupted_upload_cleanup = (
+            schedule_upload_cleanup
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "services.startup_recovery_service",
+            startup_recovery_module,
+        )
+
+        start_evaluation_maintenance = MagicMock()
+        evaluation_maintenance_module = types.ModuleType(
+            "services.evaluation_maintenance"
+        )
+        evaluation_maintenance_module.start = start_evaluation_maintenance
+        monkeypatch.setitem(
+            sys.modules,
+            "services.evaluation_maintenance",
+            evaluation_maintenance_module,
+        )
+
+        dreaming_scheduler = MagicMock()
+        dreaming_scheduler.start = AsyncMock()
+        dreaming_scheduler.stop = AsyncMock()
+        dreaming_scheduler_module = types.ModuleType(
+            "services.memory_dreaming_scheduler"
+        )
+        dreaming_scheduler_module.dreaming_scheduler = dreaming_scheduler
+        monkeypatch.setitem(
+            sys.modules,
+            "services.memory_dreaming_scheduler",
+            dreaming_scheduler_module,
+        )
+
+        sync_defaults = AsyncMock()
+
+        async def exercise_lifespan():
+            async with config_app.config_lifespan(None):
+                pass
+
+        with patch.object(
+            config_app,
+            "sync_default_prompt_template_on_startup",
+            new=sync_defaults,
+        ):
+            asyncio.run(exercise_lifespan())
+
+        assert config_app.app.lifespan is config_app.config_lifespan
+        recover_config_tasks.assert_called_once_with()
+        start_evaluation_maintenance.assert_called_once_with()
+        schedule_upload_cleanup.assert_awaited_once_with()
+        sync_defaults.assert_awaited_once_with()
+        dreaming_scheduler.start.assert_awaited_once_with()
+        dreaming_scheduler.stop.assert_awaited_once_with()
 
     def test_create_app_with_multiple_routers(self):
         """Test that create_app can include multiple routers."""

--- a/test/backend/app/test_config_app.py
+++ b/test/backend/app/test_config_app.py
@@ -249,7 +249,7 @@ class TestConfigAppRouterConfiguration:
         assert config_app.app.lifespan is config_app.config_lifespan
         recover_config_tasks.assert_called_once_with()
         start_evaluation_maintenance.assert_called_once_with()
-        schedule_upload_cleanup.assert_awaited_once_with()
+        schedule_upload_cleanup.assert_awaited_once_with("nexent-config")
         sync_defaults.assert_awaited_once_with()
         dreaming_scheduler.start.assert_awaited_once_with()
         dreaming_scheduler.stop.assert_awaited_once_with()

--- a/test/backend/app/test_file_management_app.py
+++ b/test/backend/app/test_file_management_app.py
@@ -36,7 +36,15 @@ sfms_stub = types.ModuleType("services.file_management_service")
 async def _stub_upload_to_minio(files, folder, user_id=None):
     return []
 
-async def _stub_upload_files_impl(destination, file, folder, index_name, user_id=None):
+async def _stub_upload_files_impl(
+    destination,
+    file,
+    folder,
+    index_name,
+    user_id=None,
+    uploader_tenant_id=None,
+    upload_owner_service=None,
+):
     return [], [], []
 
 async def _stub_get_file_url_impl(object_name: str, expires: int):
@@ -243,7 +251,16 @@ async def test_options_route_ok():
 
 @pytest.mark.asyncio
 async def test_upload_files_success(monkeypatch):
-    async def fake_upload_impl(dest, files, folder, index_name, user_id=None, uploader_tenant_id=None):
+    async def fake_upload_impl(
+        dest,
+        files,
+        folder,
+        index_name,
+        user_id=None,
+        uploader_tenant_id=None,
+        upload_owner_service=None,
+    ):
+        assert upload_owner_service == "nexent-config"
         return [], ["/abs/path1"], ["a.txt"]
 
     monkeypatch.setattr(file_management_app, "upload_files_impl", fake_upload_impl)
@@ -319,7 +336,15 @@ async def test_upload_files_no_valid_files_uploaded(monkeypatch):
             ]
             return result
 
-    async def fake_upload_impl(dest, files, folder, index_name, user_id=None, uploader_tenant_id=None):
+    async def fake_upload_impl(
+        dest,
+        files,
+        folder,
+        index_name,
+        user_id=None,
+        uploader_tenant_id=None,
+        upload_owner_service=None,
+    ):
         return UploadResult()
 
     monkeypatch.setattr(file_management_app, "upload_files_impl", fake_upload_impl)
@@ -341,7 +366,15 @@ async def test_upload_files_no_valid_files_uploaded(monkeypatch):
 @pytest.mark.asyncio
 async def test_upload_files_internal_error(monkeypatch):
     """Test upload_files with internal error returns 500."""
-    async def fake_upload_impl(dest, files, folder, index_name, user_id=None, uploader_tenant_id=None):
+    async def fake_upload_impl(
+        dest,
+        files,
+        folder,
+        index_name,
+        user_id=None,
+        uploader_tenant_id=None,
+        upload_owner_service=None,
+    ):
         raise RuntimeError("Storage failed")
 
     monkeypatch.setattr(file_management_app, "upload_files_impl", fake_upload_impl)

--- a/test/backend/app/test_northbound_base_app.py
+++ b/test/backend/app/test_northbound_base_app.py
@@ -229,7 +229,8 @@ sys.modules['apps.app_factory'] = app_factory_module
 
 # Provide a real create_app function that returns a FastAPI app
 def _create_app_impl(title, description="", version="1.0.0", root_path="/api",
-                     cors_origins=None, cors_methods=None, enable_monitoring=True):
+                     cors_origins=None, cors_methods=None, enable_monitoring=True,
+                     lifespan=None):
     """Minimal implementation of create_app for testing."""
     from fastapi import FastAPI
     from fastapi.middleware.cors import CORSMiddleware
@@ -238,7 +239,8 @@ def _create_app_impl(title, description="", version="1.0.0", root_path="/api",
         title=title,
         description=description,
         version=version,
-        root_path=root_path
+        root_path=root_path,
+        lifespan=lifespan,
     )
 
     # Add CORS middleware (simplified)

--- a/test/backend/app/test_northbound_base_app.py
+++ b/test/backend/app/test_northbound_base_app.py
@@ -4,6 +4,7 @@ Unit tests for northbound_base_app module.
 Tests cover FastAPI application configuration, CORS middleware, router inclusion,
 and basic A2A endpoint routing and error handling.
 """
+import asyncio
 import os
 import sys
 import types
@@ -288,6 +289,7 @@ async def _async_iter(items):
 # ---------------------------------------------------------------------------
 # SAFE TO IMPORT THE TARGET MODULE
 # ---------------------------------------------------------------------------
+import apps.northbound_base_app as northbound_base_app_module  # noqa: E402
 from apps.northbound_base_app import A2AServerSettings, northbound_app as app  # noqa: E402
 from fastapi import HTTPException  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
@@ -298,6 +300,44 @@ class TestNorthboundBaseApp(unittest.TestCase):
 
     def setUp(self):
         self.client = TestClient(app)
+
+    def test_startup_recovery_runs_a2a_and_upload_cleanup(self):
+        recover_northbound_tasks = MagicMock()
+        schedule_upload_cleanup = AsyncMock()
+        startup_recovery_module = types.ModuleType(
+            "services.startup_recovery_service"
+        )
+        startup_recovery_module.recover_northbound_tasks = recover_northbound_tasks
+        startup_recovery_module.schedule_interrupted_upload_cleanup = (
+            schedule_upload_cleanup
+        )
+
+        with patch.dict(
+            sys.modules,
+            {"services.startup_recovery_service": startup_recovery_module},
+        ):
+            asyncio.run(
+                northbound_base_app_module.recover_northbound_tasks_on_startup()
+            )
+
+        recover_northbound_tasks.assert_called_once_with()
+        schedule_upload_cleanup.assert_awaited_once_with()
+
+    def test_lifespan_runs_startup_recovery(self):
+        recover_on_startup = AsyncMock()
+
+        async def exercise_lifespan():
+            async with northbound_base_app_module.northbound_lifespan(None):
+                pass
+
+        with patch.object(
+            northbound_base_app_module,
+            "recover_northbound_tasks_on_startup",
+            new=recover_on_startup,
+        ):
+            asyncio.run(exercise_lifespan())
+
+        recover_on_startup.assert_awaited_once_with()
 
     # -------------------------------------------------------------------
     # Application configuration

--- a/test/backend/app/test_northbound_base_app.py
+++ b/test/backend/app/test_northbound_base_app.py
@@ -321,7 +321,7 @@ class TestNorthboundBaseApp(unittest.TestCase):
             )
 
         recover_northbound_tasks.assert_called_once_with()
-        schedule_upload_cleanup.assert_awaited_once_with()
+        schedule_upload_cleanup.assert_awaited_once_with("nexent-northbound")
 
     def test_lifespan_runs_startup_recovery(self):
         recover_on_startup = AsyncMock()

--- a/test/backend/app/test_northbound_knowledge_app.py
+++ b/test/backend/app/test_northbound_knowledge_app.py
@@ -634,6 +634,7 @@ class TestIndexManagement:
 class TestUploadAndDownload:
     def test_upload_success_returns_created_payload(self, client, mock_northbound_context):
         mock_northbound_context.return_value = ASSET_CTX
+        file_mgmt_module.upload_files_impl.reset_mock()
         file_mgmt_module.upload_files_impl.return_value = (
             [], ["docs/guide.txt"], ["guide.txt"]
         )
@@ -647,6 +648,9 @@ class TestUploadAndDownload:
 
         assert response.status_code == 201
         assert response.json()["process_tasks"] == {"status": "queued"}
+        assert file_mgmt_module.upload_files_impl.await_args.kwargs[
+            "upload_owner_service"
+        ] == "nexent-northbound"
 
     def test_upload_processing_error_returns_detail(self, client, mock_northbound_context):
         mock_northbound_context.return_value = ASSET_CTX

--- a/test/backend/database/test_a2a_agent_db.py
+++ b/test/backend/database/test_a2a_agent_db.py
@@ -1479,6 +1479,26 @@ class TestUpdateTaskState:
             assert result is False
 
 
+class TestFailActiveTasksOnStartup:
+    def test_moves_submitted_and_working_tasks_to_failed(self):
+        query = MagicMock(name="query")
+        query.filter.return_value = query
+        query.update.return_value = 2
+        session = MagicMock(name="session")
+        session.query.return_value = query
+        context = MagicMock(name="context")
+        context.__enter__.return_value = session
+        context.__exit__.return_value = None
+
+        with patch.object(a2a_db, '_get_db_session', return_value=context):
+            assert a2a_db.fail_active_tasks_on_startup() == 2
+
+        updates = query.update.call_args.args[0]
+        assert updates["task_state"] == "TASK_STATE_FAILED"
+        assert updates["result_data"]["error"]["code"] == "CONTAINER_RESTARTED"
+        assert updates["completed_at"] is not None
+
+
 class TestListTasks:
     def test_returns_tasks_list(self, task):
         with patch.object(a2a_db, '_get_db_session') as mk:

--- a/test/backend/database/test_agent_automation_db.py
+++ b/test/backend/database/test_agent_automation_db.py
@@ -482,8 +482,15 @@ def test_lease_recovery_helpers_cover_empty_and_success_paths(monkeypatch):
     assert agent_automation_db.release_task_lock(1) is True
     assert agent_automation_db.release_task_lock(1, "scheduler-a") is True
     assert agent_automation_db.recover_orphaned_runs() == 2
+    assert agent_automation_db.release_all_task_locks() == 2
     assert agent_automation_db.release_expired_locks() == 2
-    assert any("AUTOMATION_LEASE_EXPIRED" in str(statement) for statement, _ in session.calls)
+    recovery_sql = next(
+        str(statement)
+        for statement, _ in session.calls
+        if "AUTOMATION_LEASE_EXPIRED" in str(statement)
+    )
+    assert "status = 'RUNNING'" in recovery_sql
+    assert "QUEUED" not in recovery_sql
 
 
 def test_optional_database_rows_return_empty_values(monkeypatch):

--- a/test/backend/database/test_agent_evaluation_db.py
+++ b/test/backend/database/test_agent_evaluation_db.py
@@ -1119,3 +1119,76 @@ class TestReapStaleRuns:
 
         n = agent_evaluation_db.reap_stale_runs("t1", timeout_minutes=10)
         assert n == 0
+
+
+class TestStartupRecovery:
+    def test_lists_only_tenants_with_running_work(self, session_factory):
+        from backend.database import agent_evaluation_db
+
+        session, _ = session_factory
+        query = MagicMock(name="query")
+        query.filter.return_value = query
+        query.distinct.return_value = query
+        query.all.return_value = [("tenant-1",), ("tenant-2",), (None,)]
+        session.query.return_value = query
+
+        assert agent_evaluation_db.list_evaluation_tenant_ids() == [
+            "tenant-1",
+            "tenant-2",
+        ]
+        query.distinct.assert_called_once_with()
+
+    def test_fails_interrupted_no_set_runs_and_their_pending_cases(
+        self, session_factory
+    ):
+        from backend.database import agent_evaluation_db
+
+        session, _ = session_factory
+        queries = [MagicMock(name=f"q{i}") for i in range(3)]
+        for query in queries:
+            query.filter.return_value = query
+        queries[0].all.return_value = [(10,), (20,)]
+        queries[1].update.return_value = 4
+        queries[2].update.return_value = 2
+        session.query.side_effect = queries
+
+        assert agent_evaluation_db.fail_interrupted_no_set_runs_on_startup() == 2
+        case_updates = queries[1].update.call_args.args[0]
+        run_updates = queries[2].update.call_args.args[0]
+        assert case_updates["status"] == "FAILED"
+        assert run_updates["status"] == "FAILED"
+        assert case_updates["error_message"] == run_updates["error_message"]
+        session.commit.assert_called_once_with()
+
+    def test_pending_recovery_is_noop_when_there_are_no_runs(self, session_factory):
+        from backend.database import agent_evaluation_db
+
+        session, _ = session_factory
+        query = MagicMock(name="query")
+        query.filter.return_value = query
+        query.all.return_value = []
+        session.query.return_value = query
+
+        assert agent_evaluation_db.fail_interrupted_no_set_runs_on_startup() == 0
+        query.update.assert_not_called()
+
+    def test_lists_dispatchable_pending_runs(self, session_factory, mocker):
+        from backend.database import agent_evaluation_db
+
+        session, _ = session_factory
+        query = MagicMock(name="query")
+        query.filter.return_value = query
+        query.order_by.return_value = query
+        rows = [MagicMock(name="pending-run")]
+        query.all.return_value = rows
+        session.query.return_value = query
+        as_dict = mocker.patch.object(
+            agent_evaluation_db,
+            "as_dict",
+            return_value={"agent_evaluation_id": 10},
+        )
+
+        assert agent_evaluation_db.list_dispatchable_pending_runs() == [
+            {"agent_evaluation_id": 10}
+        ]
+        as_dict.assert_called_once_with(rows[0])

--- a/test/backend/database/test_conversation_db.py
+++ b/test/backend/database/test_conversation_db.py
@@ -279,6 +279,21 @@ def test_fail_streaming_assistant_messages_returns_runtime_identities(
     assert query.with_for_update.called
 
 
+def test_fail_streaming_assistant_messages_returns_empty_without_rows(
+    monkeypatch, mock_session_ctx
+):
+    session, ctx = mock_session_ctx
+    query = MagicMock(name="query")
+    query.filter.return_value = query
+    query.with_for_update.return_value = query
+    query.all.return_value = []
+    session.query.return_value = query
+    monkeypatch.setattr("backend.database.conversation_db.get_db_session", lambda: ctx)
+
+    assert fail_streaming_assistant_messages() == []
+    query.update.assert_not_called()
+
+
 @pytest.fixture(autouse=True)
 def reset_captured():
     """Reset captured SQLAlchemy values before each test."""

--- a/test/backend/database/test_conversation_db.py
+++ b/test/backend/database/test_conversation_db.py
@@ -125,6 +125,7 @@ class ConversationMessage:
     minio_files = MagicMock(name="ConversationMessage.minio_files")
     opinion_flag = MagicMock(name="ConversationMessage.opinion_flag")
     create_time = MagicMock(name="ConversationMessage.create_time")
+    update_time = MagicMock(name="ConversationMessage.update_time")
     created_by = MagicMock(name="ConversationMessage.created_by")
 
 
@@ -211,6 +212,7 @@ from backend.database.conversation_db import (
     delete_conversations_batch,
     delete_source_image,
     delete_source_search,
+    fail_streaming_assistant_messages,
     get_conversation,
     get_conversation_history,
     get_historical_context,
@@ -246,6 +248,35 @@ from consts.exceptions import (
     ConversationNotFoundError,
     RuntimeMetadataVersionConflict,
 )
+
+
+def test_fail_streaming_assistant_messages_returns_runtime_identities(
+    monkeypatch, mock_session_ctx
+):
+    """Startup recovery fails only the rows it locked as streaming."""
+    from types import SimpleNamespace
+
+    session, ctx = mock_session_ctx
+    query = MagicMock(name="query")
+    query.filter.return_value = query
+    query.with_for_update.return_value = query
+    query.all.return_value = [
+        SimpleNamespace(message_id=7, conversation_id=11, created_by="user-1"),
+        SimpleNamespace(message_id=8, conversation_id=12, created_by="user-2"),
+    ]
+    query.update.return_value = 2
+    session.query.return_value = query
+    monkeypatch.setattr("backend.database.conversation_db.get_db_session", lambda: ctx)
+
+    rows = fail_streaming_assistant_messages()
+
+    assert rows == [
+        {"message_id": 7, "conversation_id": 11, "user_id": "user-1"},
+        {"message_id": 8, "conversation_id": 12, "user_id": "user-2"},
+    ]
+    updates = query.update.call_args.args[0]
+    assert updates["status"] == "failed"
+    assert query.with_for_update.called
 
 
 @pytest.fixture(autouse=True)

--- a/test/backend/database/test_evaluation_set_db.py
+++ b/test/backend/database/test_evaluation_set_db.py
@@ -2,6 +2,7 @@
 
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -394,6 +395,107 @@ class TestHardDeleteEvaluationSet:
         assert deleted == 2
         assert q.delete.call_count == 2
         session.commit.assert_called_once()
+
+
+class TestStartupRecovery:
+    def test_interrupted_generation_keeps_baseline_and_deletes_appended_cases(
+        self, session_factory
+    ):
+        from backend.database import evaluation_set_db
+
+        session, _ = session_factory
+        evaluation_set = SimpleNamespace(
+            evaluation_set_id=7,
+            tenant_id="tenant-1",
+            case_count=2,
+            generation_status="GENERATING",
+            generation_progress=80,
+        )
+        set_query = MagicMock(name="set_query")
+        set_query.filter.return_value = set_query
+        set_query.with_for_update.return_value = set_query
+        set_query.all.return_value = [evaluation_set]
+        case_query = MagicMock(name="case_query")
+        case_query.filter.return_value = case_query
+        case_query.order_by.return_value = case_query
+        case_query.all.return_value = [(10,), (11,), (12,), (13,)]
+        delete_query = MagicMock(name="delete_query")
+        delete_query.filter.return_value = delete_query
+        delete_query.delete.return_value = 2
+        session.query.side_effect = [set_query, case_query, delete_query]
+
+        assert evaluation_set_db.recover_interrupted_generations() == 1
+        assert evaluation_set.generation_status == "FAILED"
+        assert evaluation_set.generation_progress == 0
+        delete_query.delete.assert_called_once_with(synchronize_session=False)
+
+    def test_cleans_virtual_sets_that_were_never_linked_to_a_run(
+        self, session_factory
+    ):
+        from backend.database import evaluation_set_db
+
+        session, _ = session_factory
+        referenced_query = MagicMock(name="referenced_query")
+        referenced_query.filter.return_value = referenced_query
+        orphan_query = MagicMock(name="orphan_query")
+        orphan_query.filter.return_value = orphan_query
+        orphan_query.all.return_value = [(30, "tenant-1"), (31, "tenant-2")]
+        case_delete = MagicMock(name="case_delete")
+        case_delete.filter.return_value = case_delete
+        set_delete = MagicMock(name="set_delete")
+        set_delete.filter.return_value = set_delete
+        session.query.side_effect = [
+            referenced_query,
+            orphan_query,
+            case_delete,
+            set_delete,
+        ]
+
+        assert evaluation_set_db.cleanup_orphaned_virtual_evaluation_sets() == 2
+        case_delete.delete.assert_called_once_with(synchronize_session=False)
+        set_delete.delete.assert_called_once_with(synchronize_session=False)
+
+    def test_materializes_virtual_set_and_links_pending_run_in_one_session(
+        self, session_factory
+    ):
+        from backend.database import evaluation_set_db
+
+        session, _ = session_factory
+        run = SimpleNamespace(
+            evaluation_set_id=0,
+            progress_total=0,
+            updated_by=None,
+        )
+        query = MagicMock(name="run_query")
+        query.filter.return_value = query
+        query.with_for_update.return_value = query
+        query.first.return_value = run
+        session.query.return_value = query
+
+        def assign_primary_key():
+            for invocation in session.add.call_args_list:
+                record = invocation.args[0]
+                if isinstance(record, evaluation_set_db.EvaluationSet):
+                    record.evaluation_set_id = 99
+
+        session.flush.side_effect = assign_primary_key
+
+        set_id = evaluation_set_db.materialize_virtual_evaluation_set_for_run(
+            tenant_id="tenant-1",
+            name="[No-Set] recovery",
+            cases=[
+                {"inputs": {"query": "q1"}, "label": {"answer": ""}},
+                {"inputs": {"query": "q2"}, "label": {"answer": ""}},
+            ],
+            created_by="user-1",
+            agent_evaluation_id=5,
+        )
+
+        assert set_id == 99
+        assert run.evaluation_set_id == 99
+        assert run.progress_total == 2
+        assert run.updated_by == "user-1"
+        assert session.add.call_count == 3
 
 
 # ---------------------------------------------------------------------------

--- a/test/backend/database/test_evaluation_set_db.py
+++ b/test/backend/database/test_evaluation_set_db.py
@@ -429,6 +429,34 @@ class TestStartupRecovery:
         assert evaluation_set.generation_progress == 0
         delete_query.delete.assert_called_once_with(synchronize_session=False)
 
+    def test_interrupted_generation_without_appended_cases_skips_delete(
+        self, session_factory
+    ):
+        from backend.database import evaluation_set_db
+
+        session, _ = session_factory
+        evaluation_set = SimpleNamespace(
+            evaluation_set_id=7,
+            tenant_id="tenant-1",
+            case_count=2,
+            generation_status="GENERATING",
+            generation_progress=20,
+        )
+        set_query = MagicMock(name="set_query")
+        set_query.filter.return_value = set_query
+        set_query.with_for_update.return_value = set_query
+        set_query.all.return_value = [evaluation_set]
+        case_query = MagicMock(name="case_query")
+        case_query.filter.return_value = case_query
+        case_query.order_by.return_value = case_query
+        case_query.all.return_value = [(10,), (11,)]
+        session.query.side_effect = [set_query, case_query]
+
+        assert evaluation_set_db.recover_interrupted_generations() == 1
+        assert evaluation_set.generation_status == "FAILED"
+        assert evaluation_set.generation_progress == 0
+        assert session.query.call_count == 2
+
     def test_cleans_virtual_sets_that_were_never_linked_to_a_run(
         self, session_factory
     ):
@@ -454,6 +482,22 @@ class TestStartupRecovery:
         assert evaluation_set_db.cleanup_orphaned_virtual_evaluation_sets() == 2
         case_delete.delete.assert_called_once_with(synchronize_session=False)
         set_delete.delete.assert_called_once_with(synchronize_session=False)
+
+    def test_cleanup_virtual_sets_skips_delete_when_none_are_orphaned(
+        self, session_factory
+    ):
+        from backend.database import evaluation_set_db
+
+        session, _ = session_factory
+        referenced_query = MagicMock(name="referenced_query")
+        referenced_query.filter.return_value = referenced_query
+        orphan_query = MagicMock(name="orphan_query")
+        orphan_query.filter.return_value = orphan_query
+        orphan_query.all.return_value = []
+        session.query.side_effect = [referenced_query, orphan_query]
+
+        assert evaluation_set_db.cleanup_orphaned_virtual_evaluation_sets() == 0
+        assert session.query.call_count == 2
 
     def test_materializes_virtual_set_and_links_pending_run_in_one_session(
         self, session_factory
@@ -496,6 +540,29 @@ class TestStartupRecovery:
         assert run.progress_total == 2
         assert run.updated_by == "user-1"
         assert session.add.call_count == 3
+
+    def test_materialize_virtual_set_rejects_missing_pending_run(
+        self, session_factory
+    ):
+        from backend.database import evaluation_set_db
+
+        session, _ = session_factory
+        query = MagicMock(name="run_query")
+        query.filter.return_value = query
+        query.with_for_update.return_value = query
+        query.first.return_value = None
+        session.query.return_value = query
+
+        with pytest.raises(evaluation_set_db.AppException):
+            evaluation_set_db.materialize_virtual_evaluation_set_for_run(
+                tenant_id="tenant-1",
+                name="[No-Set] recovery",
+                cases=[],
+                created_by="user-1",
+                agent_evaluation_id=5,
+            )
+
+        session.add.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/test/backend/database/test_knowledge_file_lifecycle_db.py
+++ b/test/backend/database/test_knowledge_file_lifecycle_db.py
@@ -7,6 +7,8 @@ import types
 from datetime import datetime
 from unittest.mock import MagicMock
 
+import pytest
+
 
 def _install_storage_import_stubs() -> None:
     """Keep database tests independent from the SDK's optional model stack."""
@@ -75,6 +77,7 @@ def test_create_file_records_uses_one_transaction_for_the_whole_batch(monkeypatc
             "knowledge_id": 10,
             "index_name": "kb-1",
             "original_filename": "a.pdf",
+            "upload_owner_service": "nexent-config",
         },
         {
             "file_id": "fid-2",
@@ -89,6 +92,12 @@ def test_create_file_records_uses_one_transaction_for_the_whole_batch(monkeypatc
     session.add_all.assert_called_once_with(rows)
     session.add.assert_not_called()
     session.flush.assert_called_once_with()
+    assert lifecycle_model.call_args_list[0].kwargs[
+        "upload_owner_service"
+    ] == "nexent-config"
+    assert lifecycle_model.call_args_list[1].kwargs[
+        "upload_owner_service"
+    ] is None
 
 
 def test_create_file_records_returns_empty_for_empty_batch(monkeypatch):
@@ -241,9 +250,11 @@ def test_fail_interrupted_file_tasks_reuses_failed_state(monkeypatch):
     assert forwarding.status == "FAILED"
     assert forwarding.error_stage == "FORWARD"
     assert forwarding.version == 5
+    recovery_filter = query.filter.call_args.args[1]
+    assert "forward_task_id IS NOT NULL" in str(recovery_filter)
 
 
-def test_list_uploading_files_created_before_uses_cutoff(monkeypatch):
+def test_list_uploading_files_created_before_scopes_recovery_to_owner(monkeypatch):
     session = MagicMock()
     query = session.query.return_value
     query.filter.return_value = query
@@ -252,10 +263,36 @@ def test_list_uploading_files_created_before_uses_cutoff(monkeypatch):
     monkeypatch.setattr(lifecycle_db, "get_db_session", _session_context(session))
     monkeypatch.setattr(lifecycle_db, "as_dict", lambda value: {"file_id": value.file_id})
 
-    rows = lifecycle_db.list_uploading_files_created_before(datetime(2026, 9, 1))
+    rows = lifecycle_db.list_uploading_files_created_before(
+        datetime(2026, 9, 1),
+        "nexent-config",
+    )
 
     assert rows == [{"file_id": "uploading"}]
     query.order_by.assert_called_once()
+    owner_filter = next(
+        argument
+        for argument in query.filter.call_args.args
+        if getattr(argument.left, "name", None) == "upload_owner_service"
+    )
+    assert owner_filter.right.value == "nexent-config"
+
+
+@pytest.mark.parametrize("upload_owner_service", [None, ""])
+def test_list_uploading_files_created_before_rejects_missing_owner(
+    monkeypatch,
+    upload_owner_service,
+):
+    session = MagicMock()
+    monkeypatch.setattr(lifecycle_db, "get_db_session", _session_context(session))
+
+    with pytest.raises(ValueError, match="upload_owner_service is required"):
+        lifecycle_db.list_uploading_files_created_before(
+            datetime(2026, 9, 1),
+            upload_owner_service,
+        )
+
+    session.query.assert_not_called()
 
 
 def test_transition_file_record_updates_allowed_fields_and_version(monkeypatch):

--- a/test/backend/database/test_knowledge_file_lifecycle_db.py
+++ b/test/backend/database/test_knowledge_file_lifecycle_db.py
@@ -4,6 +4,7 @@ import contextlib
 import importlib
 import sys
 import types
+from datetime import datetime
 from unittest.mock import MagicMock
 
 
@@ -196,6 +197,65 @@ def test_list_file_records_applies_tenant_and_hides_deleted_rows(monkeypatch):
     query.order_by.return_value.all.return_value = []
     assert lifecycle_db.list_file_records(index_name="kb-1", include_hidden=True) == []
     assert query.filter.call_count == 1
+
+
+def test_fail_interrupted_file_tasks_reuses_failed_state(monkeypatch):
+    session = MagicMock()
+    query = session.query.return_value
+    query.filter.return_value = query
+    query.with_for_update.return_value = query
+    processing = types.SimpleNamespace(
+        file_id="processing",
+        status="PROCESSING",
+        stage="PROCESS",
+        process_task_id="process-1",
+        forward_task_id=None,
+        version=1,
+    )
+    forwarding = types.SimpleNamespace(
+        file_id="forwarding",
+        status="FORWARDING",
+        stage="FORWARD",
+        process_task_id="process-2",
+        forward_task_id="forward-2",
+        version=4,
+    )
+    query.all.return_value = [processing, forwarding]
+    monkeypatch.setattr(lifecycle_db, "get_db_session", _session_context(session))
+    monkeypatch.setattr(
+        lifecycle_db,
+        "as_dict",
+        lambda value: {
+            "file_id": value.file_id,
+            "process_task_id": value.process_task_id,
+            "forward_task_id": value.forward_task_id,
+        },
+    )
+
+    records = lifecycle_db.fail_interrupted_file_tasks()
+
+    assert [record["file_id"] for record in records] == ["processing", "forwarding"]
+    assert processing.status == "FAILED"
+    assert processing.error_stage == "PROCESS"
+    assert processing.version == 2
+    assert forwarding.status == "FAILED"
+    assert forwarding.error_stage == "FORWARD"
+    assert forwarding.version == 5
+
+
+def test_list_uploading_files_created_before_uses_cutoff(monkeypatch):
+    session = MagicMock()
+    query = session.query.return_value
+    query.filter.return_value = query
+    query.order_by.return_value = query
+    query.all.return_value = [types.SimpleNamespace(file_id="uploading")]
+    monkeypatch.setattr(lifecycle_db, "get_db_session", _session_context(session))
+    monkeypatch.setattr(lifecycle_db, "as_dict", lambda value: {"file_id": value.file_id})
+
+    rows = lifecycle_db.list_uploading_files_created_before(datetime(2026, 9, 1))
+
+    assert rows == [{"file_id": "uploading"}]
+    query.order_by.assert_called_once()
 
 
 def test_transition_file_record_updates_allowed_fields_and_version(monkeypatch):

--- a/test/backend/database/test_memory_dreaming_lease.py
+++ b/test/backend/database/test_memory_dreaming_lease.py
@@ -151,3 +151,15 @@ def test_ac030_recover_stale_returns_zero_when_clean(monkeypatch):
     result = memory_dreaming_db.recover_stale()
 
     assert result == 0
+
+
+def test_startup_recovery_includes_unexpired_running_leases(monkeypatch):
+    session = _mock_session(monkeypatch)
+    session.execute.return_value.rowcount = 2
+
+    result = memory_dreaming_db.recover_stale(include_unexpired=True)
+
+    assert result == 2
+    sql_text = str(session.execute.call_args[0][0])
+    assert "status = 'running'" in sql_text
+    assert "lock_until < now()" not in sql_text

--- a/test/backend/database/test_model_managment_db.py
+++ b/test/backend/database/test_model_managment_db.py
@@ -215,6 +215,29 @@ def test_update_model_record(monkeypatch):
     session.execute.assert_called_once()
 
 
+def test_fail_detecting_models_on_startup(monkeypatch):
+    """Interrupted checks reuse the existing unavailable state."""
+    mock_result = MagicMock(rowcount=3)
+    mock_stmt = MagicMock()
+    mock_stmt.where.return_value = mock_stmt
+    mock_stmt.values.return_value = mock_stmt
+    mock_update = MagicMock(return_value=mock_stmt)
+    monkeypatch.setattr("backend.database.model_management_db.update", mock_update)
+
+    session = MagicMock()
+    session.execute.return_value = mock_result
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__.return_value = session
+    mock_ctx.__exit__.return_value = None
+    monkeypatch.setattr(
+        "backend.database.model_management_db.get_db_session", lambda: mock_ctx
+    )
+
+    assert model_mgmt_db.fail_detecting_models_on_startup() == 3
+    assert mock_stmt.values.call_args.kwargs["connect_status"] == "unavailable"
+    session.execute.assert_called_once_with(mock_stmt)
+
+
 def test_delete_model_record(monkeypatch):
     """Test delete_model_record function (covers lines 99-119)"""
     mock_result = MagicMock()

--- a/test/backend/services/test_agent_automation_scheduler.py
+++ b/test/backend/services/test_agent_automation_scheduler.py
@@ -27,7 +27,7 @@ def _load_scheduler_with_runner_stub(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_store_recovers_orphans_before_releasing_expired_locks(monkeypatch):
+async def test_store_recovers_orphans_before_releasing_all_locks(monkeypatch):
     scheduler_module = _load_scheduler_with_runner_stub(monkeypatch)
     calls = []
     monkeypatch.setattr(
@@ -37,7 +37,7 @@ async def test_store_recovers_orphans_before_releasing_expired_locks(monkeypatch
     )
     monkeypatch.setattr(
         scheduler_module.agent_automation_db,
-        "release_expired_locks",
+        "release_all_task_locks",
         lambda: calls.append("release"),
     )
     await scheduler_module.AgentAutomationLeaseStore().recover()
@@ -69,7 +69,7 @@ async def test_store_skips_missed_recurring_fires_on_restart(monkeypatch):
 
     monkeypatch.setattr(scheduler_module, "_utcnow", lambda: recovery_time)
     monkeypatch.setattr(scheduler_module.agent_automation_db, "recover_orphaned_runs", lambda: None)
-    monkeypatch.setattr(scheduler_module.agent_automation_db, "release_expired_locks", lambda: None)
+    monkeypatch.setattr(scheduler_module.agent_automation_db, "release_all_task_locks", lambda: None)
     monkeypatch.setattr(
         scheduler_module.agent_automation_db,
         "claim_due_tasks",
@@ -114,7 +114,7 @@ async def test_store_keeps_once_and_post_recovery_occurrences_runnable(monkeypat
 
     monkeypatch.setattr(scheduler_module, "_utcnow", lambda: recovery_time)
     monkeypatch.setattr(scheduler_module.agent_automation_db, "recover_orphaned_runs", lambda: None)
-    monkeypatch.setattr(scheduler_module.agent_automation_db, "release_expired_locks", lambda: None)
+    monkeypatch.setattr(scheduler_module.agent_automation_db, "release_all_task_locks", lambda: None)
     monkeypatch.setattr(
         scheduler_module.agent_automation_db,
         "claim_due_tasks",

--- a/test/backend/services/test_agent_evaluation_service.py
+++ b/test/backend/services/test_agent_evaluation_service.py
@@ -146,6 +146,9 @@ _evaluation_set_db_mock.soft_delete_evaluation_set = MagicMock()
 # ---- 补齐 agent_evaluation_service.py import 的所有函数（L56-L61）----
 _evaluation_set_db_mock.create_evaluation_set = MagicMock(return_value={"evaluation_set_id": 1})
 _evaluation_set_db_mock.get_evaluation_set_cases_all = MagicMock(return_value=[])
+_evaluation_set_db_mock.materialize_virtual_evaluation_set_for_run = MagicMock(
+    return_value=1
+)
 _evaluation_set_db_mock.insert_evaluation_set_cases = MagicMock(return_value=0)
 _evaluation_set_db_mock.update_evaluation_set_case_count = MagicMock()
 _evaluation_set_db_mock.hard_delete_evaluation_set = MagicMock()
@@ -2300,11 +2303,9 @@ class TestSetupNoSetAndExecute:
 
         service_module.get_db_session = _gs
         service_module._generate_test_queries = MagicMock(return_value=["q1", "q2"])
-        service_module.create_evaluation_set = MagicMock(
-            return_value={"evaluation_set_id": 7}
+        service_module.materialize_virtual_evaluation_set_for_run = MagicMock(
+            return_value=7
         )
-        service_module.insert_evaluation_set_cases = MagicMock()
-        service_module.update_evaluation_set_case_count = MagicMock()
         service_module.get_evaluation_set_cases_all = MagicMock(
             return_value=[{"evaluation_set_case_id": 1}]
         )
@@ -2321,17 +2322,19 @@ class TestSetupNoSetAndExecute:
         # Judge model is itself an LLM -> used as-is for generation.
         assert service_module._generate_test_queries.call_args.kwargs["model_id"] == 99
         assert service_module._generate_test_queries.call_args.kwargs["query_count"] == 5
-        service_module.create_evaluation_set.assert_called_once()
+        service_module.materialize_virtual_evaluation_set_for_run.assert_called_once()
         service_module._dispatch_agent_evaluation_run.assert_called_once_with(
             agent_evaluation_id=10,
             user_id="u1",
             tenant_id="t1",
         )
-        # Second session (run update) wrote set id + total.
-        assert len(sessions) == 2
-        update_kw = sessions[-1].updates[-1][0][0]
-        assert update_kw["evaluation_set_id"] == 7
-        assert update_kw["progress_total"] == 2
+        # The virtual set and run link are now committed in one DB transaction.
+        assert len(sessions) == 1
+        materialize_kw = (
+            service_module.materialize_virtual_evaluation_set_for_run.call_args.kwargs
+        )
+        assert materialize_kw["agent_evaluation_id"] == 10
+        assert len(materialize_kw["cases"]) == 2
 
     def test_judge_not_llm_falls_back_to_newest_llm(self, service_module):
         models = [
@@ -2361,9 +2364,9 @@ class TestSetupNoSetAndExecute:
 
         service_module.get_db_session = _flaky_gs
         service_module._generate_test_queries = MagicMock(return_value=["q1"])
-        service_module.create_evaluation_set = MagicMock(return_value={"evaluation_set_id": 1})
-        service_module.insert_evaluation_set_cases = MagicMock()
-        service_module.update_evaluation_set_case_count = MagicMock()
+        service_module.materialize_virtual_evaluation_set_for_run = MagicMock(
+            return_value=1
+        )
         service_module.get_evaluation_set_cases_all = MagicMock(return_value=[])
         service_module.create_agent_evaluation_cases = MagicMock()
         service_module._dispatch_agent_evaluation_run = MagicMock()

--- a/test/backend/services/test_evaluation_maintenance.py
+++ b/test/backend/services/test_evaluation_maintenance.py
@@ -130,6 +130,38 @@ def test_dispatch_pending_runs_reuses_runtime_dispatcher(mocker, monkeypatch):
     )
 
 
+def test_dispatch_pending_runs_returns_immediately_when_empty(monkeypatch):
+    monkeypatch.delitem(sys.modules, "services.runtime_proxy_service", raising=False)
+
+    em._dispatch_pending_runs([])
+
+    assert "services.runtime_proxy_service" not in sys.modules
+
+
+def test_dispatch_pending_runs_skips_incomplete_identity(mocker, monkeypatch):
+    dispatcher = MagicMock()
+    runtime_proxy = types.ModuleType("services.runtime_proxy_service")
+    runtime_proxy.dispatch_agent_evaluation_run = dispatcher
+    monkeypatch.setitem(sys.modules, "services.runtime_proxy_service", runtime_proxy)
+    warning = mocker.patch.object(em.logger, "warning")
+
+    em._dispatch_pending_runs(
+        [
+            {
+                "agent_evaluation_id": 7,
+                "tenant_id": "tenant-1",
+                "created_by": None,
+            }
+        ]
+    )
+
+    dispatcher.assert_not_called()
+    warning.assert_called_once_with(
+        "Cannot redispatch pending evaluation %s without tenant and creator",
+        7,
+    )
+
+
 def test_dispatch_pending_runs_keeps_failed_dispatch_pending(mocker, monkeypatch):
     dispatcher = MagicMock(side_effect=RuntimeError("runtime unavailable"))
     runtime_proxy = types.ModuleType("services.runtime_proxy_service")

--- a/test/backend/services/test_evaluation_maintenance.py
+++ b/test/backend/services/test_evaluation_maintenance.py
@@ -46,6 +46,7 @@ _spec.loader.exec_module(em)
 @pytest.fixture(autouse=True)
 def _reset_running():
     em._running = False
+    em.list_dispatchable_pending_runs.return_value = []
     yield
     em._running = False
 
@@ -87,6 +88,9 @@ def _fake_session_rows(rows):
 
 def test_run_loop_reaps_and_cleans_up(mocker):
     _fake_session_rows([("t1",), ("t2",)])
+    pending_runs = [{"agent_evaluation_id": 7}]
+    em.list_dispatchable_pending_runs.return_value = pending_runs
+    dispatch = mocker.patch.object(em, "_dispatch_pending_runs")
     reap = mocker.patch("evaluation_maintenance.reap_stale_runs", return_value=2)
     cleanup = mocker.patch("evaluation_maintenance.cleanup_aged_evaluations", return_value=5)
     mocker.patch("evaluation_maintenance.time.sleep",
@@ -96,10 +100,54 @@ def test_run_loop_reaps_and_cleans_up(mocker):
     em._running = True
     em._run_loop()
 
+    dispatch.assert_called_once_with(pending_runs)
     assert reap.call_args_list == [call("t1"), call("t2")]
     assert cleanup.call_args_list == [call("t1"), call("t2")]
     info.assert_any_call("Reaped %d stale RUNNING evaluations for tenant %s", 2, "t1")
     info.assert_any_call("Cleaned up %d aged evaluations for tenant %s", 5, "t1")
+
+
+def test_dispatch_pending_runs_reuses_runtime_dispatcher(mocker, monkeypatch):
+    dispatcher = MagicMock()
+    runtime_proxy = types.ModuleType("services.runtime_proxy_service")
+    runtime_proxy.dispatch_agent_evaluation_run = dispatcher
+    monkeypatch.setitem(sys.modules, "services.runtime_proxy_service", runtime_proxy)
+
+    em._dispatch_pending_runs(
+        [
+            {
+                "agent_evaluation_id": 7,
+                "tenant_id": "tenant-1",
+                "created_by": "user-1",
+            }
+        ]
+    )
+
+    dispatcher.assert_called_once_with(
+        agent_evaluation_id=7,
+        user_id="user-1",
+        tenant_id="tenant-1",
+    )
+
+
+def test_dispatch_pending_runs_keeps_failed_dispatch_pending(mocker, monkeypatch):
+    dispatcher = MagicMock(side_effect=RuntimeError("runtime unavailable"))
+    runtime_proxy = types.ModuleType("services.runtime_proxy_service")
+    runtime_proxy.dispatch_agent_evaluation_run = dispatcher
+    monkeypatch.setitem(sys.modules, "services.runtime_proxy_service", runtime_proxy)
+    warning = mocker.patch.object(em.logger, "warning")
+
+    em._dispatch_pending_runs(
+        [
+            {
+                "agent_evaluation_id": 7,
+                "tenant_id": "tenant-1",
+                "created_by": "user-1",
+            }
+        ]
+    )
+
+    warning.assert_called_once()
 
 
 def test_run_loop_skips_cleanup_until_interval(mocker, monkeypatch):

--- a/test/backend/services/test_evaluation_pure_logic.py
+++ b/test/backend/services/test_evaluation_pure_logic.py
@@ -279,6 +279,7 @@ def _install_sys_modules_stubs() -> None:
         create_evaluation_set=MagicMock(),
         get_evaluation_set_cases_all=MagicMock(),
         insert_evaluation_set_cases=MagicMock(),
+        materialize_virtual_evaluation_set_for_run=MagicMock(),
         update_evaluation_set_case_count=MagicMock(),
     )
     _db_pkg.evaluation_set_db = _esdb_mod

--- a/test/backend/services/test_file_management_service.py
+++ b/test/backend/services/test_file_management_service.py
@@ -576,12 +576,20 @@ class TestUploadFilesImpl:
                 ])) as upload_mock, \
                 patch.dict(sys.modules, {"services.quota_service": quota_module}):
             result = await upload_files_impl(
-                destination="minio", file=[mock_file], folder="folder", index_name="kb-1", user_id="user-1"
+                destination="minio",
+                file=[mock_file],
+                folder="folder",
+                index_name="kb-1",
+                user_id="user-1",
+                upload_owner_service="nexent-config",
             )
 
         assert result.file_records[0]["file_id"] == "fid-1"
         assert result[1] == ["folder/a.txt"]
         create_records.assert_called_once()
+        assert create_records.call_args.args[0][0][
+            "upload_owner_service"
+        ] == "nexent-config"
         upload_mock.assert_awaited_once()
         transition_record.assert_called()
         assert {item[1].get("status") for item in transitions} >= {"UPLOADED"}

--- a/test/backend/services/test_memory_dreaming_scheduler.py
+++ b/test/backend/services/test_memory_dreaming_scheduler.py
@@ -54,7 +54,7 @@ async def test_lease_store_recover(monkeypatch, inline_to_thread):
     store = DreamingLeaseStore()
     await store.recover()
 
-    mock_recover.assert_called_once()
+    mock_recover.assert_called_once_with(True)
 
 
 @pytest.mark.asyncio

--- a/test/backend/services/test_startup_recovery_service.py
+++ b/test/backend/services/test_startup_recovery_service.py
@@ -173,7 +173,14 @@ def test_fail_interrupted_uploads_claims_before_deleting_partial_object(monkeypa
         transition_file_record=transition,
     )
 
-    assert startup_recovery_service.fail_interrupted_uploads(cutoff) == 1
+    assert startup_recovery_service.fail_interrupted_uploads(
+        cutoff,
+        "nexent-config",
+    ) == 1
+    list_uploads = sys.modules[
+        "database.knowledge_file_lifecycle_db"
+    ].list_uploading_files_created_before
+    list_uploads.assert_called_once_with(cutoff, "nexent-config")
     delete_object.assert_called_once_with("knowledge/a.pdf", "files")
     first_update = transition.call_args_list[0]
     assert first_update.args == ("claimed",)
@@ -213,7 +220,10 @@ def test_fail_interrupted_uploads_records_storage_cleanup_failure(monkeypatch):
         transition_file_record=transition,
     )
 
-    assert startup_recovery_service.fail_interrupted_uploads(cutoff) == 1
+    assert startup_recovery_service.fail_interrupted_uploads(
+        cutoff,
+        "nexent-northbound",
+    ) == 1
     assert transition.call_count == 2
     failure = transition.call_args_list[1]
     assert failure.args == ("failed",)
@@ -233,7 +243,9 @@ async def test_schedule_interrupted_upload_cleanup_checks_now_and_after_grace(
     monkeypatch.setattr(startup_recovery_service, "UPLOAD_RECOVERY_GRACE_SECONDS", 0)
     startup_recovery_service._upload_cleanup_tasks.clear()
 
-    await startup_recovery_service.schedule_interrupted_upload_cleanup()
+    await startup_recovery_service.schedule_interrupted_upload_cleanup(
+        "nexent-config"
+    )
     pending = list(startup_recovery_service._upload_cleanup_tasks)
     if pending:
         await asyncio.gather(*pending)
@@ -243,3 +255,7 @@ async def test_schedule_interrupted_upload_cleanup_checks_now_and_after_grace(
         fail_uploads.call_args_list[0].args[0]
         <= fail_uploads.call_args_list[1].args[0]
     )
+    assert [call_args.args[1] for call_args in fail_uploads.call_args_list] == [
+        "nexent-config",
+        "nexent-config",
+    ]

--- a/test/backend/services/test_startup_recovery_service.py
+++ b/test/backend/services/test_startup_recovery_service.py
@@ -1,0 +1,245 @@
+import asyncio
+import sys
+import types
+from datetime import datetime
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from backend.services import startup_recovery_service
+
+
+def _install_module(monkeypatch, name, **attributes):
+    module = types.ModuleType(name)
+    for attribute, value in attributes.items():
+        setattr(module, attribute, value)
+    monkeypatch.setitem(sys.modules, name, module)
+    return module
+
+
+def test_recover_runtime_tasks_finishes_database_and_redis_state(monkeypatch):
+    fail_messages = MagicMock(
+        return_value=[
+            {"message_id": 1, "conversation_id": 10, "user_id": "user-1"},
+            {"message_id": 2, "conversation_id": 20, "user_id": None},
+        ]
+    )
+    reap = MagicMock(side_effect=[2, 3])
+    runtime_state = MagicMock()
+    _install_module(
+        monkeypatch,
+        "database.conversation_db",
+        fail_streaming_assistant_messages=fail_messages,
+    )
+    _install_module(
+        monkeypatch,
+        "database.agent_automation_db",
+        recover_orphaned_runs=MagicMock(return_value=4),
+        release_all_task_locks=MagicMock(return_value=5),
+    )
+    _install_module(
+        monkeypatch,
+        "database.agent_evaluation_db",
+        list_evaluation_tenant_ids=MagicMock(return_value=["tenant-1", "tenant-2"]),
+        reap_stale_runs=reap,
+    )
+    _install_module(
+        monkeypatch,
+        "services.runtime_state_service",
+        runtime_state_service=runtime_state,
+    )
+
+    result = startup_recovery_service.recover_runtime_tasks()
+
+    assert result == {
+        "conversation_messages": 2,
+        "agent_evaluations": 5,
+        "automation_runs": 4,
+        "automation_locks": 5,
+    }
+    assert reap.call_args_list == [
+        call("tenant-1", timeout_minutes=0),
+        call("tenant-2", timeout_minutes=0),
+    ]
+    runtime_state.mark_run_finished.assert_called_once_with("user-1", 10, "failed")
+    runtime_state.mark_stream_completed.assert_called_once_with(
+        "user-1", 10, "failed"
+    )
+
+
+def test_recover_config_tasks_uses_existing_failure_states(monkeypatch):
+    _install_module(
+        monkeypatch,
+        "database.agent_evaluation_db",
+        fail_interrupted_no_set_runs_on_startup=MagicMock(return_value=2),
+    )
+    _install_module(
+        monkeypatch,
+        "database.evaluation_set_db",
+        recover_interrupted_generations=MagicMock(return_value=3),
+        cleanup_orphaned_virtual_evaluation_sets=MagicMock(return_value=4),
+    )
+    _install_module(
+        monkeypatch,
+        "database.model_management_db",
+        fail_detecting_models_on_startup=MagicMock(return_value=5),
+    )
+    _install_module(
+        monkeypatch,
+        "database.memory_dreaming_db",
+        recover_stale=MagicMock(return_value=6),
+    )
+
+    assert startup_recovery_service.recover_config_tasks() == {
+        "agent_evaluation_setups": 2,
+        "evaluation_set_generations": 3,
+        "orphaned_virtual_sets": 4,
+        "model_connectivity_checks": 5,
+        "dreaming_runs": 6,
+    }
+
+
+def test_recover_data_process_tasks_marks_each_celery_id_cancelled_once(monkeypatch):
+    records = [
+        {
+            "process_task_id": "process-1",
+            "forward_task_id": "forward-1",
+            "parent_task_id": "parent-1",
+        },
+        {
+            "process_task_id": "process-1",
+            "forward_task_id": None,
+            "parent_task_id": "parent-2",
+        },
+    ]
+    redis_service = MagicMock()
+    redis_service.mark_task_cancelled.side_effect = [True, True, False, True]
+    _install_module(
+        monkeypatch,
+        "database.knowledge_file_lifecycle_db",
+        fail_interrupted_file_tasks=MagicMock(return_value=records),
+    )
+    _install_module(
+        monkeypatch,
+        "services.redis_service",
+        get_redis_service=MagicMock(return_value=redis_service),
+    )
+
+    result = startup_recovery_service.recover_data_process_tasks()
+
+    assert result == {"knowledge_files": 2, "cancel_markers": 3}
+    assert {
+        invocation.args[0]
+        for invocation in redis_service.mark_task_cancelled.call_args_list
+    } == {"process-1", "forward-1", "parent-1", "parent-2"}
+
+
+def test_recover_northbound_tasks_fails_active_a2a_tasks(monkeypatch):
+    fail_active = MagicMock(return_value=6)
+    _install_module(
+        monkeypatch,
+        "database.a2a_agent_db",
+        fail_active_tasks_on_startup=fail_active,
+    )
+
+    assert startup_recovery_service.recover_northbound_tasks() == {"a2a_tasks": 6}
+    fail_active.assert_called_once_with()
+
+
+def test_fail_interrupted_uploads_claims_before_deleting_partial_object(monkeypatch):
+    cutoff = datetime(2026, 9, 1, 12, 0)
+    records = [
+        {
+            "file_id": "claimed",
+            "version": 2,
+            "object_name": "knowledge/a.pdf",
+            "bucket_name": "files",
+        },
+        {
+            "file_id": "stale",
+            "version": 1,
+            "object_name": "knowledge/b.pdf",
+            "bucket_name": "files",
+        },
+    ]
+    transition = MagicMock(side_effect=[{"file_id": "claimed", "version": 3}, None])
+    delete_object = MagicMock(return_value={"success": True})
+    _install_module(monkeypatch, "database.attachment_db", delete_file=delete_object)
+    _install_module(monkeypatch, "database.client", minio_client=MagicMock())
+    _install_module(
+        monkeypatch,
+        "database.knowledge_file_lifecycle_db",
+        list_uploading_files_created_before=MagicMock(return_value=records),
+        transition_file_record=transition,
+    )
+
+    assert startup_recovery_service.fail_interrupted_uploads(cutoff) == 1
+    delete_object.assert_called_once_with("knowledge/a.pdf", "files")
+    first_update = transition.call_args_list[0]
+    assert first_update.args == ("claimed",)
+    assert first_update.kwargs["status"] == "FAILED"
+    assert first_update.kwargs["stage"] == "UPLOAD"
+    assert first_update.kwargs["expected_statuses"] == ("UPLOADING",)
+    assert first_update.kwargs["expected_version"] == 2
+    assert first_update.kwargs["error_code"] == "CONTAINER_RESTARTED"
+
+
+def test_fail_interrupted_uploads_records_storage_cleanup_failure(monkeypatch):
+    cutoff = datetime(2026, 9, 1, 12, 0)
+    record = {
+        "file_id": "failed",
+        "version": 3,
+        "object_name": "knowledge/a.pdf",
+        "bucket_name": "files",
+    }
+    transition = MagicMock(
+        side_effect=[
+            {"file_id": "failed", "version": 4},
+            {"file_id": "failed", "version": 5},
+        ]
+    )
+    minio_client = MagicMock()
+    minio_client.file_exists.return_value = True
+    _install_module(
+        monkeypatch,
+        "database.attachment_db",
+        delete_file=MagicMock(return_value={"success": False, "error": "storage down"}),
+    )
+    _install_module(monkeypatch, "database.client", minio_client=minio_client)
+    _install_module(
+        monkeypatch,
+        "database.knowledge_file_lifecycle_db",
+        list_uploading_files_created_before=MagicMock(return_value=[record]),
+        transition_file_record=transition,
+    )
+
+    assert startup_recovery_service.fail_interrupted_uploads(cutoff) == 1
+    assert transition.call_count == 2
+    failure = transition.call_args_list[1]
+    assert failure.args == ("failed",)
+    assert failure.kwargs["status"] == "FAILED"
+    assert failure.kwargs["expected_statuses"] == ("FAILED",)
+    assert failure.kwargs["expected_version"] == 4
+    assert failure.kwargs["error_code"] == "UPLOAD_RECOVERY_FAILED"
+    assert failure.kwargs["error_message"] == "storage down"
+
+
+@pytest.mark.asyncio
+async def test_schedule_interrupted_upload_cleanup_checks_now_and_after_grace(
+    monkeypatch,
+):
+    fail_uploads = MagicMock(return_value=0)
+    monkeypatch.setattr(startup_recovery_service, "fail_interrupted_uploads", fail_uploads)
+    monkeypatch.setattr(startup_recovery_service, "UPLOAD_RECOVERY_GRACE_SECONDS", 0)
+    startup_recovery_service._upload_cleanup_tasks.clear()
+
+    await startup_recovery_service.schedule_interrupted_upload_cleanup()
+    pending = list(startup_recovery_service._upload_cleanup_tasks)
+    if pending:
+        await asyncio.gather(*pending)
+
+    assert fail_uploads.call_count == 2
+    assert (
+        fail_uploads.call_args_list[0].args[0]
+        <= fail_uploads.call_args_list[1].args[0]
+    )

--- a/test/backend/test_data_process_service_entrypoint.py
+++ b/test/backend/test_data_process_service_entrypoint.py
@@ -142,6 +142,10 @@ def test_start_all_services_starts_enabled_services_in_order(service_module, mon
     scheduler_module = types.ModuleType("services.auto_summary_scheduler")
     scheduler_module.auto_summary_scheduler = scheduler
     monkeypatch.setitem(sys.modules, "services.auto_summary_scheduler", scheduler_module)
+    recovery = MagicMock()
+    recovery_module = types.ModuleType("services.startup_recovery_service")
+    recovery_module.recover_data_process_tasks = recovery
+    monkeypatch.setitem(sys.modules, "services.startup_recovery_service", recovery_module)
 
     manager = service_module.ServiceManager(
         {"start_redis": True, "start_ray": True, "start_workers": False, "disable_celery_flower": True}
@@ -153,6 +157,7 @@ def test_start_all_services_starts_enabled_services_in_order(service_module, mon
 
     assert manager.start_all_services() is True
     assert started == ["redis", "ray"]
+    recovery.assert_called_once_with()
     manager.log_service_info.assert_called_once()
     scheduler.start.assert_called_once()
 
@@ -161,6 +166,10 @@ def test_start_all_services_reports_failure(service_module, monkeypatch):
     scheduler_module = types.ModuleType("services.auto_summary_scheduler")
     scheduler_module.auto_summary_scheduler = types.SimpleNamespace(start=MagicMock())
     monkeypatch.setitem(sys.modules, "services.auto_summary_scheduler", scheduler_module)
+    recovery = MagicMock()
+    recovery_module = types.ModuleType("services.startup_recovery_service")
+    recovery_module.recover_data_process_tasks = recovery
+    monkeypatch.setitem(sys.modules, "services.startup_recovery_service", recovery_module)
 
     manager = service_module.ServiceManager(
         {"start_redis": True, "start_ray": False, "start_workers": False, "disable_celery_flower": True}
@@ -169,6 +178,7 @@ def test_start_all_services_reports_failure(service_module, monkeypatch):
     manager.log_service_info = MagicMock()
 
     assert manager.start_all_services() is False
+    recovery.assert_called_once_with()
     manager.log_service_info.assert_not_called()
 
 

--- a/test/deploy/test_k8s_helm.py
+++ b/test/deploy/test_k8s_helm.py
@@ -34,16 +34,22 @@ INFRASTRUCTURE_DEPLOYMENTS = {
 }
 THREE_REPLICA_APPLICATIONS = {
     "nexent-web": {"/mnt/nexent"},
-    "nexent-config": {"/mnt/nexent", "/mnt/nexent-data/skills"},
-    "nexent-runtime": {"/mnt/nexent", "/mnt/nexent-data/skills"},
-    "nexent-northbound": {"/mnt/nexent", "/mnt/nexent-data/skills"},
 }
 APPLICATION_SINGLE_REPLICA = {
     "nexent-mcp",
+    "nexent-config",
     "nexent-data-process",
+    "nexent-northbound",
+    "nexent-runtime",
     "nexent-supabase-kong",
     "nexent-supabase-auth",
     "nexent-supabase-db",
+}
+STARTUP_RECOVERY_DEPLOYMENTS = {
+    "nexent-config",
+    "nexent-data-process",
+    "nexent-northbound",
+    "nexent-runtime",
 }
 APPLICATION_PVCS = {"nexent-workspace", "nexent-skills", "nexent-supabase-db"}
 INFRASTRUCTURE_PVCS = {
@@ -519,6 +525,78 @@ def test_infrastructure_components_cannot_be_scaled(
     )
     assert rendered.returncode != 0
     assert f"{component} must remain single-replica" in rendered.stderr
+
+
+def test_startup_recovery_deployments_use_single_replica_recreate(
+    chart_dirs: dict[str, Path],
+) -> None:
+    rendered = _template(
+        chart_dirs["application"],
+        "nexent",
+        _application_dynamic_args(),
+    )
+    assert rendered.returncode == 0, rendered.stderr
+
+    deployments = {
+        document["metadata"]["name"]: document
+        for document in _documents(rendered.stdout)
+        if document.get("kind") == "Deployment"
+    }
+    for component in STARTUP_RECOVERY_DEPLOYMENTS:
+        spec = deployments[component]["spec"]
+        assert spec["replicas"] == 1
+        assert spec["strategy"] == {"type": "Recreate"}
+
+
+@pytest.mark.parametrize("component", sorted(STARTUP_RECOVERY_DEPLOYMENTS))
+def test_startup_recovery_deployments_cannot_be_scaled(
+    chart_dirs: dict[str, Path],
+    component: str,
+) -> None:
+    rendered = _template(
+        chart_dirs["application"],
+        "nexent",
+        [*_application_dynamic_args(), "--set", f"{component}.replicaCount=2"],
+    )
+    assert rendered.returncode != 0
+    assert f"{component} must remain single-replica" in rendered.stderr
+
+
+@pytest.mark.parametrize("component", sorted(STARTUP_RECOVERY_DEPLOYMENTS))
+def test_startup_recovery_deployments_require_recreate(
+    chart_dirs: dict[str, Path],
+    component: str,
+) -> None:
+    rendered = _template(
+        chart_dirs["application"],
+        "nexent",
+        [
+            *_application_dynamic_args(),
+            "--set",
+            f"{component}.strategy.type=RollingUpdate",
+        ],
+    )
+    assert rendered.returncode != 0
+    assert (
+        f"{component} strategy.type must be Recreate"
+        in rendered.stderr
+    )
+
+
+def test_stateless_web_can_still_be_scaled(chart_dirs: dict[str, Path]) -> None:
+    rendered = _template(
+        chart_dirs["application"],
+        "nexent",
+        [*_application_dynamic_args(), "--set", "nexent-web.replicaCount=2"],
+    )
+    assert rendered.returncode == 0, rendered.stderr
+    web = next(
+        document
+        for document in _documents(rendered.stdout)
+        if document.get("kind") == "Deployment"
+        and document["metadata"]["name"] == "nexent-web"
+    )
+    assert web["spec"]["replicas"] == 2
 
 
 def test_deploy_and_uninstall_scripts_have_valid_shell_syntax() -> None:


### PR DESCRIPTION
## What changed

- coordinate interrupted-task recovery from service startup lifespans for Config, Runtime, Northbound, and Data Process
- mark non-resumable conversation, evaluation, evaluation-set generation, model detection, knowledge processing, A2A, Dreaming, and automation work with existing terminal states
- preserve dispatchable pending evaluations and resume them through the existing maintenance dispatcher
- delay cleanup of pre-restart `UPLOADING` records for 30 minutes, then fail them and remove residual objects
- migrate the affected FastAPI startup/shutdown hooks to lifespan handlers while keeping existing scheduler shutdown behavior only
- add database, service, lifespan, scheduler, and startup-recovery tests

## Why

Task state previously depended on in-process workers completing their normal state transitions. When a container exited unexpectedly, persisted rows could remain indefinitely in running states even though their worker no longer existed.

Recovery now runs on the next container startup, so it does not depend on shutdown hooks being called.

## Impact

- no database schema, migration, status enum, or public API changes
- existing retry, cancellation, dispatch, and cleanup paths are reused where available
- task types without an existing retry capability do not gain a new retry API

## Validation

- 728 focused tests passed; 4 skipped
- Python `compileall` passed for changed backend modules
- Ruff `F401`/`F821` checks passed for the new recovery service and tests
- `git diff --check` passed
- real HTTP tasks were interrupted with container `SIGKILL` and verified after restart for conversation streaming, agent evaluation, no-set evaluation setup, evaluation-set generation, model connectivity, automation, Dreaming, A2A, knowledge processing/forwarding, and upload cleanup

## Known limitations

- overlapping old and new Runtime instances during a Kubernetes rolling update can still produce late writes from the old instance; instance ownership/fencing is intentionally out of scope
- a pure dispatchable evaluation `PENDING` state could not be isolated reliably through the public API because dispatch happens immediately; this branch is covered by unit tests
