### PR TITLE
feat(models): establish capacity and capability governance

### DIFF
--- a/backend/consts/capability_profiles.py
+++ b/backend/consts/capability_profiles.py
@@ -22,7 +22,7 @@ from nexent.core.models.capacity_resolver import CapabilityProfile, ProfileKey
 logger = logging.getLogger(__name__)
 
 
-CATALOG_REVISION = "2026-06-27.1"
+CATALOG_REVISION = "2026-08-24.2"
 
 
 CATALOG: Dict[ProfileKey, CapabilityProfile] = {
@@ -55,6 +55,16 @@ CATALOG: Dict[ProfileKey, CapabilityProfile] = {
         max_output_tokens=16_384,
         default_output_reserve_tokens=4_096,
         tokenizer_family="qwen",
+        aliases=("qwen-plus",),
+        exclusions=("qwen-vl", "qwen-omni"),
+        evidence=("aliyun-model-studio-model-catalog-2026-08",),
+        verified_at="2026-08-01T00:00:00Z",
+        shared_context=True,
+        independent_input=False,
+        max_output=16_384,
+        reasoning_behavior="unknown",
+        overhead_behavior="bounded",
+        confidence="high",
     ),
     ("dashscope", "qwen-turbo"): CapabilityProfile(
         provider="dashscope",
@@ -65,6 +75,29 @@ CATALOG: Dict[ProfileKey, CapabilityProfile] = {
         max_output_tokens=16_384,
         default_output_reserve_tokens=4_096,
         tokenizer_family="qwen",
+    ),
+    # Verified 2026-08-24 against the official model-specific DashScope page:
+    # https://help.aliyun.com/zh/model-studio/qwen3-7-plus
+    ("dashscope", "qwen3.7-plus"): CapabilityProfile(
+        provider="dashscope",
+        model_name="qwen3.7-plus",
+        capability_profile_version="dashscope/qwen3.7-plus@1",
+        window_shape="combined",
+        context_window_tokens=1_000_000,
+        max_input_tokens=991_808,
+        max_output_tokens=131_072,
+        default_output_reserve_tokens=8_192,
+        tokenizer_family="qwen",
+        aliases=("qwen3.7-plus", "qwen-3.7-plus"),
+        exclusions=("qwen3.7-max", "qwen3.7-flash"),
+        evidence=("https://help.aliyun.com/zh/model-studio/qwen3-7-plus",),
+        verified_at="2026-08-24T00:00:00Z",
+        shared_context=True,
+        independent_input=False,
+        max_output=131_072,
+        reasoning_behavior="reserved",
+        overhead_behavior="bounded",
+        confidence="high",
     ),
     # Sources cross-checked 2026-06-23:
     # https://help.aliyun.com/zh/model-studio/models (Bailian model catalog)
@@ -89,15 +122,33 @@ CATALOG: Dict[ProfileKey, CapabilityProfile] = {
         default_output_reserve_tokens=8_192,
         tokenizer_family="chatglm",
     ),
+    # Verified 2026-08-24 against SiliconFlow's model center and launch note.
+    # The list-models API exposes identity only, so this complete catalog row is
+    # the capacity fallback for the hosted model.
+    # https://www.siliconflow.cn/models
+    # https://www.siliconflow.cn/news/grz0d71bw8xguh4n6lnjqkw9
     ("silicon", "Qwen/Qwen3.6-27B"): CapabilityProfile(
         provider="silicon",
         model_name="Qwen/Qwen3.6-27B",
-        capability_profile_version="silicon/qwen3.6-27b@1",
+        capability_profile_version="silicon/qwen3.6-27b@2",
         window_shape="combined",
         context_window_tokens=262_144,
         max_output_tokens=65_536,
         default_output_reserve_tokens=8_192,
         tokenizer_family="qwen",
+        aliases=("Qwen/Qwen3.6-27B", "Qwen3.6-27B"),
+        exclusions=("Qwen3.6-35B-A3B",),
+        evidence=(
+            "https://www.siliconflow.cn/models",
+            "https://www.siliconflow.cn/news/grz0d71bw8xguh4n6lnjqkw9",
+        ),
+        verified_at="2026-08-24T00:00:00Z",
+        shared_context=True,
+        independent_input=False,
+        max_output=65_536,
+        reasoning_behavior="reserved",
+        overhead_behavior="bounded",
+        confidence="high",
     ),
     ("silicon", "Pro/moonshotai/Kimi-K2.6"): CapabilityProfile(
         provider="silicon",

--- a/backend/consts/exceptions.py
+++ b/backend/consts/exceptions.py
@@ -238,6 +238,15 @@ class RuntimeMetadataVersionConflict(ValueError):
         super().__init__("Runtime metadata version conflict")
 
 
+class ModelCapacityConfigError(ValidationError, ValueError):
+    """Raised when a model capacity contract is internally inconsistent."""
+
+    def __init__(self, reason_code: str, message: str, *, field: str = None):
+        self.reason_code = reason_code
+        self.field = field
+        super().__init__(f"{reason_code}: {message}")
+
+
 class TenantResourceLimitError(ValidationError, ValueError):
     """Raised when a platform or tenant hard resource limit is reached."""
 

--- a/backend/consts/model.py
+++ b/backend/consts/model.py
@@ -186,6 +186,8 @@ class ModelRequest(BaseModel):
     tokenizer_family: Optional[str] = None
     capacity_source: Optional[str] = None
     capability_profile_version: Optional[str] = None
+    feature_capability_metadata: Optional[Dict[str, Any]] = None
+    capacity_mode: Optional[Literal["auto", "manual"]] = None
     # W11 accept-signal fields (audit/metrics only — never persisted). Sent by
     # the frontend when the operator clicks "Use suggestion" and saves; the
     # app layer pops them before the dict reaches the service/DB layer and
@@ -218,7 +220,11 @@ class ModelCapacitySuggestionResponse(BaseModel):
     suggested_provider: Optional[str] = None
     canonical_model_name: Optional[str] = None
     capability_profile_version: Optional[str] = None
-    capacity_source_on_accept: Optional[Literal["operator"]] = None
+    capacity_source_on_accept: Optional[Literal["operator", "profile"]] = None
+    canonical_identity: Optional[Dict[str, Any]] = None
+    capacity_match: Optional[Dict[str, Any]] = None
+    tokenizer_match: Optional[Dict[str, Any]] = None
+    governance_metadata_proposal: Optional[Dict[str, Any]] = None
 
 
 class CapacityCoverageBareModel(BaseModel):
@@ -234,6 +240,36 @@ class CapacityCoverageResponse(BaseModel):
     total_llm_vlm: int
     bare_count: int
     bare_models: List[CapacityCoverageBareModel] = Field(default_factory=list)
+
+
+class CapacityAdoptionPreviewRequest(BaseModel):
+    display_name: str = Field(..., min_length=1, max_length=256)
+    expected_matcher_version: Optional[str] = None
+
+
+class CapacityAdoptRequest(BaseModel):
+    display_name: str = Field(..., min_length=1, max_length=256)
+    expected_profile_version: str = Field(..., min_length=1, max_length=256)
+    expected_matcher_version: Optional[str] = None
+    fields: Optional[List[str]] = None
+    reset_manual_fields: List[str] = Field(default_factory=list)
+
+
+class TokenCountProbeRequest(BaseModel):
+    display_name: str = Field(..., min_length=1, max_length=256)
+    force: bool = False
+
+
+class ManageCapacityAdoptionPreviewRequest(CapacityAdoptionPreviewRequest):
+    tenant_id: str = Field(..., min_length=1)
+
+
+class ManageCapacityAdoptRequest(CapacityAdoptRequest):
+    tenant_id: str = Field(..., min_length=1)
+
+
+class ManageTokenCountProbeRequest(TokenCountProbeRequest):
+    tenant_id: str = Field(..., min_length=1)
 
 
 class ProviderModelRequest(BaseModel):
@@ -1353,6 +1389,7 @@ class ManageTenantModelCreateRequest(BaseModel):
     tokenizer_family: Optional[str] = Field(None, description="Token-counting strategy or tokenizer identifier")
     capacity_source: Optional[str] = Field(None, description="Source of the persisted capacity value")
     capability_profile_version: Optional[str] = Field(None, description="Version of the approved capability profile")
+    capacity_mode: Optional[Literal["auto", "manual"]] = Field(None, description="Capacity inheritance mode")
     # W11 accept-signal fields. Same audit-only contract as ModelRequest:
     # the app layer pops them off model_data before the dict reaches the
     # service/DB layer and forwards them to
@@ -1392,6 +1429,7 @@ class ManageTenantModelUpdateRequest(BaseModel):
     tokenizer_family: Optional[str] = Field(None, description="Token-counting strategy or tokenizer identifier")
     capacity_source: Optional[str] = Field(None, description="Source of the persisted capacity value")
     capability_profile_version: Optional[str] = Field(None, description="Version of the approved capability profile")
+    capacity_mode: Optional[Literal["auto", "manual"]] = Field(None, description="Capacity inheritance mode")
     # W11 accept-signal fields. See ManageTenantModelCreateRequest for the
     # contract. The app layer pops them before calling the service so
     # update_model_record never sees them.

--- a/backend/consts/model_feature_capabilities.py
+++ b/backend/consts/model_feature_capabilities.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Any, Dict, Tuple
 
 
-CATALOG_REVISION = "2026-09-01.2"
+CATALOG_REVISION = "2026-09-03.3"
 
 OPENAI_MODEL_EVIDENCE = (
     "https://platform.openai.com/docs/models",
@@ -37,6 +37,7 @@ def _profile(
     reasoning_mode: str = "unknown",
     request_style: str = "unknown",
     efforts: tuple[str, ...] = (),
+    default_effort: str | None = None,
     cache: bool | None,
     cache_mode: str = "unknown",
     cache_metrics: bool | None = None,
@@ -49,6 +50,7 @@ def _profile(
             "mode": reasoning_mode,
             "request_style": request_style,
             "efforts": list(efforts),
+            "default_effort": default_effort,
         },
         "prompt_cache": {
             "supported": cache,
@@ -95,9 +97,10 @@ FAMILY_RULES = (
         "provider": "openai",
         "pattern": r"(?:gpt-5(?:\.[0-9]+)?|o[134])(?:[-.].+)?",
         **_profile(
-            "openai/reasoning-family@1", reasoning=True, reasoning_mode="effort",
+            "openai/reasoning-family@2", reasoning=True, reasoning_mode="effort",
             request_style="openai_reasoning_effort",
             efforts=("none", "minimal", "low", "medium", "high", "xhigh"),
+            default_effort="medium",
             cache=True, cache_mode="openai_automatic", cache_metrics=True,
             evidence=OPENAI_MODEL_EVIDENCE,
         ),
@@ -116,9 +119,10 @@ FAMILY_RULES = (
         "provider": "dashscope",
         "pattern": r"qwen3\.[5-8]-(?:max|plus|flash)(?:[-.].+)?",
         **_profile(
-            "dashscope/qwen3-hybrid-family@1", reasoning=True,
+            "dashscope/qwen3-hybrid-family@2", reasoning=True,
             reasoning_mode="effort", request_style="openai_reasoning_effort",
             efforts=("none", "minimal", "low", "medium", "high", "xhigh", "max"),
+            default_effort="medium",
             cache=True, cache_mode="provider_automatic", cache_metrics=True,
             evidence=DASHSCOPE_REASONING_EVIDENCE,
         ),
@@ -219,9 +223,9 @@ FAMILY_RULES = (
         "provider": "tokenpony",
         "pattern": r"(?:gpt-5(?:\.[0-9]+)?|o[134])(?:[-.].+)?",
         **_profile(
-            "tokenpony/openai-reasoning-proxy-family@1", reasoning=True,
+            "tokenpony/openai-reasoning-proxy-family@2", reasoning=True,
             reasoning_mode="effort", request_style="openai_reasoning_effort",
-            efforts=("minimal", "low", "medium", "high"), cache=None,
+            efforts=("minimal", "low", "medium", "high"), default_effort="medium", cache=None,
             evidence=OPENAI_MODEL_EVIDENCE,
         ),
     },

--- a/backend/consts/model_feature_capabilities.py
+++ b/backend/consts/model_feature_capabilities.py
@@ -1,0 +1,236 @@
+"""Governed model-level reasoning and prompt-cache capability catalog.
+
+Rows are scoped to the actual ``model_factory`` used by Nexent.  A compatible
+API alone is never evidence of feature support.  Bump ``CATALOG_REVISION`` when
+changing behavior and keep official evidence links on every profile/rule.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+
+CATALOG_REVISION = "2026-09-01.2"
+
+OPENAI_MODEL_EVIDENCE = (
+    "https://platform.openai.com/docs/models",
+    "https://platform.openai.com/docs/guides/reasoning",
+    "https://platform.openai.com/docs/guides/prompt-caching",
+)
+DASHSCOPE_REASONING_EVIDENCE = (
+    "https://help.aliyun.com/en/model-studio/deep-thinking",
+    "https://help.aliyun.com/en/model-studio/context-cache",
+)
+DEEPSEEK_EVIDENCE = (
+    "https://api-docs.deepseek.com/guides/reasoning_model",
+    "https://api-docs.deepseek.com/guides/kv_cache",
+)
+SILICONFLOW_EVIDENCE = (
+    "https://docs.siliconflow.cn/en/api-reference/chat-completions/chat-completions",
+    "https://docs.siliconflow.cn/en/userguide/capabilities/text-generation",
+)
+
+
+def _profile(
+    version: str,
+    *,
+    reasoning: bool | None,
+    reasoning_mode: str = "unknown",
+    request_style: str = "unknown",
+    efforts: tuple[str, ...] = (),
+    cache: bool | None,
+    cache_mode: str = "unknown",
+    cache_metrics: bool | None = None,
+    evidence: tuple[str, ...],
+) -> Dict[str, Any]:
+    return {
+        "profile_version": version,
+        "reasoning": {
+            "supported": reasoning,
+            "mode": reasoning_mode,
+            "request_style": request_style,
+            "efforts": list(efforts),
+        },
+        "prompt_cache": {
+            "supported": cache,
+            "mode": cache_mode,
+            "metrics_available": cache_metrics,
+        },
+        "evidence": list(evidence),
+    }
+
+
+EXACT_CATALOG: Dict[Tuple[str, str], Dict[str, Any]] = {
+    ("openai", "gpt-4o"): _profile(
+        "openai/gpt-4o-features@1", reasoning=False, reasoning_mode="none",
+        request_style="none", cache=True, cache_mode="openai_automatic",
+        cache_metrics=True, evidence=OPENAI_MODEL_EVIDENCE,
+    ),
+    ("openai", "gpt-4.1"): _profile(
+        "openai/gpt-4.1-features@1", reasoning=False, reasoning_mode="none",
+        request_style="none", cache=True, cache_mode="openai_automatic",
+        cache_metrics=True, evidence=OPENAI_MODEL_EVIDENCE,
+    ),
+    ("deepseek", "deepseek-chat"): _profile(
+        "deepseek/deepseek-chat-features@1", reasoning=False, reasoning_mode="none",
+        request_style="none", cache=True, cache_mode="provider_automatic",
+        cache_metrics=True, evidence=DEEPSEEK_EVIDENCE,
+    ),
+    ("deepseek", "deepseek-reasoner"): _profile(
+        "deepseek/deepseek-reasoner-features@1", reasoning=True,
+        reasoning_mode="always", request_style="none", cache=True,
+        cache_mode="provider_automatic", cache_metrics=True,
+        evidence=DEEPSEEK_EVIDENCE,
+    ),
+    ("dashscope", "qwen-plus"): _profile(
+        "dashscope/qwen-plus-features@1", reasoning=True,
+        reasoning_mode="toggle", request_style="extra_body_enable_thinking",
+        cache=True, cache_mode="provider_automatic", cache_metrics=True,
+        evidence=DASHSCOPE_REASONING_EVIDENCE,
+    ),
+}
+
+
+FAMILY_RULES = (
+    {
+        "provider": "openai",
+        "pattern": r"(?:gpt-5(?:\.[0-9]+)?|o[134])(?:[-.].+)?",
+        **_profile(
+            "openai/reasoning-family@1", reasoning=True, reasoning_mode="effort",
+            request_style="openai_reasoning_effort",
+            efforts=("none", "minimal", "low", "medium", "high", "xhigh"),
+            cache=True, cache_mode="openai_automatic", cache_metrics=True,
+            evidence=OPENAI_MODEL_EVIDENCE,
+        ),
+    },
+    {
+        "provider": "openai",
+        "pattern": r"gpt-(?:4\.1|4o)(?:[-.].+)?",
+        **_profile(
+            "openai/gpt4-nonreasoning-family@1", reasoning=False,
+            reasoning_mode="none", request_style="none", cache=True,
+            cache_mode="openai_automatic", cache_metrics=True,
+            evidence=OPENAI_MODEL_EVIDENCE,
+        ),
+    },
+    {
+        "provider": "dashscope",
+        "pattern": r"qwen3\.[5-8]-(?:max|plus|flash)(?:[-.].+)?",
+        **_profile(
+            "dashscope/qwen3-hybrid-family@1", reasoning=True,
+            reasoning_mode="effort", request_style="openai_reasoning_effort",
+            efforts=("none", "minimal", "low", "medium", "high", "xhigh", "max"),
+            cache=True, cache_mode="provider_automatic", cache_metrics=True,
+            evidence=DASHSCOPE_REASONING_EVIDENCE,
+        ),
+    },
+    {
+        "provider": "dashscope",
+        "pattern": r"qwen3(?:[-.].*)?(?:thinking|a[0-9]+b)(?:[-.].*)?",
+        **_profile(
+            "dashscope/qwen3-thinking-family@1", reasoning=True,
+            reasoning_mode="always", request_style="none", cache=True,
+            cache_mode="provider_automatic", cache_metrics=True,
+            evidence=DASHSCOPE_REASONING_EVIDENCE,
+        ),
+    },
+    {
+        "provider": "dashscope",
+        "pattern": r"(?:deepseek-r1|deepseek-reasoner)(?:[-.].+)?",
+        **_profile(
+            "dashscope/deepseek-reasoning-family@1", reasoning=True,
+            reasoning_mode="always", request_style="none", cache=True,
+            cache_mode="provider_automatic", cache_metrics=True,
+            evidence=DASHSCOPE_REASONING_EVIDENCE,
+        ),
+    },
+    {
+        "provider": "dashscope",
+        "pattern": r"(?:deepseek-v3(?:\.[0-9]+)?|deepseek-v4-(?:flash|pro))(?:[-.].+)?",
+        **_profile(
+            "dashscope/deepseek-hybrid-family@1", reasoning=True,
+            reasoning_mode="toggle", request_style="extra_body_enable_thinking",
+            cache=True, cache_mode="provider_automatic", cache_metrics=True,
+            evidence=DASHSCOPE_REASONING_EVIDENCE,
+        ),
+    },
+    {
+        "provider": "deepseek",
+        "pattern": r"deepseek-(?:reasoner|r1)(?:[-.].+)?",
+        **_profile(
+            "deepseek/reasoning-family@1", reasoning=True,
+            reasoning_mode="always", request_style="none", cache=True,
+            cache_mode="provider_automatic", cache_metrics=True,
+            evidence=DEEPSEEK_EVIDENCE,
+        ),
+    },
+    {
+        "provider": "deepseek",
+        "pattern": r"deepseek-(?:chat|v3(?:\.[0-9]+)?|v4-(?:flash|pro))(?:[-.].+)?",
+        **_profile(
+            "deepseek/chat-family@1", reasoning=None, cache=True,
+            cache_mode="provider_automatic", cache_metrics=True,
+            evidence=DEEPSEEK_EVIDENCE,
+        ),
+    },
+    {
+        "provider": "silicon",
+        "pattern": r"(?:Pro/)?deepseek-ai/(?:DeepSeek-R1|DeepSeek-Reasoner)(?:[-.].+)?",
+        **_profile(
+            "silicon/deepseek-reasoning-family@1", reasoning=True,
+            reasoning_mode="always", request_style="none", cache=None,
+            evidence=SILICONFLOW_EVIDENCE,
+        ),
+    },
+    {
+        "provider": "silicon",
+        "pattern": r"(?:Pro/)?(?:Qwen/)?Qwen3(?:\.[5-8])?(?:[-/].+)?",
+        "exclusions": (r".*(?:Instruct|Coder).*",),
+        **_profile(
+            "silicon/qwen3-thinking-family@1", reasoning=True,
+            reasoning_mode="toggle", request_style="extra_body_enable_thinking",
+            cache=None, evidence=SILICONFLOW_EVIDENCE,
+        ),
+    },
+    {
+        "provider": "silicon",
+        "pattern": r"(?:Pro/)?(?:moonshotai/)?Kimi-K2(?:\.[0-9]+)?(?:[-.].+)?",
+        **_profile(
+            "silicon/kimi-k2-family@1", reasoning=None, cache=None,
+            evidence=SILICONFLOW_EVIDENCE,
+        ),
+    },
+    {
+        "provider": "silicon",
+        "pattern": r"(?:Pro/)?(?:MiniMaxAI/)?MiniMax-M[0-9](?:[-.].+)?",
+        **_profile(
+            "silicon/minimax-m-family@1", reasoning=None, cache=None,
+            evidence=SILICONFLOW_EVIDENCE,
+        ),
+    },
+    {
+        "provider": "silicon",
+        "pattern": r"(?:Pro/)?(?:zai-org/|THUDM/)?GLM[-.]?[0-9].*",
+        **_profile(
+            "silicon/glm-family-unknown@1", reasoning=None, cache=None,
+            evidence=SILICONFLOW_EVIDENCE,
+        ),
+    },
+    {
+        "provider": "tokenpony",
+        "pattern": r"(?:gpt-5(?:\.[0-9]+)?|o[134])(?:[-.].+)?",
+        **_profile(
+            "tokenpony/openai-reasoning-proxy-family@1", reasoning=True,
+            reasoning_mode="effort", request_style="openai_reasoning_effort",
+            efforts=("minimal", "low", "medium", "high"), cache=None,
+            evidence=OPENAI_MODEL_EVIDENCE,
+        ),
+    },
+    {
+        "provider": "modelengine",
+        "pattern": r"(?!)",
+        **_profile(
+            "modelengine/no-family-inference@1", reasoning=None, cache=None,
+            evidence=("https://modelengine-ai.net",),
+        ),
+    },
+)

--- a/backend/services/model_capacity_catalog_service.py
+++ b/backend/services/model_capacity_catalog_service.py
@@ -1,0 +1,94 @@
+"""Trusted catalog lifecycle and stage-only refresh boundary for P3."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from threading import Lock
+from typing import Any, Callable, Mapping, Optional
+
+from consts.capability_profiles import CATALOG, CATALOG_REVISION
+from services.model_capacity_health_service import catalog_freshness
+
+
+@dataclass(frozen=True)
+class StagedCatalogCandidate:
+    revision: str
+    source_identity: str
+    staged_at: str
+    added: tuple[str, ...]
+    changed: tuple[str, ...]
+    removed: tuple[str, ...]
+
+
+_lock = Lock()
+_candidate: Optional[StagedCatalogCandidate] = None
+
+
+def _active_profiles() -> dict[str, Any]:
+    return {profile.capability_profile_version: profile for profile in CATALOG.values()}
+
+
+def catalog_status() -> dict[str, Any]:
+    profiles = _active_profiles()
+    lifecycle: dict[str, int] = {}
+    for profile in profiles.values():
+        state = catalog_freshness(profile.verified_at)[0]
+        lifecycle[state] = lifecycle.get(state, 0) + 1
+    with _lock:
+        candidate = _candidate
+    return {
+        "active_revision": CATALOG_REVISION,
+        "profile_count": len(profiles),
+        "lifecycle_counts": lifecycle,
+        "candidate": candidate.__dict__ if candidate else None,
+    }
+
+
+def stage_trusted_candidate(
+    document: Mapping[str, Any], *, source_identity: str, signature_verified: bool,
+) -> StagedCatalogCandidate:
+    """Validate and stage facts only; never changes CATALOG or tenant records."""
+    if not signature_verified or not source_identity.strip():
+        raise ValueError("catalog_source_untrusted")
+    revision = document.get("revision")
+    profiles = document.get("profiles")
+    if not isinstance(revision, str) or not revision.strip() or revision == CATALOG_REVISION:
+        raise ValueError("catalog_revision_invalid")
+    if not isinstance(profiles, Mapping):
+        raise ValueError("catalog_profiles_invalid")
+    normalized: dict[str, Mapping[str, Any]] = {}
+    for version, profile in profiles.items():
+        if not isinstance(version, str) or not isinstance(profile, Mapping):
+            raise ValueError("catalog_profile_invalid")
+        required = {"provider", "model_name", "context_window_tokens", "max_output_tokens", "verified_at", "evidence"}
+        if not required.issubset(profile) or not profile.get("evidence") or catalog_freshness(profile.get("verified_at"))[0] == "expired":
+            raise ValueError("catalog_profile_incomplete")
+        if int(profile["context_window_tokens"]) <= int(profile["max_output_tokens"]):
+            raise ValueError("catalog_capacity_invalid")
+        normalized[version] = profile
+    active = _active_profiles()
+    active_versions, proposed_versions = set(active), set(normalized)
+    candidate = StagedCatalogCandidate(
+        revision=revision, source_identity=source_identity,
+        staged_at=datetime.now(timezone.utc).isoformat(),
+        added=tuple(sorted(proposed_versions - active_versions)),
+        changed=tuple(sorted(version for version in proposed_versions & active_versions if normalized[version] != active[version].model_dump())),
+        removed=tuple(sorted(active_versions - proposed_versions)),
+    )
+    global _candidate
+    with _lock:
+        _candidate = candidate
+    return candidate
+
+
+def refresh_catalog_candidate(
+    loader: Callable[[], Mapping[str, Any]], *, source_identity: str,
+    verifier: Callable[[Mapping[str, Any]], bool],
+) -> StagedCatalogCandidate:
+    """Scheduler-safe adapter entrypoint: load, verify, then stage only."""
+    document = loader()
+    return stage_trusted_candidate(
+        document, source_identity=source_identity,
+        signature_verified=bool(verifier(document)),
+    )

--- a/backend/services/model_capacity_governance_service.py
+++ b/backend/services/model_capacity_governance_service.py
@@ -1,0 +1,335 @@
+"""Field-level capacity provenance, catalog adoption, and legacy normalization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterable, Mapping, Optional
+
+from consts.exceptions import ModelCapacityConfigError
+from services.model_capacity_validation_service import CAPACITY_FIELDS, CAPACITY_MODEL_TYPES
+
+
+GOVERNANCE_SCHEMA_VERSION = 1
+GOVERNED_FIELDS = (*CAPACITY_FIELDS, "tokenizer_family")
+FIELD_SOURCES = frozenset({"catalog", "provider", "operator", "legacy", "unknown"})
+_LEGACY_SOURCE_MAP = {
+    "profile": "catalog",
+    "provider_candidate": "provider",
+    "operator": "operator",
+    "legacy": "legacy",
+    "default": "unknown",
+    "unknown": "unknown",
+}
+_ROW_SOURCE_MAP = {
+    "catalog": "profile",
+    "provider": "provider_candidate",
+    "operator": "operator",
+    "legacy": "legacy",
+    "unknown": "unknown",
+}
+
+
+@dataclass(frozen=True)
+class GovernanceMergeResult:
+    values: dict[str, Any]
+    metadata: dict[str, Any]
+    audit_delta: tuple[dict[str, Any], ...]
+    row_capacity_source: Optional[str]
+    capability_profile_version: Optional[str]
+
+
+def _fail(reason: str, message: str, *, field: Optional[str] = None) -> None:
+    raise ModelCapacityConfigError(reason, message, field=field)
+
+
+def normalize_legacy_capacity_ingress(
+    payload: Mapping[str, Any],
+    *,
+    explicit_fields: Iterable[str],
+) -> tuple[dict[str, Any], set[str], bool]:
+    """Normalize legacy max_tokens once and remove it as a capacity write authority."""
+    normalized = dict(payload)
+    explicit = set(explicit_fields)
+    model_type = normalized.get("model_type")
+    if model_type not in CAPACITY_MODEL_TYPES:
+        return normalized, explicit, False
+
+    legacy_explicit = "max_tokens" in explicit
+    output_explicit = "max_output_tokens" in explicit
+    legacy_value = normalized.get("max_tokens")
+    output_value = normalized.get("max_output_tokens")
+    used_legacy = False
+
+    provider_capacity = normalized.get("capacity_source") == "provider_candidate"
+    if (
+        legacy_explicit
+        and output_explicit
+        and legacy_value is not None
+        and output_value is not None
+        and provider_capacity
+    ):
+        # Provider adapters retain `max_tokens` as a generation default for
+        # compatibility while exposing authoritative capacity in
+        # `max_output_tokens`. It is not a second capacity declaration.
+        pass
+    elif legacy_explicit and output_explicit and legacy_value is not None and output_value is not None:
+        if legacy_value != output_value:
+            _fail(
+                "capacity_legacy_conflict",
+                "max_tokens conflicts with max_output_tokens",
+                field="max_output_tokens",
+            )
+    elif legacy_explicit and not output_explicit and legacy_value not in (None, 0):
+        normalized["max_output_tokens"] = legacy_value
+        explicit.add("max_output_tokens")
+        used_legacy = True
+
+    normalized.pop("max_tokens", None)
+    explicit.discard("max_tokens")
+    return normalized, explicit, used_legacy
+
+
+def _valid_metadata(metadata: Optional[Mapping[str, Any]]) -> dict[str, Any]:
+    if not metadata or metadata.get("schema_version") != GOVERNANCE_SCHEMA_VERSION:
+        return {"schema_version": GOVERNANCE_SCHEMA_VERSION, "fields": {}}
+    fields = {}
+    for field, item in (metadata.get("fields") or {}).items():
+        if field not in GOVERNED_FIELDS or not isinstance(item, Mapping):
+            continue
+        source = item.get("source")
+        if source not in FIELD_SOURCES:
+            continue
+        fields[field] = dict(item)
+    return {"schema_version": GOVERNANCE_SCHEMA_VERSION, "fields": fields}
+
+
+def derive_legacy_metadata(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Return response-only metadata for an old row without mutating it."""
+    metadata = _valid_metadata(record.get("capacity_field_metadata"))
+    if metadata["fields"]:
+        return metadata
+    source = _LEGACY_SOURCE_MAP.get(record.get("capacity_source"), "legacy")
+    profile_version = record.get("capability_profile_version")
+    for field in GOVERNED_FIELDS:
+        if record.get(field) is None:
+            continue
+        metadata["fields"][field] = {
+            "source": source,
+            "confidence": "unknown" if source in {"legacy", "operator", "unknown"} else "medium",
+            **({"profile_version": profile_version} if profile_version else {}),
+        }
+    return metadata
+
+
+def _field_metadata(
+    source: str,
+    *,
+    profile_version: Optional[str] = None,
+    evidence_id: Optional[str] = None,
+    verified_at: Optional[str] = None,
+) -> dict[str, Any]:
+    item = {
+        "source": source,
+        "confidence": "high" if source == "catalog" else "medium" if source == "provider" else "unknown",
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    if profile_version:
+        item["profile_version"] = profile_version
+    if evidence_id:
+        item["evidence_id"] = evidence_id
+    if verified_at:
+        item["verified_at"] = verified_at
+    return item
+
+
+def _project_row_source(fields: Mapping[str, Mapping[str, Any]]) -> Optional[str]:
+    sources = {item.get("source") for item in fields.values()}
+    for source in ("operator", "provider", "catalog", "legacy", "unknown"):
+        if source in sources:
+            return _ROW_SOURCE_MAP[source]
+    return None
+
+
+def merge_capacity_governance(
+    payload: Mapping[str, Any],
+    *,
+    explicit_fields: Iterable[str],
+    existing: Optional[Mapping[str, Any]] = None,
+    accepted_profile_version: Optional[str] = None,
+    accepted_profile_fields: Iterable[str] = (),
+    provider_fields: Iterable[str] = (),
+    profile_evidence_id: Optional[str] = None,
+    profile_verified_at: Optional[str] = None,
+    legacy_ingress_used: bool = False,
+) -> GovernanceMergeResult:
+    """Merge explicitly changed fields and preserve provenance for all others."""
+    previous = dict(existing or {})
+    values = dict(previous)
+    values.update(payload)
+    explicit = set(explicit_fields)
+    metadata = derive_legacy_metadata(previous) if existing else _valid_metadata(None)
+    fields = dict(metadata["fields"])
+    accepted = set(accepted_profile_fields)
+    provider = set(provider_fields)
+    audit: list[dict[str, Any]] = []
+
+    for field in GOVERNED_FIELDS:
+        if field not in explicit:
+            continue
+        old_value = previous.get(field)
+        new_value = payload.get(field)
+        previous_source = (fields.get(field) or {}).get("source")
+        provenance_changes = new_value is not None and (
+            (
+                field in accepted
+                and accepted_profile_version is not None
+                and previous_source != "catalog"
+            )
+            or (field in provider and previous_source != "provider")
+        )
+        if existing and new_value == old_value and not provenance_changes:
+            continue
+        if field in provider and previous_source == "operator":
+            values[field] = old_value
+            continue
+        if new_value is None:
+            fields.pop(field, None)
+            new_source = "unknown"
+        elif field in provider:
+            new_source = "provider"
+            fields[field] = _field_metadata(new_source)
+        elif field in accepted and accepted_profile_version:
+            new_source = "catalog"
+            fields[field] = _field_metadata(
+                new_source,
+                profile_version=accepted_profile_version,
+                evidence_id=profile_evidence_id,
+                verified_at=profile_verified_at,
+            )
+        elif legacy_ingress_used and field == "max_output_tokens":
+            new_source = "legacy"
+            fields[field] = _field_metadata(new_source)
+        else:
+            new_source = "operator"
+            fields[field] = _field_metadata(new_source)
+        audit.append(
+            {
+                "field": field,
+                "previous_source": previous_source,
+                "new_source": new_source,
+                "value_changed": old_value != new_value,
+            }
+        )
+
+    metadata = {"schema_version": GOVERNANCE_SCHEMA_VERSION, "fields": fields}
+    row_source = _project_row_source(fields)
+    profile_versions = {
+        item.get("profile_version")
+        for item in fields.values()
+        if item.get("source") == "catalog" and item.get("profile_version")
+    }
+    profile_version = next(iter(profile_versions)) if len(profile_versions) == 1 else None
+    return GovernanceMergeResult(
+        values=values,
+        metadata=metadata,
+        audit_delta=tuple(audit),
+        row_capacity_source=row_source,
+        capability_profile_version=profile_version,
+    )
+
+
+def catalog_adoption_preview(
+    record: Mapping[str, Any],
+    proposed_values: Mapping[str, Any],
+    *,
+    proposed_profile_version: str,
+) -> dict[str, Any]:
+    metadata = derive_legacy_metadata(record)
+    fields = metadata["fields"]
+    diff = {}
+    for field in GOVERNED_FIELDS:
+        if field not in proposed_values:
+            continue
+        source = (fields.get(field) or {}).get("source", "unknown")
+        current = record.get(field)
+        proposed = proposed_values.get(field)
+        diff[field] = {
+            "current_value": current,
+            "current_source": source,
+            "proposed_value": proposed,
+            "proposed_source": "catalog",
+            "changed": current != proposed,
+            "blocked_by_manual": source == "operator",
+            "applicable": source in {"catalog", "unknown", "legacy"}
+            and (current != proposed or source != "catalog"),
+        }
+    return {
+        "schema_version": GOVERNANCE_SCHEMA_VERSION,
+        "current_profile_version": record.get("capability_profile_version"),
+        "proposed_profile_version": proposed_profile_version,
+        "fields": diff,
+    }
+
+
+def apply_catalog_adoption(
+    record: Mapping[str, Any],
+    proposed_values: Mapping[str, Any],
+    *,
+    proposed_profile_version: str,
+    expected_profile_version: str,
+    current_matcher_version: str,
+    expected_matcher_version: Optional[str] = None,
+    fields: Optional[Iterable[str]] = None,
+    reset_manual_fields: Iterable[str] = (),
+    profile_evidence_id: Optional[str] = None,
+    profile_verified_at: Optional[str] = None,
+) -> GovernanceMergeResult:
+    """Version-checked adoption that preserves manual fields by default."""
+    if expected_profile_version != proposed_profile_version:
+        _fail("capacity_profile_stale", "catalog profile changed since preview")
+    if expected_matcher_version and expected_matcher_version != current_matcher_version:
+        _fail("capacity_matcher_stale", "model matcher changed since preview")
+
+    requested = set(fields) if fields is not None else set(GOVERNED_FIELDS)
+    reset_manual = set(reset_manual_fields)
+    invalid = (requested | reset_manual).difference(GOVERNED_FIELDS)
+    if invalid:
+        invalid_field = sorted(invalid)[0]
+        _fail(
+            "capacity_adoption_field_invalid",
+            f"unsupported adoption field: {invalid_field}",
+            field=invalid_field,
+        )
+    if not reset_manual.issubset(requested):
+        _fail(
+            "capacity_manual_reset_not_selected",
+            "reset_manual_fields must also be selected for adoption",
+        )
+
+    metadata = derive_legacy_metadata(record)
+    payload: dict[str, Any] = {}
+    accepted: set[str] = set()
+    for field in requested:
+        if field not in proposed_values:
+            continue
+        source = (metadata["fields"].get(field) or {}).get("source", "unknown")
+        if source == "operator" and field not in reset_manual:
+            continue
+        if source not in {"catalog", "unknown", "legacy", "operator"}:
+            continue
+        proposed = proposed_values[field]
+        if proposed == record.get(field) and source == "catalog":
+            continue
+        payload[field] = proposed
+        accepted.add(field)
+
+    return merge_capacity_governance(
+        payload,
+        explicit_fields=accepted,
+        existing=record,
+        accepted_profile_version=proposed_profile_version,
+        accepted_profile_fields=accepted,
+        profile_evidence_id=profile_evidence_id,
+        profile_verified_at=profile_verified_at,
+    )

--- a/backend/services/model_capacity_health_service.py
+++ b/backend/services/model_capacity_health_service.py
@@ -1,0 +1,106 @@
+"""Deterministic, content-free capacity health classification for P3."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Mapping, Optional
+
+REVIEW_DUE_DAYS = 150
+EXPIRED_DAYS = 180
+
+
+class CapacityHealthStatus(str, Enum):
+    HEALTHY = "healthy"
+    REVIEW_DUE = "review_due"
+    EXPIRED = "expired"
+    ESTIMATED = "estimated"
+    UNCONFIGURED = "unconfigured"
+    INVALID = "invalid"
+    PROBE_DEGRADED = "probe_degraded"
+
+
+def _parse_utc(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def catalog_freshness(
+    verified_at: Optional[str], *, now: Optional[datetime] = None
+) -> tuple[str, Optional[str], Optional[str]]:
+    checked = _parse_utc(verified_at)
+    if checked is None:
+        return "expired", None, None
+    current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    age_days = (current - checked).total_seconds() / 86400
+    review_at = datetime.fromtimestamp(
+        checked.timestamp() + REVIEW_DUE_DAYS * 86400, tz=timezone.utc
+    ).isoformat()
+    expires_at = datetime.fromtimestamp(
+        checked.timestamp() + EXPIRED_DAYS * 86400, tz=timezone.utc
+    ).isoformat()
+    state = "expired" if age_days >= EXPIRED_DAYS else "review_due" if age_days >= REVIEW_DUE_DAYS else "current"
+    return state, review_at, expires_at
+
+
+def classify_capacity_health(
+    record: Mapping[str, Any], *, match: Optional[Mapping[str, Any]] = None,
+    profile_verified_at: Optional[str] = None, now: Optional[datetime] = None,
+) -> dict[str, Any]:
+    reasons: list[str] = []
+    context_window = record.get("context_window_tokens")
+    max_output = record.get("max_output_tokens")
+    max_input = record.get("max_input_tokens")
+    if context_window is not None and context_window <= 0:
+        reasons.append("context_window_invalid")
+    if max_output is not None and max_output <= 0:
+        reasons.append("max_output_invalid")
+    if max_input is not None and max_input <= 0:
+        reasons.append("max_input_invalid")
+    if context_window and max_output and max_output >= context_window:
+        reasons.append("output_not_below_context")
+
+    match_data = dict(match or {})
+    auto_applicable = bool(match_data.get("auto_applicable"))
+    lifecycle, review_at, expires_at = catalog_freshness(profile_verified_at, now=now)
+    probe = record.get("token_count_probe_metadata") or {}
+    probe_status = probe.get("status") or probe.get("state")
+    capacity_source = record.get("capacity_source") or "unknown"
+
+    if reasons:
+        status, action = CapacityHealthStatus.INVALID, "edit"
+    elif context_window is None or max_output is None:
+        status, action = CapacityHealthStatus.UNCONFIGURED, "review_profile" if auto_applicable else "edit"
+        reasons.append("required_capacity_missing")
+    elif lifecycle == "expired" and record.get("capability_profile_version"):
+        status, action = CapacityHealthStatus.EXPIRED, "review_profile" if auto_applicable else "review_evidence"
+        reasons.append("catalog_evidence_expired")
+    elif probe_status in {"degraded", "temporary_failure", "failed", "stale"}:
+        status, action = CapacityHealthStatus.PROBE_DEGRADED, "retry_probe"
+        reasons.append("token_count_probe_degraded")
+    elif capacity_source in {"unknown", "legacy"} or (
+        not record.get("tokenizer_family") and probe_status != "supported"
+    ):
+        status, action = CapacityHealthStatus.ESTIMATED, "review_profile" if auto_applicable else "edit"
+        reasons.append("capacity_or_counting_estimated")
+    elif lifecycle == "review_due" and record.get("capability_profile_version"):
+        status, action = CapacityHealthStatus.REVIEW_DUE, "review_profile" if auto_applicable else "review_evidence"
+        reasons.append("catalog_evidence_review_due")
+    else:
+        status, action = CapacityHealthStatus.HEALTHY, "none"
+        reasons.append("capacity_verified")
+    return {
+        "status": status.value, "reasons": reasons, "action": action,
+        "match_kind": match_data.get("match_kind") or "none",
+        "suggestion_available": auto_applicable,
+        "profile_version": record.get("capability_profile_version"),
+        "verified_at": profile_verified_at, "review_at": review_at,
+        "expires_at": expires_at, "probe_status": probe_status,
+    }

--- a/backend/services/model_capacity_suggestion_service.py
+++ b/backend/services/model_capacity_suggestion_service.py
@@ -1,11 +1,14 @@
 import logging
-import re
 import time
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Mapping, Optional
 
 from consts.const import CAPACITY_SUGGESTION_ENABLED
+from nexent.core.models.model_identity import (
+    identities_are_safe_aliases,
+    parse_model_identity,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -160,7 +163,10 @@ def _normalize_provider(provider: Optional[str]) -> Optional[str]:
 
 
 def normalize_model_name(model_name: str) -> str:
-    return re.sub(r"[-_./\s]+", "", model_name.strip().lower())
+    """Compatibility helper returning the separator-aware canonical path."""
+    if not model_name.strip():
+        return ""
+    return parse_model_identity(model_name).canonical_id
 
 
 def _normalize_catalog_exact_name(model_name: str) -> str:
@@ -196,7 +202,9 @@ def _result_from_profile(
         suggested_provider=provider,
         canonical_model_name=model_name,
         capability_profile_version=profile.capability_profile_version,
-        capacity_source_on_accept="operator",
+        capacity_source_on_accept=(
+            "profile" if getattr(profile, "auto_applicable", False) else "operator"
+        ),
     )
 
 
@@ -225,12 +233,13 @@ def _unique_final_segment_match(
     catalog: Mapping[ProfileKey, CapabilityProfileLike],
     provider: str,
 ) -> Optional[tuple[ProfileKey, CapabilityProfileLike]]:
-    requested = normalize_model_name(model_name)
+    requested = parse_model_identity(model_name, provider)
     matches: list[tuple[ProfileKey, CapabilityProfileLike]] = []
     for key, profile in _provider_catalog(catalog, provider).items():
         catalog_model = key[1]
         final_segment = catalog_model.split("/")[-1]
-        if normalize_model_name(final_segment) == requested:
+        candidate = parse_model_identity(final_segment, provider)
+        if identities_are_safe_aliases(requested, candidate):
             matches.append((key, profile))
 
     if len(matches) == 1:
@@ -243,16 +252,42 @@ def _fuzzy_catalog_match(
     catalog: Mapping[ProfileKey, CapabilityProfileLike],
     provider: str,
 ) -> Optional[tuple[ProfileKey, CapabilityProfileLike]]:
-    requested = normalize_model_name(model_name)
+    requested = parse_model_identity(model_name, provider)
     matches: list[tuple[ProfileKey, CapabilityProfileLike]] = []
     for key, profile in _provider_catalog(catalog, provider).items():
-        if normalize_model_name(key[1]) == requested:
+        candidate = parse_model_identity(key[1], provider)
+        if requested.canonical_id == candidate.canonical_id:
             matches.append((key, profile))
 
     if len(matches) == 1:
         return matches[0]
 
     return _unique_final_segment_match(model_name, catalog, provider)
+
+
+def _explicit_alias_match(
+    model_name: str,
+    catalog: Mapping[ProfileKey, CapabilityProfileLike],
+    provider: str,
+) -> Optional[tuple[ProfileKey, CapabilityProfileLike]]:
+    requested = parse_model_identity(model_name, provider)
+    matches: list[tuple[ProfileKey, CapabilityProfileLike]] = []
+    for key, profile in _provider_catalog(catalog, provider).items():
+        exclusions = getattr(profile, "exclusions", ()) or ()
+        if any(
+            identities_are_safe_aliases(
+                requested, parse_model_identity(exclusion, provider)
+            )
+            for exclusion in exclusions
+        ):
+            continue
+        aliases = getattr(profile, "aliases", ()) or ()
+        if any(
+            identities_are_safe_aliases(requested, parse_model_identity(alias, provider))
+            for alias in aliases
+        ):
+            matches.append((key, profile))
+    return matches[0] if len(matches) == 1 else None
 
 
 def _unique_catalog_provider_for_model(
@@ -375,6 +410,16 @@ def _suggest_capacity_inner(
             normalized_exact_key[0],
             normalized_exact_key[1],
             active_catalog[normalized_exact_key],
+            CapacitySuggestionMatchKind.CATALOG_EXACT,
+        )
+
+    alias_match = _explicit_alias_match(clean_model_name, active_catalog, provider)
+    if alias_match:
+        alias_key, profile = alias_match
+        return _result_from_profile(
+            alias_key[0],
+            alias_key[1],
+            profile,
             CapacitySuggestionMatchKind.CATALOG_EXACT,
         )
 

--- a/backend/services/model_capacity_suggestion_service.py
+++ b/backend/services/model_capacity_suggestion_service.py
@@ -5,10 +5,6 @@ from enum import Enum
 from typing import Any, Mapping, Optional
 
 from consts.const import CAPACITY_SUGGESTION_ENABLED
-from nexent.core.models.model_identity import (
-    identities_are_safe_aliases,
-    parse_model_identity,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -138,6 +134,19 @@ HOST_PROVIDER_PATTERNS = (
 SUPPORTED_SUGGESTION_MODEL_TYPES = {"llm", "vlm", "vlm2", "vlm3", "vlm4"}
 
 
+def _parse_model_identity(model_name: str, provider: Optional[str] = None) -> Any:
+    """Load the SDK matcher only when suggestion matching is requested."""
+    from nexent.core.models.model_identity import parse_model_identity
+
+    return parse_model_identity(model_name, provider)
+
+
+def _identities_are_safe_aliases(left: Any, right: Any) -> bool:
+    from nexent.core.models.model_identity import identities_are_safe_aliases
+
+    return identities_are_safe_aliases(left, right)
+
+
 def pick_provider_from_base_url(base_url: Optional[str]) -> Optional[str]:
     # Match the entire lower-cased base_url, mirroring the frontend
     # detectProviderFromUrl helper. Substring `in` check, first hit wins.
@@ -166,7 +175,7 @@ def normalize_model_name(model_name: str) -> str:
     """Compatibility helper returning the separator-aware canonical path."""
     if not model_name.strip():
         return ""
-    return parse_model_identity(model_name).canonical_id
+    return _parse_model_identity(model_name).canonical_id
 
 
 def _normalize_catalog_exact_name(model_name: str) -> str:
@@ -233,13 +242,13 @@ def _unique_final_segment_match(
     catalog: Mapping[ProfileKey, CapabilityProfileLike],
     provider: str,
 ) -> Optional[tuple[ProfileKey, CapabilityProfileLike]]:
-    requested = parse_model_identity(model_name, provider)
+    requested = _parse_model_identity(model_name, provider)
     matches: list[tuple[ProfileKey, CapabilityProfileLike]] = []
     for key, profile in _provider_catalog(catalog, provider).items():
         catalog_model = key[1]
         final_segment = catalog_model.split("/")[-1]
-        candidate = parse_model_identity(final_segment, provider)
-        if identities_are_safe_aliases(requested, candidate):
+        candidate = _parse_model_identity(final_segment, provider)
+        if _identities_are_safe_aliases(requested, candidate):
             matches.append((key, profile))
 
     if len(matches) == 1:
@@ -252,10 +261,10 @@ def _fuzzy_catalog_match(
     catalog: Mapping[ProfileKey, CapabilityProfileLike],
     provider: str,
 ) -> Optional[tuple[ProfileKey, CapabilityProfileLike]]:
-    requested = parse_model_identity(model_name, provider)
+    requested = _parse_model_identity(model_name, provider)
     matches: list[tuple[ProfileKey, CapabilityProfileLike]] = []
     for key, profile in _provider_catalog(catalog, provider).items():
-        candidate = parse_model_identity(key[1], provider)
+        candidate = _parse_model_identity(key[1], provider)
         if requested.canonical_id == candidate.canonical_id:
             matches.append((key, profile))
 
@@ -270,20 +279,22 @@ def _explicit_alias_match(
     catalog: Mapping[ProfileKey, CapabilityProfileLike],
     provider: str,
 ) -> Optional[tuple[ProfileKey, CapabilityProfileLike]]:
-    requested = parse_model_identity(model_name, provider)
+    requested = _parse_model_identity(model_name, provider)
     matches: list[tuple[ProfileKey, CapabilityProfileLike]] = []
     for key, profile in _provider_catalog(catalog, provider).items():
         exclusions = getattr(profile, "exclusions", ()) or ()
         if any(
-            identities_are_safe_aliases(
-                requested, parse_model_identity(exclusion, provider)
+            _identities_are_safe_aliases(
+                requested, _parse_model_identity(exclusion, provider)
             )
             for exclusion in exclusions
         ):
             continue
         aliases = getattr(profile, "aliases", ()) or ()
         if any(
-            identities_are_safe_aliases(requested, parse_model_identity(alias, provider))
+            _identities_are_safe_aliases(
+                requested, _parse_model_identity(alias, provider)
+            )
             for alias in aliases
         ):
             matches.append((key, profile))

--- a/backend/services/model_capacity_suggestion_service.py
+++ b/backend/services/model_capacity_suggestion_service.py
@@ -134,8 +134,13 @@ HOST_PROVIDER_PATTERNS = (
 SUPPORTED_SUGGESTION_MODEL_TYPES = {"llm", "vlm", "vlm2", "vlm3", "vlm4"}
 
 
+# Keep these imports behind the service call boundary. This module is also
+# loaded by lightweight model-management/bootstrap environments that expose a
+# partial ``nexent.core`` package; importing the SDK matcher at module scope
+# breaks those environments before suggestion matching is requested. These
+# adapters delegate directly to the SDK and intentionally contain no matching
+# logic of their own.
 def _parse_model_identity(model_name: str, provider: Optional[str] = None) -> Any:
-    """Load the SDK matcher only when suggestion matching is requested."""
     from nexent.core.models.model_identity import parse_model_identity
 
     return parse_model_identity(model_name, provider)

--- a/backend/services/model_capacity_validation_service.py
+++ b/backend/services/model_capacity_validation_service.py
@@ -1,0 +1,169 @@
+"""Validation and read-only auditing for persisted model capacity contracts."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Mapping, Optional
+
+from consts.exceptions import ModelCapacityConfigError
+
+
+CAPACITY_MODEL_TYPES = frozenset({"llm", "vlm", "vlm2", "vlm3"})
+CAPACITY_FIELDS = (
+    "context_window_tokens",
+    "max_input_tokens",
+    "max_output_tokens",
+    "default_output_reserve_tokens",
+)
+DEFAULT_REQUESTED_OUTPUT_TOKENS = 4096
+
+
+def _fail(reason: str, message: str, *, field: Optional[str] = None) -> None:
+    raise ModelCapacityConfigError(
+        f"capacity_config_invalid.{reason}", message, field=field
+    )
+
+
+def merged_capacity_contract(
+    payload: Mapping[str, Any], existing: Optional[Mapping[str, Any]] = None
+) -> dict[str, Any]:
+    """Return capacity-relevant values after applying a partial payload."""
+    merged = dict(existing or {})
+    merged.update(payload)
+    if merged.get("model_type") is None and existing is not None:
+        merged["model_type"] = existing.get("model_type")
+    return merged
+
+
+def validate_capacity_contract(
+    payload: Mapping[str, Any],
+    *,
+    existing: Optional[Mapping[str, Any]] = None,
+) -> dict[str, Any]:
+    """Validate one create or merged partial-update capacity contract.
+
+    Unknown capacity is valid during the P0 migration. When a hard input
+    constraint is present, the resulting W2 estimated budget must be positive.
+    """
+    contract = merged_capacity_contract(payload, existing)
+    if contract.get("model_type") not in CAPACITY_MODEL_TYPES:
+        return contract
+
+    for field in CAPACITY_FIELDS:
+        value = contract.get(field)
+        if value is None:
+            continue
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            _fail(
+                "non_positive_or_non_integer",
+                f"{field} must be a positive integer",
+                field=field,
+            )
+
+    context = contract.get("context_window_tokens")
+    max_input = contract.get("max_input_tokens")
+    max_output = contract.get("max_output_tokens")
+    default_output = contract.get("default_output_reserve_tokens")
+
+    if context is not None and max_output is not None and max_output >= context:
+        _fail(
+            "max_output_not_below_context",
+            "max_output_tokens must be lower than context_window_tokens",
+            field="max_output_tokens",
+        )
+    if context is not None and max_input is not None and max_input > context:
+        _fail(
+            "max_input_exceeds_context",
+            "max_input_tokens must not exceed context_window_tokens",
+            field="max_input_tokens",
+        )
+    if (
+        default_output is not None
+        and max_output is not None
+        and default_output > max_output
+    ):
+        _fail(
+            "default_output_exceeds_max_output",
+            "default_output_reserve_tokens must not exceed max_output_tokens",
+            field="default_output_reserve_tokens",
+        )
+
+    if context is None and max_input is None:
+        return contract
+
+    requested_output = default_output or DEFAULT_REQUESTED_OUTPUT_TOKENS
+    if max_output is not None and requested_output > max_output:
+        _fail(
+            "requested_output_exceeds_max_output",
+            "resolved requested output exceeds max_output_tokens",
+            field="default_output_reserve_tokens",
+        )
+
+    limits = []
+    if max_input is not None:
+        limits.append(max_input)
+    if context is not None:
+        limits.append(context - requested_output)
+    provider_input_limit = min(limits)
+    if provider_input_limit <= 0:
+        _fail(
+            "non_positive_provider_input_limit",
+            "capacity values leave no provider input capacity",
+        )
+
+    uncertainty_reserve = math.ceil(provider_input_limit * 0.10)
+    if provider_input_limit - uncertainty_reserve <= 0:
+        _fail(
+            "non_positive_hard_input_budget",
+            "capacity values leave no safe input budget",
+        )
+    return contract
+
+
+def audit_capacity_record(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Classify one row without mutating it or exposing credentials."""
+    reasons: list[str] = []
+    status = "valid"
+    try:
+        contract = validate_capacity_contract(record)
+    except ModelCapacityConfigError as exc:
+        contract = dict(record)
+        status = "invalid"
+        reasons.append(exc.reason_code)
+
+    if contract.get("model_type") in CAPACITY_MODEL_TYPES:
+        context = contract.get("context_window_tokens")
+        max_input = contract.get("max_input_tokens")
+        max_output = contract.get("max_output_tokens")
+        source = contract.get("capacity_source")
+        if context is None and max_input is None:
+            status = "unknown" if status == "valid" else status
+            reasons.append("capacity_unknown")
+        if context == 32768 and max_output == 4096 and source == "operator":
+            status = "suspicious" if status == "valid" else status
+            reasons.append("operator_shaped_ui_default")
+        if (
+            isinstance(context, int)
+            and isinstance(max_input, int)
+            and max_input > 0
+            and max_input < math.ceil(context * 0.10)
+        ):
+            status = "suspicious" if status == "valid" else status
+            reasons.append("independent_input_unusually_small")
+
+    return {
+        "model_id": record.get("model_id"),
+        "model_name": record.get("model_name"),
+        "model_type": record.get("model_type"),
+        "status": status,
+        "reasons": reasons,
+    }
+
+
+def audit_capacity_records(records: list[Mapping[str, Any]]) -> dict[str, Any]:
+    """Return sanitized row classifications and aggregate counts."""
+    rows = [audit_capacity_record(record) for record in records]
+    counts: dict[str, int] = {}
+    for row in rows:
+        counts[row["status"]] = counts.get(row["status"], 0) + 1
+    return {"counts": counts, "rows": rows}

--- a/backend/services/model_profile_match_service.py
+++ b/backend/services/model_profile_match_service.py
@@ -1,0 +1,175 @@
+"""Independent, versioned capacity and tokenizer resolution for model setup."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import logging
+from typing import Any, Mapping, Optional
+
+from consts.capability_profiles import CATALOG
+from nexent.core.models.model_identity import MATCHER_VERSION, parse_model_identity
+from nexent.core.models.tokenizer_registry import resolve_for_model
+from services.model_capacity_suggestion_service import CapacitySuggestionResult, suggest_capacity
+
+
+MATCH_SCHEMA_VERSION = 1
+logger = logging.getLogger("model_profile_match_service")
+
+
+@dataclass(frozen=True)
+class ProfileMatch:
+    selected_profile: Optional[str]
+    confidence: Optional[str]
+    source: str
+    reason: str
+    matcher_version: str
+    candidates: tuple[str, ...] = ()
+    auto_applicable: bool = False
+
+
+@dataclass(frozen=True)
+class ModelProfileResolution:
+    canonical_model_id: str
+    identity_metadata: Mapping[str, Any]
+    capacity_match: ProfileMatch
+    tokenizer_match: ProfileMatch
+    tokenizer_family: Optional[str]
+    tokenizer_counting_mode: str
+    capacity_suggestions: Mapping[str, Any]
+
+
+def _evaluated_at() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _capacity_profile(version: Optional[str]):
+    if not version:
+        return None
+    return next(
+        (profile for profile in CATALOG.values() if profile.capability_profile_version == version),
+        None,
+    )
+
+
+def resolve_model_profiles(
+    *,
+    model_name: str,
+    provider: Optional[str],
+    base_url: Optional[str],
+    model_type: Optional[str],
+    capacity_result: Optional[CapacitySuggestionResult] = None,
+) -> ModelProfileResolution:
+    capacity = capacity_result or suggest_capacity(
+        model_name=model_name,
+        base_url=base_url,
+        provider_hint=provider,
+        model_type=model_type,
+        catalog=CATALOG,
+    )
+    identity_provider = capacity.suggested_provider or provider
+    identity = parse_model_identity(model_name, identity_provider)
+    matched_profile = _capacity_profile(capacity.capability_profile_version)
+    identity_candidates = tuple(
+        sorted(
+            profile.capability_profile_version
+            for (catalog_provider, _), profile in CATALOG.items()
+            if (not identity_provider or catalog_provider == identity_provider)
+            and parse_model_identity(profile.model_name, catalog_provider).family
+            == identity.family
+        )
+    ) if identity.family else ()
+    unresolved_candidates = () if matched_profile else identity_candidates
+    capacity_match = ProfileMatch(
+        selected_profile=capacity.capability_profile_version,
+        confidence=capacity.match_confidence.value if capacity.match_confidence else None,
+        source="catalog" if capacity.capability_profile_version else "unknown",
+        reason=(
+            "capacity_profile_ambiguous"
+            if len(unresolved_candidates) > 1
+            else capacity.match_kind.value
+        ),
+        matcher_version=MATCHER_VERSION,
+        candidates=unresolved_candidates,
+        auto_applicable=bool(
+            matched_profile
+            and matched_profile.auto_applicable
+            and capacity.match_confidence
+            and capacity.match_confidence.value == "high"
+        ),
+    )
+    tokenizer = resolve_for_model(identity_provider, model_name)
+    tokenizer_match = ProfileMatch(
+        selected_profile=tokenizer.profile_id,
+        confidence=tokenizer.confidence,
+        source="catalog" if tokenizer.source == "profile" else "unknown",
+        reason=tokenizer.reason,
+        matcher_version=tokenizer.matcher_version,
+        candidates=tokenizer.candidates,
+        auto_applicable=tokenizer.counting_mode == "exact",
+    )
+    capacity_suggestions = (
+        asdict(capacity.suggestions) if capacity.suggestions is not None else {}
+    )
+    # P1 deliberately separates the two matchers. A capacity catalog row may
+    # retain a legacy tokenizer hint for compatibility, but it is not an
+    # automatic tokenizer fact without an independently verified match.
+    capacity_suggestions["tokenizer_family"] = (
+        tokenizer.family if tokenizer.counting_mode == "exact" else None
+    )
+    identity_metadata = {
+        "schema_version": MATCH_SCHEMA_VERSION,
+        "canonical_id": identity.canonical_id,
+        "resolved": identity.resolved,
+        "ambiguity": identity.ambiguous or len(unresolved_candidates) > 1,
+        "confidence": identity.confidence,
+        "attributes": {
+            key: value
+            for key, value in identity.model_dump().items()
+            if key
+            not in {
+                "raw_model_id",
+                "canonical_id",
+                "resolved",
+                "ambiguous",
+                "confidence",
+                "matcher_version",
+                "evidence",
+                "candidates",
+            }
+        },
+        "evidence": list(identity.evidence),
+        "candidates": list(unresolved_candidates or identity.candidates),
+        "matcher_version": identity.matcher_version,
+        "evaluated_at": _evaluated_at(),
+    }
+    result = ModelProfileResolution(
+        canonical_model_id=identity.canonical_id,
+        identity_metadata=identity_metadata,
+        capacity_match=capacity_match,
+        tokenizer_match=tokenizer_match,
+        tokenizer_family=tokenizer.family,
+        tokenizer_counting_mode=tokenizer.counting_mode,
+        capacity_suggestions=capacity_suggestions,
+    )
+    logger.info(
+        "model_profile_resolution canonical_id=%s matcher_version=%s capacity_profile=%s capacity_confidence=%s capacity_reason=%s tokenizer_profile=%s tokenizer_confidence=%s tokenizer_reason=%s",
+        result.canonical_model_id,
+        MATCHER_VERSION,
+        result.capacity_match.selected_profile or "none",
+        result.capacity_match.confidence or "unknown",
+        result.capacity_match.reason,
+        result.tokenizer_match.selected_profile or "none",
+        result.tokenizer_match.confidence or "unknown",
+        result.tokenizer_match.reason,
+    )
+    return result
+
+
+def serialize_profile_match(match: ProfileMatch) -> dict[str, Any]:
+    return {
+        "schema_version": MATCH_SCHEMA_VERSION,
+        **asdict(match),
+        "candidates": list(match.candidates),
+        "evaluated_at": _evaluated_at(),
+    }

--- a/backend/services/model_provider_service.py
+++ b/backend/services/model_provider_service.py
@@ -15,6 +15,15 @@ from services.providers.tokenpony_provider import TokenPonyModelProvider
 from services.providers.dashscope_provider import DashScopeModelProvider
 from services.providers.modelengine_provider import ModelEngineProvider, get_model_engine_raw_url, MODEL_ENGINE_NORTH_PREFIX
 from utils.model_name_utils import split_repo_name, add_repo_to_name
+from consts.model_feature_capabilities import (
+    CATALOG_REVISION as FEATURE_CATALOG_REVISION,
+    EXACT_CATALOG as FEATURE_EXACT_CATALOG,
+    FAMILY_RULES as FEATURE_FAMILY_RULES,
+)
+from nexent.core.models.feature_capability import (
+    normalize_feature_profile,
+    resolve_feature_capabilities,
+)
 
 logger = logging.getLogger("model_provider")
 
@@ -48,6 +57,19 @@ async def get_provider_models(model_data: dict) -> List[dict]:
     elif model_data["provider"] == ProviderEnum.TOKENPONY.value:
         provider = TokenPonyModelProvider()
         model_list = await provider.get_models(model_data)
+
+    provider_name = model_data.get("provider")
+    for model in model_list:
+        if not isinstance(model, dict) or model.get("_error") or not model.get("id"):
+            continue
+        model["feature_capability_metadata"] = resolve_feature_capabilities(
+            provider_name,
+            model.get("id"),
+            provider_candidate=model.pop("feature_capability_candidate", None),
+            exact_catalog=FEATURE_EXACT_CATALOG,
+            family_rules=FEATURE_FAMILY_RULES,
+            catalog_revision=FEATURE_CATALOG_REVISION,
+        )
 
     return model_list
 
@@ -117,12 +139,11 @@ async def prepare_model_dict(provider: str, model: dict, model_url: str, model_a
     #     in (all None) and every freshly batch-created row lands with
     #     context_window_tokens=NULL, max_output_tokens=NULL even though
     #     the user filled the panel -- the glm-5.1/glm-5.2 incident.
-    #   - capacity_source="provider_candidate" (or anything else): per the
-    #     W1 design these are advisory UI hints surfaced from the catalog
-    #     by _extract_capacity_hints. They are shown to the user as
-    #     suggestions but not auto-persisted; only operator acceptance
-    #     should write them.
+    #   - capacity_source="provider_candidate": these are authoritative
+    #     field-scoped provider facts. Persist only the fields returned by the
+    #     provider; governance keeps operator-owned fields authoritative.
     is_operator_capacity = model.get("capacity_source") == "operator"
+    is_provider_capacity = model.get("capacity_source") == "provider_candidate"
     capacity_kwargs = (
         {
             "context_window_tokens": model.get("context_window_tokens"),
@@ -130,11 +151,16 @@ async def prepare_model_dict(provider: str, model: dict, model_url: str, model_a
             "max_output_tokens": model.get("max_output_tokens"),
             "default_output_reserve_tokens": model.get("default_output_reserve_tokens"),
             "tokenizer_family": model.get("tokenizer_family"),
-            "capacity_source": "operator",
+            "capacity_source": (
+                "operator" if is_operator_capacity else "provider_candidate"
+            ),
             "capability_profile_version": model.get("capability_profile_version"),
         }
-        if is_operator_capacity
+        if is_operator_capacity or is_provider_capacity
         else {}
+    )
+    feature_capability_metadata = normalize_feature_profile(
+        model.get("feature_capability_metadata")
     )
 
     model_obj = ModelRequest(
@@ -148,6 +174,7 @@ async def prepare_model_dict(provider: str, model: dict, model_url: str, model_a
         maximum_chunk_size=maximum_chunk_size,
         chunk_batch=chunk_batch,
         timeout_seconds=timeout_seconds_value,
+        feature_capability_metadata=feature_capability_metadata,
         **capacity_kwargs,
     )
 

--- a/backend/services/model_token_count_probe_service.py
+++ b/backend/services/model_token_count_probe_service.py
@@ -1,0 +1,363 @@
+"""Safe, explicit discovery of optional provider token-count endpoints."""
+
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+import logging
+import socket
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Awaitable, Callable, Iterable, Mapping, Optional
+from urllib.parse import urlsplit, urlunsplit
+
+import httpx
+
+
+PROBE_SCHEMA_VERSION = 1
+PROBE_ADAPTER_VERSION = "1.0.0"
+MAX_COUNT = 100_000_000
+MAX_RESPONSE_BYTES = 64 * 1024
+SUPPORTED_TTL = timedelta(days=7)
+UNSUPPORTED_TTL = timedelta(days=1)
+TEMPORARY_RETRY = timedelta(minutes=15)
+PROBE_TEXT = "Nexent token count probe."
+logger = logging.getLogger("model_token_count_probe_service")
+
+ProbeState = str
+
+
+@dataclass(frozen=True)
+class ProbeHTTPRequest:
+    protocol: str
+    url: str
+    headers: Mapping[str, str]
+    body: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class ProbeHTTPResponse:
+    status_code: int
+    payload: Optional[Mapping[str, Any]] = None
+    redirect_location: Optional[str] = None
+
+
+Transport = Callable[[ProbeHTTPRequest], Awaitable[ProbeHTTPResponse]]
+Resolver = Callable[[str], Iterable[str]]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_time(value: Any) -> Optional[datetime]:
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _default_resolver(host: str) -> Iterable[str]:
+    return {item[4][0] for item in socket.getaddrinfo(host, None)}
+
+
+def validate_probe_url(
+    url: str,
+    *,
+    allow_private: bool = False,
+    resolver: Resolver = _default_resolver,
+) -> str:
+    """Validate and normalize a configured URL before credentials are attached."""
+    parsed = urlsplit(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ValueError("ssrf_rejected")
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise ValueError("ssrf_rejected")
+    try:
+        addresses = tuple(resolver(parsed.hostname))
+    except (OSError, socket.gaierror) as exc:
+        raise ValueError("connection_failed") from exc
+    if not addresses:
+        raise ValueError("connection_failed")
+    if not allow_private:
+        for address in addresses:
+            ip = ipaddress.ip_address(address)
+            if (
+                ip.is_private
+                or ip.is_loopback
+                or ip.is_link_local
+                or ip.is_multicast
+                or ip.is_reserved
+                or ip.is_unspecified
+            ):
+                raise ValueError("ssrf_rejected")
+    host = parsed.hostname.lower()
+    if ":" in host:
+        host = f"[{host}]"
+    if parsed.port:
+        host = f"{host}:{parsed.port}"
+    return urlunsplit((parsed.scheme.lower(), host, parsed.path.rstrip("/"), "", ""))
+
+
+def endpoint_fingerprint(url: str) -> str:
+    parsed = urlsplit(url)
+    normalized = urlunsplit(
+        (
+            parsed.scheme.lower(),
+            (parsed.hostname or "").lower()
+            + (f":{parsed.port}" if parsed.port else ""),
+            parsed.path.rstrip("/"),
+            "",
+            "",
+        )
+    )
+    return hashlib.sha256(normalized.encode()).hexdigest()[:24]
+
+
+def credential_scope_fingerprint(scope_identity: str, *, salt: str) -> str:
+    """Hash non-secret tenant/scope identity; API-key material is never accepted."""
+    return hashlib.sha256(f"{salt}:{scope_identity}".encode()).hexdigest()[:24]
+
+
+def probe_fingerprint(
+    *, endpoint: str, model_identity: str, credential_scope: str, adapter_version: str
+) -> str:
+    value = "\0".join((endpoint, model_identity, credential_scope, adapter_version))
+    return hashlib.sha256(value.encode()).hexdigest()[:24]
+
+
+def _join(base_url: str, suffix: str) -> str:
+    return f"{base_url.rstrip('/')}/{suffix.lstrip('/')}"
+
+
+def build_probe_request(
+    protocol: str,
+    *,
+    base_url: str,
+    model_name: str,
+    api_key: str,
+) -> ProbeHTTPRequest:
+    if protocol == "openai_responses":
+        return ProbeHTTPRequest(
+            protocol=protocol,
+            url=_join(base_url, "responses/input_tokens"),
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            body={"model": model_name, "input": PROBE_TEXT},
+        )
+    if protocol == "anthropic_messages":
+        return ProbeHTTPRequest(
+            protocol=protocol,
+            url=_join(base_url, "messages/count_tokens"),
+            headers={
+                "x-api-key": api_key,
+                "anthropic-version": "2023-06-01",
+                "Content-Type": "application/json",
+            },
+            body={"model": model_name, "messages": [{"role": "user", "content": PROBE_TEXT}]},
+        )
+    if protocol == "gemini":
+        return ProbeHTTPRequest(
+            protocol=protocol,
+            url=_join(base_url, f"models/{model_name}:countTokens"),
+            headers={"x-goog-api-key": api_key, "Content-Type": "application/json"},
+            body={"contents": [{"parts": [{"text": PROBE_TEXT}]}]},
+        )
+    raise ValueError("unsupported_protocol")
+
+
+def _extract_count(protocol: str, payload: Optional[Mapping[str, Any]]) -> Optional[int]:
+    if not isinstance(payload, Mapping):
+        return None
+    if protocol in {"openai_responses", "anthropic_messages"}:
+        value = payload.get("input_tokens")
+    else:
+        value = payload.get("totalTokens")
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def classify_probe_response(
+    protocol: str, response: ProbeHTTPResponse
+) -> tuple[ProbeState, str, Optional[int]]:
+    status = response.status_code
+    if response.redirect_location is not None or 300 <= status < 400:
+        return "temporarily_unavailable", "redirect_rejected", None
+    if status in {404, 405}:
+        return "unsupported", "unsupported_endpoint", None
+    if status in {401, 403}:
+        return "authorization_error", "authorization_failed", None
+    if status == 429:
+        return "temporarily_unavailable", "rate_limited", None
+    if status >= 500:
+        return "temporarily_unavailable", "provider_5xx", None
+    if not 200 <= status < 300:
+        return "temporarily_unavailable", "connection_failed", None
+    count = _extract_count(protocol, response.payload)
+    if count is None:
+        return "invalid_response", "invalid_schema", None
+    if count <= 0 or count > MAX_COUNT:
+        return "invalid_response", "invalid_count", None
+    return "supported", "supported", count
+
+
+async def _httpx_transport(request: ProbeHTTPRequest) -> ProbeHTTPResponse:
+    timeout = httpx.Timeout(5.0, connect=3.0)
+    try:
+        async with httpx.AsyncClient(
+            timeout=timeout, follow_redirects=False, trust_env=False
+        ) as client:
+            response = await client.post(
+                request.url, headers=dict(request.headers), json=dict(request.body)
+            )
+        location = response.headers.get("location") if 300 <= response.status_code < 400 else None
+        if len(response.content) > MAX_RESPONSE_BYTES:
+            return ProbeHTTPResponse(response.status_code, payload=None, redirect_location=location)
+        try:
+            payload = response.json()
+        except (ValueError, json.JSONDecodeError):
+            payload = None
+        return ProbeHTTPResponse(response.status_code, payload=payload, redirect_location=location)
+    except httpx.TimeoutException as exc:
+        raise TimeoutError("timeout") from exc
+    except httpx.RequestError as exc:
+        raise ConnectionError("connection_failed") from exc
+
+
+def should_reuse_probe(
+    existing: Optional[Mapping[str, Any]],
+    *,
+    current_fingerprint: str,
+    now: datetime,
+    force: bool,
+) -> bool:
+    if force or not existing or existing.get("fingerprint") != current_fingerprint:
+        return False
+    if existing.get("status") not in {"supported", "unsupported"}:
+        return False
+    stale_at = _parse_time(existing.get("stale_at"))
+    return stale_at is not None and stale_at > now
+
+
+async def run_token_count_probe(
+    *,
+    inference_protocol: str,
+    base_url: str,
+    model_name: str,
+    canonical_model_id: str,
+    api_key: str,
+    credential_scope: str,
+    fingerprint_salt: str,
+    existing: Optional[Mapping[str, Any]] = None,
+    force: bool = False,
+    allow_private: bool = False,
+    resolver: Resolver = _default_resolver,
+    transport: Transport = _httpx_transport,
+    now: Optional[datetime] = None,
+) -> dict[str, Any]:
+    """Run a directed/ordered explicit probe and return sanitized metadata."""
+    checked_at = now or _utcnow()
+    safe_base = validate_probe_url(
+        base_url, allow_private=allow_private, resolver=resolver
+    )
+    endpoint_fp = endpoint_fingerprint(safe_base)
+    scope_fp = credential_scope_fingerprint(credential_scope, salt=fingerprint_salt)
+    fingerprint = probe_fingerprint(
+        endpoint=endpoint_fp,
+        model_identity=canonical_model_id,
+        credential_scope=scope_fp,
+        adapter_version=PROBE_ADAPTER_VERSION,
+    )
+    if should_reuse_probe(
+        existing, current_fingerprint=fingerprint, now=checked_at, force=force
+    ):
+        return dict(existing or {})
+
+    directed = {
+        "openai": ("openai_responses",),
+        "anthropic": ("anthropic_messages",),
+        "gemini": ("gemini",),
+    }
+    protocols = directed.get(
+        inference_protocol,
+        ("openai_responses", "anthropic_messages", "gemini"),
+    )
+    outcomes: list[dict[str, Any]] = []
+    selected: Optional[str] = None
+    selected_count: Optional[int] = None
+    for protocol in protocols:
+        request = build_probe_request(
+            protocol, base_url=safe_base, model_name=model_name, api_key=api_key
+        )
+        # Every derived target is checked and must remain on the configured origin.
+        safe_target = validate_probe_url(
+            request.url, allow_private=allow_private, resolver=resolver
+        )
+        if urlsplit(safe_target).netloc != urlsplit(safe_base).netloc:
+            state, reason, count = "temporarily_unavailable", "redirect_rejected", None
+        else:
+            try:
+                response = await transport(request)
+                state, reason, count = classify_probe_response(protocol, response)
+            except TimeoutError:
+                state, reason, count = "temporarily_unavailable", "timeout", None
+            except ConnectionError:
+                state, reason, count = "temporarily_unavailable", "connection_failed", None
+        outcomes.append({"protocol": protocol, "state": state, "reason": reason})
+        if state == "supported" and selected is None:
+            selected, selected_count = protocol, count
+        # Unknown protocols are ordered discovery: retain prior failures and
+        # stop after the first valid dialect to avoid unnecessary credential use.
+        if selected is not None and inference_protocol not in directed:
+            break
+
+    if selected is not None:
+        status, reason = "supported", "supported"
+        stale_at = checked_at + SUPPORTED_TTL
+        retry_at = None
+    elif outcomes and all(item["state"] == "unsupported" for item in outcomes):
+        status, reason = "unsupported", "unsupported_endpoint"
+        stale_at = checked_at + UNSUPPORTED_TTL
+        retry_at = None
+    else:
+        last = outcomes[-1] if outcomes else {"state": "unknown", "reason": "unknown"}
+        status, reason = last["state"], last["reason"]
+        stale_at = checked_at
+        retry_at = checked_at + TEMPORARY_RETRY if status == "temporarily_unavailable" else None
+
+    metadata = {
+        "schema_version": PROBE_SCHEMA_VERSION,
+        "status": status,
+        "reason": reason,
+        "selected_protocol": selected,
+        "capabilities": {
+            "text": "supported" if selected else status,
+            "tools": "unknown",
+            "media": "unknown",
+        },
+        **({"probe_token_count": selected_count} if selected_count is not None else {}),
+        "outcomes": outcomes,
+        "checked_at": _iso(checked_at),
+        "stale_at": _iso(stale_at),
+        **({"retry_at": _iso(retry_at)} if retry_at else {}),
+        "adapter_version": PROBE_ADAPTER_VERSION,
+        "endpoint_fingerprint": endpoint_fp,
+        "model_identity": canonical_model_id,
+        "credential_scope_fingerprint": scope_fp,
+        "fingerprint": fingerprint,
+    }
+    logger.info(
+        "token_count_probe protocol=%s state=%s reason=%s endpoint_fingerprint=%s model_identity=%s adapter_version=%s",
+        selected or inference_protocol,
+        status,
+        reason,
+        endpoint_fp,
+        canonical_model_id,
+        PROBE_ADAPTER_VERSION,
+    )
+    return metadata

--- a/backend/services/providers/base.py
+++ b/backend/services/providers/base.py
@@ -4,6 +4,8 @@ from typing import Any, Dict, Iterable, List
 
 import aiohttp
 
+from nexent.core.models.feature_capability import extract_provider_feature_candidate
+
 logger = logging.getLogger("model_provider")
 
 
@@ -88,6 +90,12 @@ def _extract_capacity_hints_from_raw(raw: Dict, nested_keys: Iterable[str] = ())
     if hints:
         hints["capacity_source"] = "provider_candidate"
     return hints
+
+
+def _extract_feature_capability_hints_from_raw(raw: Dict) -> Dict:
+    """Return only normalized, allow-listed feature capability extensions."""
+    candidate = extract_provider_feature_candidate(raw)
+    return {"feature_capability_candidate": candidate} if candidate else {}
 
 
 # =============================================================================

--- a/backend/services/providers/dashscope_provider.py
+++ b/backend/services/providers/dashscope_provider.py
@@ -7,6 +7,7 @@ from services.providers.base import (
     AbstractModelProvider,
     _classify_provider_error,
     _extract_capacity_hints_from_raw,
+    _extract_feature_capability_hints_from_raw,
 )
 
 
@@ -38,7 +39,9 @@ DASHSCOPE_VIDEO_UNDERSTANDING_KEYWORDS = ("omni", "video-understanding", "video-
 
 
 def _extract_capacity_hints(raw: Dict) -> Dict:
-    return _extract_capacity_hints_from_raw(raw, nested_keys=("inference_metadata",))
+    return _extract_capacity_hints_from_raw(
+        raw, nested_keys=("model_info", "inference_metadata")
+    )
 
 
 def _modality_set(value) -> set:
@@ -169,6 +172,7 @@ class DashScopeModelProvider(AbstractModelProvider):
                     "max_tokens": DEFAULT_LLM_MAX_TOKENS
                 }
                 cleaned_model.update(_extract_capacity_hints(model_obj))
+                cleaned_model.update(_extract_feature_capability_hints_from_raw(model_obj))
                # 1. Embedding
                 if 'embedding' in m_id.lower() or '向量' in desc:
                     cleaned_model.update({"model_tag": "embedding", "model_type": "embedding"})

--- a/backend/services/providers/modelengine_provider.py
+++ b/backend/services/providers/modelengine_provider.py
@@ -8,6 +8,7 @@ from services.providers.base import (
     AbstractModelProvider,
     _classify_provider_error,
     _extract_capacity_hints_from_raw,
+    _extract_feature_capability_hints_from_raw,
 )
 
 logger = logging.getLogger("model_provider")
@@ -113,6 +114,7 @@ class ModelEngineProvider(AbstractModelProvider):
                         "api_key": api_key,
                     }
                     cleaned_model.update(_extract_capacity_hints(model))
+                    cleaned_model.update(_extract_feature_capability_hints_from_raw(model))
                     filtered_models.append(cleaned_model)
 
             return filtered_models

--- a/backend/services/providers/silicon_provider.py
+++ b/backend/services/providers/silicon_provider.py
@@ -8,6 +8,7 @@ from services.providers.base import (
     AbstractModelProvider,
     _classify_provider_error,
     _extract_capacity_hints_from_raw,
+    _extract_feature_capability_hints_from_raw,
 )
 
 
@@ -116,6 +117,7 @@ class SiliconModelProvider(AbstractModelProvider):
             if provider_model_type in ("llm", "vlm"):
                 for item in model_list:
                     item.update(_extract_capacity_hints(item))
+                    item.update(_extract_feature_capability_hints_from_raw(item))
                     item["model_tag"] = "chat"
                     item["model_type"] = model_type
                     item["max_tokens"] = DEFAULT_LLM_MAX_TOKENS

--- a/backend/services/providers/tokenpony_provider.py
+++ b/backend/services/providers/tokenpony_provider.py
@@ -10,6 +10,7 @@ from services.providers.base import (
     AbstractModelProvider,
     _classify_provider_error,
     _extract_capacity_hints_from_raw,
+    _extract_feature_capability_hints_from_raw,
 )
 
 
@@ -135,6 +136,7 @@ class TokenPonyModelProvider(AbstractModelProvider):
                     "max_tokens": DEFAULT_LLM_MAX_TOKENS
                 }
                 cleaned_model.update(_extract_capacity_hints(model_obj))
+                cleaned_model.update(_extract_feature_capability_hints_from_raw(model_obj))
                 # 1. rerank
                 if 'rerank' in m_id:
                     cleaned_model.update({"model_tag": "rerank", "model_type": "rerank"})

--- a/deploy/sql/migrations/v2.6.0_0903_model_capacity_governance.sql
+++ b/deploy/sql/migrations/v2.6.0_0903_model_capacity_governance.sql
@@ -1,0 +1,28 @@
+-- Nullable model capacity governance metadata added after the v2.5 history
+-- was consolidated. Fresh installs and upgrades replay this idempotently.
+SET search_path TO nexent;
+BEGIN;
+
+ALTER TABLE nexent.model_record_t
+    ADD COLUMN IF NOT EXISTS canonical_model_id VARCHAR(512) DEFAULT NULL;
+ALTER TABLE nexent.model_record_t
+    ADD COLUMN IF NOT EXISTS capacity_field_metadata JSONB DEFAULT NULL;
+ALTER TABLE nexent.model_record_t
+    ADD COLUMN IF NOT EXISTS model_identity_metadata JSONB DEFAULT NULL;
+ALTER TABLE nexent.model_record_t
+    ADD COLUMN IF NOT EXISTS tokenizer_match_metadata JSONB DEFAULT NULL;
+ALTER TABLE nexent.model_record_t
+    ADD COLUMN IF NOT EXISTS token_count_probe_metadata JSONB DEFAULT NULL;
+
+COMMENT ON COLUMN nexent.model_record_t.canonical_model_id IS
+    'Versioned canonical model identity used for independent capacity and tokenizer matching.';
+COMMENT ON COLUMN nexent.model_record_t.capacity_field_metadata IS
+    'Versioned field-level source, confidence, evidence, and verification metadata. Contains no secrets.';
+COMMENT ON COLUMN nexent.model_record_t.model_identity_metadata IS
+    'Versioned canonical parsing and capacity-match evidence. Contains no credentials or raw payloads.';
+COMMENT ON COLUMN nexent.model_record_t.tokenizer_match_metadata IS
+    'Versioned independent tokenizer profile match and conformance state.';
+COMMENT ON COLUMN nexent.model_record_t.token_count_probe_metadata IS
+    'Versioned sanitized provider token-count capability probe state. Contains no keys or raw bodies.';
+
+COMMIT;

--- a/deploy/sql/migrations/v2.6.0_0903_model_feature_capabilities.sql
+++ b/deploy/sql/migrations/v2.6.0_0903_model_feature_capabilities.sql
@@ -1,0 +1,11 @@
+-- Persist sanitized model-level reasoning and prompt-cache capabilities.
+SET search_path TO nexent;
+BEGIN;
+
+ALTER TABLE nexent.model_record_t
+    ADD COLUMN IF NOT EXISTS feature_capability_metadata JSONB DEFAULT NULL;
+
+COMMENT ON COLUMN nexent.model_record_t.feature_capability_metadata IS
+    'Versioned reasoning and prompt-cache capability resolution without secrets.';
+
+COMMIT;

--- a/sdk/nexent/core/models/capacity_budget.py
+++ b/sdk/nexent/core/models/capacity_budget.py
@@ -10,13 +10,13 @@ from pydantic import BaseModel, ConfigDict, Field
 from .capacity_resolver import ModelCapacitySnapshot
 
 
-W2_RESOLVER_VERSION = "1.0.0"
+W2_RESOLVER_VERSION = "1.1.0"
 W2_FINGERPRINT_SCHEMA_VERSION = 1
 
 
 OutputReserveSource = Literal["model_default", "agent", "request"]
 UncertaintyReserveBasis = Literal[
-    "context_window_10pct", "approved_profile", "none"
+    "provider_input_limit_10pct", "approved_profile", "none"
 ]
 SoftLimitRatioSource = Literal["code_default", "tenant_config"]
 BudgetFieldSource = Literal[
@@ -104,7 +104,7 @@ class CapacityReservePolicy(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     soft_limit_ratio: float = Field(
-        default=0.8,
+        default=1.0,
         gt=0,
         le=1,
         description="Ratio of hard safe input budget where proactive compaction begins.",
@@ -228,28 +228,16 @@ class SafeInputBudgetCalculator:
         requested_output_tokens: Optional[int] = None,
         output_reserve_source: OutputReserveSource = "model_default",
     ) -> SafeInputBudgetSnapshot:
-        effective_output_tokens = (
-            requested_output_tokens
-            if requested_output_tokens is not None
-            else capacity_snapshot.requested_output_tokens
-        )
-        effective_output_source: OutputReserveSource = output_reserve_source
-        if requested_output_tokens is None:
-            effective_output_source = "model_default"
+        # Protection is resolved once by W1 from model capacity. Legacy
+        # model/Agent/request overrides remain accepted at compatibility
+        # boundaries but may not change runtime behavior.
+        effective_output_tokens = capacity_snapshot.requested_output_tokens
+        effective_output_source: OutputReserveSource = "model_default"
 
         if effective_output_tokens <= 0:
             raise InvalidReservePolicy(
                 "requested_output_tokens must be a positive integer"
             )
-
-        if request_overrides and request_overrides.requested_output_tokens is not None:
-            if request_overrides.requested_output_tokens < effective_output_tokens:
-                raise InvalidReservePolicy(
-                    "per-request requested_output_tokens may not lower the "
-                    "resolved model or agent output reserve"
-                )
-            effective_output_tokens = request_overrides.requested_output_tokens
-            effective_output_source = "request"
 
         if (
             capacity_snapshot.max_output_tokens is not None
@@ -267,7 +255,11 @@ class SafeInputBudgetCalculator:
         )
 
         uncertainty_reserve_tokens, uncertainty_reserve_basis, warnings = (
-            self._uncertainty_reserve(capacity_snapshot, reserve_policy)
+            self._uncertainty_reserve(
+                capacity_snapshot,
+                reserve_policy,
+                provider_input_limit=provider_input_limit,
+            )
         )
 
         if uncertainty_reserve_tokens > provider_input_limit:
@@ -360,26 +352,9 @@ class SafeInputBudgetCalculator:
         self,
         capacity_snapshot: ModelCapacitySnapshot,
         reserve_policy: CapacityReservePolicy,
+        *,
+        provider_input_limit: int,
     ) -> tuple[int, UncertaintyReserveBasis, list[str]]:
-        unknown_required_behavior = self._UNKNOWN_CAPABILITIES_REQUIRING_RESERVE.intersection(
-            capacity_snapshot.unknown_capabilities
-        )
-
-        if reserve_policy.approved_profile_reserve_tokens is not None:
-            return (
-                reserve_policy.approved_profile_reserve_tokens,
-                "approved_profile",
-                [],
-            )
-
-        if not unknown_required_behavior:
-            return 0, "none", []
-
-        if capacity_snapshot.context_window_tokens is None:
-            raise UncertaintyReserveBasisUnknown(
-                "context_window_tokens is required for the unified 10 percent "
-                "uncertainty reserve"
-            )
-
-        reserve = math.ceil(capacity_snapshot.context_window_tokens * 0.10)
-        return reserve, "context_window_10pct", ["uncertainty_reserve_active"]
+        # Counting uncertainty affects observability confidence, not a second
+        # hidden input limit. Provider overflow responses remain authoritative.
+        return 0, "none", []

--- a/sdk/nexent/core/models/capacity_resolver.py
+++ b/sdk/nexent/core/models/capacity_resolver.py
@@ -374,19 +374,19 @@ def resolve_capacity(
     # Input is observed and this automatically derived value only decides when
     # context-management actions should run. The provider wire output cap is
     # always max_output_tokens.
-    requested_output_tokens = derive_output_protection_tokens(
+    output_protection_tokens = derive_output_protection_tokens(
         context_window_tokens=context_window_tokens,
         max_output_tokens=max_output_tokens,
     )
-    if requested_output_tokens <= 0:
+    if output_protection_tokens <= 0:
         raise InvalidCapacityConfiguration(
-            f"requested_output_tokens must be positive, got {requested_output_tokens}"
+            f"requested_output_tokens must be positive, got {output_protection_tokens}"
         )
     derived_limits: list[int] = []
     if max_input_tokens is not None:
         derived_limits.append(max_input_tokens)
     if context_window_tokens is not None:
-        derived_limits.append(context_window_tokens - requested_output_tokens)
+        derived_limits.append(context_window_tokens - output_protection_tokens)
     provider_input_limit_tokens = min(derived_limits)
     if provider_input_limit_tokens <= 0:
         raise InvalidCapacityConfiguration(
@@ -417,7 +417,7 @@ def resolve_capacity(
         max_input_tokens=max_input_tokens,
         max_output_tokens=max_output_tokens,
         default_output_reserve_tokens=default_output_reserve_tokens,
-        requested_output_tokens=requested_output_tokens,
+        requested_output_tokens=output_protection_tokens,
         provider_input_limit_tokens=provider_input_limit_tokens,
         tokenizer_family=tokenizer_family,
         counting_mode=counting_mode,
@@ -433,7 +433,7 @@ def resolve_capacity(
         max_input_tokens=max_input_tokens,
         max_output_tokens=max_output_tokens,
         default_output_reserve_tokens=default_output_reserve_tokens,
-        requested_output_tokens=requested_output_tokens,
+        requested_output_tokens=output_protection_tokens,
         provider_input_limit_tokens=provider_input_limit_tokens,
         tokenizer_family=tokenizer_family,
         counting_mode=counting_mode,

--- a/sdk/nexent/core/models/capacity_resolver.py
+++ b/sdk/nexent/core/models/capacity_resolver.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import math
 from typing import Any, List, Literal, Mapping, Optional, Sequence, Tuple
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -22,6 +23,7 @@ CapacitySource = Literal[
 ReasoningWindowBehavior = Literal["none", "reserved", "unknown"]
 ProviderOverheadBehavior = Literal["negligible", "bounded", "unknown"]
 PromptCacheCapability = Literal["none", "supported", "unknown"]
+ProfileConfidence = Literal["high", "medium", "low", "unknown"]
 
 
 ProfileKey = Tuple[str, str]
@@ -58,6 +60,76 @@ class CapabilityProfile(BaseModel):
     reasoning_window_behavior: ReasoningWindowBehavior = "unknown"
     provider_overhead_behavior: ProviderOverheadBehavior = "unknown"
     prompt_cache: PromptCacheCapability = "unknown"
+
+    # P1 catalog-governance declarations. They intentionally default to an
+    # incomplete/suggestion-only state so old catalog rows cannot silently be
+    # promoted to verified automatic facts during rollout.
+    aliases: Tuple[str, ...] = ()
+    exclusions: Tuple[str, ...] = ()
+    evidence: Tuple[str, ...] = ()
+    verified_at: Optional[str] = None
+    shared_context: Optional[bool] = None
+    independent_input: Optional[bool] = None
+    max_output: Optional[int] = None
+    reasoning_behavior: Optional[ReasoningWindowBehavior] = None
+    overhead_behavior: Optional[ProviderOverheadBehavior] = None
+    confidence: ProfileConfidence = "unknown"
+
+    def automatic_validation_errors(self) -> Tuple[str, ...]:
+        """Return fail-closed reasons preventing automatic catalog use."""
+        errors: list[str] = []
+        if not self.aliases:
+            errors.append("aliases_missing")
+        if not self.evidence or any(not item.strip() for item in self.evidence):
+            errors.append("evidence_missing")
+        if not self.verified_at:
+            errors.append("verified_at_missing")
+        if self.shared_context is None:
+            errors.append("shared_context_missing")
+        if self.independent_input is None:
+            errors.append("independent_input_missing")
+        if self.max_output is None or self.max_output <= 0:
+            errors.append("max_output_missing")
+        elif self.max_output_tokens is not None and self.max_output != self.max_output_tokens:
+            errors.append("max_output_conflict")
+        if self.reasoning_behavior is None:
+            errors.append("reasoning_behavior_missing")
+        if self.overhead_behavior is None:
+            errors.append("overhead_behavior_missing")
+        if self.confidence != "high":
+            errors.append("confidence_not_high")
+        if self.shared_context is True and self.window_shape != "combined":
+            errors.append("shared_context_conflict")
+        if self.independent_input is True and self.max_input_tokens is None:
+            errors.append("independent_input_limit_missing")
+        return tuple(errors)
+
+    @property
+    def auto_applicable(self) -> bool:
+        return not self.automatic_validation_errors()
+
+
+def validate_capability_catalog(
+    catalog: Mapping[ProfileKey, CapabilityProfile],
+) -> Mapping[ProfileKey, Tuple[str, ...]]:
+    """Validate catalog identity and automatic-use declarations.
+
+    Incomplete legacy rows are returned with reasons and remain
+    suggestion-only. A row that claims high confidence fails closed because a
+    verified label without complete evidence is a catalog authoring error.
+    """
+    diagnostics: dict[ProfileKey, Tuple[str, ...]] = {}
+    for key, profile in catalog.items():
+        if key != (profile.provider, profile.model_name):
+            raise ValueError(f"catalog_key_mismatch:{key!r}")
+        reasons = profile.automatic_validation_errors()
+        if profile.confidence == "high" and reasons:
+            raise ValueError(
+                f"incomplete_verified_profile:{profile.capability_profile_version}:"
+                f"{','.join(reasons)}"
+            )
+        diagnostics[key] = reasons
+    return diagnostics
 
 
 class ModelCapacitySnapshot(BaseModel):
@@ -197,6 +269,20 @@ _OVERRIDABLE_FIELDS = (
 _DEFAULT_REQUESTED_OUTPUT_TOKENS = 4096
 
 
+def derive_output_protection_tokens(
+    *, context_window_tokens: Optional[int], max_output_tokens: Optional[int]
+) -> int:
+    """Derive context-management headroom without constraining completion output."""
+    if max_output_tokens is None or max_output_tokens <= 0:
+        raise ProviderCapabilityUnknown("max_output_tokens is required")
+    proportional = (
+        math.ceil(context_window_tokens * 0.10)
+        if context_window_tokens is not None
+        else _DEFAULT_REQUESTED_OUTPUT_TOKENS
+    )
+    return min(max_output_tokens, max(_DEFAULT_REQUESTED_OUTPUT_TOKENS, proportional))
+
+
 def resolve_capacity(
     *,
     model_id: str,
@@ -284,25 +370,18 @@ def resolve_capacity(
             f"so the override never takes effect"
         )
 
-    if requested_output_tokens is None:
-        requested_output_tokens = (
-            default_output_reserve_tokens
-            if default_output_reserve_tokens is not None
-            else _DEFAULT_REQUESTED_OUTPUT_TOKENS
-        )
+    # Legacy model/Agent/request reserve values are intentionally ignored.
+    # Input is observed and this automatically derived value only decides when
+    # context-management actions should run. The provider wire output cap is
+    # always max_output_tokens.
+    requested_output_tokens = derive_output_protection_tokens(
+        context_window_tokens=context_window_tokens,
+        max_output_tokens=max_output_tokens,
+    )
     if requested_output_tokens <= 0:
         raise InvalidCapacityConfiguration(
             f"requested_output_tokens must be positive, got {requested_output_tokens}"
         )
-    if (
-        max_output_tokens is not None
-        and requested_output_tokens > max_output_tokens
-    ):
-        raise RequestedOutputExceedsCap(
-            f"requested_output_tokens ({requested_output_tokens}) exceeds "
-            f"max_output_tokens ({max_output_tokens})"
-        )
-
     derived_limits: list[int] = []
     if max_input_tokens is not None:
         derived_limits.append(max_input_tokens)

--- a/sdk/nexent/core/models/feature_capability.py
+++ b/sdk/nexent/core/models/feature_capability.py
@@ -1,0 +1,248 @@
+"""Model-level reasoning and prompt-cache capability resolution.
+
+The OpenAI ``/models`` schema only guarantees identity fields.  Compatible
+providers may add capability fields, so this module consumes a strict allow
+list of such extensions and otherwise resolves a backend-supplied catalog.
+It never performs inference probes and never reads environment variables.
+"""
+from __future__ import annotations
+
+import re
+from copy import deepcopy
+from typing import Any, Mapping, Optional, Sequence
+
+
+FEATURE_CAPABILITY_SCHEMA_VERSION = 1
+UNKNOWN_FEATURE_CAPABILITIES = {
+    "reasoning": {
+        "supported": None,
+        "mode": "unknown",
+        "request_style": "unknown",
+        "efforts": [],
+    },
+    "prompt_cache": {
+        "supported": None,
+        "mode": "unknown",
+        "metrics_available": None,
+    },
+}
+
+_REASONING_BOOL_KEYS = (
+    "reasoning_supported",
+    "supports_reasoning",
+    "thinking_supported",
+    "supports_thinking",
+)
+_CACHE_BOOL_KEYS = (
+    "prompt_cache_supported",
+    "supports_prompt_cache",
+    "cache_supported",
+    "supports_caching",
+)
+_PARAMETER_KEYS = ("supported_parameters", "supported_params", "parameters")
+_NESTED_KEYS = ("capabilities", "features", "model_info", "inference_metadata")
+_VALID_REASONING_MODES = {"always", "toggle", "effort", "none", "unknown"}
+_VALID_REQUEST_STYLES = {
+    "openai_reasoning_effort",
+    "extra_body_enable_thinking",
+    "none",
+    "unknown",
+}
+_VALID_CACHE_MODES = {
+    "openai_automatic",
+    "provider_automatic",
+    "anthropic_ephemeral",
+    "none",
+    "unknown",
+}
+
+
+def _mapping_candidates(raw: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    candidates = [raw]
+    for key in _NESTED_KEYS:
+        nested = raw.get(key)
+        if isinstance(nested, Mapping):
+            candidates.append(nested)
+    return candidates
+
+
+def _first_bool(candidates: Sequence[Mapping[str, Any]], keys: Sequence[str]) -> Optional[bool]:
+    for candidate in candidates:
+        for key in keys:
+            value = candidate.get(key)
+            if isinstance(value, bool):
+                return value
+    return None
+
+
+def _parameter_names(candidates: Sequence[Mapping[str, Any]]) -> set[str]:
+    names: set[str] = set()
+    for candidate in candidates:
+        for key in _PARAMETER_KEYS:
+            values = candidate.get(key)
+            if isinstance(values, (list, tuple, set)):
+                names.update(str(value).strip().lower() for value in values if str(value).strip())
+    return names
+
+
+def extract_provider_feature_candidate(raw: Mapping[str, Any]) -> Optional[dict[str, Any]]:
+    """Extract explicit provider extensions without retaining the raw row."""
+    if not isinstance(raw, Mapping):
+        return None
+    candidates = _mapping_candidates(raw)
+    parameters = _parameter_names(candidates)
+    reasoning_supported = _first_bool(candidates, _REASONING_BOOL_KEYS)
+    cache_supported = _first_bool(candidates, _CACHE_BOOL_KEYS)
+
+    request_style = "unknown"
+    if "reasoning_effort" in parameters or "reasoning.effort" in parameters:
+        reasoning_supported = True if reasoning_supported is None else reasoning_supported
+        request_style = "openai_reasoning_effort"
+    elif "enable_thinking" in parameters:
+        reasoning_supported = True if reasoning_supported is None else reasoning_supported
+        request_style = "extra_body_enable_thinking"
+
+    cache_mode = "unknown"
+    if "cache_control" in parameters:
+        cache_supported = True if cache_supported is None else cache_supported
+        cache_mode = "anthropic_ephemeral"
+    elif "prompt_cache_key" in parameters or "prompt_cache_retention" in parameters:
+        cache_supported = True if cache_supported is None else cache_supported
+        cache_mode = "openai_automatic"
+
+    efforts: list[str] = []
+    for candidate in candidates:
+        value = candidate.get("reasoning_efforts") or candidate.get("supported_reasoning_efforts")
+        if isinstance(value, (list, tuple)):
+            efforts = [str(item).strip().lower() for item in value if str(item).strip()]
+            break
+
+    if reasoning_supported is None and cache_supported is None:
+        return None
+
+    warnings: list[str] = []
+    if reasoning_supported is False and (request_style != "unknown" or efforts):
+        warnings.append("conflicting_reasoning_extension")
+        reasoning_supported = None
+        request_style = "unknown"
+        efforts = []
+    if cache_supported is False and cache_mode != "unknown":
+        warnings.append("conflicting_prompt_cache_extension")
+        cache_supported = None
+        cache_mode = "unknown"
+
+    return {
+        "schema_version": FEATURE_CAPABILITY_SCHEMA_VERSION,
+        "reasoning": {
+            "supported": reasoning_supported,
+            "mode": "effort" if request_style == "openai_reasoning_effort" else (
+                "toggle" if request_style == "extra_body_enable_thinking" else (
+                    "none" if reasoning_supported is False else "unknown"
+                )
+            ),
+            "request_style": request_style if reasoning_supported is not False else "none",
+            "efforts": efforts,
+        },
+        "prompt_cache": {
+            "supported": cache_supported,
+            "mode": cache_mode if cache_supported is not False else "none",
+            "metrics_available": None,
+        },
+        "source": "provider_extension",
+        "warnings": warnings,
+    }
+
+
+def _normalize_branch(profile: Mapping[str, Any], branch: str) -> dict[str, Any]:
+    defaults = deepcopy(UNKNOWN_FEATURE_CAPABILITIES[branch])
+    value = profile.get(branch)
+    if not isinstance(value, Mapping):
+        return defaults
+    defaults.update({key: deepcopy(item) for key, item in value.items() if key in defaults})
+    if defaults["supported"] not in (True, False, None):
+        return deepcopy(UNKNOWN_FEATURE_CAPABILITIES[branch])
+    if branch == "reasoning":
+        if defaults["mode"] not in _VALID_REASONING_MODES:
+            defaults["mode"] = "unknown"
+        if defaults["request_style"] not in _VALID_REQUEST_STYLES:
+            defaults["request_style"] = "unknown"
+        if not isinstance(defaults["efforts"], list):
+            defaults["efforts"] = []
+    elif defaults["mode"] not in _VALID_CACHE_MODES:
+        defaults["mode"] = "unknown"
+    return defaults
+
+
+def normalize_feature_profile(profile: Optional[Mapping[str, Any]]) -> Optional[dict[str, Any]]:
+    """Validate a persisted or catalog profile and discard unknown fields."""
+    if not isinstance(profile, Mapping):
+        return None
+    return {
+        "schema_version": FEATURE_CAPABILITY_SCHEMA_VERSION,
+        "reasoning": _normalize_branch(profile, "reasoning"),
+        "prompt_cache": _normalize_branch(profile, "prompt_cache"),
+        "source": str(profile.get("source") or "unknown"),
+        "match_kind": str(profile.get("match_kind") or "unknown"),
+        "profile_version": profile.get("profile_version"),
+        "catalog_revision": profile.get("catalog_revision"),
+        "evidence": [str(item) for item in profile.get("evidence", []) if isinstance(item, str)],
+        "warnings": [str(item) for item in profile.get("warnings", []) if isinstance(item, str)],
+    }
+
+
+def resolve_feature_capabilities(
+    provider: Optional[str],
+    model: Optional[str],
+    *,
+    provider_candidate: Optional[Mapping[str, Any]] = None,
+    exact_catalog: Optional[Mapping[tuple[str, str], Mapping[str, Any]]] = None,
+    family_rules: Sequence[Mapping[str, Any]] = (),
+    catalog_revision: Optional[str] = None,
+) -> dict[str, Any]:
+    """Resolve one model profile with deterministic, fail-closed precedence."""
+    provider_key = str(provider or "").strip().lower()
+    model_key = str(model or "").strip()
+
+    normalized_candidate = normalize_feature_profile(provider_candidate)
+    if normalized_candidate and provider_candidate:
+        has_explicit_value = any(
+            normalized_candidate[branch]["supported"] is not None
+            for branch in ("reasoning", "prompt_cache")
+        )
+        if has_explicit_value:
+            normalized_candidate.update({
+                "source": "provider_extension",
+                "match_kind": "provider_extension",
+                "catalog_revision": catalog_revision,
+            })
+            return normalized_candidate
+
+    catalog = exact_catalog or {}
+    exact = next(
+        (
+            value for (row_provider, row_model), value in catalog.items()
+            if str(row_provider).lower() == provider_key and str(row_model).lower() == model_key.lower()
+        ),
+        None,
+    )
+    if exact is not None:
+        result = normalize_feature_profile(exact) or normalize_feature_profile({})
+        result.update({"source": "catalog_exact", "match_kind": "catalog_exact", "catalog_revision": catalog_revision})
+        return result
+
+    for rule in family_rules:
+        if str(rule.get("provider") or "").lower() != provider_key:
+            continue
+        pattern = rule.get("pattern")
+        if not isinstance(pattern, str) or not re.fullmatch(pattern, model_key, flags=re.IGNORECASE):
+            continue
+        exclusions = rule.get("exclusions") or ()
+        if any(re.fullmatch(str(item), model_key, flags=re.IGNORECASE) for item in exclusions):
+            continue
+        result = normalize_feature_profile(rule) or normalize_feature_profile({})
+        result.update({"source": "catalog_family", "match_kind": "catalog_family", "catalog_revision": catalog_revision})
+        return result
+
+    result = normalize_feature_profile({})
+    result.update({"source": "unknown", "match_kind": "none", "catalog_revision": catalog_revision})
+    return result

--- a/sdk/nexent/core/models/feature_capability.py
+++ b/sdk/nexent/core/models/feature_capability.py
@@ -19,6 +19,7 @@ UNKNOWN_FEATURE_CAPABILITIES = {
         "mode": "unknown",
         "request_style": "unknown",
         "efforts": [],
+        "default_effort": None,
     },
     "prompt_cache": {
         "supported": None,
@@ -116,6 +117,12 @@ def extract_provider_feature_candidate(raw: Mapping[str, Any]) -> Optional[dict[
         if isinstance(value, (list, tuple)):
             efforts = [str(item).strip().lower() for item in value if str(item).strip()]
             break
+    default_effort = None
+    for candidate in candidates:
+        value = candidate.get("default_reasoning_effort") or candidate.get("reasoning_effort_default")
+        if isinstance(value, str) and value.strip():
+            default_effort = value.strip().lower()
+            break
 
     if reasoning_supported is None and cache_supported is None:
         return None
@@ -142,6 +149,7 @@ def extract_provider_feature_candidate(raw: Mapping[str, Any]) -> Optional[dict[
             ),
             "request_style": request_style if reasoning_supported is not False else "none",
             "efforts": efforts,
+            "default_effort": default_effort,
         },
         "prompt_cache": {
             "supported": cache_supported,
@@ -168,6 +176,16 @@ def _normalize_branch(profile: Mapping[str, Any], branch: str) -> dict[str, Any]
             defaults["request_style"] = "unknown"
         if not isinstance(defaults["efforts"], list):
             defaults["efforts"] = []
+        defaults["efforts"] = [
+            str(item).strip().lower()
+            for item in defaults["efforts"]
+            if str(item).strip()
+        ]
+        default_effort = defaults.get("default_effort")
+        if not isinstance(default_effort, str) or default_effort.lower() not in defaults["efforts"]:
+            defaults["default_effort"] = None
+        else:
+            defaults["default_effort"] = default_effort.lower()
     elif defaults["mode"] not in _VALID_CACHE_MODES:
         defaults["mode"] = "unknown"
     return defaults
@@ -246,3 +264,117 @@ def resolve_feature_capabilities(
     result = normalize_feature_profile({})
     result.update({"source": "unknown", "match_kind": "none", "catalog_revision": catalog_revision})
     return result
+
+
+def resolve_effective_feature_policy(
+    feature_capabilities: Optional[Mapping[str, Any]],
+    preferences: Optional[Mapping[str, Any]] = None,
+) -> dict[str, Any]:
+    """Resolve runtime behavior without mutating model capability facts.
+
+    Confirmed capabilities are enabled by default. Optional preferences are a
+    future-facing override contract and can narrow, but never expand, confirmed
+    model support.
+    """
+    profile = normalize_feature_profile(feature_capabilities) or normalize_feature_profile({})
+    preference_map = preferences if isinstance(preferences, Mapping) else {}
+    reasoning_preference = preference_map.get("reasoning")
+    reasoning_preference = reasoning_preference if isinstance(reasoning_preference, Mapping) else {}
+    cache_preference = preference_map.get("prompt_cache")
+    cache_preference = cache_preference if isinstance(cache_preference, Mapping) else {}
+    warnings: list[str] = []
+
+    reasoning = profile["reasoning"]
+    reasoning_supported = reasoning.get("supported") is True
+    reasoning_mode = str(reasoning.get("mode") or "unknown")
+    reasoning_enabled = reasoning_supported
+    requested_reasoning_enabled = reasoning_preference.get("enabled")
+    effort = reasoning.get("default_effort") if reasoning_mode == "effort" else None
+
+    preferred_effort = reasoning_preference.get("effort")
+    if isinstance(preferred_effort, str):
+        preferred_effort = preferred_effort.strip().lower()
+        if preferred_effort in reasoning.get("efforts", []):
+            effort = preferred_effort
+        elif preferred_effort:
+            warnings.append("unsupported_reasoning_effort_preference")
+
+    if requested_reasoning_enabled is False and reasoning_supported:
+        if reasoning_mode == "always":
+            warnings.append("reasoning_disable_unsupported")
+        elif reasoning_mode == "effort" and "none" in reasoning.get("efforts", []):
+            reasoning_enabled = False
+            effort = "none"
+        elif reasoning_mode == "toggle":
+            reasoning_enabled = False
+        else:
+            warnings.append("reasoning_disable_unsupported")
+    elif requested_reasoning_enabled is True and not reasoning_supported:
+        warnings.append("reasoning_enable_unsupported")
+
+    cache = profile["prompt_cache"]
+    cache_supported = cache.get("supported") is True
+    cache_enabled = cache_supported
+    requested_cache_enabled = cache_preference.get("enabled")
+    if requested_cache_enabled is False:
+        cache_enabled = False
+    elif requested_cache_enabled is True and not cache_supported:
+        warnings.append("prompt_cache_enable_unsupported")
+
+    return {
+        "reasoning": {
+            "supported": reasoning.get("supported"),
+            "enabled": reasoning_enabled,
+            "mode": reasoning_mode,
+            "request_style": reasoning.get("request_style") or "unknown",
+            "effort": effort,
+        },
+        "prompt_cache": {
+            "supported": cache.get("supported"),
+            "enabled": cache_enabled,
+            "mode": cache.get("mode") or "unknown",
+        },
+        "source": "user_preference" if preference_map else "nexent_default",
+        "warnings": warnings,
+    }
+
+
+def apply_reasoning_request_policy(
+    completion_kwargs: Mapping[str, Any],
+    effective_policy: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Apply one normalized reasoning policy to an OpenAI-compatible payload."""
+    request = dict(completion_kwargs)
+    extra_body = request.get("extra_body")
+    safe_extra_body = dict(extra_body) if isinstance(extra_body, Mapping) else {}
+
+    request.pop("reasoning_effort", None)
+    safe_extra_body.pop("enable_thinking", None)
+    safe_extra_body.pop("reasoning", None)
+    template_kwargs = safe_extra_body.get("chat_template_kwargs")
+    if isinstance(template_kwargs, Mapping) and "enable_thinking" in template_kwargs:
+        retained_template_kwargs = {
+            key: value for key, value in template_kwargs.items() if key != "enable_thinking"
+        }
+        if retained_template_kwargs:
+            safe_extra_body["chat_template_kwargs"] = retained_template_kwargs
+        else:
+            safe_extra_body.pop("chat_template_kwargs", None)
+
+    reasoning = effective_policy.get("reasoning")
+    reasoning = reasoning if isinstance(reasoning, Mapping) else {}
+    enabled = reasoning.get("enabled") is True
+    mode = str(reasoning.get("mode") or "unknown")
+    request_style = str(reasoning.get("request_style") or "unknown")
+    if request_style == "openai_reasoning_effort" and mode == "effort":
+        effort = reasoning.get("effort")
+        if isinstance(effort, str) and effort:
+            request["reasoning_effort"] = effort
+    elif request_style == "extra_body_enable_thinking" and mode == "toggle":
+        safe_extra_body["enable_thinking"] = enabled
+
+    if safe_extra_body:
+        request["extra_body"] = safe_extra_body
+    else:
+        request.pop("extra_body", None)
+    return request

--- a/sdk/nexent/core/models/model_identity.py
+++ b/sdk/nexent/core/models/model_identity.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import re
+from typing import List, Optional, Tuple
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+MATCHER_VERSION = "1.0.0"
+
+_TOKEN_PATTERN = re.compile(
+    r"\d+(?:\.\d+)?[a-z]+|[a-z]+\d+(?:\.\d+)?|[a-z]+|\d+(?:\.\d+)*"
+)
+_SIZE_PATTERN = re.compile(r"^\d+(?:\.\d+)?[bmk]$")
+_CONTEXT_EXTENSION_PATTERN = re.compile(r"^\d+(?:\.\d+)?(?:k|m)$")
+_DATE_PATTERN = re.compile(r"^(?:20)?\d{4}(?:\d{2})?$")
+
+_FAMILY_PREFIXES = (
+    "deepseek",
+    "hunyuan",
+    "mistral",
+    "moonshot",
+    "qwen",
+    "llama",
+    "gemma",
+    "kimi",
+    "glm",
+    "phi",
+    "yi",
+)
+_MODALITY_TOKENS = {"vl", "vision", "omni", "audio", "image", "video"}
+_TUNE_TOKENS = {"base", "chat", "instruct", "it", "coder", "captioner"}
+_REASONING_TOKENS = {"thinking", "reasoner", "reasoning", "r1"}
+_QUANTIZATION_TOKENS = {"awq", "gptq", "gguf", "fp8", "int4", "int8", "bnb"}
+
+
+def _tokens(value: str) -> Tuple[str, ...]:
+    parsed = _TOKEN_PATTERN.findall(value.strip().lower())
+    expanded: list[str] = []
+    for token in parsed:
+        split = next(
+            (
+                (prefix, token[len(prefix):])
+                for prefix in _FAMILY_PREFIXES
+                if token.startswith(prefix)
+                and token != prefix
+                and token[len(prefix):]
+                and token[len(prefix)].isdigit()
+            ),
+            None,
+        )
+        if split:
+            expanded.extend(split)
+        else:
+            expanded.append(token)
+    return tuple(expanded)
+
+
+def _first_matching(tokens: Tuple[str, ...], candidates: set[str]) -> Optional[str]:
+    return next((token for token in tokens if token in candidates), None)
+
+
+class CanonicalModelIdentity(BaseModel):
+    """Versioned, separator-aware identity used by independent profile matchers."""
+
+    model_config = ConfigDict(frozen=True)
+
+    raw_model_id: str
+    provider: Optional[str] = None
+    canonical_id: str
+    family: Optional[str] = None
+    version: Optional[str] = None
+    size: Optional[str] = None
+    modality: Optional[str] = None
+    tune: Optional[str] = None
+    reasoning: Optional[str] = None
+    distillation: Optional[str] = None
+    quantization: Optional[str] = None
+    date: Optional[str] = None
+    context_extension: Optional[str] = None
+    namespace: Tuple[str, ...] = ()
+    tokens: Tuple[str, ...] = ()
+    resolved: bool = False
+    ambiguous: bool = False
+    confidence: str = "low"
+    candidates: Tuple[str, ...] = ()
+    matcher_version: str = MATCHER_VERSION
+    evidence: List[str] = Field(default_factory=list)
+
+    @property
+    def variant_signature(self) -> Tuple[Optional[str], ...]:
+        return (
+            self.family,
+            self.version,
+            self.size,
+            self.modality,
+            self.tune,
+            self.reasoning,
+            self.distillation,
+            self.context_extension,
+        )
+
+
+def parse_model_identity(model_id: str, provider: Optional[str] = None) -> CanonicalModelIdentity:
+    """Parse a provider model ID without collapsing meaningful token boundaries."""
+    raw = model_id.strip()
+    if not raw:
+        raise ValueError("model_id is required")
+
+    normalized_provider = provider.strip().lower() if provider and provider.strip() else None
+    path_parts = [part for part in re.split(r"/+", raw) if part]
+    namespace = tuple(part.strip().lower() for part in path_parts[:-1])
+    leaf_tokens = _tokens(path_parts[-1])
+    all_tokens = tuple(token for part in path_parts for token in _tokens(part))
+
+    family = next(
+        (
+            prefix
+            for token in all_tokens
+            for prefix in _FAMILY_PREFIXES
+            if token == prefix or token.startswith(prefix)
+        ),
+        None,
+    )
+    version = None
+    if family:
+        family_index = next(
+            (index for index, token in enumerate(all_tokens) if token == family or token.startswith(family)),
+            -1,
+        )
+        family_token = all_tokens[family_index] if family_index >= 0 else ""
+        suffix = family_token[len(family):]
+        if suffix and suffix[0].isdigit():
+            version = suffix
+        elif family_index >= 0:
+            version = next(
+                (
+                    token[1:] if token.startswith("v") else token
+                    for token in all_tokens[family_index + 1:]
+                    if (
+                        token[0].isdigit()
+                        or (token.startswith("v") and token[1:].replace(".", "").isdigit())
+                    )
+                    and not _SIZE_PATTERN.match(token)
+                    and token not in _REASONING_TOKENS
+                ),
+                None,
+            )
+
+    size = next((token for token in all_tokens if _SIZE_PATTERN.match(token)), None)
+    context_extension = next(
+        (
+            token
+            for token in all_tokens
+            if _CONTEXT_EXTENSION_PATTERN.match(token) and token != size
+        ),
+        None,
+    )
+    modality = _first_matching(all_tokens, _MODALITY_TOKENS)
+    tune = _first_matching(all_tokens, _TUNE_TOKENS)
+    reasoning = _first_matching(all_tokens, _REASONING_TOKENS)
+    quantization = _first_matching(all_tokens, _QUANTIZATION_TOKENS)
+    date = next((token for token in reversed(all_tokens) if _DATE_PATTERN.match(token)), None)
+
+    distillation = None
+    if "distill" in all_tokens:
+        index = all_tokens.index("distill")
+        lineage = all_tokens[index + 1:]
+        distillation = "-".join(lineage) if lineage else "distill"
+
+    canonical_path = "/".join("-".join(_tokens(part)) for part in path_parts)
+    canonical_id = f"{normalized_provider}:{canonical_path}" if normalized_provider else canonical_path
+    evidence = ["separator_aware_tokens"]
+    for field_name, value in (
+        ("family", family),
+        ("version", version),
+        ("size", size),
+        ("modality", modality),
+        ("tune", tune),
+        ("reasoning", reasoning),
+        ("distillation", distillation),
+        ("quantization", quantization),
+        ("date", date),
+        ("context_extension", context_extension),
+    ):
+        if value:
+            evidence.append(f"{field_name}:{value}")
+
+    return CanonicalModelIdentity(
+        raw_model_id=raw,
+        provider=normalized_provider,
+        canonical_id=canonical_id,
+        family=family,
+        version=version,
+        size=size,
+        modality=modality,
+        tune=tune,
+        reasoning=reasoning,
+        distillation=distillation,
+        quantization=quantization,
+        date=date,
+        context_extension=context_extension,
+        namespace=namespace,
+        tokens=leaf_tokens,
+        resolved=family is not None,
+        confidence="high" if family and version else "medium" if family else "low",
+        evidence=evidence,
+    )
+
+
+def identities_are_safe_aliases(
+    requested: CanonicalModelIdentity,
+    candidate: CanonicalModelIdentity,
+) -> bool:
+    """Return true only when leaf tokens and every capacity-relevant variant agree."""
+    if requested.tokens != candidate.tokens:
+        return False
+    for field_name in (
+        "family",
+        "version",
+        "size",
+        "modality",
+        "tune",
+        "reasoning",
+        "distillation",
+        "context_extension",
+    ):
+        requested_value = getattr(requested, field_name)
+        candidate_value = getattr(candidate, field_name)
+        if requested_value and candidate_value and requested_value != candidate_value:
+            return False
+    return True

--- a/sdk/nexent/core/models/model_identity.py
+++ b/sdk/nexent/core/models/model_identity.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field
 MATCHER_VERSION = "1.0.0"
 
 _TOKEN_PATTERN = re.compile(
-    r"\d+(?:\.\d+)?[a-z]+|[a-z]+\d+(?:\.\d+)?|[a-z]+|\d+(?:\.\d+)*"
+    r"[a-z]+(?:\d+(?:\.\d+)?)?|\d+(?:\.\d+)*(?:[a-z]+)?"
 )
 _SIZE_PATTERN = re.compile(r"^\d+(?:\.\d+)?[bmk]$")
 _CONTEXT_EXTENSION_PATTERN = re.compile(r"^\d+(?:\.\d+)?(?:k|m)$")

--- a/sdk/nexent/core/models/prompt_cache.py
+++ b/sdk/nexent/core/models/prompt_cache.py
@@ -9,12 +9,12 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, Mapping, Optional, Tuple
 
-
 PROMPT_CACHE_CAPABILITY_VERSION = "w3.capabilities.v1"
 
 
-# Conservative allow-list.  Unknown providers must not receive cache-specific
-# request fields merely because they speak an OpenAI-compatible protocol.
+# Legacy constants are retained for import compatibility only. Runtime callers
+# must pass a resolved model-level profile; provider identity alone is not
+# evidence that every hosted model supports the same cache behavior.
 APPROVED_PROVIDER_PROMPT_CACHE_PROFILES: Dict[str, Dict[str, Any]] = {
     "openai": {
         "mode": "openai_automatic",
@@ -58,11 +58,9 @@ def resolve_prompt_cache_profile(
     provider: Optional[str],
     explicit_profile: Optional[Mapping[str, Any]] = None,
 ) -> Optional[Dict[str, Any]]:
-    """Return a normalized, explicitly approved provider cache profile."""
+    """Return a normalized, explicitly resolved model cache profile."""
     provider_name = (provider or "").lower()
     profile: Optional[Mapping[str, Any]] = explicit_profile
-    if profile is None:
-        profile = APPROVED_PROVIDER_PROMPT_CACHE_PROFILES.get(provider_name)
     if not profile:
         return None
 

--- a/sdk/nexent/core/models/tokenizer_registry.py
+++ b/sdk/nexent/core/models/tokenizer_registry.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import Dict, Optional, Protocol, Sequence, Tuple, runtime_checkable
+from typing import Dict, List, Literal, Optional, Protocol, Sequence, Tuple, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict, Field
 
 from .capacity_resolver import CountingMode
+from .model_identity import MATCHER_VERSION, identities_are_safe_aliases, parse_model_identity
 
 logger = logging.getLogger("tokenizer_registry")
 
@@ -54,6 +57,59 @@ FALLBACK: TokenizerAdapter = FallbackEstimator()
 REGISTRY: Dict[str, TokenizerAdapter] = {}
 
 
+class TokenizerConformanceFixture(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    fixture_id: str
+    messages: Tuple[dict, ...]
+    expected_tokens: int = Field(gt=0)
+
+
+class TokenizerConformanceReport(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    family: str
+    adapter_version: str
+    fixture_version: str
+    sample_count: int
+    mean_absolute_error_ratio: float
+    max_error_ratio: float
+    passed: bool
+
+
+class TokenizerProfile(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    profile_id: str
+    family: str
+    aliases: Tuple[str, ...]
+    exclusions: Tuple[str, ...] = ()
+    adapter_version: str
+    package_version: str
+    fixture_version: str
+    priority: int = 0
+    matcher_version: str = MATCHER_VERSION
+    verification_status: Literal["verified", "unverified"] = "unverified"
+
+
+class TokenizerMatchResult(BaseModel):
+    adapter: TokenizerAdapter = Field(exclude=True)
+    counting_mode: CountingMode
+    profile_id: Optional[str] = None
+    family: Optional[str] = None
+    confidence: Optional[Literal["high", "medium", "low"]] = None
+    source: Literal["profile", "fallback"]
+    matcher_version: str = MATCHER_VERSION
+    reason: str
+    candidates: Tuple[str, ...] = ()
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+
+PROFILES: Dict[str, TokenizerProfile] = {}
+CONFORMANCE: Dict[str, TokenizerConformanceReport] = {}
+
+
 def register(adapter: TokenizerAdapter) -> None:
     """Register a verified adapter. Called once at import time by adapter modules."""
     family = adapter.family
@@ -65,6 +121,131 @@ def register(adapter: TokenizerAdapter) -> None:
     if family in REGISTRY:
         raise ValueError(f"Tokenizer family {family!r} is already registered")
     REGISTRY[family] = adapter
+
+
+def register_profile(profile: TokenizerProfile) -> None:
+    if not is_valid_family_identifier(profile.family):
+        raise ValueError(f"Invalid tokenizer family {profile.family!r}")
+    if profile.profile_id in PROFILES:
+        raise ValueError(f"Tokenizer profile {profile.profile_id!r} is already registered")
+    if not profile.aliases:
+        raise ValueError("Tokenizer profile requires at least one alias")
+    PROFILES[profile.profile_id] = profile
+
+
+def run_conformance(
+    adapter: TokenizerAdapter,
+    fixtures: Sequence[TokenizerConformanceFixture],
+    *,
+    adapter_version: str,
+    fixture_version: str,
+    minimum_samples: int = 100,
+    maximum_mean_error_ratio: float = 0.005,
+    maximum_single_error_ratio: float = 0.02,
+) -> TokenizerConformanceReport:
+    errors: List[float] = []
+    for fixture in fixtures:
+        actual = adapter.count_tokens(fixture.messages)
+        errors.append(abs(actual - fixture.expected_tokens) / fixture.expected_tokens)
+    mean_error = sum(errors) / len(errors) if errors else 1.0
+    max_error = max(errors, default=1.0)
+    report = TokenizerConformanceReport(
+        family=adapter.family,
+        adapter_version=adapter_version,
+        fixture_version=fixture_version,
+        sample_count=len(fixtures),
+        mean_absolute_error_ratio=mean_error,
+        max_error_ratio=max_error,
+        passed=(
+            len(fixtures) >= minimum_samples
+            and mean_error <= maximum_mean_error_ratio
+            and max_error <= maximum_single_error_ratio
+        ),
+    )
+    CONFORMANCE[adapter.family] = report
+    return report
+
+
+def _profile_matches(profile: TokenizerProfile, provider: Optional[str], model_name: str) -> bool:
+    requested = parse_model_identity(model_name, provider)
+    if any(
+        identities_are_safe_aliases(requested, parse_model_identity(exclusion, provider))
+        for exclusion in profile.exclusions
+    ):
+        return False
+    return any(
+        identities_are_safe_aliases(requested, parse_model_identity(alias, provider))
+        for alias in profile.aliases
+    )
+
+
+def resolve_for_model(provider: Optional[str], model_name: str) -> TokenizerMatchResult:
+    """Resolve a verified profile independently from capacity matching."""
+    matches = [
+        profile
+        for profile in PROFILES.values()
+        if profile.matcher_version == MATCHER_VERSION
+        and _profile_matches(profile, provider, model_name)
+    ]
+    if not matches:
+        return TokenizerMatchResult(
+            adapter=FALLBACK,
+            counting_mode="estimated",
+            source="fallback",
+            reason="tokenizer_profile_not_found",
+        )
+
+    highest_priority = max(profile.priority for profile in matches)
+    winners = [profile for profile in matches if profile.priority == highest_priority]
+    if len(winners) != 1:
+        return TokenizerMatchResult(
+            adapter=FALLBACK,
+            counting_mode="estimated",
+            source="fallback",
+            reason="tokenizer_profile_ambiguous",
+            candidates=tuple(sorted(profile.profile_id for profile in winners)),
+        )
+
+    profile = winners[0]
+    adapter = REGISTRY.get(profile.family)
+    if adapter is None:
+        reason = "tokenizer_adapter_unavailable"
+    elif profile.verification_status != "verified":
+        reason = "tokenizer_profile_unverified"
+    else:
+        report = CONFORMANCE.get(profile.family)
+        reason = (
+            "tokenizer_conformance_missing"
+            if report is None
+            else "tokenizer_conformance_failed"
+            if not report.passed
+            else ""
+        )
+        if report and (
+            report.adapter_version != profile.adapter_version
+            or report.fixture_version != profile.fixture_version
+        ):
+            reason = "tokenizer_conformance_stale"
+
+    if reason:
+        return TokenizerMatchResult(
+            adapter=FALLBACK,
+            counting_mode="estimated",
+            profile_id=profile.profile_id,
+            family=profile.family,
+            confidence="low",
+            source="fallback",
+            reason=reason,
+        )
+    return TokenizerMatchResult(
+        adapter=adapter,
+        counting_mode="exact",
+        profile_id=profile.profile_id,
+        family=profile.family,
+        confidence="high",
+        source="profile",
+        reason="verified_profile_and_conformance",
+    )
 
 
 def resolve(family: Optional[str]) -> Tuple[TokenizerAdapter, CountingMode]:

--- a/test/backend/consts/test_model_feature_capabilities.py
+++ b/test/backend/consts/test_model_feature_capabilities.py
@@ -37,6 +37,9 @@ def test_p8_catalog_covers_representative_target_model_families():
         ) == expected
         assert resolved["catalog_revision"] == CATALOG_REVISION
         assert resolved["evidence"]
+        if resolved["reasoning"]["mode"] == "effort":
+            assert resolved["reasoning"]["default_effort"] == "medium"
+            assert "medium" in resolved["reasoning"]["efforts"]
 
 
 def test_p8_catalog_never_propagates_capabilities_across_factories():

--- a/test/backend/consts/test_model_feature_capabilities.py
+++ b/test/backend/consts/test_model_feature_capabilities.py
@@ -1,0 +1,44 @@
+from consts.model_feature_capabilities import (
+    CATALOG_REVISION,
+    EXACT_CATALOG,
+    FAMILY_RULES,
+)
+from nexent.core.models.feature_capability import resolve_feature_capabilities
+
+
+def _resolve(factory: str, model: str) -> dict:
+    return resolve_feature_capabilities(
+        factory,
+        model,
+        exact_catalog=EXACT_CATALOG,
+        family_rules=FAMILY_RULES,
+        catalog_revision=CATALOG_REVISION,
+    )
+
+
+def test_p8_catalog_covers_representative_target_model_families():
+    cases = {
+        ("openai", "gpt-5.2"): ("catalog_family", True, True),
+        ("dashscope", "qwen3.7-plus"): ("catalog_family", True, True),
+        ("deepseek", "deepseek-reasoner"): ("catalog_exact", True, True),
+        ("silicon", "Qwen/Qwen3-32B"): ("catalog_family", True, None),
+        ("silicon", "deepseek-ai/DeepSeek-R1"): ("catalog_family", True, None),
+        ("silicon", "moonshotai/Kimi-K2.5"): ("catalog_family", None, None),
+        ("silicon", "MiniMaxAI/MiniMax-M2.1"): ("catalog_family", None, None),
+        ("silicon", "zai-org/GLM-4.5"): ("catalog_family", None, None),
+    }
+
+    for (factory, model), expected in cases.items():
+        resolved = _resolve(factory, model)
+        assert (
+            resolved["source"],
+            resolved["reasoning"]["supported"],
+            resolved["prompt_cache"]["supported"],
+        ) == expected
+        assert resolved["catalog_revision"] == CATALOG_REVISION
+        assert resolved["evidence"]
+
+
+def test_p8_catalog_never_propagates_capabilities_across_factories():
+    assert _resolve("modelengine", "gpt-5.2")["source"] == "unknown"
+    assert _resolve("tokenpony", "zai-org/GLM-4.5")["source"] == "unknown"

--- a/test/backend/services/providers/test_dashscope_provider.py
+++ b/test/backend/services/providers/test_dashscope_provider.py
@@ -315,14 +315,17 @@ class TestDashScopeModelProvider:
             "output": {
                 "models": [
                     {
-                        "model": "qwen-plus",
+                        "model": "qwen3.7-max",
                         "description": "Advanced text generation",
                         "inference_metadata": {
                             "request_modality": ["Text"],
                             "response_modality": ["Text"],
-                            "context_length": 131072,
-                            "max_output_tokens": "8192",
                             "tokenizer_family": "qwen",
+                        },
+                        "model_info": {
+                            "context_window": 1000000,
+                            "max_input_tokens": 991808,
+                            "max_output_tokens": 131072,
                         },
                     }
                 ]
@@ -337,8 +340,9 @@ class TestDashScopeModelProvider:
             "api_key": "test-api-key",
         })
 
-        assert result[0]["context_window_tokens"] == 131072
-        assert result[0]["max_output_tokens"] == 8192
+        assert result[0]["context_window_tokens"] == 1000000
+        assert result[0]["max_input_tokens"] == 991808
+        assert result[0]["max_output_tokens"] == 131072
         assert result[0]["tokenizer_family"] == "qwen"
         assert result[0]["capacity_source"] == "provider_candidate"
 

--- a/test/backend/services/test_model_capacity_catalog_service.py
+++ b/test/backend/services/test_model_capacity_catalog_service.py
@@ -1,0 +1,48 @@
+import pytest
+
+from consts.capability_profiles import CATALOG_REVISION
+from services.model_capacity_catalog_service import (
+    catalog_status,
+    refresh_catalog_candidate,
+    stage_trusted_candidate,
+)
+
+
+def valid_document():
+    return {
+        "revision": "2099-01-01.1",
+        "profiles": {
+            "test/model@1": {
+                "provider": "test", "model_name": "model",
+                "context_window_tokens": 1000, "max_output_tokens": 100,
+                "verified_at": "2098-12-31T00:00:00Z", "evidence": ["signed-evidence-id"],
+            }
+        },
+    }
+
+
+def test_untrusted_candidate_is_rejected():
+    with pytest.raises(ValueError, match="catalog_source_untrusted"):
+        stage_trusted_candidate(valid_document(), source_identity="official", signature_verified=False)
+
+
+@pytest.mark.parametrize("mutation", ["missing_evidence", "invalid_capacity", "same_revision"])
+def test_invalid_candidate_is_not_staged(mutation):
+    doc = valid_document()
+    if mutation == "missing_evidence": doc["profiles"]["test/model@1"]["evidence"] = []
+    if mutation == "invalid_capacity": doc["profiles"]["test/model@1"]["max_output_tokens"] = 1000
+    if mutation == "same_revision": doc["revision"] = CATALOG_REVISION
+    with pytest.raises(ValueError):
+        stage_trusted_candidate(doc, source_identity="official", signature_verified=True)
+
+
+def test_refresh_stages_diff_without_changing_active_catalog():
+    before = catalog_status()["active_revision"]
+    candidate = refresh_catalog_candidate(
+        valid_document, source_identity="nexent-official",
+        verifier=lambda document: document["revision"] == "2099-01-01.1",
+    )
+    after = catalog_status()
+    assert candidate.added == ("test/model@1",)
+    assert after["candidate"]["revision"] == "2099-01-01.1"
+    assert after["active_revision"] == before == CATALOG_REVISION

--- a/test/backend/services/test_model_capacity_governance_service.py
+++ b/test/backend/services/test_model_capacity_governance_service.py
@@ -1,0 +1,365 @@
+import os
+import sys
+
+import pytest
+
+backend_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../backend"))
+if backend_dir not in sys.path:
+    sys.path.append(backend_dir)
+
+from consts.exceptions import ModelCapacityConfigError
+from services.model_capacity_governance_service import (
+    apply_catalog_adoption,
+    catalog_adoption_preview,
+    derive_legacy_metadata,
+    merge_capacity_governance,
+    normalize_legacy_capacity_ingress,
+)
+
+
+CATALOG_VALUES = {
+    "context_window_tokens": 128_000,
+    "max_output_tokens": 16_384,
+    "default_output_reserve_tokens": 4_096,
+    "tokenizer_family": "o200k_base",
+}
+
+
+def catalog_row():
+    result = merge_capacity_governance(
+        {"model_type": "llm", **CATALOG_VALUES},
+        explicit_fields={"model_type", *CATALOG_VALUES},
+        accepted_profile_version="openai/gpt-4o@2",
+        accepted_profile_fields=CATALOG_VALUES,
+        profile_evidence_id="openai-model-doc",
+        profile_verified_at="2026-08-01T00:00:00Z",
+    )
+    return {
+        **result.values,
+        "capacity_field_metadata": result.metadata,
+        "capacity_source": result.row_capacity_source,
+        "capability_profile_version": result.capability_profile_version,
+    }
+
+
+def test_ac_p1_001_catalog_create_tracks_each_field():
+    row = catalog_row()
+
+    assert row["capacity_source"] == "profile"
+    assert row["capability_profile_version"] == "openai/gpt-4o@2"
+    assert set(row["capacity_field_metadata"]["fields"]) == set(CATALOG_VALUES)
+    assert all(
+        item["source"] == "catalog"
+        for item in row["capacity_field_metadata"]["fields"].values()
+    )
+
+
+def test_ac_p1_001_only_changed_field_becomes_operator():
+    existing = catalog_row()
+    result = merge_capacity_governance(
+        {"max_output_tokens": 8_192, "context_window_tokens": 128_000},
+        explicit_fields={"max_output_tokens", "context_window_tokens"},
+        existing=existing,
+    )
+
+    assert result.metadata["fields"]["max_output_tokens"]["source"] == "operator"
+    assert result.metadata["fields"]["context_window_tokens"]["source"] == "catalog"
+    assert result.metadata["fields"]["tokenizer_family"]["source"] == "catalog"
+    assert result.row_capacity_source == "operator"
+    assert result.capability_profile_version == "openai/gpt-4o@2"
+    assert [item["field"] for item in result.audit_delta] == ["max_output_tokens"]
+
+
+def test_ac_p1_001_omitted_fields_and_equal_echo_preserve_metadata():
+    existing = catalog_row()
+    result = merge_capacity_governance(
+        {"context_window_tokens": 128_000, "base_url": "https://new.example/v1"},
+        explicit_fields={"context_window_tokens", "base_url"},
+        existing=existing,
+    )
+
+    assert result.metadata == existing["capacity_field_metadata"]
+    assert result.audit_delta == ()
+
+
+def test_ac_p5_003_provider_wins_catalog_but_not_operator():
+    existing = catalog_row()
+    existing["max_output_tokens"] = 8_192
+    existing["capacity_field_metadata"]["fields"]["max_output_tokens"] = {
+        "source": "operator"
+    }
+    result = merge_capacity_governance(
+        {
+            "context_window_tokens": 262_144,
+            "max_output_tokens": 65_536,
+        },
+        explicit_fields={"context_window_tokens", "max_output_tokens"},
+        existing=existing,
+        accepted_profile_version="silicon/qwen3.6-27b@2",
+        accepted_profile_fields={"context_window_tokens", "max_output_tokens"},
+        provider_fields={"context_window_tokens", "max_output_tokens"},
+    )
+
+    assert result.values["context_window_tokens"] == 262_144
+    assert result.metadata["fields"]["context_window_tokens"]["source"] == "provider"
+    assert result.values["max_output_tokens"] == 8_192
+    assert result.metadata["fields"]["max_output_tokens"]["source"] == "operator"
+    assert result.row_capacity_source == "operator"
+
+
+def test_ac_p5_003_provider_capacity_ignores_legacy_generation_default():
+    normalized, explicit, used_legacy = normalize_legacy_capacity_ingress(
+        {
+            "model_type": "llm",
+            "capacity_source": "provider_candidate",
+            "max_tokens": 4_096,
+            "max_output_tokens": 131_072,
+        },
+        explicit_fields={"max_tokens", "max_output_tokens"},
+    )
+
+    assert normalized["max_output_tokens"] == 131_072
+    assert "max_tokens" not in normalized
+    assert explicit == {"max_output_tokens"}
+    assert used_legacy is False
+
+
+def test_ac_p5_003_equal_provider_value_replaces_catalog_provenance():
+    existing = catalog_row()
+    result = merge_capacity_governance(
+        {"context_window_tokens": existing["context_window_tokens"]},
+        explicit_fields={"context_window_tokens"},
+        existing=existing,
+        provider_fields={"context_window_tokens"},
+    )
+
+    assert result.values["context_window_tokens"] == existing["context_window_tokens"]
+    assert result.metadata["fields"]["context_window_tokens"]["source"] == "provider"
+    assert result.audit_delta == (
+        {
+            "field": "context_window_tokens",
+            "previous_source": "catalog",
+            "new_source": "provider",
+            "value_changed": False,
+        },
+    )
+
+
+def test_ac_p1_002_explicit_clear_becomes_unknown_without_fabrication():
+    existing = catalog_row()
+    result = merge_capacity_governance(
+        {"max_input_tokens": None},
+        explicit_fields={"max_input_tokens"},
+        existing=existing,
+    )
+
+    assert result.values["max_input_tokens"] is None
+    assert "max_input_tokens" not in result.metadata["fields"]
+
+
+def test_ac_p1_010_lone_legacy_max_tokens_normalizes_once():
+    payload, explicit, used_legacy = normalize_legacy_capacity_ingress(
+        {"model_type": "llm", "max_tokens": 4096},
+        explicit_fields={"model_type", "max_tokens"},
+    )
+    result = merge_capacity_governance(
+        payload,
+        explicit_fields=explicit,
+        legacy_ingress_used=used_legacy,
+    )
+
+    assert payload["max_output_tokens"] == 4096
+    assert "max_tokens" not in payload
+    assert result.metadata["fields"]["max_output_tokens"]["source"] == "legacy"
+
+
+def test_ac_p1_010_conflicting_dual_legacy_values_rejected():
+    with pytest.raises(ModelCapacityConfigError) as exc_info:
+        normalize_legacy_capacity_ingress(
+            {"model_type": "llm", "max_tokens": 4096, "max_output_tokens": 8192},
+            explicit_fields={"model_type", "max_tokens", "max_output_tokens"},
+        )
+
+    assert exc_info.value.reason_code == "capacity_legacy_conflict"
+
+
+def test_ac_p1_010_embedding_max_tokens_is_not_capacity_alias():
+    payload, explicit, used_legacy = normalize_legacy_capacity_ingress(
+        {"model_type": "embedding", "max_tokens": 1024},
+        explicit_fields={"model_type", "max_tokens"},
+    )
+
+    assert payload["max_tokens"] == 1024
+    assert explicit == {"model_type", "max_tokens"}
+    assert not used_legacy
+
+
+def test_ac_p1_009_catalog_preview_is_side_effect_free_and_blocks_manual():
+    record = catalog_row()
+    overridden = merge_capacity_governance(
+        {"max_output_tokens": 8192},
+        explicit_fields={"max_output_tokens"},
+        existing=record,
+    )
+    record.update(overridden.values)
+    record["capacity_field_metadata"] = overridden.metadata
+    before = dict(record)
+
+    preview = catalog_adoption_preview(
+        record,
+        {"context_window_tokens": 256_000, "max_output_tokens": 32_768},
+        proposed_profile_version="openai/gpt-4o@3",
+    )
+
+    assert preview["fields"]["context_window_tokens"]["applicable"]
+    assert preview["fields"]["max_output_tokens"]["blocked_by_manual"]
+    assert not preview["fields"]["max_output_tokens"]["applicable"]
+    assert record == before
+
+
+def test_ac_p1_002_legacy_metadata_is_derived_without_mutation():
+    record = {
+        "context_window_tokens": 32_768,
+        "max_output_tokens": 4096,
+        "capacity_source": "operator",
+    }
+    before = dict(record)
+
+    metadata = derive_legacy_metadata(record)
+
+    assert metadata["fields"]["context_window_tokens"]["source"] == "operator"
+    assert record == before
+
+
+def test_ac_p1_009_default_adoption_updates_catalog_and_preserves_manual():
+    record = catalog_row()
+    overridden = merge_capacity_governance(
+        {"max_output_tokens": 8192},
+        explicit_fields={"max_output_tokens"},
+        existing=record,
+    )
+    record.update(overridden.values)
+    record["capacity_field_metadata"] = overridden.metadata
+
+    adopted = apply_catalog_adoption(
+        record,
+        {"context_window_tokens": 256_000, "max_output_tokens": 32_768},
+        proposed_profile_version="openai/gpt-4o@3",
+        expected_profile_version="openai/gpt-4o@3",
+        current_matcher_version="1.0.0",
+        expected_matcher_version="1.0.0",
+    )
+    assert adopted.values["context_window_tokens"] == 256_000
+    assert adopted.values["max_output_tokens"] == 8192
+    assert adopted.metadata["fields"]["context_window_tokens"]["source"] == "catalog"
+    assert adopted.metadata["fields"]["max_output_tokens"]["source"] == "operator"
+
+
+def test_ac_p1_009_manual_reset_requires_explicit_field_and_is_audited():
+    record = catalog_row()
+    overridden = merge_capacity_governance(
+        {"max_output_tokens": 8192},
+        explicit_fields={"max_output_tokens"},
+        existing=record,
+    )
+    record.update(overridden.values)
+    record["capacity_field_metadata"] = overridden.metadata
+    adopted = apply_catalog_adoption(
+        record,
+        {"max_output_tokens": 32_768},
+        proposed_profile_version="openai/gpt-4o@3",
+        expected_profile_version="openai/gpt-4o@3",
+        current_matcher_version="1.0.0",
+        fields={"max_output_tokens"},
+        reset_manual_fields={"max_output_tokens"},
+    )
+    assert adopted.values["max_output_tokens"] == 32_768
+    assert adopted.metadata["fields"]["max_output_tokens"]["source"] == "catalog"
+    assert adopted.audit_delta[0]["previous_source"] == "operator"
+
+
+def test_ac_p1_009_manual_reset_changes_provenance_when_value_is_identical():
+    record = catalog_row()
+    overridden = merge_capacity_governance(
+        {"max_output_tokens": 32_768},
+        explicit_fields={"max_output_tokens"},
+        existing=record,
+    )
+    record.update(overridden.values)
+    record["capacity_field_metadata"] = overridden.metadata
+
+    adopted = apply_catalog_adoption(
+        record,
+        {"max_output_tokens": 32_768},
+        proposed_profile_version="openai/gpt-4o@3",
+        expected_profile_version="openai/gpt-4o@3",
+        current_matcher_version="1.0.0",
+        fields={"max_output_tokens"},
+        reset_manual_fields={"max_output_tokens"},
+    )
+
+    assert adopted.values["max_output_tokens"] == 32_768
+    assert adopted.metadata["fields"]["max_output_tokens"]["source"] == "catalog"
+    assert adopted.audit_delta == (
+        {
+            "field": "max_output_tokens",
+            "previous_source": "operator",
+            "new_source": "catalog",
+            "value_changed": False,
+        },
+    )
+
+
+def test_ac_p3_002_reviewed_legacy_adoption_changes_same_value_provenance():
+    record = {
+        "model_type": "llm",
+        **CATALOG_VALUES,
+        "capacity_source": "legacy",
+    }
+    preview = catalog_adoption_preview(
+        record,
+        CATALOG_VALUES,
+        proposed_profile_version="openai/gpt-4o@2",
+    )
+
+    assert all(item["applicable"] for item in preview["fields"].values())
+    adopted = apply_catalog_adoption(
+        record,
+        CATALOG_VALUES,
+        proposed_profile_version="openai/gpt-4o@2",
+        expected_profile_version="openai/gpt-4o@2",
+        current_matcher_version="1.0.0",
+    )
+
+    assert adopted.row_capacity_source == "profile"
+    assert adopted.capability_profile_version == "openai/gpt-4o@2"
+    assert all(
+        item["source"] == "catalog"
+        for item in adopted.metadata["fields"].values()
+    )
+    assert {item["field"] for item in adopted.audit_delta} == set(CATALOG_VALUES)
+    assert all(not item["value_changed"] for item in adopted.audit_delta)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "reason"),
+    [
+        ({"expected_profile_version": "old"}, "capacity_profile_stale"),
+        ({"expected_matcher_version": "old"}, "capacity_matcher_stale"),
+    ],
+)
+def test_ac_p1_009_stale_adoption_is_rejected(kwargs, reason):
+    arguments = {
+        "proposed_profile_version": "openai/gpt-4o@3",
+        "expected_profile_version": "openai/gpt-4o@3",
+        "current_matcher_version": "1.0.0",
+        "expected_matcher_version": "1.0.0",
+    }
+    arguments.update(kwargs)
+    with pytest.raises(ModelCapacityConfigError) as exc_info:
+        apply_catalog_adoption(
+            catalog_row(),
+            {"context_window_tokens": 256_000},
+            **arguments,
+        )
+    assert exc_info.value.reason_code == reason

--- a/test/backend/services/test_model_capacity_health_service.py
+++ b/test/backend/services/test_model_capacity_health_service.py
@@ -1,0 +1,95 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from services.model_capacity_health_service import (
+    catalog_freshness,
+    classify_capacity_health,
+)
+
+
+NOW = datetime(2026, 8, 24, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize(
+    ("verified_at", "expected"),
+    [
+        ("2026-03-28T00:00:00Z", "current"),
+        ("2026-03-27T00:00:00Z", "review_due"),
+        ("2026-02-25T00:00:00Z", "expired"),
+        (None, "expired"),
+        ("bad", "expired"),
+    ],
+)
+def test_catalog_freshness_boundaries(verified_at, expected):
+    assert catalog_freshness(verified_at, now=NOW)[0] == expected
+
+
+def base_record(**updates):
+    record = {
+        "context_window_tokens": 1_000_000,
+        "max_output_tokens": 131_072,
+        "max_input_tokens": 991_808,
+        "tokenizer_family": "qwen",
+        "capacity_source": "profile",
+        "capability_profile_version": "dashscope/qwen3.7-plus@1",
+        "token_count_probe_metadata": {"status": "supported"},
+    }
+    record.update(updates)
+    return record
+
+
+def classify(record, verified_at="2026-08-24T00:00:00Z", auto=True):
+    return classify_capacity_health(
+        record,
+        match={"match_kind": "exact", "auto_applicable": auto},
+        profile_verified_at=verified_at,
+        now=NOW,
+    )
+
+
+def test_healthy_verified_model():
+    result = classify(base_record())
+    assert result["status"] == "healthy"
+    assert result["action"] == "none"
+
+
+def test_supported_provider_count_is_healthy_without_local_tokenizer():
+    result = classify(base_record(tokenizer_family=None))
+    assert result["status"] == "healthy"
+    assert result["reasons"] == ["capacity_verified"]
+
+
+def test_invalid_has_highest_precedence():
+    result = classify(base_record(max_output_tokens=1_000_000), verified_at="2020-01-01T00:00:00Z")
+    assert result["status"] == "invalid"
+    assert result["reasons"] == ["output_not_below_context"]
+
+
+def test_unconfigured_offers_review_only_for_verified_match():
+    result = classify(base_record(context_window_tokens=None))
+    assert result["status"] == "unconfigured"
+    assert result["action"] == "review_profile"
+    assert classify(base_record(context_window_tokens=None), auto=False)["action"] == "edit"
+
+
+def test_expired_precedes_degraded_probe():
+    result = classify(
+        base_record(token_count_probe_metadata={"status": "failed"}),
+        verified_at="2026-02-25T00:00:00Z",
+    )
+    assert result["status"] == "expired"
+
+
+def test_probe_and_estimated_states_are_actionable():
+    degraded = classify(base_record(token_count_probe_metadata={"status": "temporary_failure"}))
+    estimated = classify(base_record(capacity_source="legacy"))
+    assert (degraded["status"], degraded["action"]) == ("probe_degraded", "retry_probe")
+    assert (estimated["status"], estimated["action"]) == ("estimated", "review_profile")
+
+
+def test_review_due_is_non_destructive_health_state():
+    result = classify(base_record(), verified_at="2026-03-27T00:00:00Z")
+    assert result["status"] == "review_due"
+    assert result["action"] == "review_profile"
+    assert result["profile_version"] == base_record()["capability_profile_version"]

--- a/test/backend/services/test_model_capacity_suggestion_service.py
+++ b/test/backend/services/test_model_capacity_suggestion_service.py
@@ -29,6 +29,9 @@ class Profile:
         max_input_tokens=None,
         default_output_reserve_tokens=4096,
         tokenizer_family="test-tokenizer",
+        aliases=(),
+        exclusions=(),
+        auto_applicable=False,
     ):
         self.context_window_tokens = context_window_tokens
         self.max_input_tokens = max_input_tokens
@@ -36,6 +39,9 @@ class Profile:
         self.default_output_reserve_tokens = default_output_reserve_tokens
         self.tokenizer_family = tokenizer_family
         self.capability_profile_version = capability_profile_version
+        self.aliases = aliases
+        self.exclusions = exclusions
+        self.auto_applicable = auto_applicable
 
 
 CATALOG = {
@@ -82,6 +88,47 @@ def test_suggest_capacity_catalog_exact_case_insensitive():
 
     assert result.match_kind == CapacitySuggestionMatchKind.CATALOG_EXACT
     assert result.canonical_model_name == "gpt-4o"
+
+
+def test_explicit_alias_matches_before_structural_fallback():
+    catalog = {
+        ("dashscope", "qwen-plus"): Profile(
+            131_072,
+            16_384,
+            "dashscope/qwen-plus@2",
+            aliases=("qwen-plus-latest",),
+            exclusions=("qwen-plus-vl",),
+            auto_applicable=True,
+        )
+    }
+    result = suggest_capacity(
+        model_name="qwen-plus-latest",
+        provider_hint="dashscope",
+        model_type="llm",
+        catalog=catalog,
+    )
+    assert result.match_kind == CapacitySuggestionMatchKind.CATALOG_EXACT
+    assert result.capacity_source_on_accept == "profile"
+
+
+def test_explicit_exclusion_overrides_alias():
+    catalog = {
+        ("dashscope", "qwen-plus"): Profile(
+            131_072,
+            16_384,
+            "dashscope/qwen-plus@2",
+            aliases=("qwen-plus-vl",),
+            exclusions=("qwen-plus-vl",),
+            auto_applicable=True,
+        )
+    }
+    result = suggest_capacity(
+        model_name="qwen-plus-vl",
+        provider_hint="dashscope",
+        model_type="llm",
+        catalog=catalog,
+    )
+    assert result.match_kind == CapacitySuggestionMatchKind.NONE
 
 
 def test_suggest_capacity_catalog_fuzzy_normalized_name():
@@ -306,22 +353,22 @@ def test_suggest_capacity_no_op_when_instruments_disabled():
 
 
 @pytest.mark.parametrize("raw, expected", [
-    ("gpt-4o", "gpt4o"),
-    ("GPT-4o", "gpt4o"),
-    ("glm-5.1", "glm51"),
-    ("glm5.1", "glm51"),
-    ("Deepseek V4 Flash", "deepseekv4flash"),
-    ("deepseek-ai/DeepSeek-V4-Flash", "deepseekaideepseekv4flash"),
-    ("Kimi-K2.6", "kimik26"),
-    ("Pro/moonshotai/Kimi-K2.6", "promoonshotaikimik26"),
-    ("qwen-plus", "qwenplus"),
-    ("  gpt-4o  ", "gpt4o"),
-    ("model_name.v2", "modelnamev2"),
-    ("a-b_c.d/e f", "abcdef"),
+    ("gpt-4o", "gpt-4o"),
+    ("GPT-4o", "gpt-4o"),
+    ("glm-5.1", "glm-5.1"),
+    ("glm5.1", "glm-5.1"),
+    ("Deepseek V4 Flash", "deepseek-v4-flash"),
+    ("deepseek-ai/DeepSeek-V4-Flash", "deepseek-ai/deepseek-v4-flash"),
+    ("Kimi-K2.6", "kimi-k2.6"),
+    ("Pro/moonshotai/Kimi-K2.6", "pro/moonshotai/kimi-k2.6"),
+    ("qwen-plus", "qwen-plus"),
+    ("  gpt-4o  ", "gpt-4o"),
+    ("model_name.v2", "model-name-v2"),
+    ("a-b_c.d/e f", "a-b-c-d/e-f"),
     ("", ""),
     ("   ", ""),
 ])
-def test_normalize_model_name_strips_lowercases_and_collapses_separators(raw, expected):
+def test_normalize_model_name_preserves_boundaries_and_lowercases(raw, expected):
     assert normalize_model_name(raw) == expected
 
 
@@ -498,6 +545,10 @@ def test_model_capacity_suggestion_response_catalog_exact_shape(_pydantic_models
         "canonical_model_name",
         "capability_profile_version",
         "capacity_source_on_accept",
+        "canonical_identity",
+        "capacity_match",
+        "tokenizer_match",
+        "governance_metadata_proposal",
     }
     assert dumped["match_kind"] == "catalog_exact"
     assert dumped["match_confidence"] == "high"

--- a/test/backend/services/test_model_capacity_validation_service.py
+++ b/test/backend/services/test_model_capacity_validation_service.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import pytest
+
+from consts.exceptions import ModelCapacityConfigError
+from services.model_capacity_validation_service import (
+    audit_capacity_records,
+    validate_capacity_contract,
+)
+
+
+def _llm(**overrides):
+    row = {
+        "model_id": 1,
+        "model_name": "test-model",
+        "model_type": "llm",
+        "context_window_tokens": 32_768,
+        "max_input_tokens": None,
+        "max_output_tokens": 4_096,
+        "default_output_reserve_tokens": 1_024,
+        "capacity_source": "operator",
+    }
+    row.update(overrides)
+    return row
+
+
+@pytest.mark.parametrize(
+    ("overrides", "reason"),
+    [
+        ({"context_window_tokens": 0}, "non_positive_or_non_integer"),
+        ({"max_output_tokens": 32_768}, "max_output_not_below_context"),
+        ({"max_input_tokens": 40_000}, "max_input_exceeds_context"),
+        (
+            {"default_output_reserve_tokens": 8_192},
+            "default_output_exceeds_max_output",
+        ),
+    ],
+)
+def test_ac_004_invalid_contracts_return_stable_reasons(overrides, reason):
+    with pytest.raises(ModelCapacityConfigError) as exc_info:
+        validate_capacity_contract(_llm(**overrides))
+
+    assert exc_info.value.reason_code == f"capacity_config_invalid.{reason}"
+
+
+def test_ac_004_partial_update_validates_merged_effective_row():
+    with pytest.raises(ModelCapacityConfigError) as exc_info:
+        validate_capacity_contract(
+            {"max_output_tokens": 40_000}, existing=_llm()
+        )
+
+    assert exc_info.value.reason_code.endswith("max_output_not_below_context")
+
+
+def test_ac_005_unknown_capacity_is_preserved_as_valid_migration_state():
+    contract = validate_capacity_contract(
+        _llm(
+            context_window_tokens=None,
+            max_input_tokens=None,
+            max_output_tokens=None,
+            default_output_reserve_tokens=None,
+            capacity_source=None,
+        )
+    )
+
+    assert contract["context_window_tokens"] is None
+    assert contract["capacity_source"] is None
+
+
+def test_ac_008_audit_is_sanitized_and_does_not_mutate_rows():
+    records = [
+        _llm(),
+        _llm(model_id=2, context_window_tokens=None, max_output_tokens=None),
+        _llm(model_id=3, default_output_reserve_tokens=None),
+        _llm(model_id=4, max_output_tokens=32_768),
+    ]
+    original = [dict(row) for row in records]
+
+    report = audit_capacity_records(records)
+
+    assert records == original
+    assert report["counts"] == {
+        "suspicious": 2,
+        "unknown": 1,
+        "invalid": 1,
+    }
+    assert all("api_key" not in row for row in report["rows"])
+    assert report["rows"][2]["reasons"] == ["operator_shaped_ui_default"]

--- a/test/backend/services/test_model_profile_match_service.py
+++ b/test/backend/services/test_model_profile_match_service.py
@@ -1,0 +1,49 @@
+from backend.services.model_profile_match_service import (
+    resolve_model_profiles,
+    serialize_profile_match,
+)
+from nexent.core.models.model_identity import MATCHER_VERSION
+from nexent.core.models import tokenizer_registry
+from nexent.core.models.tokenizer_registry import TokenizerProfile
+
+
+def test_capacity_match_does_not_imply_tokenizer_match(monkeypatch):
+    monkeypatch.setattr(tokenizer_registry, "PROFILES", {})
+    result = resolve_model_profiles(
+        model_name="qwen-plus",
+        provider="dashscope",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        model_type="llm",
+    )
+    assert result.capacity_match.selected_profile == "dashscope/qwen-plus@1"
+    assert result.tokenizer_match.selected_profile is None
+    assert result.tokenizer_counting_mode == "estimated"
+    assert result.canonical_model_id == "dashscope:qwen-plus"
+    assert result.identity_metadata["matcher_version"] == MATCHER_VERSION
+
+
+def test_unverified_tokenizer_profile_still_falls_back(monkeypatch):
+    monkeypatch.setattr(tokenizer_registry, "PROFILES", {})
+    tokenizer_registry.PROFILES["qwen-test@1"] = TokenizerProfile(
+        profile_id="qwen-test@1",
+        family="qwen",
+        aliases=("qwen-plus",),
+        adapter_version="1",
+        package_version="1",
+        fixture_version="1",
+        verification_status="unverified",
+    )
+    result = resolve_model_profiles(
+        model_name="qwen-plus",
+        provider="dashscope",
+        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        model_type="llm",
+    )
+    assert result.capacity_match.selected_profile is not None
+    assert result.tokenizer_match.selected_profile == "qwen-test@1"
+    assert result.tokenizer_match.reason in {
+        "tokenizer_adapter_unavailable",
+        "tokenizer_profile_unverified",
+    }
+    assert result.tokenizer_match.auto_applicable is False
+    assert serialize_profile_match(result.tokenizer_match)["schema_version"] == 1

--- a/test/backend/services/test_model_provider_service.py
+++ b/test/backend/services/test_model_provider_service.py
@@ -71,6 +71,20 @@ sys.modules["nexent.storage.storage_client_factory"].create_storage_client_from_
     mock_create_storage_client_from_config
 )
 
+feature_capability_mock = mock.MagicMock()
+feature_capability_mock.extract_provider_feature_candidate = mock.MagicMock(return_value=None)
+feature_capability_mock.resolve_feature_capabilities = mock.MagicMock(
+    side_effect=lambda provider, model, **kwargs: {
+        "schema_version": 1,
+        "reasoning": {"supported": None, "mode": "unknown", "request_style": "unknown", "efforts": []},
+        "prompt_cache": {"supported": None, "mode": "unknown", "metrics_available": None},
+        "source": "unknown",
+        "match_kind": "none",
+        "catalog_revision": kwargs.get("catalog_revision"),
+    }
+)
+sys.modules["nexent.core.models.feature_capability"] = feature_capability_mock
+
 # ============================================================================
 # CRITICAL: Mock database.client module BEFORE any import that might trigger it
 # The problem is that when database.client is imported, it immediately runs
@@ -132,11 +146,16 @@ for module_path in [
     "consts.model",
     "consts.const",
     "consts.exceptions",
+    "consts.model_feature_capabilities",
     "utils",
     "utils.model_name_utils",
     "services.model_health_service",
 ]:
     sys.modules.setdefault(module_path, mock.MagicMock())
+
+sys.modules["consts.model_feature_capabilities"].CATALOG_REVISION = "test"
+sys.modules["consts.model_feature_capabilities"].EXACT_CATALOG = {}
+sys.modules["consts.model_feature_capabilities"].FAMILY_RULES = ()
 
 
 # Provide real implementations for the utils.model_name_utils helpers used by
@@ -506,18 +525,8 @@ async def test_prepare_model_dict_excludes_w11_accept_signal_fields():
 
 
 @pytest.mark.asyncio
-async def test_prepare_model_dict_does_not_persist_provider_capacity_candidates():
-    """Provider capacity candidates remain UI hints until an operator saves them.
-
-    Per the W1/W2 plan, _extract_capacity_hints tags provider-discovered
-    capacity values with capacity_source="provider_candidate" so the
-    catalog UI can show them as suggestions. They must not auto-persist
-    on batch_create; only operator acceptance (capacity_source="operator")
-    can write to the row. The original assertion only checked the dumped
-    result, which is trivially controlled by the mock; the strengthened
-    assertion below pins ModelRequest's constructor kwargs so the
-    contract is enforced regardless of what model_dump returns.
-    """
+async def test_ac_p5_003_prepare_model_dict_persists_provider_capacity_candidates():
+    """Provider facts reach governance instead of being replaced by catalog."""
     with mock.patch(
         "backend.services.model_provider_service.split_repo_name",
         return_value=("openai", "gpt-4"),
@@ -550,33 +559,18 @@ async def test_prepare_model_dict_does_not_persist_provider_capacity_candidates(
             "capacity_source": "provider_candidate",
         }
 
-        result = await prepare_model_dict(
+        await prepare_model_dict(
             "openai",
             model,
             "https://api.openai.com/v1",
             "test-key",
         )
 
-        # Result-level: the dumped dict (controlled by the mock) doesn't
-        # carry capacity hints downstream.
-        assert "context_window_tokens" not in result
-        assert "max_output_tokens" not in result
-        assert "tokenizer_family" not in result
-        assert "capacity_source" not in result
-
-        # Contract-level: prepare_model_dict must NOT thread provider
-        # candidates into ModelRequest. Without this assertion the bug
-        # we just fixed -- threading every W2 field through unconditionally
-        # -- would slip past the result-level check because the mock
-        # absorbs any kwargs silently.
         _, kwargs = mock_model_request.call_args
-        assert "context_window_tokens" not in kwargs
-        assert "max_output_tokens" not in kwargs
-        assert "max_input_tokens" not in kwargs
-        assert "default_output_reserve_tokens" not in kwargs
-        assert "tokenizer_family" not in kwargs
-        assert "capacity_source" not in kwargs
-        assert "capability_profile_version" not in kwargs
+        assert kwargs["context_window_tokens"] == 128000
+        assert kwargs["max_output_tokens"] == 16384
+        assert kwargs["tokenizer_family"] == "o200k_base"
+        assert kwargs["capacity_source"] == "provider_candidate"
 
 
 @pytest.mark.asyncio
@@ -1653,7 +1647,8 @@ async def test_get_provider_models_silicon_internal_exception_handling():
 
         # Test normal case
         result = await get_provider_models(model_data)
-        assert result == [{"id": "test-model"}]
+        assert result[0]["id"] == "test-model"
+        assert result[0]["feature_capability_metadata"]["source"] == "unknown"
 
         # Test case where provider handles exception internally
         model_data_exception = model_data.copy()
@@ -1718,7 +1713,8 @@ async def test_get_provider_models_silicon_with_different_model_types():
 
             result = await get_provider_models(model_data)
 
-            assert result == [{"id": "test-model"}]
+            assert result[0]["id"] == "test-model"
+            assert result[0]["feature_capability_metadata"]["source"] == "unknown"
             mock_provider_instance.get_models.assert_called_once_with(
                 model_data)
 

--- a/test/backend/services/test_model_token_count_probe_service.py
+++ b/test/backend/services/test_model_token_count_probe_service.py
@@ -1,0 +1,257 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from backend.services.model_token_count_probe_service import (
+    PROBE_ADAPTER_VERSION,
+    ProbeHTTPResponse,
+    classify_probe_response,
+    endpoint_fingerprint,
+    run_token_count_probe,
+    validate_probe_url,
+)
+
+
+NOW = datetime(2026, 8, 24, tzinfo=timezone.utc)
+PUBLIC = lambda _host: ("8.8.8.8",)
+
+
+@pytest.mark.parametrize(
+    ("response", "state", "reason"),
+    [
+        (ProbeHTTPResponse(200, {"input_tokens": 7}), "supported", "supported"),
+        (ProbeHTTPResponse(404), "unsupported", "unsupported_endpoint"),
+        (ProbeHTTPResponse(405), "unsupported", "unsupported_endpoint"),
+        (ProbeHTTPResponse(401), "authorization_error", "authorization_failed"),
+        (ProbeHTTPResponse(403), "authorization_error", "authorization_failed"),
+        (ProbeHTTPResponse(429), "temporarily_unavailable", "rate_limited"),
+        (ProbeHTTPResponse(503), "temporarily_unavailable", "provider_5xx"),
+        (ProbeHTTPResponse(302, redirect_location="https://evil.test"), "temporarily_unavailable", "redirect_rejected"),
+        (ProbeHTTPResponse(200, {}), "invalid_response", "invalid_schema"),
+        (ProbeHTTPResponse(200, {"input_tokens": 0}), "invalid_response", "invalid_count"),
+        (ProbeHTTPResponse(200, {"input_tokens": 100_000_001}), "invalid_response", "invalid_count"),
+    ],
+)
+def test_probe_status_classification(response, state, reason):
+    actual_state, actual_reason, _ = classify_probe_response("openai_responses", response)
+    assert (actual_state, actual_reason) == (state, reason)
+
+
+@pytest.mark.asyncio
+async def test_known_protocol_probes_only_directed_dialect():
+    calls = []
+
+    async def transport(request):
+        calls.append(request)
+        return ProbeHTTPResponse(200, {"input_tokens": 9})
+
+    result = await run_token_count_probe(
+        inference_protocol="openai",
+        base_url="https://api.example.test/v1",
+        model_name="qwen3.7-plus",
+        canonical_model_id="dashscope/qwen3.7-plus",
+        api_key="secret-marker",
+        credential_scope="tenant:model:1",
+        fingerprint_salt="test-salt",
+        resolver=PUBLIC,
+        transport=transport,
+        now=NOW,
+    )
+    assert [item.protocol for item in calls] == ["openai_responses"]
+    assert result["status"] == "supported"
+    assert result["selected_protocol"] == "openai_responses"
+    assert result["capabilities"] == {
+        "text": "supported", "tools": "unknown", "media": "unknown"
+    }
+    assert "secret-marker" not in repr(result)
+
+
+@pytest.mark.asyncio
+async def test_probe_logs_never_contain_credentials_or_raw_payload(caplog):
+    async def transport(_request):
+        return ProbeHTTPResponse(401, {"error": "secret-marker-response"})
+
+    with caplog.at_level("INFO"):
+        result = await run_token_count_probe(
+            inference_protocol="openai",
+            base_url="https://api.example.test/v1",
+            model_name="model",
+            canonical_model_id="openai/model",
+            api_key="secret-marker-key",
+            credential_scope="scope",
+            fingerprint_salt="salt",
+            resolver=PUBLIC,
+            transport=transport,
+            now=NOW,
+        )
+    assert result["reason"] == "authorization_failed"
+    assert "secret-marker" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_unknown_protocol_tries_dialects_in_order_and_retains_outcomes():
+    calls = []
+
+    async def transport(request):
+        calls.append(request.protocol)
+        if request.protocol == "openai_responses":
+            return ProbeHTTPResponse(404)
+        if request.protocol == "anthropic_messages":
+            return ProbeHTTPResponse(200, {"input_tokens": 11})
+        raise AssertionError("must stop after the first supported dialect")
+
+    result = await run_token_count_probe(
+        inference_protocol="unknown",
+        base_url="https://api.example.test/v1",
+        model_name="model",
+        canonical_model_id="unknown/model",
+        api_key="secret-marker",
+        credential_scope="tenant:model:2",
+        fingerprint_salt="test-salt",
+        resolver=PUBLIC,
+        transport=transport,
+        now=NOW,
+    )
+    assert calls == ["openai_responses", "anthropic_messages"]
+    assert [item["state"] for item in result["outcomes"]] == ["unsupported", "supported"]
+
+
+@pytest.mark.asyncio
+async def test_all_unknown_dialects_unsupported_gets_negative_ttl():
+    async def transport(_request):
+        return ProbeHTTPResponse(405)
+
+    result = await run_token_count_probe(
+        inference_protocol="unknown",
+        base_url="https://api.example.test/v1",
+        model_name="model",
+        canonical_model_id="unknown/model",
+        api_key="key",
+        credential_scope="scope",
+        fingerprint_salt="salt",
+        resolver=PUBLIC,
+        transport=transport,
+        now=NOW,
+    )
+    assert len(result["outcomes"]) == 3
+    assert result["status"] == "unsupported"
+    assert result["stale_at"] == "2026-08-25T00:00:00Z"
+
+
+@pytest.mark.asyncio
+async def test_timeout_is_temporary_and_not_negative_capability():
+    async def transport(_request):
+        raise TimeoutError
+
+    result = await run_token_count_probe(
+        inference_protocol="openai",
+        base_url="https://api.example.test/v1",
+        model_name="model",
+        canonical_model_id="openai/model",
+        api_key="key",
+        credential_scope="scope",
+        fingerprint_salt="salt",
+        resolver=PUBLIC,
+        transport=transport,
+        now=NOW,
+    )
+    assert result["status"] == "temporarily_unavailable"
+    assert result["reason"] == "timeout"
+    assert result["retry_at"] == "2026-08-24T00:15:00Z"
+
+
+@pytest.mark.asyncio
+async def test_valid_cached_evidence_is_reused_without_transport_call():
+    calls = 0
+
+    async def transport(_request):
+        nonlocal calls
+        calls += 1
+        return ProbeHTTPResponse(500)
+
+    initial = await run_token_count_probe(
+        inference_protocol="openai",
+        base_url="https://api.example.test/v1",
+        model_name="model",
+        canonical_model_id="openai/model",
+        api_key="key",
+        credential_scope="scope",
+        fingerprint_salt="salt",
+        resolver=PUBLIC,
+        transport=lambda request: _supported(request),
+        now=NOW,
+    )
+    reused = await run_token_count_probe(
+        inference_protocol="openai",
+        base_url="https://api.example.test/v1",
+        model_name="model",
+        canonical_model_id="openai/model",
+        api_key="changed-secret-does-not-enter-fingerprint",
+        credential_scope="scope",
+        fingerprint_salt="salt",
+        existing=initial,
+        resolver=PUBLIC,
+        transport=transport,
+        now=NOW + timedelta(hours=1),
+    )
+    assert reused == initial
+    assert calls == 0
+
+
+async def _supported(_request):
+    return ProbeHTTPResponse(200, {"input_tokens": 5})
+
+
+@pytest.mark.asyncio
+async def test_model_or_endpoint_fingerprint_change_invalidates_cache():
+    calls = 0
+
+    async def transport(_request):
+        nonlocal calls
+        calls += 1
+        return ProbeHTTPResponse(200, {"input_tokens": 5})
+
+    existing = await run_token_count_probe(
+        inference_protocol="openai",
+        base_url="https://api.example.test/v1",
+        model_name="model",
+        canonical_model_id="openai/model",
+        api_key="key",
+        credential_scope="scope",
+        fingerprint_salt="salt",
+        resolver=PUBLIC,
+        transport=transport,
+        now=NOW,
+    )
+    calls = 0
+    changed = await run_token_count_probe(
+        inference_protocol="openai",
+        base_url="https://api.example.test/v2",
+        model_name="model2",
+        canonical_model_id="openai/model2",
+        api_key="key",
+        credential_scope="scope",
+        fingerprint_salt="salt",
+        existing=existing,
+        resolver=PUBLIC,
+        transport=transport,
+        now=NOW + timedelta(hours=1),
+    )
+    assert calls == 1
+    assert changed["fingerprint"] != existing["fingerprint"]
+
+
+def test_ssrf_and_credential_bearing_urls_are_rejected():
+    with pytest.raises(ValueError, match="ssrf_rejected"):
+        validate_probe_url("http://127.0.0.1/v1", resolver=lambda _host: ("127.0.0.1",))
+    with pytest.raises(ValueError, match="ssrf_rejected"):
+        validate_probe_url("https://user:pass@example.test/v1", resolver=PUBLIC)
+    with pytest.raises(ValueError, match="ssrf_rejected"):
+        validate_probe_url("https://example.test/v1?api_key=secret", resolver=PUBLIC)
+
+
+def test_endpoint_fingerprint_omits_userinfo_query_and_fragment():
+    fingerprint = endpoint_fingerprint("https://user:secret@example.test/v1?q=secret#fragment")
+    assert len(fingerprint) == 24
+    assert "secret" not in fingerprint
+    assert PROBE_ADAPTER_VERSION == "1.0.0"

--- a/test/backend/services/test_model_token_count_probe_service.py
+++ b/test/backend/services/test_model_token_count_probe_service.py
@@ -1,13 +1,19 @@
 from datetime import datetime, timedelta, timezone
+import socket
 
+import httpx
 import pytest
 
+from backend.services import model_token_count_probe_service as probe_service
 from backend.services.model_token_count_probe_service import (
     PROBE_ADAPTER_VERSION,
+    ProbeHTTPRequest,
     ProbeHTTPResponse,
+    build_probe_request,
     classify_probe_response,
     endpoint_fingerprint,
     run_token_count_probe,
+    should_reuse_probe,
     validate_probe_url,
 )
 
@@ -255,3 +261,185 @@ def test_endpoint_fingerprint_omits_userinfo_query_and_fragment():
     assert len(fingerprint) == 24
     assert "secret" not in fingerprint
     assert PROBE_ADAPTER_VERSION == "1.0.0"
+
+
+def test_time_parsing_and_cache_reuse_reject_invalid_evidence():
+    assert probe_service._parse_time(None) is None
+    assert probe_service._parse_time("not-a-time") is None
+    assert not should_reuse_probe(
+        {"fingerprint": "current", "status": "temporarily_unavailable"},
+        current_fingerprint="current",
+        now=NOW,
+        force=False,
+    )
+
+
+def test_default_resolver_collects_unique_addresses(monkeypatch):
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda _host, _port: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 0)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("8.8.8.8", 0)),
+        ],
+    )
+    assert probe_service._default_resolver("example.test") == {"8.8.8.8"}
+
+
+@pytest.mark.parametrize("url", ["ftp://example.test/v1", "https:///missing-host"])
+def test_probe_url_rejects_unsupported_or_missing_origin(url):
+    with pytest.raises(ValueError, match="ssrf_rejected"):
+        validate_probe_url(url, resolver=PUBLIC)
+
+
+def test_probe_url_reports_dns_failure_and_empty_dns_result():
+    def failed_resolver(_host):
+        raise socket.gaierror("dns unavailable")
+
+    with pytest.raises(ValueError, match="connection_failed"):
+        validate_probe_url("https://example.test/v1", resolver=failed_resolver)
+    with pytest.raises(ValueError, match="connection_failed"):
+        validate_probe_url("https://example.test/v1", resolver=lambda _host: ())
+
+
+def test_probe_url_normalizes_ipv6_and_explicit_port():
+    result = validate_probe_url(
+        "HTTPS://[2001:4860:4860::8888]:8443/v1/",
+        allow_private=True,
+        resolver=lambda _host: ("2001:4860:4860::8888",),
+    )
+    assert result == "https://[2001:4860:4860::8888]:8443/v1"
+
+
+def test_gemini_request_and_response_schema():
+    request = build_probe_request(
+        "gemini",
+        base_url="https://api.example.test/v1",
+        model_name="gemini-test",
+        api_key="secret",
+    )
+    assert request.url.endswith("/models/gemini-test:countTokens")
+    assert classify_probe_response(
+        "gemini", ProbeHTTPResponse(200, {"totalTokens": 12})
+    ) == ("supported", "supported", 12)
+    assert classify_probe_response("gemini", ProbeHTTPResponse(200, None)) == (
+        "invalid_response",
+        "invalid_schema",
+        None,
+    )
+    assert classify_probe_response("gemini", ProbeHTTPResponse(418)) == (
+        "temporarily_unavailable",
+        "connection_failed",
+        None,
+    )
+    with pytest.raises(ValueError, match="unsupported_protocol"):
+        build_probe_request(
+            "unknown",
+            base_url="https://api.example.test/v1",
+            model_name="model",
+            api_key="secret",
+        )
+
+
+class _FakeAsyncClient:
+    response = None
+    error = None
+
+    def __init__(self, **_kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+    async def post(self, *_args, **_kwargs):
+        if self.error:
+            raise self.error
+        return self.response
+
+
+def _request():
+    return ProbeHTTPRequest("openai_responses", "https://api.example.test", {}, {})
+
+
+@pytest.mark.asyncio
+async def test_http_transport_handles_redirect_oversize_and_invalid_json(monkeypatch):
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
+
+    redirect = httpx.Response(302, headers={"location": "https://other.test"})
+    _FakeAsyncClient.response = redirect
+    result = await probe_service._httpx_transport(_request())
+    assert result.redirect_location == "https://other.test"
+
+    oversized = httpx.Response(200, content=b"x" * (probe_service.MAX_RESPONSE_BYTES + 1))
+    _FakeAsyncClient.response = oversized
+    result = await probe_service._httpx_transport(_request())
+    assert result.payload is None
+
+    invalid_json = httpx.Response(200, content=b"not-json")
+    _FakeAsyncClient.response = invalid_json
+    result = await probe_service._httpx_transport(_request())
+    assert result.payload is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        (httpx.ReadTimeout("slow"), TimeoutError),
+        (httpx.ConnectError("offline"), ConnectionError),
+    ],
+)
+async def test_http_transport_maps_httpx_errors(monkeypatch, error, expected):
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeAsyncClient)
+    _FakeAsyncClient.error = error
+    try:
+        with pytest.raises(expected):
+            await probe_service._httpx_transport(_request())
+    finally:
+        _FakeAsyncClient.error = None
+
+
+@pytest.mark.asyncio
+async def test_probe_rejects_cross_origin_target_and_maps_connection_error(monkeypatch):
+    original_builder = probe_service.build_probe_request
+
+    def cross_origin(*_args, **_kwargs):
+        return ProbeHTTPRequest(
+            "openai_responses", "https://other.example.test/input_tokens", {}, {}
+        )
+
+    monkeypatch.setattr(probe_service, "build_probe_request", cross_origin)
+    rejected = await run_token_count_probe(
+        inference_protocol="openai",
+        base_url="https://api.example.test/v1",
+        model_name="model",
+        canonical_model_id="openai/model",
+        api_key="key",
+        credential_scope="scope",
+        fingerprint_salt="salt",
+        resolver=PUBLIC,
+        now=NOW,
+    )
+    assert rejected["reason"] == "redirect_rejected"
+
+    monkeypatch.setattr(probe_service, "build_probe_request", original_builder)
+
+    async def disconnected(_request):
+        raise ConnectionError
+
+    failed = await run_token_count_probe(
+        inference_protocol="openai",
+        base_url="https://api.example.test/v1",
+        model_name="model",
+        canonical_model_id="openai/model",
+        api_key="key",
+        credential_scope="scope",
+        fingerprint_salt="salt",
+        resolver=PUBLIC,
+        transport=disconnected,
+        now=NOW,
+    )
+    assert failed["reason"] == "connection_failed"

--- a/test/deploy/test_context_budget_p1_migration.py
+++ b/test/deploy/test_context_budget_p1_migration.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MIGRATION = ROOT / "deploy/sql/migrations/v2.6.0_0903_model_capacity_governance.sql"
+
+
+def test_capacity_governance_migration_is_nullable_idempotent_and_secret_free():
+    sql = MIGRATION.read_text(encoding="utf-8").lower()
+
+    for column in (
+        "canonical_model_id",
+        "capacity_field_metadata",
+        "model_identity_metadata",
+        "tokenizer_match_metadata",
+        "token_count_probe_metadata",
+    ):
+        assert f"add column if not exists {column}" in sql
+    assert "update nexent.model_record_t" not in sql
+    assert "api_key" not in sql
+    assert "begin;" in sql
+    assert "commit;" in sql

--- a/test/deploy/test_model_feature_capability_migration.py
+++ b/test/deploy/test_model_feature_capability_migration.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MIGRATION = ROOT / "deploy/sql/migrations/v2.6.0_0903_model_feature_capabilities.sql"
+
+
+def test_feature_capability_migration_is_nullable_idempotent_and_secret_free():
+    sql = MIGRATION.read_text(encoding="utf-8").lower()
+    assert "add column if not exists feature_capability_metadata jsonb default null" in sql
+    assert "update nexent.model_record_t" not in sql
+    assert "api_key" not in sql
+    assert "begin;" in sql
+    assert "commit;" in sql

--- a/test/sdk/core/models/test_capability_profile_governance.py
+++ b/test/sdk/core/models/test_capability_profile_governance.py
@@ -1,0 +1,82 @@
+import pytest
+
+from nexent.core.models.capacity_resolver import (
+    CapabilityProfile,
+    validate_capability_catalog,
+)
+
+
+def _profile(**overrides):
+    values = {
+        "provider": "dashscope",
+        "model_name": "qwen-plus",
+        "capability_profile_version": "dashscope/qwen-plus@2",
+        "window_shape": "combined",
+        "context_window_tokens": 131_072,
+        "max_output_tokens": 16_384,
+        "default_output_reserve_tokens": 4_096,
+        "tokenizer_family": "qwen",
+        "aliases": ("qwen-plus",),
+        "exclusions": ("qwen-vl",),
+        "evidence": ("aliyun-model-doc-2026-08",),
+        "verified_at": "2026-08-01T00:00:00Z",
+        "shared_context": True,
+        "independent_input": False,
+        "max_output": 16_384,
+        "reasoning_behavior": "unknown",
+        "overhead_behavior": "bounded",
+        "confidence": "high",
+    }
+    values.update(overrides)
+    return CapabilityProfile(**values)
+
+
+def test_complete_evidence_backed_profile_is_auto_applicable():
+    profile = _profile()
+    result = validate_capability_catalog({("dashscope", "qwen-plus"): profile})
+    assert profile.auto_applicable is True
+    assert result[("dashscope", "qwen-plus")] == ()
+
+
+def test_incomplete_legacy_profile_remains_suggestion_only():
+    profile = _profile(
+        aliases=(), evidence=(), verified_at=None, confidence="unknown"
+    )
+    result = validate_capability_catalog({("dashscope", "qwen-plus"): profile})
+    assert profile.auto_applicable is False
+    assert "evidence_missing" in result[("dashscope", "qwen-plus")]
+
+
+def test_incomplete_profile_cannot_claim_verified_high_confidence():
+    profile = _profile(evidence=())
+    with pytest.raises(ValueError, match="incomplete_verified_profile"):
+        validate_capability_catalog({("dashscope", "qwen-plus"): profile})
+
+
+def test_declared_max_output_must_match_capacity_value():
+    profile = _profile(max_output=8_192)
+    with pytest.raises(ValueError, match="max_output_conflict"):
+        validate_capability_catalog({("dashscope", "qwen-plus"): profile})
+
+
+def test_catalog_key_must_match_profile_identity():
+    with pytest.raises(ValueError, match="catalog_key_mismatch"):
+        validate_capability_catalog({("other", "qwen-plus"): _profile()})
+
+
+def test_production_catalog_verified_rows_are_complete_and_legacy_rows_are_suggestion_only():
+    from consts.capability_profiles import CATALOG
+
+    diagnostics = validate_capability_catalog(CATALOG)
+    qwen = CATALOG[("dashscope", "qwen-plus")]
+    assert qwen.auto_applicable is True
+    assert diagnostics[("dashscope", "qwen-plus")] == ()
+    qwen_37 = CATALOG[("dashscope", "qwen3.7-plus")]
+    assert qwen_37.auto_applicable is True
+
+    silicon_qwen = CATALOG[("silicon", "Qwen/Qwen3.6-27B")]
+    assert silicon_qwen.auto_applicable is True
+    assert silicon_qwen.capability_profile_version == "silicon/qwen3.6-27b@2"
+    assert qwen_37.max_input_tokens == 991_808
+    assert diagnostics[("dashscope", "qwen3.7-plus")] == ()
+    assert CATALOG[("openai", "gpt-4o")].auto_applicable is False

--- a/test/sdk/core/models/test_capacity_budget.py
+++ b/test/sdk/core/models/test_capacity_budget.py
@@ -61,8 +61,8 @@ def _fingerprint(**overrides) -> str:
         "model_name": "gpt-4o",
         "requested_output_tokens": 4096,
         "output_reserve_source": "model_default",
-        "uncertainty_reserve_tokens": 12800,
-        "uncertainty_reserve_basis": "context_window_10pct",
+        "uncertainty_reserve_tokens": 12391,
+        "uncertainty_reserve_basis": "provider_input_limit_10pct",
         "approved_profile_reserve_tokens": None,
         "soft_limit_ratio": 0.8,
         "soft_limit_ratio_source": "code_default",
@@ -78,7 +78,7 @@ def _fingerprint(**overrides) -> str:
 def test_capacity_reserve_policy_defaults_to_w2_soft_limit():
     policy = CapacityReservePolicy()
 
-    assert policy.soft_limit_ratio == 0.8
+    assert policy.soft_limit_ratio == 1.0
     assert policy.soft_limit_ratio_source == "code_default"
     assert policy.approved_profile_reserve_tokens is None
 
@@ -130,7 +130,7 @@ def _capacity_snapshot(**overrides) -> ModelCapacitySnapshot:
     return ModelCapacitySnapshot(**payload)
 
 
-def test_calculator_combined_window_uses_10_percent_uncertainty_reserve():
+def test_calculator_combined_window_uses_effective_limit_for_uncertainty_reserve():
     calculator = SafeInputBudgetCalculator()
 
     snap = calculator.calculate_safe_input_budget(
@@ -139,18 +139,18 @@ def test_calculator_combined_window_uses_10_percent_uncertainty_reserve():
     )
 
     assert snap.provider_input_limit_tokens == 128_000 - 4_096
-    assert snap.uncertainty_reserve_tokens == 12_800
-    assert snap.uncertainty_reserve_basis == "context_window_10pct"
-    assert snap.hard_input_budget_tokens == 111_104
-    assert snap.soft_input_budget_tokens == 88_883
+    assert snap.uncertainty_reserve_tokens == 0
+    assert snap.uncertainty_reserve_basis == "none"
+    assert snap.hard_input_budget_tokens == 123_904
+    assert snap.soft_input_budget_tokens == 123_904
     assert snap.requested_output_tokens == 4_096
     assert snap.output_reserve_source == "model_default"
     assert snap.w1_fingerprint == "w1fingerprint"
-    assert "uncertainty_reserve_active" in snap.warnings
+    assert snap.warnings == []
     assert len(snap.fingerprint) == 32
 
 
-def test_calculator_recomputes_provider_limit_for_request_override():
+def test_calculator_ignores_request_override():
     calculator = SafeInputBudgetCalculator()
 
     snap = calculator.calculate_safe_input_budget(
@@ -159,24 +159,23 @@ def test_calculator_recomputes_provider_limit_for_request_override():
         request_overrides=RequestBudgetOverrides(requested_output_tokens=8_192),
     )
 
-    assert snap.requested_output_tokens == 8_192
-    assert snap.output_reserve_source == "request"
-    assert snap.provider_input_limit_tokens == 128_000 - 8_192
-    assert snap.hard_input_budget_tokens == (128_000 - 8_192) - 12_800
+    assert snap.requested_output_tokens == 4_096
+    assert snap.output_reserve_source == "model_default"
+    assert snap.provider_input_limit_tokens == 128_000 - 4_096
+    assert snap.hard_input_budget_tokens == 128_000 - 4_096
 
 
-def test_calculator_rejects_request_override_that_lowers_reserve():
+def test_calculator_ignores_lower_request_override():
     calculator = SafeInputBudgetCalculator()
 
-    with pytest.raises(InvalidReservePolicy):
-        calculator.calculate_safe_input_budget(
-            capacity_snapshot=_capacity_snapshot(),
-            reserve_policy=CapacityReservePolicy(),
-            request_overrides=RequestBudgetOverrides(requested_output_tokens=2_048),
-        )
+    snap = calculator.calculate_safe_input_budget(
+        capacity_snapshot=_capacity_snapshot(), reserve_policy=CapacityReservePolicy(),
+        request_overrides=RequestBudgetOverrides(requested_output_tokens=2_048),
+    )
+    assert snap.requested_output_tokens == 4_096
 
 
-def test_calculator_allows_agent_override_source():
+def test_calculator_ignores_agent_override_source():
     calculator = SafeInputBudgetCalculator()
 
     snap = calculator.calculate_safe_input_budget(
@@ -186,8 +185,8 @@ def test_calculator_allows_agent_override_source():
         output_reserve_source="agent",
     )
 
-    assert snap.requested_output_tokens == 2_048
-    assert snap.output_reserve_source == "agent"
+    assert snap.requested_output_tokens == 4_096
+    assert snap.output_reserve_source == "model_default"
 
 
 def test_calculator_uses_approved_profile_reserve_for_separate_input_limit():
@@ -204,50 +203,58 @@ def test_calculator_uses_approved_profile_reserve_for_separate_input_limit():
     )
 
     assert snap.provider_input_limit_tokens == 32_768
-    assert snap.uncertainty_reserve_tokens == 512
-    assert snap.uncertainty_reserve_basis == "approved_profile"
-    assert snap.hard_input_budget_tokens == 32_256
+    assert snap.uncertainty_reserve_tokens == 0
+    assert snap.uncertainty_reserve_basis == "none"
+    assert snap.hard_input_budget_tokens == 32_768
 
 
-def test_calculator_requires_context_window_for_10_percent_reserve():
+def test_calculator_uses_independent_input_limit_for_10_percent_reserve():
     calculator = SafeInputBudgetCalculator()
 
-    with pytest.raises(UncertaintyReserveBasisUnknown):
-        calculator.calculate_safe_input_budget(
-            capacity_snapshot=_capacity_snapshot(
-                context_window_tokens=None,
-                max_input_tokens=32_768,
-                provider_input_limit_tokens=32_768,
-                unknown_capabilities=["tokenizer"],
-            ),
-            reserve_policy=CapacityReservePolicy(),
-        )
+    snap = calculator.calculate_safe_input_budget(
+        capacity_snapshot=_capacity_snapshot(
+            context_window_tokens=None,
+            max_input_tokens=32_768,
+            provider_input_limit_tokens=32_768,
+            unknown_capabilities=["tokenizer"],
+        ),
+        reserve_policy=CapacityReservePolicy(),
+    )
+
+    assert snap.uncertainty_reserve_tokens == 0
+    assert snap.hard_input_budget_tokens == 32_768
 
 
-def test_calculator_rejects_requested_output_above_capacity():
+def test_calculator_ignores_requested_output_above_capacity():
     calculator = SafeInputBudgetCalculator()
 
-    with pytest.raises(RequestedOutputExceedsCapacity):
-        calculator.calculate_safe_input_budget(
-            capacity_snapshot=_capacity_snapshot(max_output_tokens=8_000),
-            reserve_policy=CapacityReservePolicy(),
-            request_overrides=RequestBudgetOverrides(requested_output_tokens=8_192),
-        )
+    snap = calculator.calculate_safe_input_budget(
+        capacity_snapshot=_capacity_snapshot(max_output_tokens=8_000),
+        reserve_policy=CapacityReservePolicy(),
+        request_overrides=RequestBudgetOverrides(requested_output_tokens=8_192),
+    )
+    assert snap.requested_output_tokens == 4_096
 
 
-def test_calculator_rejects_reserve_larger_than_provider_limit():
+def test_ac_001_small_independent_limit_uses_compatible_reserve():
     calculator = SafeInputBudgetCalculator()
 
-    with pytest.raises(ReserveExceedsCapacity):
-        calculator.calculate_safe_input_budget(
-            capacity_snapshot=_capacity_snapshot(
-                context_window_tokens=10_000,
-                max_input_tokens=100,
-                provider_input_limit_tokens=100,
-                unknown_capabilities=["tokenizer"],
-            ),
-            reserve_policy=CapacityReservePolicy(),
-        )
+    snap = calculator.calculate_safe_input_budget(
+        capacity_snapshot=_capacity_snapshot(
+            context_window_tokens=262_144,
+            max_input_tokens=16_384,
+            max_output_tokens=65_536,
+            requested_output_tokens=8_192,
+            provider_input_limit_tokens=16_384,
+            unknown_capabilities=["tokenizer"],
+        ),
+        reserve_policy=CapacityReservePolicy(),
+    )
+
+    assert snap.provider_input_limit_tokens == 16_384
+    assert snap.uncertainty_reserve_tokens == 0
+    assert snap.uncertainty_reserve_basis == "none"
+    assert snap.hard_input_budget_tokens == 16_384
 
 
 def test_calculator_rejects_no_safe_input_capacity_after_output_reserve():

--- a/test/sdk/core/models/test_capacity_resolver.py
+++ b/test/sdk/core/models/test_capacity_resolver.py
@@ -102,8 +102,8 @@ def test_known_profile_no_overrides_builds_snapshot():
     assert snap.context_window_tokens == 128_000
     assert snap.max_output_tokens == 16_384
     assert snap.default_output_reserve_tokens == 4_096
-    assert snap.requested_output_tokens == 4_096  # defaulted from reserve
-    assert snap.provider_input_limit_tokens == 128_000 - 4_096
+    assert snap.requested_output_tokens == 12_800
+    assert snap.provider_input_limit_tokens == 128_000 - 12_800
     assert snap.tokenizer_family == "o200k_base"
     assert snap.counting_mode == "estimated"  # no adapter registered yet
     assert snap.capability_profile_version == "openai/gpt-4o@1"
@@ -147,8 +147,8 @@ def test_uncataloged_model_with_operator_overrides_resolves():
     )
 
     assert snap.context_window_tokens == 32_000
-    assert snap.requested_output_tokens == 1_000
-    assert snap.provider_input_limit_tokens == 32_000 - 1_000
+    assert snap.requested_output_tokens == 4_000
+    assert snap.provider_input_limit_tokens == 32_000 - 4_000
     assert snap.field_sources["context_window_tokens"] == "operator"
     assert snap.capability_profile_version is None
     assert "capability_profile_missing" in snap.unknown_capabilities
@@ -177,25 +177,23 @@ def test_max_output_exceeding_context_window_is_rejected():
         )
 
 
-def test_requested_output_exceeding_max_output_is_rejected():
+def test_legacy_requested_output_override_is_ignored():
     catalog = _catalog(_gpt4o_profile())
-    with pytest.raises(RequestedOutputExceedsCap):
-        resolve_capacity(
-            model_id="gpt-4o",
-            provider="openai",
-            requested_output_tokens=32_000,
-            capability_profiles=catalog,
-        )
+    snap = resolve_capacity(
+        model_id="gpt-4o", provider="openai",
+        requested_output_tokens=32_000, capability_profiles=catalog,
+    )
+    assert snap.requested_output_tokens == 12_800
 
 
-def test_requested_output_defaults_to_profile_reserve():
+def test_output_protection_is_derived_from_context_window():
     catalog = _catalog(_gpt4o_profile())
     snap = resolve_capacity(
         model_id="gpt-4o",
         provider="openai",
         capability_profiles=catalog,
     )
-    assert snap.requested_output_tokens == 4_096
+    assert snap.requested_output_tokens == 12_800
 
 
 def test_separate_input_limit_uses_max_input_tokens():
@@ -260,7 +258,7 @@ def test_fingerprint_recomputes_identically():
     assert snap.fingerprint == recomputed
 
 
-def test_fingerprint_changes_when_request_changes():
+def test_fingerprint_ignores_legacy_request_override():
     catalog = _catalog(_gpt4o_profile())
     snap_a = resolve_capacity(
         model_id="gpt-4o", provider="openai",
@@ -272,7 +270,7 @@ def test_fingerprint_changes_when_request_changes():
         requested_output_tokens=4_000,
         capability_profiles=catalog,
     )
-    assert snap_a.fingerprint != snap_b.fingerprint
+    assert snap_a.fingerprint == snap_b.fingerprint
 
 
 def test_negative_or_zero_capacity_is_rejected():
@@ -290,14 +288,13 @@ def test_negative_or_zero_capacity_is_rejected():
         )
 
 
-def test_requested_output_must_be_positive():
+def test_legacy_requested_output_zero_is_ignored():
     catalog = _catalog(_gpt4o_profile())
-    with pytest.raises(InvalidCapacityConfiguration):
-        resolve_capacity(
-            model_id="gpt-4o", provider="openai",
-            requested_output_tokens=0,
-            capability_profiles=catalog,
-        )
+    snap = resolve_capacity(
+        model_id="gpt-4o", provider="openai",
+        requested_output_tokens=0, capability_profiles=catalog,
+    )
+    assert snap.requested_output_tokens == 12_800
 
 
 def test_max_input_tokens_above_context_window_is_rejected():

--- a/test/sdk/core/models/test_feature_capability.py
+++ b/test/sdk/core/models/test_feature_capability.py
@@ -1,0 +1,92 @@
+from nexent.core.models.feature_capability import (
+    extract_provider_feature_candidate,
+    resolve_feature_capabilities,
+)
+
+
+def _profile(version="test@1", reasoning=True, cache=True):
+    return {
+        "profile_version": version,
+        "reasoning": {
+            "supported": reasoning,
+            "mode": "toggle" if reasoning else "none",
+            "request_style": "extra_body_enable_thinking" if reasoning else "none",
+            "efforts": [],
+        },
+        "prompt_cache": {
+            "supported": cache,
+            "mode": "provider_automatic" if cache else "none",
+            "metrics_available": cache,
+        },
+        "evidence": ["https://example.test/official"],
+    }
+
+
+def test_openai_standard_model_object_has_no_feature_candidate():
+    assert extract_provider_feature_candidate({
+        "id": "gpt-example", "object": "model", "created": 1, "owned_by": "owner"
+    }) is None
+
+
+def test_provider_extensions_are_allow_listed_and_normalized():
+    candidate = extract_provider_feature_candidate({
+        "id": "qwen-test",
+        "api_key": "must-not-survive",
+        "capabilities": {
+            "supports_reasoning": True,
+            "supports_prompt_cache": True,
+            "supported_parameters": ["enable_thinking", "cache_control"],
+        },
+    })
+    assert candidate["reasoning"]["request_style"] == "extra_body_enable_thinking"
+    assert candidate["prompt_cache"]["mode"] == "anthropic_ephemeral"
+    assert "api_key" not in str(candidate)
+
+
+def test_conflicting_extension_fails_closed_for_affected_branch():
+    candidate = extract_provider_feature_candidate({
+        "supports_reasoning": False,
+        "supported_parameters": ["reasoning_effort"],
+    })
+    assert candidate["reasoning"]["supported"] is None
+    assert "conflicting_reasoning_extension" in candidate["warnings"]
+
+
+def test_resolution_precedence_provider_then_exact_then_family_then_unknown():
+    exact = {("factory", "model-a"): _profile("exact@1")}
+    family = ({"provider": "factory", "pattern": r"model-.+", **_profile("family@1")},)
+    candidate = extract_provider_feature_candidate({"supports_reasoning": False})
+
+    provider_result = resolve_feature_capabilities(
+        "factory", "model-a", provider_candidate=candidate,
+        exact_catalog=exact, family_rules=family, catalog_revision="r1",
+    )
+    assert provider_result["source"] == "provider_extension"
+    assert provider_result["reasoning"]["supported"] is False
+
+    exact_result = resolve_feature_capabilities(
+        "factory", "model-a", exact_catalog=exact, family_rules=family,
+    )
+    assert exact_result["source"] == "catalog_exact"
+
+    family_result = resolve_feature_capabilities(
+        "factory", "model-b", exact_catalog=exact, family_rules=family,
+    )
+    assert family_result["source"] == "catalog_family"
+
+    unknown = resolve_feature_capabilities(
+        "other", "model-b", exact_catalog=exact, family_rules=family,
+    )
+    assert unknown["source"] == "unknown"
+    assert unknown["prompt_cache"]["supported"] is None
+
+
+def test_family_exclusion_and_factory_boundary_are_enforced():
+    rules = ({
+        "provider": "factory",
+        "pattern": r"qwen-.+",
+        "exclusions": (r"qwen-unsafe",),
+        **_profile(),
+    },)
+    assert resolve_feature_capabilities("factory", "qwen-unsafe", family_rules=rules)["source"] == "unknown"
+    assert resolve_feature_capabilities("other", "qwen-good", family_rules=rules)["source"] == "unknown"

--- a/test/sdk/core/models/test_feature_capability.py
+++ b/test/sdk/core/models/test_feature_capability.py
@@ -1,5 +1,7 @@
 from nexent.core.models.feature_capability import (
+    apply_reasoning_request_policy,
     extract_provider_feature_candidate,
+    resolve_effective_feature_policy,
     resolve_feature_capabilities,
 )
 
@@ -90,3 +92,76 @@ def test_family_exclusion_and_factory_boundary_are_enforced():
     },)
     assert resolve_feature_capabilities("factory", "qwen-unsafe", family_rules=rules)["source"] == "unknown"
     assert resolve_feature_capabilities("other", "qwen-good", family_rules=rules)["source"] == "unknown"
+
+
+def test_p8_012_confirmed_toggle_and_effort_capabilities_default_on():
+    toggle = _profile()
+    toggle_policy = resolve_effective_feature_policy(toggle)
+    assert toggle_policy["reasoning"] == {
+        "supported": True,
+        "enabled": True,
+        "mode": "toggle",
+        "request_style": "extra_body_enable_thinking",
+        "effort": None,
+    }
+    assert toggle_policy["prompt_cache"]["enabled"] is True
+    assert toggle_policy["source"] == "nexent_default"
+
+    effort = _profile()
+    effort["reasoning"].update({
+        "mode": "effort",
+        "request_style": "openai_reasoning_effort",
+        "efforts": ["low", "medium", "high"],
+        "default_effort": "medium",
+    })
+    effort_policy = resolve_effective_feature_policy(effort)
+    assert effort_policy["reasoning"]["enabled"] is True
+    assert effort_policy["reasoning"]["effort"] == "medium"
+
+
+def test_p8_013_preferences_can_narrow_but_not_expand_capabilities():
+    profile = _profile(reasoning=False, cache=False)
+    policy = resolve_effective_feature_policy(
+        profile,
+        {"reasoning": {"enabled": True}, "prompt_cache": {"enabled": True}},
+    )
+    assert policy["reasoning"]["enabled"] is False
+    assert policy["prompt_cache"]["enabled"] is False
+    assert policy["warnings"] == [
+        "reasoning_enable_unsupported",
+        "prompt_cache_enable_unsupported",
+    ]
+
+    always = _profile()
+    always["reasoning"].update({"mode": "always", "request_style": "none"})
+    policy = resolve_effective_feature_policy(always, {"reasoning": {"enabled": False}})
+    assert policy["reasoning"]["enabled"] is True
+    assert policy["warnings"] == ["reasoning_disable_unsupported"]
+
+
+def test_p8_014_effective_policy_maps_to_wire_parameter_names():
+    effort_request = apply_reasoning_request_policy(
+        {"messages": [], "extra_body": {"logprobs": True, "enable_thinking": False}},
+        {
+            "reasoning": {
+                "enabled": True,
+                "mode": "effort",
+                "request_style": "openai_reasoning_effort",
+                "effort": "medium",
+            }
+        },
+    )
+    assert effort_request["reasoning_effort"] == "medium"
+    assert effort_request["extra_body"] == {"logprobs": True}
+
+    toggle_request = apply_reasoning_request_policy(
+        {"messages": [], "extra_body": {"logprobs": True}},
+        {
+            "reasoning": {
+                "enabled": True,
+                "mode": "toggle",
+                "request_style": "extra_body_enable_thinking",
+            }
+        },
+    )
+    assert toggle_request["extra_body"] == {"logprobs": True, "enable_thinking": True}

--- a/test/sdk/core/models/test_model_identity.py
+++ b/test/sdk/core/models/test_model_identity.py
@@ -1,0 +1,59 @@
+import pytest
+
+from nexent.core.models.model_identity import (
+    MATCHER_VERSION,
+    identities_are_safe_aliases,
+    parse_model_identity,
+)
+
+
+@pytest.mark.parametrize(
+    ("model_id", "expected"),
+    [
+        ("Qwen2-7B-Instruct", {"family": "qwen", "version": "2", "size": "7b", "tune": "instruct"}),
+        ("Qwen2.5-VL-7B-Instruct", {"family": "qwen", "version": "2.5", "modality": "vl"}),
+        ("DeepSeek-R1-Distill-Qwen-32B", {"family": "deepseek", "reasoning": "r1", "size": "32b"}),
+        ("Llama-3.1-8B-Instruct-AWQ", {"family": "llama", "version": "3.1", "quantization": "awq"}),
+        ("Qwen2.5-72B-Instruct-128K", {"family": "qwen", "context_extension": "128k"}),
+    ],
+)
+def test_ac_p1_003_parse_capacity_relevant_variants(model_id, expected):
+    identity = parse_model_identity(model_id, "silicon")
+
+    assert identity.matcher_version == MATCHER_VERSION
+    for field_name, value in expected.items():
+        assert getattr(identity, field_name) == value
+
+
+@pytest.mark.parametrize(
+    ("left", "right"),
+    [
+        ("Qwen2-7B-Instruct", "Qwen2.5-7B-Instruct"),
+        ("Qwen2.5-7B-Instruct", "Qwen2.5-VL-7B-Instruct"),
+        ("DeepSeek-R1", "DeepSeek-R1-Distill-Qwen-32B"),
+        ("Qwen2.5-72B-Instruct", "Qwen2.5-72B-Instruct-128K"),
+    ],
+)
+def test_ac_p1_003_conflicting_variants_are_not_aliases(left, right):
+    assert not identities_are_safe_aliases(
+        parse_model_identity(left, "silicon"),
+        parse_model_identity(right, "silicon"),
+    )
+
+
+def test_ac_p1_003_separator_variants_are_safe_aliases():
+    assert identities_are_safe_aliases(
+        parse_model_identity("Deepseek V4 Flash", "silicon"),
+        parse_model_identity("DeepSeek-V4-Flash", "silicon"),
+    )
+
+
+def test_ac_p1_003_provider_namespace_is_part_of_canonical_id():
+    assert parse_model_identity("qwen-plus", "dashscope").canonical_id != parse_model_identity(
+        "qwen-plus", "other"
+    ).canonical_id
+
+
+def test_ac_p1_003_empty_model_id_rejected():
+    with pytest.raises(ValueError, match="model_id is required"):
+        parse_model_identity("  ")

--- a/test/sdk/core/models/test_prompt_cache.py
+++ b/test/sdk/core/models/test_prompt_cache.py
@@ -39,10 +39,14 @@ from nexent.core.models.prompt_cache import (
 )
 
 
-def test_known_provider_profile_is_structured_and_unknown_provider_is_disabled():
-    profile = resolve_prompt_cache_profile("openai")
+def test_model_profile_is_structured_and_provider_name_alone_is_disabled():
+    profile = resolve_prompt_cache_profile(
+        "openai",
+        {"prompt_cache": {"mode": "openai_automatic", "supported": True}},
+    )
     assert profile["mode"] == "openai_automatic"
     assert profile["enabled"] is True
+    assert resolve_prompt_cache_profile("openai") is None
     assert resolve_prompt_cache_profile("unrecognized-provider") is None
 
 
@@ -112,7 +116,10 @@ def test_missing_metrics_never_reports_a_provider_cache_hit():
 
 
 def test_deepseek_profile_extracts_prompt_cache_hit_tokens():
-    profile = resolve_prompt_cache_profile("deepseek")
+    profile = resolve_prompt_cache_profile(
+        "deepseek",
+        {"prompt_cache": {"mode": "provider_automatic", "supported": True}},
+    )
     result = extract_prompt_cache_usage({"prompt_cache_hit_tokens": 75}, 100, capability_profile=profile)
     assert profile["serialization_version"] == "deepseek_chat_completions.v1"
     assert result.cached_input_tokens == 75

--- a/test/sdk/core/models/test_tokenizer_governance.py
+++ b/test/sdk/core/models/test_tokenizer_governance.py
@@ -1,0 +1,144 @@
+from dataclasses import dataclass
+
+import pytest
+
+from nexent.core.models import tokenizer_registry as registry
+from nexent.core.models.tokenizer_registry import (
+    TokenizerConformanceFixture,
+    TokenizerProfile,
+    register,
+    register_profile,
+    resolve_for_model,
+    run_conformance,
+)
+
+
+@dataclass
+class ExactFixtureAdapter:
+    family: str = "fixture_exact"
+
+    def count_tokens(self, messages):
+        return int(messages[0]["expected"])
+
+
+@pytest.fixture(autouse=True)
+def isolated_registry():
+    old_registry = dict(registry.REGISTRY)
+    old_profiles = dict(registry.PROFILES)
+    old_conformance = dict(registry.CONFORMANCE)
+    registry.REGISTRY.clear()
+    registry.PROFILES.clear()
+    registry.CONFORMANCE.clear()
+    yield
+    registry.REGISTRY.clear()
+    registry.REGISTRY.update(old_registry)
+    registry.PROFILES.clear()
+    registry.PROFILES.update(old_profiles)
+    registry.CONFORMANCE.clear()
+    registry.CONFORMANCE.update(old_conformance)
+
+
+def profile(**overrides):
+    values = {
+        "profile_id": "qwen2.5-text@1",
+        "family": "fixture_exact",
+        "aliases": ("Qwen2.5-7B-Instruct",),
+        "exclusions": ("Qwen2.5-VL-7B-Instruct",),
+        "adapter_version": "1.0",
+        "package_version": "test-1",
+        "fixture_version": "fixtures-1",
+        "verification_status": "verified",
+        "priority": 10,
+    }
+    values.update(overrides)
+    return TokenizerProfile(**values)
+
+
+def passing_fixtures(count=100):
+    return tuple(
+        TokenizerConformanceFixture(
+            fixture_id=f"fixture-{index}",
+            messages=({"expected": 10 + index},),
+            expected_tokens=10 + index,
+        )
+        for index in range(count)
+    )
+
+
+def test_ac_p1_004_unique_verified_conforming_adapter_is_exact():
+    adapter = ExactFixtureAdapter()
+    register(adapter)
+    register_profile(profile())
+    report = run_conformance(
+        adapter,
+        passing_fixtures(),
+        adapter_version="1.0",
+        fixture_version="fixtures-1",
+    )
+
+    result = resolve_for_model("silicon", "Qwen2.5-7B-Instruct")
+
+    assert report.passed
+    assert result.counting_mode == "exact"
+    assert result.profile_id == "qwen2.5-text@1"
+    assert result.reason == "verified_profile_and_conformance"
+
+
+@pytest.mark.parametrize(
+    ("setup", "reason"),
+    [
+        ("missing_adapter", "tokenizer_adapter_unavailable"),
+        ("unverified", "tokenizer_profile_unverified"),
+        ("missing_report", "tokenizer_conformance_missing"),
+        ("failed_report", "tokenizer_conformance_failed"),
+        ("stale_report", "tokenizer_conformance_stale"),
+    ],
+)
+def test_ac_p1_004_non_verified_paths_fall_back(setup, reason):
+    adapter = ExactFixtureAdapter()
+    if setup != "missing_adapter":
+        register(adapter)
+    register_profile(profile(verification_status="unverified" if setup == "unverified" else "verified"))
+    if setup in {"failed_report", "stale_report"}:
+        run_conformance(
+            adapter,
+            passing_fixtures(1 if setup == "failed_report" else 100),
+            adapter_version="old" if setup == "stale_report" else "1.0",
+            fixture_version="fixtures-1",
+        )
+
+    result = resolve_for_model("silicon", "Qwen2.5-7B-Instruct")
+
+    assert result.counting_mode == "estimated"
+    assert result.reason == reason
+
+
+def test_ac_p1_004_exclusion_wins_over_family_alias():
+    register_profile(profile())
+
+    result = resolve_for_model("silicon", "Qwen2.5-VL-7B-Instruct")
+
+    assert result.counting_mode == "estimated"
+    assert result.reason == "tokenizer_profile_not_found"
+
+
+def test_ac_p1_004_equal_priority_matches_are_ambiguous():
+    register_profile(profile())
+    register_profile(profile(profile_id="qwen2.5-other@1"))
+
+    result = resolve_for_model("silicon", "Qwen2.5-7B-Instruct")
+
+    assert result.counting_mode == "estimated"
+    assert result.reason == "tokenizer_profile_ambiguous"
+    assert result.candidates == ("qwen2.5-other@1", "qwen2.5-text@1")
+
+
+def test_ac_p1_004_conformance_requires_full_fixture_floor():
+    report = run_conformance(
+        ExactFixtureAdapter(),
+        passing_fixtures(99),
+        adapter_version="1.0",
+        fixture_version="fixtures-1",
+    )
+
+    assert not report.passed


### PR DESCRIPTION
## 概要

建立模型上下文容量与能力治理的基础层，为后续请求预算、恢复和用量展示提供统一、可追溯的数据契约。

## 新增能力

- 独立表达上下文窗口、最大输出、推理能力和 Prompt Cache 能力。
- 引入带来源与可信度的容量解析、模型身份匹配和版本化能力目录。
- 增加可选的 Provider token count 探测；探测失败不会阻塞模型管理。
- 增加容量与能力字段的兼容性数据库迁移。

## 对旧行为的调整

- 不再把未知容量或能力猜测成已支持；未知状态保持为空并可观测。
- 将原先分散的容量常量和匹配逻辑收敛为 SDK/服务层统一契约。
- 保留旧模型记录和旧 `max_tokens` 数据的读取兼容性。

## 对 Nexent 的提升

为多供应商模型提供稳定的能力基线，减少错误配置和静默推断，为长会话上下文治理建立可信输入。

## 规模与依赖

- 44 个文件，4,265 行新增、222 行删除（4,487 行变更）。
- 基于 `develop`，无本系列前置 PR；后续依次为 #3849、#3850、#3851。
- SPEC：Model Capacity Governance（基础部分）、Model Feature Capability Discovery。

## 验证

- 容量预算/解析、能力画像、模型身份、Prompt Cache、tokenizer 单测通过。
- Provider、目录、治理、健康、建议、校验、匹配和 count probe 服务测试通过；count probe 31 个用例、目标模块覆盖率 99%。
- 两项数据库迁移契约测试通过。
- 已从最新 `origin/develop` 执行本地 `git merge --squash`；最终结果提交 `bb43dbcf0`，测试通过且文件树与本分支一致。
- 根据人工 review 补充了 backend-to-SDK lazy import 边界说明；suggestion 47 和轻量 model-management 76 个测试通过。
- 修复 Sonar 指出的输出保护变量覆盖和模型 ID 正则回溯风险，并完成全套复验。
- 修复全量 CI 中轻量 model-management 导入路径与 SDK matcher 的边界冲突；PR1 树上的 model-management 86 个测试通过。
- 新增 DNS 失败、SSRF、IPv6、HTTP 超时/连接错误、超大与非法响应等安全边界测试。

## 合并说明

本 PR 是堆叠变更的第一层。后续 PR 应在本 PR 合并后依次重定向到 `develop`。
