### PR TITLE
feat(context): meter final requests and recover safely

### DIFF
--- a/sdk/nexent/core/agents/context/composition.py
+++ b/sdk/nexent/core/agents/context/composition.py
@@ -1,0 +1,166 @@
+"""Content-free semantic composition estimates for final provider requests."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import json
+from typing import Any, Iterable, Mapping, Optional
+
+from ...utils.token_estimation import estimate_tokens_text
+from .models import ContextItemType
+
+
+CONTEXT_COMPOSITION_ESTIMATOR_VERSION = "context-composition-v2"
+SEGMENT_NAMES = (
+    "system_instructions",
+    "user_history",
+    "assistant_history",
+    "current_request",
+    "retrieved_context",
+    "tool_definitions",
+    "tool_calls_results",
+    "attachments_media",
+    "provider_overhead",
+)
+
+
+@dataclass(frozen=True)
+class ContextComposition:
+    source: str
+    denominator_tokens: int
+    estimator_version: str
+    segments: dict[str, int]
+    adjustment_ratio: float
+    high_adjustment: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def estimate_context_segments(
+    items: Iterable[Any],
+    *,
+    purpose_messages: Iterable[Any] = (),
+    tools: Iterable[Any] = (),
+) -> dict[str, int]:
+    """Estimate semantic segments from ContextItem provenance before reconciliation."""
+    result = {name: 0 for name in SEGMENT_NAMES}
+    for item in items:
+        item_type = getattr(item, "type", None)
+        content = getattr(item, "content", {}) or {}
+        estimate = max(0, int(getattr(item, "token_estimate", 0) or 0))
+        if item_type in {
+            ContextItemType.SYSTEM,
+            ContextItemType.SKILL,
+        }:
+            result["system_instructions"] += estimate
+        elif item_type in {
+            ContextItemType.MEMORY,
+            ContextItemType.KNOWLEDGE_BASE,
+        }:
+            result["retrieved_context"] += estimate
+        elif item_type == ContextItemType.HISTORY_SUMMARY:
+            result["assistant_history"] += estimate
+        elif item_type == ContextItemType.CONVERSATION_TURN:
+            result["user_history"] += _estimate_value(content.get("user_message"))
+            result["assistant_history"] += _estimate_value(
+                content.get("assistant_final_answer")
+            )
+        elif item_type == ContextItemType.CURRENT_TASK:
+            result["current_request"] += estimate
+        elif item_type in {
+            ContextItemType.TOOL,
+            ContextItemType.MANAGED_AGENT,
+            ContextItemType.EXTERNAL_AGENT,
+        }:
+            result["tool_definitions"] += estimate
+        elif item_type in {
+            ContextItemType.CURRENT_PLANNING,
+            ContextItemType.CURRENT_ACTION,
+        }:
+            result["tool_calls_results"] += estimate
+        else:
+            result["provider_overhead"] += estimate
+
+    for message in purpose_messages:
+        role = _message_role(message)
+        estimate = _estimate_value(_message_content(message))
+        if role in {"system", "developer"}:
+            result["system_instructions"] += estimate
+        elif role == "user":
+            result["current_request"] += estimate
+        else:
+            result["tool_calls_results"] += estimate
+
+    tool_list = list(tools)
+    if tool_list:
+        result["tool_definitions"] += _estimate_value(tool_list)
+    return result
+
+
+def reconcile_context_composition(
+    estimated_segments: Mapping[str, Any],
+    provider_input_tokens: Optional[int],
+) -> ContextComposition:
+    """Reconcile non-negative semantic estimates to an exact input denominator."""
+    segments = {
+        name: max(0, int(estimated_segments.get(name, 0) or 0))
+        for name in SEGMENT_NAMES
+    }
+    segments["provider_overhead"] = 0
+    estimated_sum = sum(segments.values())
+
+    if provider_input_tokens is None:
+        denominator = estimated_sum
+        return ContextComposition(
+            source="estimated",
+            denominator_tokens=denominator,
+            estimator_version=CONTEXT_COMPOSITION_ESTIMATOR_VERSION,
+            segments=segments,
+            adjustment_ratio=0.0,
+            high_adjustment=False,
+        )
+
+    denominator = max(0, int(provider_input_tokens))
+    if estimated_sum <= denominator:
+        adjustment = denominator - estimated_sum
+        segments["provider_overhead"] = adjustment
+    elif estimated_sum:
+        scale = denominator / estimated_sum
+        for name in SEGMENT_NAMES:
+            if name != "provider_overhead":
+                segments[name] = int(segments[name] * scale)
+        segments["provider_overhead"] = denominator - sum(segments.values())
+        adjustment = estimated_sum - denominator
+    else:
+        segments["provider_overhead"] = denominator
+        adjustment = denominator
+
+    ratio = round(adjustment / denominator, 4) if denominator else (1.0 if adjustment else 0.0)
+    return ContextComposition(
+        source="estimated",
+        denominator_tokens=denominator,
+        estimator_version=CONTEXT_COMPOSITION_ESTIMATOR_VERSION,
+        segments=segments,
+        adjustment_ratio=ratio,
+        high_adjustment=ratio > 0.1,
+    )
+
+
+def _estimate_value(value: Any) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, str):
+        text = value
+    else:
+        text = json.dumps(value, ensure_ascii=False, default=str, sort_keys=True)
+    return max(0, estimate_tokens_text(text))
+
+
+def _message_role(message: Any) -> str:
+    value = message.get("role") if isinstance(message, Mapping) else getattr(message, "role", "")
+    return str(getattr(value, "value", value) or "").lower()
+
+
+def _message_content(message: Any) -> Any:
+    return message.get("content") if isinstance(message, Mapping) else getattr(message, "content", None)

--- a/sdk/nexent/core/agents/context_budget_event.py
+++ b/sdk/nexent/core/agents/context_budget_event.py
@@ -1,0 +1,75 @@
+"""Build the content-free P3 conversation budget event."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+_COMPRESSION_REASON_BY_CALL_TYPE = {
+    "history_summary": "history_summary",
+    "history_incremental": "history_incremental",
+    "long_term_memory_block_selection": "long_term_memory_selection",
+}
+
+
+def _compression_reasons(context_evidence: Any) -> list[str]:
+    """Project internal compression records onto a stable, content-free enum."""
+    reasons: list[str] = []
+    for record in getattr(context_evidence, "compression_records", ()) or ():
+        call_type = getattr(record, "call_type", None)
+        if call_type is None and isinstance(record, dict):
+            call_type = record.get("call_type")
+        reason = _COMPRESSION_REASON_BY_CALL_TYPE.get(call_type)
+        if reason is not None and reason not in reasons:
+            reasons.append(reason)
+    if bool(getattr(context_evidence, "fallback_compaction_used", False)):
+        reasons.append("representation_compaction")
+    return reasons
+
+
+def build_context_budget_event(
+    preflight: Any,
+    context_evidence: Any,
+    *,
+    step_number: int,
+    recovery_state: str = "not_needed",
+    recovery: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    components = preflight.components
+    raw_context = int(getattr(context_evidence, "raw_token_estimate", 0) or 0)
+    final_context = int(getattr(context_evidence, "final_token_estimate", 0) or 0)
+    saved = max(raw_context - final_context, 0)
+    event = {
+        "schema_version": 1, "purpose": getattr(context_evidence, "purpose", "step"),
+        "step_number": int(step_number), "raw_tokens": raw_context, "final_tokens": final_context,
+        "soft_budget": int(preflight.soft_budget), "hard_budget": int(preflight.hard_budget),
+        "hard_count": int(preflight.hard_count),
+        "components": {
+            "message_text": int(components.message_text), "message_framing": int(components.message_framing),
+            "tools": int(components.tools), "media": int(components.media),
+            "reasoning": int(components.reasoning), "other_semantic": int(components.other_semantic),
+        },
+        "count_source": getattr(preflight.count_source, "value", str(preflight.count_source)),
+        "compression": {
+            "attempted": bool(getattr(context_evidence, "compression_attempted", False)),
+            "saved_tokens": saved, "ratio": saved / raw_context if raw_context else 0.0,
+            "fallback_compaction": bool(getattr(context_evidence, "fallback_compaction_used", False)),
+            "reasons": _compression_reasons(context_evidence),
+        },
+        "recovery_state": recovery_state, "request_fingerprint": preflight.request_fingerprint,
+        "budget_fingerprint": preflight.identity_fingerprint, "retry_ordinal": int(preflight.retry_ordinal),
+    }
+    archive_active = bool(getattr(context_evidence, "archive_active", False))
+    if archive_active or recovery:
+        details = dict(recovery or {})
+        details.setdefault("phase", "archive" if archive_active else "compression")
+        details.setdefault("attempt", int(preflight.retry_ordinal))
+        details.setdefault("maximum_attempts", 2)
+        details.setdefault("compression_target", int(preflight.hard_budget))
+        details.setdefault("archive_active", archive_active)
+        details.setdefault("archived_item_count", int(getattr(context_evidence, "archived_item_count", 0)))
+        details.setdefault("retained_item_count", int(getattr(context_evidence, "retained_item_count", 0)))
+        details.setdefault("recall_invocation_count", int(getattr(context_evidence, "recall_invocation_count", 0)))
+        details.setdefault("recalled_tokens", int(getattr(context_evidence, "recalled_tokens", 0)))
+        event["recovery"] = details
+    return event

--- a/sdk/nexent/core/models/final_request_budget.py
+++ b/sdk/nexent/core/models/final_request_budget.py
@@ -1,0 +1,740 @@
+"""Trusted final Provider-request metering and bounded usage calibration.
+
+The request passed here is the already-rendered adapter payload.  This module
+never stores request content: evidence consists only of hashes, classifications
+and numerical counts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import threading
+import time
+import uuid
+from collections import deque
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Literal, Optional
+
+from ..utils.token_estimation import estimate_tokens_text
+
+
+ESTIMATOR_VERSION = "final-request-v1"
+DEFAULT_CORRECTION_MULTIPLIER = 1.15
+MIN_CALIBRATION_SAMPLES = 20
+MAX_CALIBRATION_SAMPLES = 256
+CALIBRATION_TTL_SECONDS = 24 * 60 * 60
+MAX_OBSERVED_RATIO = 4.0
+MAX_GATE_MULTIPLIER = 2.0
+TOOL_PROTOCOL_OVERHEAD_TOKENS = 208
+
+RequestShape = Literal["text", "tools", "media", "tools_media"]
+CountSource = Literal["provider", "tokenizer", "estimated", "provider_anchor_delta"]
+SideEffectState = Literal[
+    "pristine", "response_started", "tool_effect", "application_effect", "persisted"
+]
+
+_TRANSPORT_KEYS = frozenset(
+    {
+        "stream",
+        "stream_options",
+        "timeout",
+        "request_timeout",
+        "http_client",
+    }
+)
+_NON_TOKEN_CONTROL_KEYS = frozenset(
+    {
+        "model",
+        "max_tokens",
+        "max_completion_tokens",
+        "temperature",
+        "top_p",
+        "n",
+        "stop",
+        "frequency_penalty",
+        "presence_penalty",
+        "seed",
+        "parallel_tool_calls",
+        "tool_choice",
+    }
+)
+_REASONING_KEYS = frozenset(
+    {
+        "reasoning",
+        "reasoning_effort",
+        "thinking",
+        "enable_thinking",
+        "chat_template_kwargs",
+    }
+)
+_MEDIA_TYPES = frozenset(
+    {
+        "image",
+        "image_url",
+        "input_image",
+        "audio",
+        "input_audio",
+        "file",
+        "document",
+    }
+)
+
+
+class FinalRequestBudgetError(Exception):
+    reason_code = "final_request_budget_error"
+
+
+class FinalRequestOverHardBudget(FinalRequestBudgetError):
+    reason_code = "final_request_over_hard_budget"
+
+    def __init__(
+        self,
+        *,
+        actual: int,
+        hard_budget: int,
+        preflight: Optional["FinalRequestPreflight"] = None,
+    ) -> None:
+        self.actual = actual
+        self.hard_budget = hard_budget
+        self.preflight = preflight
+        super().__init__(
+            f"{self.reason_code}: final request {actual} exceeds hard budget {hard_budget}"
+        )
+
+
+class StaleRequestBudgetIdentity(FinalRequestBudgetError):
+    reason_code = "stale_request_budget_identity"
+
+
+class FinalRequestSoftBudgetExceeded(FinalRequestBudgetError):
+    reason_code = "final_request_over_soft_budget"
+
+    def __init__(self, preflight: "FinalRequestPreflight") -> None:
+        self.preflight = preflight
+        super().__init__(
+            f"{self.reason_code}: final request {preflight.soft_count} exceeds "
+            f"soft budget {preflight.soft_budget}"
+        )
+
+
+class ProviderContextOverflow(FinalRequestBudgetError):
+    reason_code = "provider_context_overflow"
+
+
+class ProviderContextOverflowRetryUnsafe(FinalRequestBudgetError):
+    reason_code = "provider_context_overflow_retry_unsafe"
+
+
+class ProviderContextOverflowRetryExhausted(FinalRequestBudgetError):
+    reason_code = "provider_context_overflow_retry_exhausted"
+
+
+class CompactionNoReduction(FinalRequestBudgetError):
+    reason_code = "compaction_no_reduction"
+
+
+class ContextRebuildOverBudget(FinalRequestBudgetError):
+    """A source-backed rebuild could not satisfy its requested input target."""
+
+    reason_code = "context_rebuild_over_budget"
+
+    def __init__(self, *, failure_reason: str, actual: int, hard_budget: int) -> None:
+        self.context_rebuild_over_budget = True
+        self.failure_reason = failure_reason
+        self.actual = actual
+        self.hard_budget = hard_budget
+        super().__init__(
+            f"{failure_reason}: Context input remains over the model hard budget "
+            f"after compaction: {actual} > {hard_budget} tokens"
+        )
+
+
+class RequestSideEffectGuard:
+    """Monotonic proof that a physical request is still safe to rebuild."""
+
+    _ORDER = {
+        "pristine": 0,
+        "response_started": 1,
+        "tool_effect": 2,
+        "application_effect": 3,
+        "persisted": 4,
+    }
+
+    def __init__(self) -> None:
+        self._state: SideEffectState = "pristine"
+        self._lock = threading.Lock()
+
+    @property
+    def state(self) -> SideEffectState:
+        with self._lock:
+            return self._state
+
+    @property
+    def recovery_safe(self) -> bool:
+        return self.state == "pristine"
+
+    def mark(self, state: SideEffectState) -> None:
+        with self._lock:
+            if self._ORDER[state] > self._ORDER[self._state]:
+                self._state = state
+
+
+def is_provider_context_overflow(error: BaseException) -> bool:
+    """Classify structured OpenAI-compatible overflow errors conservatively."""
+    code = getattr(error, "code", None)
+    body = getattr(error, "body", None)
+    if isinstance(body, Mapping):
+        nested = body.get("error") if isinstance(body.get("error"), Mapping) else body
+        code = code or nested.get("code") or nested.get("type")
+    if str(code or "").lower() in {
+        "context_length_exceeded",
+        "max_tokens_exceeded",
+        "input_too_long",
+    }:
+        return True
+    message = str(error).lower()
+    return any(
+        marker in message
+        for marker in (
+            "context_length_exceeded",
+            "maximum context length",
+            "input tokens exceed",
+            "too many tokens",
+        )
+    )
+
+
+@dataclass(frozen=True)
+class FinalRequestIdentity:
+    endpoint_fingerprint: str
+    credential_scope_fingerprint: str
+    canonical_model_id: str
+    provider: str
+    model_name: str
+    w1_fingerprint: str
+    w2_fingerprint: str
+
+    @property
+    def fingerprint(self) -> str:
+        return _fingerprint(
+            {
+                "endpoint": self.endpoint_fingerprint,
+                "scope": self.credential_scope_fingerprint,
+                "canonical_model": self.canonical_model_id,
+                "provider": self.provider,
+                "model": self.model_name,
+                "w1": self.w1_fingerprint,
+                "w2": self.w2_fingerprint,
+            }
+        )
+
+
+@dataclass(frozen=True)
+class RequestComponentCounts:
+    message_text: int = 0
+    message_framing: int = 0
+    tools: int = 0
+    media: int = 0
+    reasoning: int = 0
+    other_semantic: int = 0
+
+    @property
+    def raw_total(self) -> int:
+        return max(
+            1,
+            self.message_text
+            + self.message_framing
+            + self.tools
+            + self.media
+            + self.reasoning
+            + self.other_semantic,
+        )
+
+
+@dataclass(frozen=True)
+class FinalRequestShape:
+    fingerprint: str
+    request_shape: RequestShape
+    reasoning_mode: str
+    semantic_request: Mapping[str, Any] = field(repr=False, compare=False)
+    components: RequestComponentCounts = field(default_factory=RequestComponentCounts)
+
+
+@dataclass(frozen=True)
+class CalibrationKey:
+    endpoint_fingerprint: str
+    credential_scope_fingerprint: str
+    canonical_model_id: str
+    request_shape: RequestShape
+    reasoning_mode: str
+    estimator_version: str = ESTIMATOR_VERSION
+
+    @property
+    def fingerprint(self) -> str:
+        return _fingerprint(self.__dict__)
+
+
+@dataclass(frozen=True)
+class CalibrationStats:
+    sample_count: int = 0
+    mature: bool = False
+    p95: Optional[float] = None
+    p99: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class FinalRequestPreflight:
+    request_id: str
+    request_fingerprint: str
+    identity_fingerprint: str
+    request_shape: RequestShape
+    reasoning_mode: str
+    count_source: CountSource
+    components: RequestComponentCounts
+    raw_estimate: int
+    provider_count: Optional[int]
+    soft_count: int
+    hard_count: int
+    soft_budget: int
+    hard_budget: int
+    soft_exceeded: bool
+    hard_exceeded: bool
+    calibration_key_fingerprint: str
+    calibration_sample_count: int
+    calibration_p95: Optional[float]
+    calibration_p99: Optional[float]
+    fallback_reason: Optional[str]
+    stable_semantic_fingerprint: str = ""
+    context_stable_fingerprint: str = ""
+    message_fingerprints: tuple[str, ...] = ()
+    anchor_input_tokens: Optional[int] = None
+    estimated_delta_tokens: Optional[int] = None
+    anchor_invalidation_reason: Optional[str] = None
+    retry_ordinal: int = 0
+    estimator_version: str = ESTIMATOR_VERSION
+
+
+@dataclass(frozen=True)
+class _Sample:
+    request_id: str
+    ratio: float
+    observed_at: float
+
+
+@dataclass(frozen=True)
+class _ObservedRequestAnchor:
+    identity_fingerprint: str
+    stable_semantic_fingerprint: str
+    context_stable_fingerprint: str
+    message_fingerprints: tuple[str, ...]
+    input_tokens: int
+
+
+class CalibrationStore:
+    """Bounded, expiring and request-id-deduplicated calibration samples."""
+
+    def __init__(
+        self,
+        *,
+        max_samples: int = MAX_CALIBRATION_SAMPLES,
+        ttl_seconds: int = CALIBRATION_TTL_SECONDS,
+        minimum_samples: int = MIN_CALIBRATION_SAMPLES,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self.max_samples = max_samples
+        self.ttl_seconds = ttl_seconds
+        self.minimum_samples = minimum_samples
+        self._clock = clock
+        self._samples: dict[CalibrationKey, deque[_Sample]] = {}
+        self._lock = threading.Lock()
+
+    def observe(
+        self,
+        key: CalibrationKey,
+        *,
+        request_id: str,
+        raw_estimate: int,
+        provider_prompt_tokens: int,
+    ) -> bool:
+        if raw_estimate <= 0 or provider_prompt_tokens <= 0:
+            return False
+        now = self._clock()
+        ratio = min(
+            MAX_OBSERVED_RATIO,
+            max(0.5, provider_prompt_tokens / raw_estimate),
+        )
+        with self._lock:
+            samples = self._prune_locked(key, now)
+            if any(sample.request_id == request_id for sample in samples):
+                return False
+            samples.append(_Sample(request_id, ratio, now))
+            while len(samples) > self.max_samples:
+                samples.popleft()
+        return True
+
+    def stats(self, key: CalibrationKey) -> CalibrationStats:
+        with self._lock:
+            samples = list(self._prune_locked(key, self._clock()))
+        ratios = sorted(sample.ratio for sample in samples)
+        if not ratios:
+            return CalibrationStats()
+        return CalibrationStats(
+            sample_count=len(ratios),
+            mature=len(ratios) >= self.minimum_samples,
+            p95=_nearest_rank(ratios, 0.95),
+            p99=_nearest_rank(ratios, 0.99),
+        )
+
+    def clear(self) -> None:
+        with self._lock:
+            self._samples.clear()
+
+    def _prune_locked(self, key: CalibrationKey, now: float) -> deque[_Sample]:
+        samples = self._samples.setdefault(key, deque())
+        cutoff = now - self.ttl_seconds
+        while samples and samples[0].observed_at < cutoff:
+            samples.popleft()
+        if not samples:
+            self._samples.pop(key, None)
+            samples = self._samples.setdefault(key, deque())
+        return samples
+
+
+GLOBAL_CALIBRATION_STORE = CalibrationStore()
+
+
+def build_final_request_shape(completion_kwargs: Mapping[str, Any]) -> FinalRequestShape:
+    semantic = {
+        str(key): _normalize(value)
+        for key, value in completion_kwargs.items()
+        if key not in _TRANSPORT_KEYS
+    }
+    messages = semantic.get("messages")
+    message_list = messages if isinstance(messages, list) else []
+    message_text_parts: list[str] = []
+    media_count = 0
+    for message in message_list:
+        message_text_parts.append(_extract_text(message))
+        media_count += _count_media(message)
+    framing = (3 * len(message_list) + (3 if message_list else 0))
+    tools = semantic.get("tools") or semantic.get("functions")
+    tool_tokens = (
+        _json_tokens(tools) + TOOL_PROTOCOL_OVERHEAD_TOKENS
+        if tools
+        else 0
+    )
+    media_tokens = media_count * 256
+
+    reasoning_values: dict[str, Any] = {}
+    for key in _REASONING_KEYS:
+        if key in semantic:
+            reasoning_values[key] = semantic[key]
+    extra_body = semantic.get("extra_body")
+    if isinstance(extra_body, Mapping):
+        for key, value in extra_body.items():
+            if key in _REASONING_KEYS:
+                reasoning_values[key] = value
+
+    consumed = {
+        "messages",
+        "tools",
+        "functions",
+        *_NON_TOKEN_CONTROL_KEYS,
+        *reasoning_values.keys(),
+    }
+    other = {
+        key: value
+        for key, value in semantic.items()
+        if key not in consumed and key != "extra_body"
+    }
+    if isinstance(extra_body, Mapping):
+        remaining_extra = {
+            key: value for key, value in extra_body.items() if key not in _REASONING_KEYS
+        }
+        if remaining_extra:
+            other["extra_body"] = remaining_extra
+
+    has_tools = bool(tools)
+    has_media = media_count > 0
+    shape: RequestShape = (
+        "tools_media" if has_tools and has_media else
+        "tools" if has_tools else
+        "media" if has_media else
+        "text"
+    )
+    reasoning_mode = _fingerprint(reasoning_values)[:12] if reasoning_values else "default"
+    components = RequestComponentCounts(
+        message_text=estimate_tokens_text("".join(message_text_parts)) if message_text_parts else 0,
+        message_framing=framing,
+        tools=tool_tokens,
+        media=media_tokens,
+        reasoning=_json_tokens(reasoning_values) if reasoning_values else 0,
+        other_semantic=_json_tokens(other) if other else 0,
+    )
+    return FinalRequestShape(
+        fingerprint=_fingerprint(semantic),
+        request_shape=shape,
+        reasoning_mode=reasoning_mode,
+        semantic_request=semantic,
+        components=components,
+    )
+
+
+class FinalRequestMeter:
+    def __init__(self, calibration_store: CalibrationStore = GLOBAL_CALIBRATION_STORE) -> None:
+        self.calibration_store = calibration_store
+        self._observed_anchor: Optional[_ObservedRequestAnchor] = None
+        self._anchor_lock = threading.Lock()
+
+    def clear_observed_anchor(self) -> None:
+        with self._anchor_lock:
+            self._observed_anchor = None
+
+    def observe_request_input(
+        self,
+        preflight: FinalRequestPreflight,
+        identity: FinalRequestIdentity,
+        *,
+        provider_prompt_tokens: int,
+    ) -> None:
+        if provider_prompt_tokens <= 0 or preflight.identity_fingerprint != identity.fingerprint:
+            return
+        with self._anchor_lock:
+            self._observed_anchor = _ObservedRequestAnchor(
+                identity_fingerprint=identity.fingerprint,
+                stable_semantic_fingerprint=preflight.stable_semantic_fingerprint,
+                context_stable_fingerprint=preflight.context_stable_fingerprint,
+                message_fingerprints=preflight.message_fingerprints,
+                input_tokens=provider_prompt_tokens,
+            )
+
+    def estimate_context_candidate(
+        self, messages: Sequence[Any], tools: Sequence[Any]
+    ) -> Optional[int]:
+        message_fingerprints = tuple(_fingerprint(message) for message in messages)
+        context_stable = _fingerprint({"tools": list(tools)})
+        with self._anchor_lock:
+            anchor = self._observed_anchor
+        if anchor is None or anchor.context_stable_fingerprint != context_stable:
+            return None
+        if message_fingerprints[: len(anchor.message_fingerprints)] != anchor.message_fingerprints:
+            return None
+        delta = _estimate_message_delta(messages[len(anchor.message_fingerprints) :])
+        return anchor.input_tokens + math.ceil(delta * DEFAULT_CORRECTION_MULTIPLIER)
+
+    def _anchor_delta(
+        self,
+        *,
+        identity: FinalRequestIdentity,
+        stable_semantic_fingerprint: str,
+        message_fingerprints: tuple[str, ...],
+        messages: Sequence[Any],
+    ) -> tuple[Optional[int], Optional[int], Optional[str]]:
+        with self._anchor_lock:
+            anchor = self._observed_anchor
+        if anchor is None:
+            return None, None, None
+        if anchor.identity_fingerprint != identity.fingerprint:
+            return None, None, "anchor_identity_changed"
+        if anchor.stable_semantic_fingerprint != stable_semantic_fingerprint:
+            return None, None, "anchor_semantics_changed"
+        if message_fingerprints[: len(anchor.message_fingerprints)] != anchor.message_fingerprints:
+            return None, None, "anchor_non_append_only"
+        delta = _estimate_message_delta(messages[len(anchor.message_fingerprints) :])
+        return anchor.input_tokens, delta, None
+
+    def measure(
+        self,
+        completion_kwargs: Mapping[str, Any],
+        *,
+        identity: FinalRequestIdentity,
+        soft_budget: int,
+        hard_budget: int,
+        provider_count: Optional[int] = None,
+        tokenizer_count: Optional[int] = None,
+        fallback_reason: Optional[str] = None,
+        retry_ordinal: int = 0,
+        request_id: Optional[str] = None,
+    ) -> FinalRequestPreflight:
+        shape = build_final_request_shape(completion_kwargs)
+        messages = list(shape.semantic_request.get("messages") or [])
+        message_fingerprints = tuple(_fingerprint(message) for message in messages)
+        stable_semantic_fingerprint = _fingerprint(
+            {key: value for key, value in shape.semantic_request.items() if key != "messages"}
+        )
+        context_stable_fingerprint = _fingerprint(
+            {"tools": shape.semantic_request.get("tools") or []}
+        )
+        raw = shape.components.raw_total
+        key = CalibrationKey(
+            endpoint_fingerprint=identity.endpoint_fingerprint,
+            credential_scope_fingerprint=identity.credential_scope_fingerprint,
+            canonical_model_id=identity.canonical_model_id,
+            request_shape=shape.request_shape,
+            reasoning_mode=shape.reasoning_mode,
+        )
+        stats = self.calibration_store.stats(key)
+        anchor_input, estimated_delta, anchor_reason = self._anchor_delta(
+            identity=identity,
+            stable_semantic_fingerprint=stable_semantic_fingerprint,
+            message_fingerprints=message_fingerprints,
+            messages=messages,
+        )
+        if provider_count is not None:
+            if provider_count <= 0:
+                raise ValueError("provider_count must be positive")
+            source: CountSource = "provider"
+            soft_count = hard_count = provider_count
+        elif anchor_input is not None and estimated_delta is not None:
+            source = "provider_anchor_delta"
+            soft_count = hard_count = anchor_input + math.ceil(
+                estimated_delta * DEFAULT_CORRECTION_MULTIPLIER
+            )
+        else:
+            base = tokenizer_count if tokenizer_count is not None else raw
+            if base <= 0:
+                raise ValueError("tokenizer_count must be positive")
+            source = "tokenizer" if tokenizer_count is not None else "estimated"
+            if stats.mature:
+                soft_multiplier = _gate_multiplier(stats.p95)
+                hard_multiplier = _gate_multiplier(stats.p99)
+            else:
+                soft_multiplier = hard_multiplier = DEFAULT_CORRECTION_MULTIPLIER
+            soft_count = math.ceil(base * soft_multiplier)
+            hard_count = math.ceil(base * hard_multiplier)
+        preflight = FinalRequestPreflight(
+            request_id=request_id or uuid.uuid4().hex,
+            request_fingerprint=shape.fingerprint,
+            identity_fingerprint=identity.fingerprint,
+            request_shape=shape.request_shape,
+            reasoning_mode=shape.reasoning_mode,
+            count_source=source,
+            components=shape.components,
+            raw_estimate=raw,
+            provider_count=provider_count,
+            soft_count=soft_count,
+            hard_count=hard_count,
+            soft_budget=soft_budget,
+            hard_budget=hard_budget,
+            soft_exceeded=soft_count > soft_budget,
+            hard_exceeded=hard_count > hard_budget,
+            calibration_key_fingerprint=key.fingerprint,
+            calibration_sample_count=stats.sample_count,
+            calibration_p95=stats.p95,
+            calibration_p99=stats.p99,
+            fallback_reason=fallback_reason,
+            stable_semantic_fingerprint=stable_semantic_fingerprint,
+            context_stable_fingerprint=context_stable_fingerprint,
+            message_fingerprints=message_fingerprints,
+            anchor_input_tokens=anchor_input,
+            estimated_delta_tokens=estimated_delta,
+            anchor_invalidation_reason=anchor_reason,
+            retry_ordinal=retry_ordinal,
+        )
+        if provider_count is not None:
+            self.observe_request_input(
+                preflight, identity, provider_prompt_tokens=provider_count
+            )
+        return preflight
+
+    def observe_usage(
+        self,
+        preflight: FinalRequestPreflight,
+        identity: FinalRequestIdentity,
+        *,
+        provider_prompt_tokens: int,
+    ) -> bool:
+        key = CalibrationKey(
+            endpoint_fingerprint=identity.endpoint_fingerprint,
+            credential_scope_fingerprint=identity.credential_scope_fingerprint,
+            canonical_model_id=identity.canonical_model_id,
+            request_shape=preflight.request_shape,
+            reasoning_mode=preflight.reasoning_mode,
+        )
+        if key.fingerprint != preflight.calibration_key_fingerprint:
+            raise StaleRequestBudgetIdentity("calibration identity changed")
+        return self.calibration_store.observe(
+            key,
+            request_id=preflight.request_id,
+            raw_estimate=preflight.raw_estimate,
+            provider_prompt_tokens=provider_prompt_tokens,
+        )
+
+
+def _nearest_rank(values: Sequence[float], quantile: float) -> float:
+    index = max(0, math.ceil(quantile * len(values)) - 1)
+    return values[index]
+
+
+def _gate_multiplier(value: Optional[float]) -> float:
+    return min(MAX_GATE_MULTIPLIER, max(1.0, value or 1.0))
+
+
+def _json_tokens(value: Any) -> int:
+    encoded = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return estimate_tokens_text(encoded)
+
+
+def _estimate_message_delta(messages: Sequence[Any]) -> int:
+    if not messages:
+        return 0
+    return build_final_request_shape({"messages": list(messages)}).components.raw_total
+
+
+def _fingerprint(value: Any) -> str:
+    encoded = json.dumps(
+        _normalize(value),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(encoded.encode()).hexdigest()
+
+
+def _normalize(value: Any, *, _depth: int = 0) -> Any:
+    if _depth >= 32:
+        return {"__max_depth__": type(value).__name__}
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, Mapping):
+        return {
+            str(key): _normalize(item, _depth=_depth + 1)
+            for key, item in sorted(value.items(), key=lambda pair: str(pair[0]))
+        }
+    if isinstance(value, (list, tuple)):
+        return [_normalize(item, _depth=_depth + 1) for item in value]
+    if hasattr(value, "model_dump"):
+        return _normalize(value.model_dump(mode="json"), _depth=_depth + 1)
+    return str(value)
+
+
+def _extract_text(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Mapping):
+        if str(value.get("type", "")).lower() in _MEDIA_TYPES:
+            return ""
+        return "".join(
+            _extract_text(item)
+            for key, item in value.items()
+            if key not in {"image_url", "url", "data", "audio", "file"}
+        )
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return "".join(_extract_text(item) for item in value)
+    return ""
+
+
+def _count_media(value: Any) -> int:
+    if isinstance(value, Mapping):
+        own = 1 if str(value.get("type", "")).lower() in _MEDIA_TYPES else 0
+        return own + sum(
+            _count_media(item)
+            for key, item in value.items()
+            if key not in {"image_url", "url", "data", "audio", "file"}
+        )
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return sum(_count_media(item) for item in value)
+    return 0

--- a/sdk/nexent/core/models/openai_llm.py
+++ b/sdk/nexent/core/models/openai_llm.py
@@ -1258,24 +1258,29 @@ class OpenAIModel(OpenAIServerModel):
                     json.dumps(record.to_dict(), ensure_ascii=False),
                 )
             record._usage_event_emitted = True
+        usage_span_attributes = {
+            "usage.call_id": record.call_id,
+            "usage.source": record.source,
+            "usage.status": record.status,
+            "usage.input_tokens": record.usage.input_tokens,
+            "usage.output_tokens": record.usage.output_tokens,
+            "usage.total_tokens": record.usage.total_tokens,
+            "usage.fresh_input_tokens": record.usage.fresh_input_tokens,
+            "usage.cache_read_tokens": record.usage.cache_read_tokens,
+            "usage.cache_write_tokens": record.usage.cache_write_tokens,
+            "usage.reasoning_tokens": record.usage.reasoning_tokens,
+            "usage.visible_output_tokens": record.usage.visible_output_tokens,
+            "usage.quality_reasons": json.dumps(record.quality.reasons),
+            **{
+                f"context.composition.{name}": value
+                for name, value in record.context_composition["segments"].items()
+            },
+        }
         self._monitoring.set_span_attributes(
             **{
-                "usage.call_id": record.call_id,
-                "usage.source": record.source,
-                "usage.status": record.status,
-                "usage.input_tokens": record.usage.input_tokens,
-                "usage.output_tokens": record.usage.output_tokens,
-                "usage.total_tokens": record.usage.total_tokens,
-                "usage.fresh_input_tokens": record.usage.fresh_input_tokens,
-                "usage.cache_read_tokens": record.usage.cache_read_tokens,
-                "usage.cache_write_tokens": record.usage.cache_write_tokens,
-                "usage.reasoning_tokens": record.usage.reasoning_tokens,
-                "usage.visible_output_tokens": record.usage.visible_output_tokens,
-                "usage.quality_reasons": json.dumps(record.quality.reasons),
-                **{
-                    f"context.composition.{name}": value
-                    for name, value in record.context_composition["segments"].items()
-                },
+                key: value
+                for key, value in usage_span_attributes.items()
+                if value is not None
             }
         )
 

--- a/sdk/nexent/core/models/openai_llm.py
+++ b/sdk/nexent/core/models/openai_llm.py
@@ -26,6 +26,10 @@ from .capacity_budget import (
     compute_w2_fingerprint,
 )
 from .capacity_resolver import derive_output_protection_tokens
+from .feature_capability import (
+    apply_reasoning_request_policy,
+    resolve_effective_feature_policy,
+)
 from ..utils.observer import MessageObserver, ProcessType
 from .prompt_cache import (
     apply_cache_directives,
@@ -147,6 +151,9 @@ class OpenAIModel(OpenAIServerModel):
         self.feature_capabilities: Optional[Dict[str, Any]] = kwargs.pop(
             "feature_capabilities", None
         )
+        self.feature_preferences: Optional[Dict[str, Any]] = kwargs.pop(
+            "feature_preferences", None
+        )
         self.provider_usage_profile: Optional[Dict[str, Any]] = kwargs.pop(
             "provider_usage_profile", None
         )
@@ -177,6 +184,7 @@ class OpenAIModel(OpenAIServerModel):
         self.last_prompt_cache_usage = None
         self.last_cached_input_token_count = 0
         self.last_response_diagnostics = None
+        self.last_effective_feature_policy = None
         self.provider_call_usages: list[ProviderCallUsage] = []
         self.turn_provider_call_usages: list[ProviderCallUsage] = []
         self._provider_usage_turn_id: Optional[str] = None
@@ -440,29 +448,37 @@ class OpenAIModel(OpenAIServerModel):
 
         completion_kwargs["stream_options"] = {"include_usage": True}
 
-        # Provider-specific extras (e.g. Qwen3 chat_template_kwargs) - only
-        # set when the caller actually supplied something so default OpenAI
-        # behaviour is unchanged for everyone else.
-        reasoning_supported = (
-            (self.feature_capabilities or {}).get("reasoning", {}).get("supported")
-            is True
-        )
-        if not reasoning_supported:
-            completion_kwargs.pop("reasoning_effort", None)
         if self.extra_body:
-            safe_extra_body = dict(self.extra_body)
-            if not reasoning_supported:
-                safe_extra_body.pop("enable_thinking", None)
-                safe_extra_body.pop("reasoning", None)
-                template_kwargs = safe_extra_body.get("chat_template_kwargs")
-                if isinstance(template_kwargs, dict) and "enable_thinking" in template_kwargs:
-                    safe_extra_body["chat_template_kwargs"] = {
-                        key: value
-                        for key, value in template_kwargs.items()
-                        if key != "enable_thinking"
-                    }
-            if safe_extra_body:
-                completion_kwargs["extra_body"] = safe_extra_body
+            completion_kwargs["extra_body"] = dict(self.extra_body)
+        runtime_feature_capabilities = dict(self.feature_capabilities or {})
+        runtime_cache_capability = runtime_feature_capabilities.get("prompt_cache")
+        runtime_cache_capability = (
+            dict(runtime_cache_capability)
+            if isinstance(runtime_cache_capability, dict)
+            else {}
+        )
+        if runtime_cache_capability.get("supported") is None and self.prompt_cache:
+            cache_mode = str(self.prompt_cache.get("mode") or "unknown")
+            runtime_cache_capability = {
+                "supported": bool(
+                    self.prompt_cache.get(
+                        "enabled",
+                        cache_mode not in {"unknown", "none", "disabled", ""},
+                    )
+                ),
+                "mode": cache_mode,
+                "metrics_available": self.prompt_cache.get("metrics_available"),
+            }
+            runtime_feature_capabilities["prompt_cache"] = runtime_cache_capability
+        effective_feature_policy = resolve_effective_feature_policy(
+            runtime_feature_capabilities,
+            self.feature_preferences,
+        )
+        self.last_effective_feature_policy = effective_feature_policy
+        completion_kwargs = apply_reasoning_request_policy(
+            completion_kwargs,
+            effective_feature_policy,
+        )
 
         trusted_budget_snapshot = (
             safe_input_budget_snapshot or self.safe_input_budget_snapshot
@@ -485,9 +501,10 @@ class OpenAIModel(OpenAIServerModel):
         ):
             completion_kwargs["max_tokens"] = self.max_output_tokens
 
+        cache_enabled = effective_feature_policy["prompt_cache"]["enabled"] is True
         selected_cache_profile = resolve_prompt_cache_profile(
             self.model_factory or "unknown", self.prompt_cache
-        )
+        ) if cache_enabled else None
         # Provider protocol decisions depend only on the approved provider/model
         # capability profile.  Context partitioning and ordering are owned by
         # ContextManager and are intentionally opaque to this adapter.
@@ -526,6 +543,15 @@ class OpenAIModel(OpenAIServerModel):
                 ),
                 "llm.reasoning.request_style": str(
                     reasoning_profile.get("request_style") or "unknown"
+                ),
+                "llm.reasoning.effective_enabled": bool(
+                    effective_feature_policy["reasoning"]["enabled"]
+                ),
+                "llm.reasoning.effective_effort": str(
+                    effective_feature_policy["reasoning"].get("effort") or ""
+                ),
+                "llm.feature.policy_source": str(
+                    effective_feature_policy.get("source") or "nexent_default"
                 ),
                 "llm.prompt_cache.mode": cache_advice.mode,
                 "llm.prompt_cache.supported": cache_advice.supported,

--- a/sdk/nexent/core/models/openai_llm.py
+++ b/sdk/nexent/core/models/openai_llm.py
@@ -12,9 +12,9 @@ import threading
 import asyncio
 import time
 import json
-from typing import List, Optional, Dict, Any
+import re
+from typing import Callable, List, Optional, Dict, Any
 
-from openai.types.chat.chat_completion_message import ChatCompletionMessage
 from smolagents import Tool
 from smolagents.models import OpenAIServerModel, ChatMessage, MessageRole
 
@@ -25,6 +25,7 @@ from .capacity_budget import (
     SafeInputBudgetSnapshot,
     compute_w2_fingerprint,
 )
+from .capacity_resolver import derive_output_protection_tokens
 from ..utils.observer import MessageObserver, ProcessType
 from .prompt_cache import (
     apply_cache_directives,
@@ -32,19 +33,64 @@ from .prompt_cache import (
     extract_prompt_cache_usage,
     resolve_prompt_cache_profile,
 )
-from .message_utils import content_has_multimodal_blocks, prepare_messages_for_smolagents_text_flattening
+from .message_utils import (
+    content_has_multimodal_blocks,
+    prepare_messages_for_smolagents_text_flattening,
+)
 from .retry import DEFAULT_MODEL_RETRY, ModelRetryConfig, classify_model_error
+from .final_request_budget import (
+    FinalRequestIdentity,
+    FinalRequestMeter,
+    FinalRequestPreflight,
+    FinalRequestSoftBudgetExceeded,
+    CompactionNoReduction,
+    ContextRebuildOverBudget,
+    ProviderContextOverflowRetryExhausted,
+    ProviderContextOverflowRetryUnsafe,
+    RequestSideEffectGuard,
+    build_final_request_shape,
+    is_provider_context_overflow,
+)
+from .provider_request_count import count_final_request, endpoint_fingerprint
+from .provider_usage import (
+    ProviderCallUsage,
+    normalize_provider_usage,
+    resolve_provider_usage_profile,
+)
+from .tokenizer_registry import resolve as resolve_tokenizer
 
 logger = logging.getLogger("openai_llm")
 
-# Raised (with this message) when a model invocation is aborted because the
-# caller's stop event was set. Reused at every stop_event check site so the
-# message stays consistent and is easy to assert against in tests.
 STOP_EVENT_INTERRUPTED_MESSAGE = "Model is interrupted by stop event"
+
+
+def _token_usage(*, input_tokens: int, output_tokens: int) -> Any:
+    """Create TokenUsage without making lightweight model imports load monitoring."""
+    from smolagents.monitoring import TokenUsage
+
+    return TokenUsage(input_tokens=input_tokens, output_tokens=output_tokens)
 
 
 class EmptyModelResponseError(RuntimeError):
     """Raised when a completed provider stream contains no user-visible content."""
+
+
+class IncompleteToolCallError(RuntimeError):
+    """Raised when a length stop leaves tool-call arguments incomplete."""
+
+
+def _merge_continuation_text(existing: str, continuation: str) -> tuple[str, bool]:
+    """Join an automatic continuation while removing a repeated boundary prefix."""
+    if not continuation.strip():
+        return existing, False
+    max_overlap = min(len(existing), len(continuation), 2048)
+    for overlap in range(max_overlap, 0, -1):
+        if existing[-overlap:] == continuation[:overlap]:
+            continuation = continuation[overlap:]
+            break
+    if not continuation.strip():
+        return existing, False
+    return existing + continuation, True
 
 
 class OpenAIModel(OpenAIServerModel):
@@ -59,7 +105,7 @@ class OpenAIModel(OpenAIServerModel):
                  flatten_messages_as_text: Optional[bool] = None,
                  safe_input_budget_snapshot: Optional[SafeInputBudgetSnapshot | Dict[str, Any]] = None,
                  timeout_seconds: Optional[float] = None,
-                 retry_config: Optional["ModelRetryConfig"] = None,
+                 retry_config: Optional[ModelRetryConfig] = None,
                  *args, **kwargs):
         """
         Initialize OpenAI Model with observer and SSL verification option.
@@ -98,6 +144,20 @@ class OpenAIModel(OpenAIServerModel):
         """
         capacity_snapshot: Optional[Dict[str, Any]] = kwargs.pop("capacity_snapshot", None)
         prompt_cache: Optional[Dict[str, Any]] = kwargs.pop("prompt_cache", None)
+        self.feature_capabilities: Optional[Dict[str, Any]] = kwargs.pop(
+            "feature_capabilities", None
+        )
+        self.provider_usage_profile: Optional[Dict[str, Any]] = kwargs.pop(
+            "provider_usage_profile", None
+        )
+        self.canonical_model_id = kwargs.pop("canonical_model_id", None)
+        self.model_identity_metadata = kwargs.pop("model_identity_metadata", None)
+        self.tokenizer_match_metadata = kwargs.pop("tokenizer_match_metadata", None)
+        self.tokenizer_family = kwargs.pop("tokenizer_family", None)
+        self.token_count_probe_metadata = kwargs.pop("token_count_probe_metadata", None)
+        self._token_count_api_base = str(kwargs.get("api_base") or "")
+        self._token_count_api_key = str(kwargs.get("api_key") or "")
+        self._token_count_ssl_verify = bool(ssl_verify)
 
         self.observer = observer
         self.temperature = temperature
@@ -105,6 +165,10 @@ class OpenAIModel(OpenAIServerModel):
         self.stop_event = threading.Event()
         self._monitoring = get_monitoring_manager()
         self.model_factory = (model_factory or "").lower()
+        self.provider_usage_profile = self.provider_usage_profile or resolve_provider_usage_profile(
+            self.model_factory,
+            getattr(self, "capability_profile_version", None),
+        )
         self.flatten_messages_as_text = flatten_messages_as_text
         self.display_name = display_name
         self.extra_body = extra_body or None
@@ -113,6 +177,14 @@ class OpenAIModel(OpenAIServerModel):
         self.last_prompt_cache_usage = None
         self.last_cached_input_token_count = 0
         self.last_response_diagnostics = None
+        self.provider_call_usages: list[ProviderCallUsage] = []
+        self.turn_provider_call_usages: list[ProviderCallUsage] = []
+        self._provider_usage_turn_id: Optional[str] = None
+        self.last_provider_call_usage: Optional[ProviderCallUsage] = None
+        self.last_final_request_preflight: Optional[FinalRequestPreflight] = None
+        self.last_recovery_state = "not_needed"
+        self.context_budget_step_number = 0
+        self._final_request_meter = FinalRequestMeter()
         self.safe_input_budget_snapshot = safe_input_budget_snapshot
         self.capacity_snapshot = capacity_snapshot
         if max_output_tokens is None and max_tokens is not None:
@@ -160,12 +232,36 @@ class OpenAIModel(OpenAIServerModel):
     def __call__(self, messages: List[Dict[str, Any]], stop_sequences: Optional[List[str]] = None,
                  response_format: dict[str, str] | None = None, tools_to_call_from: Optional[List[Tool]] = None,
                  _token_tracker=None, safe_input_budget_snapshot: Optional[SafeInputBudgetSnapshot] = None,
+                 context_rebuild: Optional[Callable[[int], Any]] = None,
+                 _budget_retry_ordinal: int = 0,
+                 _soft_rebuild_attempted: bool = False,
+                 _previous_preflight: Optional[FinalRequestPreflight] = None,
+                 _side_effect_guard: Optional[RequestSideEffectGuard] = None,
+                 _recovery_original_hard_count: Optional[int] = None,
+                 _provider_safe_limit: Optional[int] = None,
+                 _length_continuation_ordinal: int = 0,
+                 _transport_retry_ordinal: int = 0,
+                 usage_purpose: str = "main_agent",
+                 usage_turn_id: Optional[str] = None,
                  **kwargs, ) -> ChatMessage:
         _monitoring_operation.set("chat_completion")
+        side_effect_guard = _side_effect_guard or RequestSideEffectGuard()
 
         if _token_tracker is None:
+            effective_turn_id = usage_turn_id or getattr(
+                self, "default_usage_turn_id", None
+            )
+            self.provider_call_usages = []
+            self.last_provider_call_usage = None
+            self._active_usage_purpose = usage_purpose
+            self._active_usage_turn_id = effective_turn_id
+            if effective_turn_id != self._provider_usage_turn_id:
+                self.turn_provider_call_usages = []
+                self._final_request_meter.clear_observed_anchor()
+                self._provider_usage_turn_id = effective_turn_id
             trusted_budget_snapshot = (
                 safe_input_budget_snapshot or self.safe_input_budget_snapshot
+                or (self._provisional_budget_snapshot() if context_rebuild is not None else None)
             )
             invocation_parameters = {
                 "temperature": self.temperature,
@@ -200,11 +296,92 @@ class OpenAIModel(OpenAIServerModel):
                     tools_to_call_from=tools_to_call_from,
                     _token_tracker=token_tracker,
                     safe_input_budget_snapshot=safe_input_budget_snapshot,
+                    context_rebuild=context_rebuild,
+                    _budget_retry_ordinal=_budget_retry_ordinal,
+                    _soft_rebuild_attempted=_soft_rebuild_attempted,
+                    _previous_preflight=_previous_preflight,
+                    _side_effect_guard=side_effect_guard,
+                    _recovery_original_hard_count=_recovery_original_hard_count,
+                    _provider_safe_limit=_provider_safe_limit,
+                    _length_continuation_ordinal=_length_continuation_ordinal,
+                    _transport_retry_ordinal=_transport_retry_ordinal,
+                    usage_purpose=usage_purpose,
+                    usage_turn_id=usage_turn_id,
                     **kwargs,
                 )
 
         token_tracker = _token_tracker or self._monitoring.create_token_tracker(
             self.model_id)
+        if _transport_retry_ordinal == 0:
+            self.last_retry_count = 0
+        if self.stop_event.is_set():
+            if token_tracker:
+                self._monitoring.add_span_event(
+                    "model_stopped", {"reason": "stop_event_set"}
+                )
+            raise RuntimeError(STOP_EVENT_INTERRUPTED_MESSAGE)
+
+        def retry_transport_error(error: BaseException) -> ChatMessage:
+            is_empty_stop = (
+                isinstance(error, EmptyModelResponseError)
+                and self.last_finish_reason in (None, "stop")
+            )
+            max_attempts = (
+                min(self.retry_config.max_attempts, 2)
+                if is_empty_stop
+                else self.retry_config.max_attempts
+            )
+            retryable = is_empty_stop or classify_model_error(error) == "retryable"
+            if (
+                not retryable
+                or not side_effect_guard.recovery_safe
+                or _transport_retry_ordinal + 1 >= max_attempts
+            ):
+                raise error
+
+            next_ordinal = _transport_retry_ordinal + 1
+            backoff = self.retry_config.calculate_backoff(next_ordinal)
+            logger.warning(
+                "event=model_retry attempt=%d/%d error_type=%s retrying_after_seconds=%.2f",
+                next_ordinal,
+                max_attempts,
+                type(error).__name__,
+                backoff,
+            )
+            self.last_retry_count = next_ordinal
+            if self.stop_event.is_set():
+                raise RuntimeError(STOP_EVENT_INTERRUPTED_MESSAGE)
+            self.stop_event.wait(backoff)
+            if self.stop_event.is_set():
+                raise RuntimeError(STOP_EVENT_INTERRUPTED_MESSAGE)
+            return self.__call__(
+                messages=messages,
+                stop_sequences=stop_sequences,
+                response_format=response_format,
+                tools_to_call_from=tools_to_call_from,
+                _token_tracker=token_tracker,
+                safe_input_budget_snapshot=safe_input_budget_snapshot,
+                context_rebuild=context_rebuild,
+                _budget_retry_ordinal=_budget_retry_ordinal,
+                _soft_rebuild_attempted=_soft_rebuild_attempted,
+                _previous_preflight=_previous_preflight,
+                _side_effect_guard=side_effect_guard,
+                _recovery_original_hard_count=_recovery_original_hard_count,
+                _provider_safe_limit=_provider_safe_limit,
+                _length_continuation_ordinal=_length_continuation_ordinal,
+                _transport_retry_ordinal=next_ordinal,
+                usage_purpose=usage_purpose,
+                usage_turn_id=usage_turn_id,
+                **kwargs,
+            )
+        trusted_budget_snapshot = (
+            safe_input_budget_snapshot or self.safe_input_budget_snapshot
+            or (self._provisional_budget_snapshot() if context_rebuild is not None else None)
+        )
+        self._using_provisional_capacity = bool(
+            trusted_budget_snapshot
+            and "provisional_32768_capacity" in getattr(trusted_budget_snapshot, "warnings", ())
+        )
         self.last_response_diagnostics = None
 
         # Normalize incoming messages so we can accept plain dict payloads like
@@ -239,8 +416,8 @@ class OpenAIModel(OpenAIServerModel):
             )
 
         has_media = any(
-            content_has_multimodal_blocks(getattr(m, "content", None))
-            for m in normalized_messages
+            content_has_multimodal_blocks(getattr(message, "content", None))
+            for message in normalized_messages
         )
         flatten_messages_as_text = (
             self.model_factory == "modelengine" and not has_media
@@ -266,12 +443,33 @@ class OpenAIModel(OpenAIServerModel):
         # Provider-specific extras (e.g. Qwen3 chat_template_kwargs) - only
         # set when the caller actually supplied something so default OpenAI
         # behaviour is unchanged for everyone else.
+        reasoning_supported = (
+            (self.feature_capabilities or {}).get("reasoning", {}).get("supported")
+            is True
+        )
+        if not reasoning_supported:
+            completion_kwargs.pop("reasoning_effort", None)
         if self.extra_body:
-            completion_kwargs["extra_body"] = self.extra_body
+            safe_extra_body = dict(self.extra_body)
+            if not reasoning_supported:
+                safe_extra_body.pop("enable_thinking", None)
+                safe_extra_body.pop("reasoning", None)
+                template_kwargs = safe_extra_body.get("chat_template_kwargs")
+                if isinstance(template_kwargs, dict) and "enable_thinking" in template_kwargs:
+                    safe_extra_body["chat_template_kwargs"] = {
+                        key: value
+                        for key, value in template_kwargs.items()
+                        if key != "enable_thinking"
+                    }
+            if safe_extra_body:
+                completion_kwargs["extra_body"] = safe_extra_body
 
         trusted_budget_snapshot = (
             safe_input_budget_snapshot or self.safe_input_budget_snapshot
+            or (self._provisional_budget_snapshot() if context_rebuild is not None else None)
         )
+        if trusted_budget_snapshot is None:
+            self.last_final_request_preflight = None
 
         # Bound completion length unless the caller passed their own override
         # via kwargs (which already landed in completion_kwargs above).
@@ -302,11 +500,41 @@ class OpenAIModel(OpenAIServerModel):
         # and assembles the result. Drop a stale construction-time ``stream``
         # so it cannot collide with the explicit ``stream=True`` at dispatch.
         dispatch_kwargs.pop("stream", None)
+        feature_profile = self.feature_capabilities or {}
+        reasoning_profile = feature_profile.get("reasoning") or {}
+        cache_profile = feature_profile.get("prompt_cache") or {}
+        resolved_reasoning_support = reasoning_profile.get("supported")
         self._monitoring.set_span_attributes(
             **{
+                "llm.feature.source": str(feature_profile.get("source") or "unknown"),
+                "llm.feature.match_kind": str(
+                    feature_profile.get("match_kind") or "unknown"
+                ),
+                "llm.feature.catalog_revision": str(
+                    feature_profile.get("catalog_revision") or ""
+                ),
+                "llm.feature.profile_version": str(
+                    feature_profile.get("profile_version") or ""
+                ),
+                "llm.reasoning.supported": (
+                    resolved_reasoning_support
+                    if isinstance(resolved_reasoning_support, bool)
+                    else "unknown"
+                ),
+                "llm.reasoning.mode": str(
+                    reasoning_profile.get("mode") or "unknown"
+                ),
+                "llm.reasoning.request_style": str(
+                    reasoning_profile.get("request_style") or "unknown"
+                ),
                 "llm.prompt_cache.mode": cache_advice.mode,
                 "llm.prompt_cache.supported": cache_advice.supported,
                 "llm.prompt_cache.directive_reason": cache_advice.reason,
+                "llm.prompt_cache.profile_supported": (
+                    cache_profile.get("supported")
+                    if isinstance(cache_profile.get("supported"), bool)
+                    else "unknown"
+                ),
             }
         )
         context_evidence = getattr(self, "last_context_evidence", None)
@@ -315,7 +543,7 @@ class OpenAIModel(OpenAIServerModel):
                 **{
                     "llm.prompt_cache.stable_prefix_fingerprint": getattr(
                         context_evidence, "stable_prefix_fingerprint", None
-                    ),
+                    ) or "",
                     "llm.prompt_cache.prefix_change_reasons": json.dumps(
                         list(getattr(context_evidence, "prefix_change_reasons", ())),
                         ensure_ascii=False,
@@ -329,295 +557,490 @@ class OpenAIModel(OpenAIServerModel):
                 }
             )
 
-        for attempt in range(1, self.retry_config.max_attempts + 1):
-            if self.stop_event.is_set():
-                if token_tracker:
-                    self._monitoring.add_span_event("model_stopped", {
-                        "reason": "stop_event_set"})
-                raise RuntimeError(STOP_EVENT_INTERRUPTED_MESSAGE)
-            try:
-                current_request = self._dispatch_chat_completion(
-                    safe_input_budget_snapshot=trusted_budget_snapshot,
-                    capacity_snapshot=self.capacity_snapshot,
-                    stream=True,
-                    **dispatch_kwargs,
+        try:
+            current_request = self._dispatch_chat_completion(
+                safe_input_budget_snapshot=trusted_budget_snapshot,
+                capacity_snapshot=(
+                    None
+                    if "provisional_32768_capacity" in getattr(trusted_budget_snapshot, "warnings", ())
+                    else self.capacity_snapshot
+                ),
+                retry_ordinal=_budget_retry_ordinal,
+                request_rebuild_available=context_rebuild is not None,
+                soft_rebuild_attempted=_soft_rebuild_attempted,
+                previous_preflight=_previous_preflight,
+                usage_purpose=usage_purpose,
+                usage_turn_id=usage_turn_id,
+                stream=True,
+                **dispatch_kwargs,
+            )
+            provider_call_record = self.last_provider_call_usage
+        except FinalRequestSoftBudgetExceeded as soft_error:
+            return self._rebuild_and_retry(
+                soft_error.preflight,
+                context_rebuild=context_rebuild,
+                token_tracker=token_tracker,
+                stop_sequences=stop_sequences,
+                response_format=response_format,
+                tools_to_call_from=tools_to_call_from,
+                trusted_budget_snapshot=trusted_budget_snapshot,
+                retry_ordinal=_budget_retry_ordinal,
+                soft_rebuild_attempted=True,
+                call_kwargs=kwargs,
+                recovery_original_hard_count=_recovery_original_hard_count,
+                provider_safe_limit=_provider_safe_limit,
+            )
+        except Exception as error:
+            if not is_provider_context_overflow(error):
+                return retry_transport_error(error)
+            if trusted_budget_snapshot is None:
+                raise
+            return self._recover_provider_overflow(
+                error,
+                preflight=self.last_final_request_preflight,
+                context_rebuild=context_rebuild,
+                token_tracker=token_tracker,
+                stop_sequences=stop_sequences,
+                response_format=response_format,
+                tools_to_call_from=tools_to_call_from,
+                trusted_budget_snapshot=trusted_budget_snapshot,
+                retry_ordinal=_budget_retry_ordinal,
+                call_kwargs=kwargs,
+                recovery_original_hard_count=_recovery_original_hard_count,
+                provider_safe_limit=_provider_safe_limit,
+            )
+
+        # Validate response type: ensure we got a proper iterator, not error strings or dicts
+        # Some APIs return error strings like "error: rate limit" or JSON dicts on failure
+        if isinstance(current_request, str):
+            raise ValueError(f"LLM API returned error string: {current_request}")
+        if isinstance(current_request, dict):
+            error_msg = current_request.get("error") or current_request.get("message") or str(current_request)
+            raise ValueError(f"LLM API returned error: {error_msg}")
+
+        chunk_list = []
+        token_join = []
+        role = None
+        finish_reason = None
+        self.last_finish_reason = None
+        content_chunk_count = 0
+        reasoning_chunk_count = 0
+        reasoning_char_count = 0
+        empty_choices_chunk_count = 0
+        nonstandard_chunk_count = 0
+        tool_call_chunk_count = 0
+        tool_call_fragments: Dict[int, Dict[str, Any]] = {}
+
+        # Reset output mode
+        self.observer.current_mode = ProcessType.MODEL_OUTPUT_THINKING
+
+        # Track streaming metrics
+        stream_start_time = time.time()
+        first_token_received = False
+
+        try:
+            for chunk in current_request:
+                # Safety check: skip non-standard chunks that lack expected attributes
+                # This handles edge cases where API returns error responses as chunks
+                if not hasattr(chunk, 'choices'):
+                    # Log warning and continue processing
+                    if hasattr(chunk, '__str__'):
+                        chunk_str = str(chunk)
+                        logger.warning(f"Received non-standard chunk (no 'choices'): {chunk_str[:200]}")
+                    chunk_list.append(chunk)
+                    nonstandard_chunk_count += 1
+                    continue
+
+                if not chunk.choices:
+                    chunk_list.append(chunk)
+                    empty_choices_chunk_count += 1
+                    continue
+
+                chunk_finish_reason = getattr(chunk.choices[0], "finish_reason", None)
+                if chunk_finish_reason is not None:
+                    finish_reason = str(chunk_finish_reason)
+
+                delta = chunk.choices[0].delta
+                delta_role = getattr(delta, "role", None)
+                if delta_role is not None:
+                    role = delta_role
+                new_token = delta.content
+                reasoning_content = getattr(
+                    delta, 'reasoning_content', None)
+                delta_tool_calls = getattr(delta, "tool_calls", None) or []
+                # OpenAI emits a concrete sequence. Treat dynamic proxy values
+                # (including permissive mocks) as absent instead of inventing a
+                # tool side effect that would incorrectly disable safe retries.
+                if not isinstance(delta_tool_calls, (list, tuple)):
+                    delta_tool_calls = []
+                if delta_tool_calls:
+                    side_effect_guard.mark("tool_effect")
+                for position, tool_call in enumerate(delta_tool_calls):
+                    index = getattr(tool_call, "index", position)
+                    if not isinstance(index, int):
+                        index = position
+                    fragment = tool_call_fragments.setdefault(
+                        index,
+                        {"id": "", "type": "function", "name": "", "arguments": ""},
+                    )
+                    call_id = getattr(tool_call, "id", None)
+                    call_type = getattr(tool_call, "type", None)
+                    function = getattr(tool_call, "function", None)
+                    if call_id:
+                        fragment["id"] += str(call_id)
+                    if call_type:
+                        fragment["type"] = str(call_type)
+                    if function is not None:
+                        name = getattr(function, "name", None)
+                        arguments = getattr(function, "arguments", None)
+                        if name:
+                            fragment["name"] += str(name)
+                        if arguments:
+                            fragment["arguments"] += str(arguments)
+                    tool_call_chunk_count += 1
+
+                # Handle reasoning_content if it exists and is not null
+                if reasoning_content is not None:
+                    reasoning_chunk_count += 1
+                    reasoning_char_count += len(str(reasoning_content))
+                    self.observer.add_model_reasoning_content(
+                        reasoning_content)
+                    if token_tracker and not first_token_received:
+                        token_tracker.record_first_token()
+                        first_token_received = True
+                        if provider_call_record is not None:
+                            provider_call_record._first_token_at = time.time()
+
+                if new_token is not None:
+                    if str(new_token):
+                        side_effect_guard.mark("response_started")
+                    content_chunk_count += 1
+                    # Record first token timing
+                    if token_tracker and not first_token_received:
+                        token_tracker.record_first_token()
+                        first_token_received = True
+                        if provider_call_record is not None:
+                            provider_call_record._first_token_at = time.time()
+
+                    # Track each token
+                    if token_tracker:
+                        token_tracker.record_token(new_token)
+
+                    self.observer.add_model_new_token(new_token)
+                    token_join.append(new_token)
+
+                chunk_list.append(chunk)
+                if self.stop_event.is_set():
+                    if token_tracker:
+                        self._monitoring.add_span_event("model_stopped", {
+                            "reason": "stop_event_set"})
+                    raise RuntimeError(STOP_EVENT_INTERRUPTED_MESSAGE)
+
+            # Send end marker
+            self.observer.flush_remaining_tokens()
+            model_output = "".join(token_join)
+            tool_calls = [
+                {
+                    "id": fragment["id"] or f"tool_call_{index}",
+                    "type": fragment["type"],
+                    "function": {
+                        "name": fragment["name"],
+                        "arguments": fragment["arguments"],
+                    },
+                }
+                for index, fragment in sorted(tool_call_fragments.items())
+            ]
+            self.last_finish_reason = finish_reason
+            if finish_reason == "length":
+                logger.warning(
+                    "Model output reached the configured completion token limit; "
+                    "the answer is incomplete"
+                )
+                self._monitoring.add_span_event("completion_truncated", {
+                    "finish_reason": finish_reason,
+                })
+
+            # Extract token usage
+            input_tokens = 0
+            output_tokens = 0
+            usage = None
+            if chunk_list and chunk_list[-1].usage is not None:
+                usage = chunk_list[-1].usage
+                input_tokens = usage.prompt_tokens
+                output_tokens = usage.completion_tokens if hasattr(
+                    usage, 'completion_tokens') else usage.total_tokens
+                self.last_input_token_count = input_tokens
+                self.last_output_token_count = output_tokens
+            else:
+                input_text = ""
+                for msg in normalized_messages:
+                    if hasattr(msg, 'content'):
+                        content = msg.content
+                        if isinstance(content, str):
+                            input_text += content
+                        elif isinstance(content, list):
+                            for part in content:
+                                if isinstance(part, dict) and part.get("type") == "text":
+                                    input_text += part.get("text", "")
+                input_tokens = estimate_tokens_text(input_text)
+                output_tokens = estimate_tokens_text(model_output)
+                self.last_input_token_count = input_tokens
+                self.last_output_token_count = output_tokens
+                logger.debug(
+                    f"Token usage not returned by API, using estimation: "
+                    f"input_tokens={input_tokens}, output_tokens={output_tokens}"
                 )
 
-                # Validate response type: ensure we got a proper iterator, not error strings or dicts
-                # Some APIs return error strings like "error: rate limit" or JSON dicts on failure
-                if isinstance(current_request, str):
-                    raise ValueError(f"LLM API returned error string: {current_request}")
-                if isinstance(current_request, dict):
-                    error_msg = current_request.get("error") or current_request.get("message") or str(current_request)
-                    raise ValueError(f"LLM API returned error: {error_msg}")
+            self._finalize_provider_call_usage(
+                provider_call_record,
+                raw_usage=usage,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                status="completed",
+                finish_reason=finish_reason,
+                first_token_received=first_token_received,
+            )
 
-                chunk_list = []
-                token_join = []
-                role = None
-                finish_reason = None
-                self.last_finish_reason = None
-                content_chunk_count = 0
-                reasoning_chunk_count = 0
-                reasoning_char_count = 0
-                empty_choices_chunk_count = 0
-                nonstandard_chunk_count = 0
-
-                # Reset output mode
-                self.observer.current_mode = ProcessType.MODEL_OUTPUT_THINKING
-
-                # Track streaming metrics
-                stream_start_time = time.time()
-                first_token_received = False
-
-                try:
-                    for chunk in current_request:
-                        # Safety check: skip non-standard chunks that lack expected attributes
-                        # This handles edge cases where API returns error responses as chunks
-                        if not hasattr(chunk, 'choices'):
-                            # Log warning and continue processing
-                            if hasattr(chunk, '__str__'):
-                                chunk_str = str(chunk)
-                                logger.warning(f"Received non-standard chunk (no 'choices'): {chunk_str[:200]}")
-                            chunk_list.append(chunk)
-                            nonstandard_chunk_count += 1
-                            continue
-
-                        if not chunk.choices:
-                            chunk_list.append(chunk)
-                            empty_choices_chunk_count += 1
-                            continue
-
-                        chunk_finish_reason = getattr(chunk.choices[0], "finish_reason", None)
-                        if chunk_finish_reason is not None:
-                            finish_reason = str(chunk_finish_reason)
-
-                        new_token = chunk.choices[0].delta.content
-                        reasoning_content = getattr(
-                            chunk.choices[0].delta, 'reasoning_content', None)
-
-                        # Handle reasoning_content if it exists and is not null
-                        if reasoning_content is not None:
-                            reasoning_chunk_count += 1
-                            reasoning_char_count += len(str(reasoning_content))
-                            self.observer.add_model_reasoning_content(
-                                reasoning_content)
-                            if token_tracker and not first_token_received:
-                                token_tracker.record_first_token()
-                                first_token_received = True
-
-                        if new_token is not None:
-                            content_chunk_count += 1
-                            # Record first token timing
-                            if token_tracker and not first_token_received:
-                                token_tracker.record_first_token()
-                                first_token_received = True
-
-                            # Track each token
-                            if token_tracker:
-                                token_tracker.record_token(new_token)
-
-                            self.observer.add_model_new_token(new_token)
-                            token_join.append(new_token)
-                            role = chunk.choices[0].delta.role
-
-                        chunk_list.append(chunk)
-                        if self.stop_event.is_set():
-                            if token_tracker:
-                                self._monitoring.add_span_event("model_stopped", {
-                                    "reason": "stop_event_set"})
-                            raise RuntimeError(STOP_EVENT_INTERRUPTED_MESSAGE)
-
-                    # Send end marker
-                    self.observer.flush_remaining_tokens()
-                    model_output = "".join(token_join)
-                    self.last_finish_reason = finish_reason
-                    if finish_reason == "length":
-                        logger.warning(
-                            "Model output reached the configured completion token limit; "
-                            "the answer is incomplete"
-                        )
-                        self._monitoring.add_span_event("completion_truncated", {
-                            "finish_reason": finish_reason,
-                        })
-
-                    # Extract token usage
-                    input_tokens = 0
-                    output_tokens = 0
-                    usage = None
-                    if chunk_list and chunk_list[-1].usage is not None:
-                        usage = chunk_list[-1].usage
-                        input_tokens = usage.prompt_tokens
-                        output_tokens = usage.completion_tokens if hasattr(
-                            usage, 'completion_tokens') else usage.total_tokens
-                        self.last_input_token_count = input_tokens
-                        self.last_output_token_count = output_tokens
-                    else:
-                        input_text = ""
-                        for msg in normalized_messages:
-                            if hasattr(msg, 'content'):
-                                content = msg.content
-                                if isinstance(content, str):
-                                    input_text += content
-                                elif isinstance(content, list):
-                                    for part in content:
-                                        if isinstance(part, dict) and part.get("type") == "text":
-                                            input_text += part.get("text", "")
-                        input_tokens = estimate_tokens_text(input_text)
-                        output_tokens = estimate_tokens_text(model_output)
-                        self.last_input_token_count = input_tokens
-                        self.last_output_token_count = output_tokens
-                        logger.debug(
-                            f"Token usage not returned by API, using estimation: "
-                            f"input_tokens={input_tokens}, output_tokens={output_tokens}"
-                        )
-
-                    cache_usage = extract_prompt_cache_usage(
-                        usage, input_tokens, capability_profile=selected_cache_profile
-                    )
-                    self.last_prompt_cache_usage = cache_usage
-                    self.last_cached_input_token_count = cache_usage.cached_input_tokens
-                    self._monitoring.set_span_attributes(
-                        **{
-                            "llm.prompt_cache.cached_input_tokens": cache_usage.cached_input_tokens,
-                            "llm.prompt_cache.uncached_input_tokens": cache_usage.uncached_input_tokens,
-                            "llm.prompt_cache.provider_cache_hit": cache_usage.provider_cache_hit,
-                            "llm.prompt_cache.hit_ratio": cache_usage.hit_ratio,
-                            "llm.prompt_cache.metrics_source": cache_usage.metrics_source,
-                            "llm.prompt_cache.estimated_saved_input_tokens": cache_usage.estimated_saved_input_tokens,
-                            "llm.prompt_cache.estimated_input_savings_ratio": cache_usage.estimated_input_savings_ratio,
-                        }
-                    )
-
-                    # Record completion metrics
-                    if token_tracker:
-                        token_tracker.record_completion(
-                            input_tokens, output_tokens)
-
-                    response_diagnostics = {
-                        "finish_reason": finish_reason,
-                        "chunk_count": len(chunk_list),
-                        "content_chunk_count": content_chunk_count,
-                        "content_char_count": len(model_output),
-                        "reasoning_chunk_count": reasoning_chunk_count,
-                        "reasoning_char_count": reasoning_char_count,
-                        "empty_choices_chunk_count": empty_choices_chunk_count,
-                        "nonstandard_chunk_count": nonstandard_chunk_count,
-                        "input_tokens": input_tokens,
-                        "output_tokens": output_tokens,
+            if (
+                usage is not None
+                and trusted_budget_snapshot is not None
+                and self.last_final_request_preflight is not None
+            ):
+                calibration_added = self._final_request_meter.observe_usage(
+                    self.last_final_request_preflight,
+                    self._build_final_request_identity(trusted_budget_snapshot),
+                    provider_prompt_tokens=input_tokens,
+                )
+                self._final_request_meter.observe_request_input(
+                    self.last_final_request_preflight,
+                    self._build_final_request_identity(trusted_budget_snapshot),
+                    provider_prompt_tokens=input_tokens,
+                )
+                self._monitoring.set_span_attributes(
+                    **{
+                        "context.final_request.calibration_observed": calibration_added,
+                        "context.final_request.provider_prompt_tokens": input_tokens,
                     }
-                    self.last_response_diagnostics = response_diagnostics
-                    self._monitoring.set_span_attributes(
-                        **{f"llm.response.{key}": value for key, value in response_diagnostics.items()}
-                    )
-
-                    if token_tracker:
-                        total_duration = time.time() - stream_start_time
-                        self._monitoring.set_openinference_output(model_output)
-                        self._monitoring.add_span_event("completion_finished", {
-                            "total_duration": total_duration,
-                            "output_length": len(model_output),
-                            "chunk_count": len(chunk_list)
-                        })
-
-                    if not model_output.strip():
-                        logger.warning(
-                            "event=empty_model_response model_id=%s provider=%s "
-                            "finish_reason=%s chunk_count=%d content_chunk_count=%d "
-                            "reasoning_chunk_count=%d reasoning_char_count=%d "
-                            "empty_choices_chunk_count=%d nonstandard_chunk_count=%d "
-                            "input_tokens=%d output_tokens=%d",
-                            self.model_id,
-                            self.model_factory or "unknown",
-                            finish_reason,
-                            len(chunk_list),
-                            content_chunk_count,
-                            reasoning_chunk_count,
-                            reasoning_char_count,
-                            empty_choices_chunk_count,
-                            nonstandard_chunk_count,
-                            input_tokens,
-                            output_tokens,
-                        )
-                        self._monitoring.add_span_event("empty_model_response", response_diagnostics)
-                        raise EmptyModelResponseError(
-                            "Model stream completed without user-visible content "
-                            f"(finish_reason={finish_reason}, reasoning_chunks={reasoning_chunk_count}, "
-                            f"output_tokens={output_tokens})"
-                        )
-
-                    message = ChatMessage.from_dict(
-                        ChatCompletionMessage(role=role if role else "assistant",  # If there is no explicit role, default to "assistant"
-                                              content=model_output).model_dump(include={"role", "content", "tool_calls"}))
-
-                    from smolagents.monitoring import TokenUsage
-
-                    if input_tokens > 0 or output_tokens > 0:
-                        message.token_usage = TokenUsage(
-                            input_tokens=input_tokens,
-                            output_tokens=output_tokens
-                        )
-                    message.raw = current_request
-                    message.role = MessageRole.ASSISTANT
-                    return message
-
-                except Exception as e:
-                    if token_tracker:
-                        self._monitoring.add_span_event("error_occurred", {"error_type": type(
-                            e).__name__, "error_message": str(e)})
-
-                    if "context_length_exceeded" in str(e):
-                        raise ValueError(f"Token limit exceeded: {str(e)}")
-                    raise e
-            except EmptyModelResponseError:
-                # Some reasoning-capable OpenAI-compatible providers
-                # occasionally finish with ``stop`` after emitting only
-                # reasoning chunks. Retry once inside the model adapter so an
-                # otherwise transient malformed stream does not consume a
-                # visible agent step. A ``length`` finish is deterministic
-                # truncation and must still surface immediately.
-                empty_retry_limit = min(self.retry_config.max_attempts, 2)
-                if self.last_finish_reason not in (None, "stop") or attempt >= empty_retry_limit:
-                    raise
-                backoff = self.retry_config.calculate_backoff(attempt)
-                logger.warning(
-                    "event=retry_empty_model_response attempt=%d/%d finish_reason=%s "
-                    "retrying_after_seconds=%.2f",
-                    attempt,
-                    empty_retry_limit,
-                    self.last_finish_reason,
-                    backoff,
                 )
-                self.last_retry_count = attempt
-                if self.stop_event.is_set():
-                    raise RuntimeError(STOP_EVENT_INTERRUPTED_MESSAGE)
-                self.stop_event.wait(backoff)
-                continue
-            except Exception as e:
-                if classify_model_error(e) != "retryable":
-                    raise
-                if attempt >= self.retry_config.max_attempts:
-                    logging.exception(
-                        "Model call failed after %d attempts: %s",
-                        attempt, str(e),
-                    )
-                    raise
-                backoff = self.retry_config.calculate_backoff(attempt)
+
+            cache_usage = extract_prompt_cache_usage(
+                usage, input_tokens, capability_profile=selected_cache_profile
+            )
+            self.last_prompt_cache_usage = cache_usage
+            self.last_cached_input_token_count = cache_usage.cached_input_tokens
+            self._monitoring.set_span_attributes(
+                **{
+                    "llm.prompt_cache.cached_input_tokens": cache_usage.cached_input_tokens,
+                    "llm.prompt_cache.uncached_input_tokens": cache_usage.uncached_input_tokens,
+                    "llm.prompt_cache.provider_cache_hit": cache_usage.provider_cache_hit,
+                    "llm.prompt_cache.hit_ratio": cache_usage.hit_ratio,
+                    "llm.prompt_cache.metrics_source": cache_usage.metrics_source,
+                    "llm.prompt_cache.estimated_saved_input_tokens": cache_usage.estimated_saved_input_tokens,
+                    "llm.prompt_cache.estimated_input_savings_ratio": cache_usage.estimated_input_savings_ratio,
+                }
+            )
+
+            # Record completion metrics
+            if token_tracker:
+                token_tracker.record_completion(
+                    input_tokens, output_tokens)
+
+            response_diagnostics = {
+                "finish_reason": finish_reason,
+                "chunk_count": len(chunk_list),
+                "content_chunk_count": content_chunk_count,
+                "content_char_count": len(model_output),
+                "reasoning_chunk_count": reasoning_chunk_count,
+                "reasoning_char_count": reasoning_char_count,
+                "empty_choices_chunk_count": empty_choices_chunk_count,
+                "nonstandard_chunk_count": nonstandard_chunk_count,
+                "tool_call_chunk_count": tool_call_chunk_count,
+                "tool_call_count": len(tool_calls),
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            }
+            self.last_response_diagnostics = response_diagnostics
+            self._monitoring.set_span_attributes(
+                **{f"llm.response.{key}": value for key, value in response_diagnostics.items()}
+            )
+
+            if token_tracker:
+                total_duration = time.time() - stream_start_time
+                self._monitoring.set_openinference_output(model_output)
+                self._monitoring.add_span_event("completion_finished", {
+                    "total_duration": total_duration,
+                    "output_length": len(model_output),
+                    "chunk_count": len(chunk_list)
+                })
+
+            if not model_output.strip() and not tool_calls:
                 logger.warning(
-                    "Model call attempt %d/%d failed with retryable error (%s); "
-                    "retrying after %.2fs",
-                    attempt, self.retry_config.max_attempts, str(e), backoff,
+                    "event=empty_model_response model_id=%s provider=%s "
+                    "finish_reason=%s chunk_count=%d content_chunk_count=%d "
+                    "reasoning_chunk_count=%d reasoning_char_count=%d "
+                    "empty_choices_chunk_count=%d nonstandard_chunk_count=%d "
+                    "input_tokens=%d output_tokens=%d",
+                    self.model_id,
+                    self.model_factory or "unknown",
+                    finish_reason,
+                    len(chunk_list),
+                    content_chunk_count,
+                    reasoning_chunk_count,
+                    reasoning_char_count,
+                    empty_choices_chunk_count,
+                    nonstandard_chunk_count,
+                    input_tokens,
+                    output_tokens,
                 )
-                self.last_retry_count = attempt
-                if self.stop_event.is_set():
-                    raise RuntimeError(STOP_EVENT_INTERRUPTED_MESSAGE)
-                self.stop_event.wait(backoff)
-                continue
+                self._monitoring.add_span_event("empty_model_response", response_diagnostics)
+                raise EmptyModelResponseError(
+                    "Model stream completed without user-visible content "
+                    f"(finish_reason={finish_reason}, reasoning_chunks={reasoning_chunk_count}, "
+                    f"output_tokens={output_tokens})"
+                )
+
+            message = ChatMessage.from_dict({
+                "role": role if role else "assistant",
+                "content": model_output or None,
+                "tool_calls": tool_calls or None,
+            })
+
+            if input_tokens > 0 or output_tokens > 0:
+                message.token_usage = _token_usage(
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens
+                )
+            message.raw = current_request
+            message.provider_call_usages = tuple(self.provider_call_usages)
+            message.role = MessageRole.ASSISTANT
+
+            if finish_reason == "length":
+                if tool_calls:
+                    self._monitoring.add_span_event(
+                        "length_continuation_blocked",
+                        {"reason": "incomplete_tool_call"},
+                    )
+                    raise IncompleteToolCallError(
+                        "model output limit interrupted a tool call; the partial call was not executed"
+                    )
+                if _length_continuation_ordinal < 2 and model_output.strip():
+                    self._monitoring.add_span_event(
+                        "length_continuation_started",
+                        {"ordinal": _length_continuation_ordinal + 1},
+                    )
+                    continuation_messages = [
+                        *messages,
+                        {"role": "assistant", "content": model_output},
+                        {
+                            "role": "user",
+                            "content": (
+                                "Continue the preceding answer exactly where it stopped. "
+                                "Do not repeat existing text and do not add a new introduction."
+                            ),
+                        },
+                    ]
+                    continuation = self.__call__(
+                        messages=continuation_messages,
+                        stop_sequences=stop_sequences,
+                        response_format=response_format,
+                        tools_to_call_from=tools_to_call_from,
+                        _token_tracker=token_tracker,
+                        safe_input_budget_snapshot=safe_input_budget_snapshot,
+                        context_rebuild=context_rebuild,
+                        _budget_retry_ordinal=_budget_retry_ordinal,
+                        _soft_rebuild_attempted=_soft_rebuild_attempted,
+                        _previous_preflight=self.last_final_request_preflight,
+                        _side_effect_guard=side_effect_guard,
+                        _recovery_original_hard_count=_recovery_original_hard_count,
+                        _provider_safe_limit=_provider_safe_limit,
+                        _length_continuation_ordinal=_length_continuation_ordinal + 1,
+                        usage_purpose=usage_purpose,
+                        usage_turn_id=usage_turn_id,
+                        **kwargs,
+                    )
+                    continuation_text = continuation.content or ""
+                    merged_content, made_progress = _merge_continuation_text(
+                        model_output, continuation_text
+                    )
+                    if made_progress:
+                        continuation.content = merged_content
+                        if continuation.token_usage is not None and message.token_usage is not None:
+                            continuation.token_usage = _token_usage(
+                                input_tokens=(
+                                    message.token_usage.input_tokens
+                                    + continuation.token_usage.input_tokens
+                                ),
+                                output_tokens=(
+                                    message.token_usage.output_tokens
+                                    + continuation.token_usage.output_tokens
+                                ),
+                            )
+                        continuation.provider_call_usages = tuple(self.provider_call_usages)
+                        return continuation
+            return message
+
+        except Exception as e:
+            partial_usage = None
+            if chunk_list:
+                partial_usage = getattr(chunk_list[-1], "usage", None)
+            self._finalize_provider_call_usage(
+                locals().get("provider_call_record"),
+                raw_usage=partial_usage,
+                input_tokens=None,
+                output_tokens=None,
+                status="partial" if token_join or partial_usage is not None else "failed",
+                finish_reason=finish_reason,
+                first_token_received=first_token_received,
+            )
+            if token_tracker:
+                self._monitoring.add_span_event("error_occurred", {"error_type": type(
+                    e).__name__, "error_message": str(e)})
+
+            if is_provider_context_overflow(e):
+                if trusted_budget_snapshot is None:
+                    raise ValueError(f"Token limit exceeded: {str(e)}") from e
+                partial_prose = "".join(token_join)
+                if tool_call_fragments:
+                    self._record_recovery_state("retry_unsafe_after_response")
+                    raise ProviderContextOverflowRetryUnsafe(
+                        "provider overflow arrived after tool-call fragments"
+                    ) from e
+                if not side_effect_guard.recovery_safe and not partial_prose:
+                    self._record_recovery_state("retry_unsafe_after_response")
+                    raise ProviderContextOverflowRetryUnsafe(
+                        "provider overflow arrived after an observable side effect"
+                    ) from e
+                recovered = self._recover_provider_overflow(
+                    e,
+                    preflight=self.last_final_request_preflight,
+                    context_rebuild=context_rebuild,
+                    token_tracker=token_tracker,
+                    stop_sequences=stop_sequences,
+                    response_format=response_format,
+                    tools_to_call_from=tools_to_call_from,
+                    trusted_budget_snapshot=trusted_budget_snapshot,
+                    retry_ordinal=_budget_retry_ordinal,
+                    call_kwargs=kwargs,
+                    recovery_original_hard_count=_recovery_original_hard_count,
+                    provider_safe_limit=_provider_safe_limit,
+                    continuation_prefix=partial_prose or None,
+                )
+                if partial_prose:
+                    recovered.content = partial_prose + (recovered.content or "")
+                return recovered
+            return retry_transport_error(e)
 
     def _dispatch_chat_completion(
         self,
         *,
         safe_input_budget_snapshot: Optional[SafeInputBudgetSnapshot | Dict[str, Any]] = None,
         capacity_snapshot: Optional[Dict[str, Any]] = None,
+        retry_ordinal: int = 0,
+        request_rebuild_available: bool = False,
+        soft_rebuild_attempted: bool = False,
+        previous_preflight: Optional[FinalRequestPreflight] = None,
+        usage_purpose: str = "main_agent",
+        usage_turn_id: Optional[str] = None,
         **completion_kwargs: Any,
     ) -> Any:
         """Dispatch the OpenAI chat completion request.
@@ -631,13 +1054,27 @@ class OpenAIModel(OpenAIServerModel):
         identity to catch a stale or cross-model W2 snapshot before the
         provider call.
         """
+        from ...monitor.monitoring import set_monitoring_final_request_evidence
+        set_monitoring_final_request_evidence(None)
         snapshot = self._coerce_safe_input_budget_snapshot(safe_input_budget_snapshot)
         if snapshot is not None:
             self._verify_w1_w2_consistency(
                 budget_snapshot=snapshot,
                 capacity_snapshot=capacity_snapshot,
             )
-            trusted_max_tokens = snapshot.requested_output_tokens
+            request_model = completion_kwargs.get("model")
+            if request_model is not None and str(request_model) != snapshot.model_name:
+                raise SafeInputBudgetCapacityMismatch(
+                    field="model_name",
+                    expected=snapshot.model_name,
+                    actual=str(request_model),
+                )
+            # Profile/operator model capacity is the wire authority. The
+            # snapshot fallback only keeps legacy SDK callers without a model
+            # capacity contract operational during the compatibility window.
+            trusted_max_tokens = (
+                self.max_output_tokens or snapshot.requested_output_tokens
+            )
             caller_max_tokens = completion_kwargs.get("max_tokens")
             if caller_max_tokens is not None and caller_max_tokens != trusted_max_tokens:
                 raise CallerMaxTokensOverrideForbidden(
@@ -645,16 +1082,543 @@ class OpenAIModel(OpenAIServerModel):
                     caller_value=caller_max_tokens,
                 )
             completion_kwargs["max_tokens"] = trusted_max_tokens
-        logger.info(
-            "event=chat_completion_create model_id=%s kwargs=%s",
-            self.model_id,
-            json.dumps(
-                {k: v for k, v in completion_kwargs.items() if k != "messages"},
-                ensure_ascii=False,
-                default=str,
+            self._monitoring.set_span_attributes(
+                **{"llm.request.max_output_tokens": trusted_max_tokens}
+            )
+            identity = self._build_final_request_identity(snapshot)
+            final_shape = build_final_request_shape(completion_kwargs)
+            provider_count, fallback_reason = count_final_request(
+                final_shape,
+                metadata=self.token_count_probe_metadata,
+                base_url=self._token_count_api_base,
+                api_key=self._token_count_api_key,
+                model_name=self.model_id,
+                canonical_model_id=identity.canonical_model_id,
+                ssl_verify=self._token_count_ssl_verify,
+            )
+            tokenizer_count = self._verified_tokenizer_count(final_shape)
+            preflight = self._final_request_meter.measure(
+                completion_kwargs,
+                identity=identity,
+                soft_budget=snapshot.soft_input_budget_tokens,
+                hard_budget=snapshot.hard_input_budget_tokens,
+                provider_count=provider_count,
+                tokenizer_count=tokenizer_count,
+                fallback_reason=fallback_reason,
+                retry_ordinal=retry_ordinal,
+            )
+            if retry_ordinal > 0 and previous_preflight is not None and (
+                preflight.request_fingerprint == previous_preflight.request_fingerprint
+                or preflight.hard_count >= previous_preflight.hard_count
+            ):
+                self._record_recovery_state("no_reduction")
+                raise CompactionNoReduction(
+                    "compaction_no_reduction: rebuilt final request did not strictly shrink"
+                )
+            self.last_final_request_preflight = preflight
+            self._record_final_request_preflight(
+                preflight,
+                recovery_state=(
+                    "recovered"
+                    if retry_ordinal > 0
+                    else "soft_rebuilt"
+                    if soft_rebuild_attempted
+                    else "not_attempted"
+                ),
+            )
+            if (
+                preflight.soft_exceeded
+                and request_rebuild_available
+                and not soft_rebuild_attempted
+            ):
+                raise FinalRequestSoftBudgetExceeded(preflight)
+        call_record = ProviderCallUsage(
+            turn_id=getattr(self, "_active_usage_turn_id", usage_turn_id),
+            step_number=self.context_budget_step_number,
+            purpose=getattr(self, "_active_usage_purpose", usage_purpose),
+            attempt=retry_ordinal,
+            provider=self.model_factory or "unknown",
+            model=self.model_id,
+            capability_profile_version=(self.provider_usage_profile or {}).get(
+                "capability_profile_version"
             ),
+            status="failed",
         )
-        return self.client.chat.completions.create(**completion_kwargs)
+        call_record._started_at = time.time()
+        self.provider_call_usages.append(call_record)
+        self.turn_provider_call_usages.append(call_record)
+        self.last_provider_call_usage = call_record
+        try:
+            logger.info(
+                "event=chat_completion_create model_id=%s kwargs=%s",
+                self.model_id,
+                json.dumps(
+                    {key: value for key, value in completion_kwargs.items() if key != "messages"},
+                    ensure_ascii=False,
+                    default=str,
+                ),
+            )
+            return self.client.chat.completions.create(**completion_kwargs)
+        except Exception:
+            self._finalize_provider_call_usage(
+                call_record,
+                raw_usage=None,
+                input_tokens=None,
+                output_tokens=None,
+                status="failed",
+                finish_reason=None,
+                first_token_received=False,
+            )
+            raise
+
+    def _finalize_provider_call_usage(
+        self,
+        record: Optional[ProviderCallUsage],
+        *,
+        raw_usage: Any,
+        input_tokens: Optional[int],
+        output_tokens: Optional[int],
+        status: str,
+        finish_reason: Optional[str],
+        first_token_received: bool,
+    ) -> None:
+        """Finalize a physical-call record once without exposing request content."""
+        if record is None or record.status in {"completed", "partial"}:
+            return
+        normalized, quality, source, metadata = normalize_provider_usage(
+            raw_usage,
+            provider=record.provider,
+            model=record.model,
+            capability_profile=self.provider_usage_profile,
+        )
+        started_at = getattr(record, "_started_at", None)
+        record.source = source
+        record.status = status
+        record.usage = normalized
+        record.quality = quality
+        record.finish_reason = finish_reason
+        record.duration_ms = (
+            max(0, round((time.time() - started_at) * 1000))
+            if started_at is not None
+            else None
+        )
+        first_token_at = getattr(record, "_first_token_at", None)
+        record.time_to_first_token_ms = (
+            max(0, round((first_token_at - started_at) * 1000))
+            if first_token_received and first_token_at is not None and started_at is not None
+            else None
+        )
+        record.provider_metadata = metadata
+        from ..agents.context.composition import reconcile_context_composition
+
+        evidence = getattr(self, "last_context_evidence", None)
+        raw_composition = dict(
+            getattr(evidence, "context_composition_estimate", ()) or ()
+        )
+        record.context_composition = reconcile_context_composition(
+            raw_composition,
+            record.usage.input_tokens if record.source == "provider" else None,
+        ).to_dict()
+        if not getattr(record, "_usage_event_emitted", False):
+            usage_event_type = getattr(ProcessType, "LLM_USAGE", None)
+            if (
+                usage_event_type is not None
+                and self.observer is not None
+                and hasattr(self.observer, "add_message")
+            ):
+                self.observer.add_message(
+                    "",
+                    usage_event_type,
+                    json.dumps(record.to_dict(), ensure_ascii=False),
+                )
+            record._usage_event_emitted = True
+        self._monitoring.set_span_attributes(
+            **{
+                "usage.call_id": record.call_id,
+                "usage.source": record.source,
+                "usage.status": record.status,
+                "usage.input_tokens": record.usage.input_tokens,
+                "usage.output_tokens": record.usage.output_tokens,
+                "usage.total_tokens": record.usage.total_tokens,
+                "usage.fresh_input_tokens": record.usage.fresh_input_tokens,
+                "usage.cache_read_tokens": record.usage.cache_read_tokens,
+                "usage.cache_write_tokens": record.usage.cache_write_tokens,
+                "usage.reasoning_tokens": record.usage.reasoning_tokens,
+                "usage.visible_output_tokens": record.usage.visible_output_tokens,
+                "usage.quality_reasons": json.dumps(record.quality.reasons),
+                **{
+                    f"context.composition.{name}": value
+                    for name, value in record.context_composition["segments"].items()
+                },
+            }
+        )
+
+    def _verified_tokenizer_count(self, shape: Any) -> Optional[int]:
+        metadata = self.tokenizer_match_metadata or {}
+        if (
+            shape.request_shape != "text"
+            or not self.tokenizer_family
+            or metadata.get("auto_applicable") is not True
+        ):
+            return None
+        adapter, mode = resolve_tokenizer(self.tokenizer_family)
+        if mode != "exact":
+            return None
+        messages = shape.semantic_request.get("messages") or []
+        message_count = adapter.count_tokens(messages)
+        return max(
+            1,
+            message_count
+            + shape.components.reasoning
+            + shape.components.other_semantic,
+        )
+
+    def _recover_provider_overflow(
+        self,
+        error: BaseException,
+        *,
+        preflight: Optional[FinalRequestPreflight],
+        context_rebuild: Optional[Callable[[int], Any]],
+        token_tracker: Any,
+        stop_sequences: Optional[List[str]],
+        response_format: Optional[dict[str, str]],
+        tools_to_call_from: Optional[List[Tool]],
+        trusted_budget_snapshot: Optional[SafeInputBudgetSnapshot | Dict[str, Any]],
+        retry_ordinal: int,
+        call_kwargs: Dict[str, Any],
+        recovery_original_hard_count: Optional[int],
+        provider_safe_limit: Optional[int],
+        continuation_prefix: Optional[str] = None,
+    ) -> ChatMessage:
+        if retry_ordinal >= 2:
+            self._record_recovery_state("retry_exhausted")
+            raise ProviderContextOverflowRetryExhausted(
+                "provider context overflow persisted after two safe recovery requests"
+            ) from error
+        if context_rebuild is None or preflight is None:
+            self._record_recovery_state("retry_unsafe")
+            raise ProviderContextOverflowRetryUnsafe(
+                "provider context overflow cannot be rebuilt from source"
+            ) from error
+        self._monitoring.add_span_event(
+            "provider_context_overflow",
+            {"retry_ordinal": retry_ordinal, "recovery_safe": True},
+        )
+        self._record_recovery_state("retrying")
+        original_hard_count = recovery_original_hard_count or preflight.hard_count
+        reported_limit = self._provider_context_limit(error) or provider_safe_limit
+        return self._rebuild_and_retry(
+            preflight,
+            context_rebuild=context_rebuild,
+            token_tracker=token_tracker,
+            stop_sequences=stop_sequences,
+            response_format=response_format,
+            tools_to_call_from=tools_to_call_from,
+            trusted_budget_snapshot=trusted_budget_snapshot,
+            retry_ordinal=retry_ordinal + 1,
+            soft_rebuild_attempted=True,
+            call_kwargs=call_kwargs,
+            recovery_original_hard_count=original_hard_count,
+            provider_safe_limit=reported_limit,
+            continuation_prefix=continuation_prefix,
+        )
+
+    def _rebuild_and_retry(
+        self,
+        preflight: FinalRequestPreflight,
+        *,
+        context_rebuild: Optional[Callable[[int], Any]],
+        token_tracker: Any,
+        stop_sequences: Optional[List[str]],
+        response_format: Optional[dict[str, str]],
+        tools_to_call_from: Optional[List[Tool]],
+        trusted_budget_snapshot: Optional[SafeInputBudgetSnapshot | Dict[str, Any]],
+        retry_ordinal: int,
+        soft_rebuild_attempted: bool,
+        call_kwargs: Dict[str, Any],
+        recovery_original_hard_count: Optional[int] = None,
+        provider_safe_limit: Optional[int] = None,
+        continuation_prefix: Optional[str] = None,
+    ) -> ChatMessage:
+        if context_rebuild is None:
+            self._record_recovery_state("retry_unsafe")
+            raise ProviderContextOverflowRetryUnsafe(
+                "final request needs source-backed rebuild but none is available"
+            )
+        if recovery_original_hard_count is None:
+            target = max(1, min(preflight.soft_budget, int(preflight.hard_count * 0.9)))
+        else:
+            ratio = 0.75 if retry_ordinal == 1 else 0.5
+            target = max(1, int(recovery_original_hard_count * ratio))
+            if provider_safe_limit is not None:
+                target = min(target, provider_safe_limit)
+        if continuation_prefix:
+            continuation_instruction = (
+                "Continue the interrupted answer exactly where it stopped. "
+                "Do not repeat any text already written."
+            )
+            target = max(
+                1,
+                target - estimate_tokens_text(continuation_prefix + continuation_instruction),
+            )
+        try:
+            rebuilt = (
+                context_rebuild(target, emergency_archive=True)
+                if retry_ordinal >= 2
+                else context_rebuild(target)
+            )
+        except Exception as rebuild_error:
+            recoverable_reasons = {
+                "compaction_no_reduction",
+                "final_request_over_hard_budget",
+            }
+            if (
+                getattr(rebuild_error, "context_rebuild_over_budget", False) is True
+                and
+                recovery_original_hard_count is not None
+                and retry_ordinal == 1
+                and getattr(rebuild_error, "failure_reason", None) in recoverable_reasons
+            ):
+                self._monitoring.add_span_event(
+                    "provider_context_rebuild_exhausted",
+                    {
+                        "retry_ordinal": retry_ordinal,
+                        "failure_reason": getattr(rebuild_error, "failure_reason", "unknown"),
+                        "advancing_to_emergency_archive": True,
+                    },
+                )
+                return self._rebuild_and_retry(
+                    preflight,
+                    context_rebuild=context_rebuild,
+                    token_tracker=token_tracker,
+                    stop_sequences=stop_sequences,
+                    response_format=response_format,
+                    tools_to_call_from=tools_to_call_from,
+                    trusted_budget_snapshot=trusted_budget_snapshot,
+                    retry_ordinal=2,
+                    soft_rebuild_attempted=True,
+                    call_kwargs=call_kwargs,
+                    recovery_original_hard_count=recovery_original_hard_count,
+                    provider_safe_limit=provider_safe_limit,
+                    continuation_prefix=continuation_prefix,
+                )
+            raise
+        rebuilt_messages = getattr(rebuilt, "messages", rebuilt)
+        if not isinstance(rebuilt_messages, list):
+            raise TypeError("context_rebuild must return FinalContext or a message list")
+        if continuation_prefix:
+            rebuilt_messages = [
+                *rebuilt_messages,
+                {"role": "assistant", "content": continuation_prefix},
+                {
+                    "role": "user",
+                    "content": (
+                        continuation_instruction
+                    ),
+                },
+            ]
+        evidence = getattr(rebuilt, "evidence", None)
+        if evidence is not None:
+            self.last_context_evidence = evidence
+        rebuilt_runtime_tools = getattr(rebuilt, "runtime_tools", ())
+        if rebuilt_runtime_tools:
+            tools_to_call_from = list(rebuilt_runtime_tools)
+        return self.__call__(
+            messages=rebuilt_messages,
+            stop_sequences=stop_sequences,
+            response_format=response_format,
+            tools_to_call_from=tools_to_call_from,
+            _token_tracker=token_tracker,
+            safe_input_budget_snapshot=trusted_budget_snapshot,
+            context_rebuild=context_rebuild,
+            _budget_retry_ordinal=retry_ordinal,
+            _soft_rebuild_attempted=soft_rebuild_attempted,
+            _previous_preflight=preflight,
+            _side_effect_guard=RequestSideEffectGuard(),
+            _recovery_original_hard_count=recovery_original_hard_count,
+            _provider_safe_limit=provider_safe_limit,
+            **call_kwargs,
+        )
+
+    @staticmethod
+    def _provider_context_limit(error: BaseException) -> Optional[int]:
+        """Extract a provider-reported maximum for this run only."""
+        for pattern in (
+            r"maximum context(?: length)?(?: is|:)?\s*([0-9][0-9,]*)",
+            r"max(?:imum)?[_ ]context[_ ](?:length|tokens)(?: is|:|=)?\s*([0-9][0-9,]*)",
+            r"context window(?: is|:)?\s*([0-9][0-9,]*)",
+        ):
+            match = re.search(pattern, str(error), re.IGNORECASE)
+            if match:
+                return max(1, int(match.group(1).replace(",", "")))
+        return None
+
+    def _provisional_budget_snapshot(self) -> SafeInputBudgetSnapshot:
+        """Build a non-persisted 32K capacity snapshot for this invocation."""
+        requested_output = derive_output_protection_tokens(
+            context_window_tokens=32_768,
+            max_output_tokens=max(1, int(self.max_output_tokens or 4096)),
+        )
+        provider_input = max(1, 32_768 - requested_output)
+        soft = provider_input
+        fields = {
+            "requested_output_tokens": "model_default",
+            "soft_limit_ratio": "code_default",
+            "uncertainty_reserve_tokens": "derived",
+            "provider_input_limit_tokens": "derived",
+            "hard_input_budget_tokens": "derived",
+            "soft_input_budget_tokens": "derived",
+        }
+        provider = self.model_factory or "unknown"
+        w1 = "provisional-32768"
+        fingerprint = compute_w2_fingerprint(
+            w2_resolver_version="1.1.0", w1_fingerprint=w1,
+            provider=provider, model_name=self.model_id,
+            requested_output_tokens=requested_output, output_reserve_source="model_default",
+            uncertainty_reserve_tokens=0, uncertainty_reserve_basis="none",
+            approved_profile_reserve_tokens=None, soft_limit_ratio=0.9,
+            soft_limit_ratio_source="code_default", soft_input_budget_tokens=soft,
+            hard_input_budget_tokens=provider_input, field_sources=fields,
+            warnings=("provisional_32768_capacity",),
+        )
+        return SafeInputBudgetSnapshot(
+            w1_fingerprint=w1, provider=provider, model_name=self.model_id,
+            requested_output_tokens=requested_output, output_reserve_source="model_default",
+            provider_input_limit_tokens=provider_input, uncertainty_reserve_tokens=0,
+            uncertainty_reserve_basis="none", soft_limit_ratio=0.9,
+            soft_limit_ratio_source="code_default", soft_input_budget_tokens=soft,
+            hard_input_budget_tokens=provider_input, field_sources=fields,
+            warnings=("provisional_32768_capacity",), fingerprint=fingerprint,
+        )
+
+    def _build_final_request_identity(
+        self,
+        snapshot: SafeInputBudgetSnapshot | Dict[str, Any],
+    ) -> FinalRequestIdentity:
+        resolved = self._coerce_safe_input_budget_snapshot(snapshot)
+        if resolved is None:  # pragma: no cover - protected by callers
+            raise ValueError("safe input budget snapshot is required")
+        probe = self.token_count_probe_metadata or {}
+        runtime_endpoint = (
+            endpoint_fingerprint(self._token_count_api_base)
+            if self._token_count_api_base
+            else "unknown_endpoint"
+        )
+        return FinalRequestIdentity(
+            endpoint_fingerprint=runtime_endpoint,
+            credential_scope_fingerprint=str(
+                probe.get("credential_scope_fingerprint") or "unknown_scope"
+            ),
+            canonical_model_id=str(
+                self.canonical_model_id
+                or probe.get("model_identity")
+                or f"{resolved.provider}:{resolved.model_name}"
+            ),
+            provider=resolved.provider,
+            model_name=resolved.model_name,
+            w1_fingerprint=resolved.w1_fingerprint,
+            w2_fingerprint=resolved.fingerprint,
+        )
+
+    def _record_recovery_state(self, state: str) -> None:
+        self.last_recovery_state = state
+        from ...monitor.monitoring import update_monitoring_final_request_evidence
+        update_monitoring_final_request_evidence(
+            recovery_state=state,
+            provider_overflow=state in {"retrying", "retry_exhausted", "retry_unsafe", "retry_unsafe_after_response"},
+            recovery_attempted=state in {"retrying", "recovered", "retry_exhausted"},
+            recovery_succeeded=state == "recovered",
+        )
+        self._monitoring.set_span_attributes(
+            **{"context.final_request.recovery_state": state}
+        )
+
+    def _record_final_request_preflight(
+        self,
+        preflight: FinalRequestPreflight,
+        *,
+        recovery_state: str,
+    ) -> None:
+        self.last_recovery_state = recovery_state
+        components = preflight.components
+        from ...monitor.monitoring import set_monitoring_final_request_evidence
+        context_evidence = getattr(self, "last_context_evidence", None)
+        set_monitoring_final_request_evidence({
+            "schema_version": 1,
+            "provider_protocol": getattr(self, "model_factory", None),
+            "count_source": getattr(preflight.count_source, "value", str(preflight.count_source)),
+            "raw_estimate_tokens": preflight.raw_estimate,
+            "hard_count_tokens": preflight.hard_count,
+            "context_raw_tokens": int(getattr(context_evidence, "raw_token_estimate", 0) or 0),
+            "context_final_tokens": int(getattr(context_evidence, "final_token_estimate", 0) or 0),
+            "compression_attempted": bool(getattr(context_evidence, "compression_attempted", False)),
+            "request_fingerprint": preflight.request_fingerprint,
+            "retry_ordinal": preflight.retry_ordinal,
+            "recovery_state": recovery_state,
+            "provider_overflow": recovery_state in {"retrying", "retry_exhausted", "retry_unsafe"},
+            "recovery_attempted": preflight.retry_ordinal > 0,
+            "recovery_succeeded": recovery_state == "recovered",
+            "anchor_input_tokens": preflight.anchor_input_tokens,
+            "estimated_delta_tokens": preflight.estimated_delta_tokens,
+            "anchor_invalidation_reason": preflight.anchor_invalidation_reason,
+        })
+        context_budget_type = getattr(ProcessType, "CONTEXT_BUDGET", None)
+        if self.observer is not None and context_budget_type is not None:
+            # Keep Agent-layer event projection optional for lightweight SDK
+            # integrations that import the model package without Agent modules.
+            from ..agents.context_budget_event import build_context_budget_event
+
+            budget_event = build_context_budget_event(
+                preflight, context_evidence,
+                step_number=self.context_budget_step_number,
+                recovery_state=recovery_state,
+                recovery=(
+                    {
+                        "trigger": "provider_overflow" if preflight.retry_ordinal else "preflight",
+                        "phase": "archive" if getattr(context_evidence, "archive_active", False) else "compression",
+                        "attempt": int(preflight.retry_ordinal),
+                        "maximum_attempts": 2,
+                        "compression_target": int(preflight.hard_budget),
+                        "provisional_capacity": bool(getattr(self, "_using_provisional_capacity", False)),
+                    }
+                    if preflight.retry_ordinal or getattr(self, "_using_provisional_capacity", False)
+                    else None
+                ),
+            )
+            self.observer.add_message(
+                "", context_budget_type,
+                json.dumps(budget_event, ensure_ascii=False),
+            )
+        self._monitoring.set_span_attributes(
+            **{
+                "context.final_request.fingerprint": preflight.request_fingerprint,
+                "context.final_request.identity_fingerprint": preflight.identity_fingerprint,
+                "context.final_request.shape": preflight.request_shape,
+                "context.final_request.count_source": preflight.count_source,
+                "context.final_request.raw_estimate": preflight.raw_estimate,
+                "context.final_request.soft_count": preflight.soft_count,
+                "context.final_request.hard_count": preflight.hard_count,
+                "context.final_request.soft_exceeded": preflight.soft_exceeded,
+                "context.final_request.hard_exceeded": preflight.hard_exceeded,
+                "context.final_request.components.message_text": components.message_text,
+                "context.final_request.components.message_framing": components.message_framing,
+                "context.final_request.components.tools": components.tools,
+                "context.final_request.components.media": components.media,
+                "context.final_request.components.reasoning": components.reasoning,
+                "context.final_request.components.other_semantic": components.other_semantic,
+                "context.final_request.calibration_key": preflight.calibration_key_fingerprint,
+                "context.final_request.calibration_samples": preflight.calibration_sample_count,
+                "context.final_request.calibration_p95": preflight.calibration_p95 or 0.0,
+                "context.final_request.calibration_p99": preflight.calibration_p99 or 0.0,
+                "context.final_request.estimator_version": preflight.estimator_version,
+                "context.final_request.anchor_input_tokens": preflight.anchor_input_tokens or 0,
+                "context.final_request.estimated_delta_tokens": preflight.estimated_delta_tokens or 0,
+                "context.final_request.anchor_invalidation_reason": preflight.anchor_invalidation_reason or "",
+                "context.final_request.retry_ordinal": preflight.retry_ordinal,
+                "context.final_request.recovery_state": recovery_state,
+                "context.final_request.count_fallback_reason": preflight.fallback_reason or "",
+            }
+        )
 
     @staticmethod
     def _verify_w1_w2_consistency(

--- a/sdk/nexent/core/models/provider_request_count.py
+++ b/sdk/nexent/core/models/provider_request_count.py
@@ -1,0 +1,154 @@
+"""Runtime use of a previously verified Provider full-request count capability."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from typing import Any, Mapping, Optional
+from urllib.parse import urlsplit, urlunsplit
+
+import httpx
+
+from .final_request_budget import FinalRequestShape
+
+
+COUNT_ADAPTER_VERSION = "1.0.0"
+MAX_COUNT = 100_000_000
+MAX_RESPONSE_BYTES = 64 * 1024
+
+
+def endpoint_fingerprint(url: str) -> str:
+    parsed = urlsplit(url)
+    normalized = urlunsplit(
+        (
+            parsed.scheme.lower(),
+            (parsed.hostname or "").lower()
+            + (f":{parsed.port}" if parsed.port else ""),
+            parsed.path.rstrip("/"),
+            "",
+            "",
+        )
+    )
+    return hashlib.sha256(normalized.encode()).hexdigest()[:24]
+
+
+def count_final_request(
+    shape: FinalRequestShape,
+    *,
+    metadata: Optional[Mapping[str, Any]],
+    base_url: str,
+    api_key: str,
+    model_name: str,
+    canonical_model_id: str,
+    ssl_verify: bool = True,
+    timeout_seconds: float = 5.0,
+) -> tuple[Optional[int], Optional[str]]:
+    """Return a Provider count or a stable, non-mutating fallback reason."""
+    reason = _capability_reason(
+        shape,
+        metadata=metadata,
+        base_url=base_url,
+        canonical_model_id=canonical_model_id,
+    )
+    if reason:
+        return None, reason
+    protocol = str((metadata or {}).get("selected_protocol"))
+    if protocol != "openai_responses":
+        return None, "runtime_count_protocol_not_implemented"
+
+    count_url = f"{base_url.rstrip('/')}/responses/input_tokens"
+    if urlsplit(count_url).netloc != urlsplit(base_url).netloc:
+        return None, "count_origin_mismatch"
+    semantic = shape.semantic_request
+    body: dict[str, Any] = {
+        "model": semantic.get("model") or model_name,
+        "input": semantic.get("messages") or [],
+    }
+    if semantic.get("tools"):
+        body["tools"] = semantic["tools"]
+    try:
+        with httpx.Client(
+            timeout=httpx.Timeout(timeout_seconds, connect=min(timeout_seconds, 3.0)),
+            follow_redirects=False,
+            trust_env=False,
+            verify=ssl_verify,
+        ) as client:
+            response = client.post(
+                count_url,
+                headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+                json=body,
+            )
+    except httpx.TimeoutException:
+        return None, "count_timeout"
+    except httpx.RequestError:
+        return None, "count_connection_failed"
+    if 300 <= response.status_code < 400:
+        return None, "count_redirect_rejected"
+    if response.status_code in {401, 403}:
+        return None, "count_authorization_failed"
+    if response.status_code == 429:
+        return None, "count_rate_limited"
+    if response.status_code in {404, 405}:
+        return None, "count_unsupported_endpoint"
+    if response.status_code >= 500:
+        return None, "count_provider_5xx"
+    if not 200 <= response.status_code < 300:
+        return None, "count_unexpected_status"
+    if len(response.content) > MAX_RESPONSE_BYTES:
+        return None, "count_response_too_large"
+    try:
+        payload = response.json()
+    except ValueError:
+        return None, "count_invalid_schema"
+    count = payload.get("input_tokens") if isinstance(payload, Mapping) else None
+    if not isinstance(count, int) or isinstance(count, bool) or not 0 < count <= MAX_COUNT:
+        return None, "count_invalid_value"
+    return count, None
+
+
+def _capability_reason(
+    shape: FinalRequestShape,
+    *,
+    metadata: Optional[Mapping[str, Any]],
+    base_url: str,
+    canonical_model_id: str,
+) -> Optional[str]:
+    parsed = urlsplit(base_url)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+    ):
+        return "count_ssrf_rejected"
+    if not metadata:
+        return "count_capability_missing"
+    if metadata.get("status") != "supported":
+        return f"count_capability_{metadata.get('status') or 'unknown'}"
+    if metadata.get("adapter_version") != COUNT_ADAPTER_VERSION:
+        return "count_capability_stale_adapter"
+    if metadata.get("endpoint_fingerprint") != endpoint_fingerprint(base_url):
+        return "count_capability_endpoint_mismatch"
+    if metadata.get("model_identity") != canonical_model_id:
+        return "count_capability_model_mismatch"
+    stale_at = metadata.get("stale_at")
+    try:
+        expiry = datetime.fromisoformat(str(stale_at).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return "count_capability_stale"
+    if expiry <= datetime.now(timezone.utc):
+        return "count_capability_stale"
+    capabilities = metadata.get("capabilities") or {}
+    required = (
+        ("tools", "media") if shape.request_shape == "tools_media" else
+        ("tools",) if shape.request_shape == "tools" else
+        ("media",) if shape.request_shape == "media" else
+        ("text",)
+    )
+    if shape.reasoning_mode != "default":
+        required = (*required, "reasoning")
+    if any(capabilities.get(item) != "supported" for item in required):
+        return "count_capability_shape_unsupported"
+    return None

--- a/sdk/nexent/core/models/provider_usage.py
+++ b/sdk/nexent/core/models/provider_usage.py
@@ -1,0 +1,272 @@
+"""Normalized, content-free usage records for physical provider calls."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+import math
+from typing import Any, Mapping, Optional
+from uuid import uuid4
+
+
+PROVIDER_USAGE_SCHEMA_VERSION = 3
+
+
+def resolve_provider_usage_profile(
+    provider: Optional[str],
+    capability_profile_version: Optional[str] = None,
+) -> dict[str, Any]:
+    """Return conservative semantics for the approved OpenAI-compatible providers."""
+    name = str(provider or "unknown").lower()
+    common = {
+        "capability_profile_version": capability_profile_version,
+        "reasoning_usage_semantics": "unavailable",
+    }
+    if name == "dashscope":
+        return {**common, "cache_partition_semantics": "disjoint_inclusive"}
+    if name == "siliconflow":
+        return {
+            **common,
+            "cache_write_semantics": "unsupported",
+            "cache_hit_miss_semantics": "disjoint_inclusive",
+        }
+    return common
+
+
+@dataclass(frozen=True)
+class NormalizedTokenUsage:
+    input_tokens: Optional[int] = None
+    output_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
+    fresh_input_tokens: Optional[int] = None
+    cache_read_tokens: Optional[int] = None
+    cache_write_tokens: Optional[int] = None
+    reasoning_tokens: Optional[int] = None
+    visible_output_tokens: Optional[int] = None
+    total_source: str = "missing"
+
+
+@dataclass(frozen=True)
+class UsageQuality:
+    degraded: bool = False
+    reasons: tuple[str, ...] = ()
+
+
+@dataclass
+class ProviderCallUsage:
+    """Final record for exactly one physical provider request."""
+
+    call_id: str = field(default_factory=lambda: str(uuid4()))
+    turn_id: Optional[str] = None
+    step_number: Optional[int] = None
+    purpose: str = "main_agent"
+    attempt: int = 0
+    provider: str = "unknown"
+    model: str = "unknown"
+    capability_profile_version: Optional[str] = None
+    source: str = "missing"
+    status: str = "failed"
+    usage: NormalizedTokenUsage = field(default_factory=NormalizedTokenUsage)
+    quality: UsageQuality = field(default_factory=UsageQuality)
+    finish_reason: Optional[str] = None
+    duration_ms: Optional[int] = None
+    time_to_first_token_ms: Optional[int] = None
+    provider_metadata: dict[str, int] = field(default_factory=dict)
+    context_composition: Optional[dict[str, Any]] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["schema_version"] = PROVIDER_USAGE_SCHEMA_VERSION
+        return {"schema_version": payload.pop("schema_version"), **payload}
+
+
+def normalize_provider_usage(
+    raw_usage: Any,
+    *,
+    provider: Optional[str],
+    model: Optional[str],
+    capability_profile: Optional[Mapping[str, Any]] = None,
+) -> tuple[NormalizedTokenUsage, UsageQuality, str, dict[str, int]]:
+    """Normalize OpenAI-compatible usage without turning missing fields into zero."""
+
+    profile = dict(capability_profile or {})
+    reasons: list[str] = []
+    metadata: dict[str, int] = {}
+
+    input_tokens = _first_token_value(
+        raw_usage, ("prompt_tokens", "input_tokens"), "input_tokens", reasons
+    )
+    output_tokens = _first_token_value(
+        raw_usage, ("completion_tokens", "output_tokens"), "output_tokens", reasons
+    )
+    provider_total = _first_token_value(
+        raw_usage, ("total_tokens",), "total_tokens", reasons
+    )
+
+    source = "provider" if raw_usage is not None and (input_tokens is not None or output_tokens is not None) else "missing"
+    if input_tokens is None and output_tokens is None:
+        source = "missing"
+
+    cache_read = _first_nested_token_value(
+        raw_usage,
+        (
+            ("prompt_tokens_details", "cached_tokens"),
+            ("input_tokens_details", "cached_tokens"),
+            (None, "prompt_cache_hit_tokens"),
+            (None, "cache_read_input_tokens"),
+        ),
+        "cache_read_tokens",
+        reasons,
+        metadata,
+    )
+    cache_write = _first_nested_token_value(
+        raw_usage,
+        (
+            ("prompt_tokens_details", "cache_creation_input_tokens"),
+            ("input_tokens_details", "cache_creation_input_tokens"),
+            (None, "cache_creation_input_tokens"),
+        ),
+        "cache_write_tokens",
+        reasons,
+        metadata,
+    )
+    cache_miss = _first_nested_token_value(
+        raw_usage,
+        ((None, "prompt_cache_miss_tokens"),),
+        "prompt_cache_miss_tokens",
+        reasons,
+        metadata,
+    )
+
+    if profile.get("cache_read_semantics") == "unsupported":
+        cache_read = 0
+    if profile.get("cache_write_semantics") == "unsupported":
+        cache_write = 0
+
+    fresh_input: Optional[int] = None
+    cache_semantics = profile.get("cache_partition_semantics")
+    if input_tokens is not None and cache_read is not None and cache_write is not None:
+        if cache_semantics == "disjoint_inclusive":
+            if cache_read + cache_write > input_tokens:
+                reasons.append("cache_partition_exceeds_input")
+            fresh_input = max(0, input_tokens - cache_read - cache_write)
+        elif cache_read or cache_write:
+            reasons.append("cache_partition_semantics_unknown")
+    if cache_miss is not None and input_tokens is not None:
+        if cache_read is not None and cache_read + cache_miss != input_tokens:
+            reasons.append("cache_hit_miss_input_conflict")
+        elif profile.get("cache_hit_miss_semantics") == "disjoint_inclusive":
+            fresh_input = cache_miss
+
+    reasoning = _first_nested_token_value(
+        raw_usage,
+        (
+            ("completion_tokens_details", "reasoning_tokens"),
+            ("output_tokens_details", "reasoning_tokens"),
+            (None, "reasoning_tokens"),
+        ),
+        "reasoning_tokens",
+        reasons,
+        metadata,
+    )
+    reasoning_semantics = profile.get("reasoning_usage_semantics", "unavailable")
+    visible_output: Optional[int] = None
+    if reasoning is not None and output_tokens is not None:
+        if reasoning_semantics == "included":
+            if reasoning > output_tokens:
+                reasons.append("reasoning_exceeds_output")
+            visible_output = max(0, output_tokens - reasoning)
+        else:
+            reasons.append("reasoning_semantics_unknown")
+    elif reasoning_semantics == "unsupported" and output_tokens is not None:
+        reasoning = 0
+        visible_output = output_tokens
+
+    if provider_total is not None:
+        total_tokens = provider_total
+        total_source = "provider"
+        if input_tokens is not None and output_tokens is not None and provider_total != input_tokens + output_tokens:
+            reasons.append("total_tokens_inconsistent")
+    elif input_tokens is not None or output_tokens is not None:
+        total_tokens = (input_tokens or 0) + (output_tokens or 0)
+        total_source = "derived"
+    else:
+        total_tokens = None
+        total_source = "missing"
+
+    normalized = NormalizedTokenUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+        fresh_input_tokens=fresh_input,
+        cache_read_tokens=cache_read,
+        cache_write_tokens=cache_write,
+        reasoning_tokens=reasoning,
+        visible_output_tokens=visible_output,
+        total_source=total_source,
+    )
+    unique_reasons = tuple(dict.fromkeys(reasons))
+    return normalized, UsageQuality(bool(unique_reasons), unique_reasons), source, metadata
+
+
+def _valid_estimate(value: Any) -> Optional[int]:
+    parsed = _coerce_non_negative_int(value)
+    return parsed if parsed is not None else None
+
+
+def _first_token_value(
+    value: Any,
+    keys: tuple[str, ...],
+    field_name: str,
+    reasons: list[str],
+) -> Optional[int]:
+    for key in keys:
+        candidate = _get_value(value, key)
+        if candidate is None:
+            continue
+        parsed = _coerce_non_negative_int(candidate)
+        if parsed is None:
+            reasons.append(f"invalid_{field_name}")
+            continue
+        return parsed
+    return None
+
+
+def _first_nested_token_value(
+    value: Any,
+    paths: tuple[tuple[Optional[str], str], ...],
+    field_name: str,
+    reasons: list[str],
+    metadata: dict[str, int],
+) -> Optional[int]:
+    for parent, child in paths:
+        container = _get_value(value, parent) if parent else value
+        candidate = _get_value(container, child)
+        if candidate is None:
+            continue
+        parsed = _coerce_non_negative_int(candidate)
+        if parsed is None:
+            reasons.append(f"invalid_{field_name}")
+            continue
+        metadata[child] = parsed
+        return parsed
+    return None
+
+
+def _coerce_non_negative_int(value: Any) -> Optional[int]:
+    if isinstance(value, bool):
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(numeric) or numeric < 0 or not numeric.is_integer():
+        return None
+    return int(numeric)
+
+
+def _get_value(value: Any, key: Optional[str]) -> Any:
+    if value is None or key is None:
+        return value
+    if isinstance(value, Mapping):
+        return value.get(key)
+    return getattr(value, key, None)

--- a/sdk/nexent/monitor/monitoring.py
+++ b/sdk/nexent/monitor/monitoring.py
@@ -76,6 +76,19 @@ _monitoring_capacity_snapshot: ContextVar[Optional[Dict[str, Any]]] = ContextVar
     "_monitoring_capacity_snapshot", default=None)
 _monitoring_safe_input_budget_snapshot: ContextVar[Optional[Dict[str, Any]]] = ContextVar(
     "_monitoring_safe_input_budget_snapshot", default=None)
+_monitoring_final_request_evidence: ContextVar[Optional[Dict[str, Any]]] = ContextVar(
+    "_monitoring_final_request_evidence", default=None)
+
+
+def set_monitoring_final_request_evidence(evidence: Optional[Dict[str, Any]]) -> None:
+    """Set allowlisted P3 evidence for the current physical request."""
+    _monitoring_final_request_evidence.set(dict(evidence or {}))
+
+
+def update_monitoring_final_request_evidence(**values: Any) -> None:
+    current = dict(_monitoring_final_request_evidence.get() or {})
+    current.update({key: value for key, value in values.items() if value is not None})
+    _monitoring_final_request_evidence.set(current)
 
 
 def set_monitoring_context(
@@ -1387,6 +1400,7 @@ class MonitoringManager:
             "context.tokens.pre_compression": getattr(evidence, "raw_token_estimate", 0),
             "context.tokens.post_compression": getattr(evidence, "final_token_estimate", 0),
             "context.budget.hard_exceeded": bool(getattr(evidence, "over_hard_budget", False)),
+            "context.budget.failure_reason": getattr(evidence, "budget_failure_reason", "") or "",
             "context.compression.attempted": bool(getattr(evidence, "compression_attempted", False)),
             "context.compression.fallback_compaction": bool(getattr(evidence, "fallback_compaction_used", False)),
             "context.compression.records": json.dumps(compression_records, ensure_ascii=False, sort_keys=True),
@@ -2107,6 +2121,21 @@ def _enrich_record_with_safe_input_budget_snapshot(record: Dict[str, Any]) -> No
         record.update(budget_fields)
 
 
+def _enrich_record_with_final_request_evidence(record: Dict[str, Any]) -> None:
+    evidence = dict(_monitoring_final_request_evidence.get() or {})
+    if not evidence:
+        return
+    prompt_usage = record.get("input_tokens")
+    if isinstance(prompt_usage, int) and prompt_usage > 0:
+        evidence["provider_prompt_usage_tokens"] = prompt_usage
+    error_text = str(record.get("error_message") or "").lower()
+    if any(marker in error_text for marker in (
+        "context_length_exceeded", "maximum context length", "input tokens exceed",
+    )):
+        evidence["provider_overflow"] = True
+    record["context_budget_evidence"] = evidence
+
+
 def record_model_call(
     model_type: str,
     model_name: str,
@@ -2191,6 +2220,7 @@ class RecordModelCallContext:
 
             _enrich_record_with_capacity_snapshot(record)
             _enrich_record_with_safe_input_budget_snapshot(record)
+            _enrich_record_with_final_request_evidence(record)
 
             buffer = get_monitoring_buffer()
             if buffer and buffer.is_enabled:
@@ -2422,6 +2452,7 @@ def _enqueue_client_monitoring_record(
 
         _enrich_record_with_capacity_snapshot(record)
         _enrich_record_with_safe_input_budget_snapshot(record)
+        _enrich_record_with_final_request_evidence(record)
 
         buffer.add_record(record)
     except Exception:
@@ -2510,6 +2541,7 @@ def _enrich_record_with_context(record, tracker, kwargs):
 
     _enrich_record_with_capacity_snapshot(record)
     _enrich_record_with_safe_input_budget_snapshot(record)
+    _enrich_record_with_final_request_evidence(record)
 
     return tenant_id
 

--- a/test/sdk/core/agents/test_context_budget_event.py
+++ b/test/sdk/core/agents/test_context_budget_event.py
@@ -1,0 +1,76 @@
+import json
+from types import SimpleNamespace
+
+from nexent.core.agents.context_budget_event import build_context_budget_event
+from nexent.core.agents.summary_cache import CompressionCallRecord
+
+
+def test_context_budget_event_is_content_free_and_totals_savings():
+    preflight = SimpleNamespace(
+        components=SimpleNamespace(message_text=40, message_framing=5, tools=7, media=0, reasoning=3, other_semantic=2),
+        count_source=SimpleNamespace(value="provider"), soft_budget=90, hard_budget=100,
+        hard_count=57, request_fingerprint="request-hash", identity_fingerprint="budget-hash", retry_ordinal=1,
+    )
+    evidence = SimpleNamespace(
+        purpose="step", raw_token_estimate=80, final_token_estimate=50,
+        compression_attempted=True, fallback_compaction_used=False,
+        compression_records=(CompressionCallRecord(call_type="history_summary"),),
+    )
+    event = build_context_budget_event(preflight, evidence, step_number=2, recovery_state="recovered")
+    assert event["compression"] == {
+        "attempted": True,
+        "saved_tokens": 30,
+        "ratio": 0.375,
+        "fallback_compaction": False,
+        "reasons": ["history_summary"],
+    }
+    assert sum(event["components"].values()) == 57
+    assert event["count_source"] == "provider"
+    serialized = json.dumps(event)
+    for secret in ("messages", "prompt", "api_key", "tool_arguments", "endpoint"):
+        assert secret not in serialized
+
+
+def test_context_budget_event_handles_missing_context_evidence():
+    preflight = SimpleNamespace(
+        components=SimpleNamespace(message_text=1, message_framing=1, tools=0, media=0, reasoning=0, other_semantic=0),
+        count_source="estimator", soft_budget=9, hard_budget=10, hard_count=2,
+        request_fingerprint="r", identity_fingerprint="b", retry_ordinal=0,
+    )
+    event = build_context_budget_event(preflight, None, step_number=1)
+    assert event["raw_tokens"] == event["final_tokens"] == 0
+    assert event["compression"]["ratio"] == 0
+
+
+def test_context_budget_event_allowlists_compression_reasons():
+    preflight = SimpleNamespace(
+        components=SimpleNamespace(message_text=1, message_framing=1, tools=0, media=0, reasoning=0, other_semantic=0),
+        count_source="estimator", soft_budget=9, hard_budget=10, hard_count=2,
+        request_fingerprint="r", identity_fingerprint="b", retry_ordinal=0,
+    )
+    evidence = SimpleNamespace(
+        raw_token_estimate=8,
+        final_token_estimate=4,
+        compression_attempted=True,
+        fallback_compaction_used=True,
+        compression_records=(
+            CompressionCallRecord(call_type="history_incremental"),
+            CompressionCallRecord(call_type="history_incremental"),
+            {"call_type": "long_term_memory_block_selection"},
+            CompressionCallRecord(
+                call_type="attacker-controlled-value",
+                details={"error": "prompt and credential text must not escape"},
+            ),
+        ),
+    )
+
+    event = build_context_budget_event(preflight, evidence, step_number=3)
+
+    assert event["compression"]["reasons"] == [
+        "history_incremental",
+        "long_term_memory_selection",
+        "representation_compaction",
+    ]
+    serialized = json.dumps(event)
+    assert "attacker-controlled-value" not in serialized
+    assert "credential text" not in serialized

--- a/test/sdk/core/agents/test_context_composition.py
+++ b/test/sdk/core/agents/test_context_composition.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+
+from nexent.core.agents.context.composition import (
+    SEGMENT_NAMES,
+    estimate_context_segments,
+    reconcile_context_composition,
+)
+from nexent.core.agents.context.models import ContextItemType
+
+
+def _item(item_type, tokens, **content):
+    return SimpleNamespace(type=item_type, token_estimate=tokens, content=content)
+
+
+def test_ac_tu_006_classifies_context_item_provenance():
+    segments = estimate_context_segments(
+        [
+            _item(ContextItemType.SYSTEM, 10, text="system"),
+            _item(ContextItemType.MEMORY, 7, text="memory"),
+            _item(ContextItemType.KNOWLEDGE_BASE, 8, text="knowledge"),
+            _item(ContextItemType.CURRENT_TASK, 5, text="task"),
+            _item(ContextItemType.TOOL, 6, name="tool"),
+            _item(ContextItemType.CURRENT_ACTION, 9, text="result"),
+        ],
+        purpose_messages=[{"role": "system", "content": "header"}],
+        tools=[{"type": "function", "function": {"name": "search"}}],
+    )
+
+    assert segments["system_instructions"] >= 10
+    assert segments["retrieved_context"] == 15
+    assert segments["current_request"] == 5
+    assert segments["tool_definitions"] > 6
+    assert segments["tool_calls_results"] == 9
+    assert set(segments) == set(SEGMENT_NAMES)
+
+
+def test_ac_tu_006_reconciles_shortfall_to_provider_overhead_exactly():
+    composition = reconcile_context_composition(
+        {"system_instructions": 30, "current_request": 10},
+        100,
+    )
+
+    assert composition.source == "estimated"
+    assert composition.segments["provider_overhead"] == 60
+    assert sum(composition.segments.values()) == 100
+    assert composition.adjustment_ratio == 0.6
+    assert composition.high_adjustment is True
+
+
+def test_ac_tu_006_scales_overestimate_and_assigns_rounding_remainder():
+    composition = reconcile_context_composition(
+        {"system_instructions": 70, "current_request": 70, "tool_definitions": 10},
+        100,
+    )
+
+    assert all(value >= 0 for value in composition.segments.values())
+    assert sum(composition.segments.values()) == 100
+    assert composition.segments["provider_overhead"] >= 0
+    assert composition.high_adjustment is True
+
+
+def test_ac_tu_006_estimated_fallback_has_no_fabricated_overhead():
+    composition = reconcile_context_composition(
+        {"system_instructions": 3, "current_request": 2},
+        None,
+    )
+
+    assert composition.source == "estimated"
+    assert composition.denominator_tokens == 5
+    assert composition.segments["provider_overhead"] == 0
+    assert sum(composition.segments.values()) == 5

--- a/test/sdk/core/models/test_final_request_budget.py
+++ b/test/sdk/core/models/test_final_request_budget.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import pytest
+
+from nexent.core.models.final_request_budget import (
+    CalibrationKey,
+    CalibrationStore,
+    FinalRequestIdentity,
+    FinalRequestMeter,
+    FinalRequestOverHardBudget,
+    RequestSideEffectGuard,
+    build_final_request_shape,
+)
+
+
+def _identity(model="qwen3.7-plus"):
+    return FinalRequestIdentity(
+        endpoint_fingerprint="endpoint",
+        credential_scope_fingerprint="scope",
+        canonical_model_id=f"dashscope:{model}",
+        provider="dashscope",
+        model_name=model,
+        w1_fingerprint="w1",
+        w2_fingerprint="w2",
+    )
+
+
+def test_ac_p2_001_shape_fingerprint_ignores_transport_but_not_semantics():
+    base = {"model": "m", "messages": [{"role": "user", "content": "hello"}]}
+    first = build_final_request_shape({**base, "stream": True, "stream_options": {"include_usage": True}})
+    second = build_final_request_shape({**base, "stream": False})
+    changed = build_final_request_shape({**base, "response_format": {"type": "json_object"}})
+
+    assert first.fingerprint == second.fingerprint
+    assert changed.fingerprint != first.fingerprint
+
+
+def test_ac_p2_002_unified_components_cover_tools_media_reasoning_and_other():
+    shape = build_final_request_shape(
+        {
+            "model": "m",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "你好 code {}"},
+                        {"type": "image_url", "image_url": {"url": "data:image/png;base64,secret"}},
+                    ],
+                }
+            ],
+            "tools": [{"type": "function", "function": {"name": "search", "parameters": {"type": "object"}}}],
+            "extra_body": {"chat_template_kwargs": {"enable_thinking": True}, "semantic_flag": "x"},
+        }
+    )
+
+    assert shape.request_shape == "tools_media"
+    assert shape.components.message_text > 0
+    assert shape.components.message_framing > 0
+    assert shape.components.tools > 0
+    assert shape.components.media == 256
+    assert shape.components.reasoning > 0
+    assert shape.components.other_semantic > 0
+    assert "secret" not in repr(shape)
+
+
+def test_ac_p5_002_generation_controls_are_not_prompt_tokens():
+    base = build_final_request_shape({
+        "messages": [{"role": "user", "content": "hello"}],
+    })
+    controlled = build_final_request_shape({
+        "model": "Qwen/Qwen3.6-27B",
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_tokens": 1,
+        "temperature": 0,
+        "top_p": 0.9,
+        "seed": 7,
+    })
+
+    assert controlled.components.raw_total == base.components.raw_total
+    assert controlled.fingerprint != base.fingerprint
+
+
+def test_ac_p5_002_tools_include_provider_protocol_envelope():
+    without_tools = build_final_request_shape({
+        "messages": [{"role": "user", "content": "weather"}],
+    })
+    with_tools = build_final_request_shape({
+        "messages": [{"role": "user", "content": "weather"}],
+        "tools": [{
+            "type": "function",
+            "function": {
+                "name": "weather",
+                "parameters": {"type": "object"},
+            },
+        }],
+    })
+
+    assert with_tools.components.tools >= 208
+    assert with_tools.components.raw_total > without_tools.components.raw_total + 208
+
+
+def test_ac_p2_004_exact_boundary_and_no_over_hard_dispatch_decision():
+    meter = FinalRequestMeter(CalibrationStore(minimum_samples=2))
+    kwargs = {"model": "m", "messages": [{"role": "user", "content": "x"}]}
+
+    at_boundary = meter.measure(
+        kwargs, identity=_identity(), soft_budget=9, hard_budget=10, provider_count=10
+    )
+    assert at_boundary.soft_exceeded is True
+    assert at_boundary.hard_exceeded is False
+
+    over = meter.measure(
+        kwargs, identity=_identity(), soft_budget=9, hard_budget=10, provider_count=11
+    )
+    assert over.hard_exceeded is True
+
+
+def test_ac_p2_008_usage_is_deduplicated_by_own_physical_request_id():
+    store = CalibrationStore(minimum_samples=2)
+    meter = FinalRequestMeter(store)
+    identity = _identity()
+    preflight = meter.measure(
+        {"model": "m", "messages": [{"role": "user", "content": "hello"}]},
+        identity=identity,
+        soft_budget=1000,
+        hard_budget=1000,
+        request_id="physical-1",
+    )
+
+    assert meter.observe_usage(preflight, identity, provider_prompt_tokens=20) is True
+    assert meter.observe_usage(preflight, identity, provider_prompt_tokens=20) is False
+    key = CalibrationKey(
+        "endpoint", "scope", "dashscope:qwen3.7-plus", preflight.request_shape, preflight.reasoning_mode
+    )
+    assert store.stats(key).sample_count == 1
+
+
+def test_ac_p2_009_mature_p95_soft_and_p99_hard_are_independent():
+    now = [1000.0]
+    store = CalibrationStore(minimum_samples=20, clock=lambda: now[0])
+    identity = _identity()
+    key = CalibrationKey("endpoint", "scope", "dashscope:qwen3.7-plus", "text", "default")
+    ratios = [1.0] * 18 + [1.5, 1.9]
+    for index, ratio in enumerate(ratios):
+        store.observe(
+            key,
+            request_id=f"r-{index}",
+            raw_estimate=100,
+            provider_prompt_tokens=int(100 * ratio),
+        )
+    stats = store.stats(key)
+    assert stats.mature is True
+    assert stats.p95 == 1.5
+    assert stats.p99 == 1.9
+
+    meter = FinalRequestMeter(store)
+    preflight = meter.measure(
+        {"messages": [{"role": "user", "content": "x"}]},
+        identity=identity,
+        soft_budget=10_000,
+        hard_budget=10_000,
+    )
+    assert preflight.soft_count == pytest.approx(preflight.raw_estimate * 1.5, abs=1)
+    assert preflight.hard_count == pytest.approx(preflight.raw_estimate * 1.9, abs=1)
+
+
+def test_ac_p2_009_calibration_isolated_expiring_and_outlier_capped():
+    now = [1000.0]
+    store = CalibrationStore(minimum_samples=1, ttl_seconds=10, clock=lambda: now[0])
+    key = CalibrationKey("e", "s", "m", "text", "default")
+    other = CalibrationKey("e", "s", "other", "text", "default")
+    store.observe(key, request_id="one", raw_estimate=1, provider_prompt_tokens=100)
+
+    assert store.stats(key).p99 == 4.0
+    assert store.stats(other).sample_count == 0
+    now[0] = 1011.0
+    assert store.stats(key).sample_count == 0
+
+
+def test_ac_p2_005_side_effect_guard_is_monotonic_and_only_pristine_is_safe():
+    guard = RequestSideEffectGuard()
+    assert guard.recovery_safe is True
+    guard.mark("response_started")
+    assert guard.recovery_safe is False
+    guard.mark("pristine")
+    assert guard.state == "response_started"
+    guard.mark("tool_effect")
+    assert guard.state == "tool_effect"
+
+
+def test_p10_ac_002_observed_anchor_estimates_only_appended_messages():
+    meter = FinalRequestMeter(CalibrationStore(minimum_samples=20))
+    identity = _identity()
+    base = {
+        "model": "m",
+        "messages": [{"role": "user", "content": "first request"}],
+        "tools": [{"type": "function", "function": {"name": "search"}}],
+    }
+    observed = meter.measure(
+        base,
+        identity=identity,
+        soft_budget=10_000,
+        hard_budget=10_000,
+        provider_count=120,
+    )
+    assert observed.count_source == "provider"
+
+    appended = meter.measure(
+        {
+            **base,
+            "messages": [
+                *base["messages"],
+                {"role": "assistant", "content": "tool call"},
+                {"role": "tool", "content": "tool result"},
+            ],
+        },
+        identity=identity,
+        soft_budget=10_000,
+        hard_budget=10_000,
+    )
+
+    assert appended.count_source == "provider_anchor_delta"
+    assert appended.anchor_input_tokens == 120
+    assert appended.estimated_delta_tokens > 0
+    assert appended.soft_count - 120 == pytest.approx(
+        appended.estimated_delta_tokens * 1.15,
+        abs=1,
+    )
+    assert meter.estimate_context_candidate(
+        appended_messages := [
+            *base["messages"],
+            {"role": "assistant", "content": "tool call"},
+            {"role": "tool", "content": "tool result"},
+        ],
+        base["tools"],
+    ) == appended.soft_count
+    assert len(appended_messages) == 3
+
+
+@pytest.mark.parametrize(
+    ("change", "reason"),
+    [
+        ({"tools": [{"type": "function", "function": {"name": "other"}}]}, "anchor_semantics_changed"),
+        ({"response_format": {"type": "json_object"}}, "anchor_semantics_changed"),
+    ],
+)
+def test_p10_ac_003_semantic_changes_invalidate_anchor(change, reason):
+    meter = FinalRequestMeter(CalibrationStore(minimum_samples=20))
+    identity = _identity()
+    base = {"model": "m", "messages": [{"role": "user", "content": "first"}]}
+    meter.measure(
+        base,
+        identity=identity,
+        soft_budget=10_000,
+        hard_budget=10_000,
+        provider_count=100,
+    )
+
+    preflight = meter.measure(
+        {**base, **change},
+        identity=identity,
+        soft_budget=10_000,
+        hard_budget=10_000,
+    )
+
+    assert preflight.count_source == "estimated"
+    assert preflight.anchor_invalidation_reason == reason
+
+
+def test_p10_ac_003_history_rewrite_invalidates_anchor():
+    meter = FinalRequestMeter(CalibrationStore(minimum_samples=20))
+    identity = _identity()
+    meter.measure(
+        {"messages": [{"role": "user", "content": "old"}]},
+        identity=identity,
+        soft_budget=10_000,
+        hard_budget=10_000,
+        provider_count=100,
+    )
+
+    rewritten = meter.measure(
+        {"messages": [{"role": "user", "content": "summary"}]},
+        identity=identity,
+        soft_budget=10_000,
+        hard_budget=10_000,
+    )
+
+    assert rewritten.count_source == "estimated"
+    assert rewritten.anchor_invalidation_reason == "anchor_non_append_only"

--- a/test/sdk/core/models/test_openai_llm.py
+++ b/test/sdk/core/models/test_openai_llm.py
@@ -589,6 +589,13 @@ def test_call_normal_operation(openai_model_instance):
         assert call_usage.usage.total_tokens == 15
         assert call_usage.to_dict()["schema_version"] == 3
         assert tuple(openai_model_instance.provider_call_usages) == result.provider_call_usages
+        usage_attributes = next(
+            call.kwargs
+            for call in openai_model_instance._monitoring.set_span_attributes.call_args_list
+            if "usage.call_id" in call.kwargs
+        )
+        assert all(value is not None for value in usage_attributes.values())
+        assert "usage.fresh_input_tokens" not in usage_attributes
 
         # Verify observer calls
         openai_model_instance.observer.add_model_new_token.assert_any_call(

--- a/test/sdk/core/models/test_openai_llm.py
+++ b/test/sdk/core/models/test_openai_llm.py
@@ -291,10 +291,13 @@ class SimpleChatMessage:
     def __init__(self, role=None, content=None, tool_calls=None):
         self.role = role
         self.content = content
+        self.tool_calls = tool_calls
         self.raw = None
     @staticmethod
     def from_dict(d):
-        return SimpleChatMessage(role=d.get("role"), content=d.get("content"))
+        return SimpleChatMessage(
+            role=d.get("role"), content=d.get("content"), tool_calls=d.get("tool_calls")
+        )
 mock_models_module.ChatMessage = SimpleChatMessage
 mock_models_module.MessageRole = MagicMock()
 mock_smolagents.models = mock_models_module
@@ -576,6 +579,16 @@ def test_call_normal_operation(openai_model_instance):
         # Verify the result
         assert result == mock_result_message
         mock_prepare.assert_called_once()
+
+        # P10-AC-001: one physical dispatch produces one complete observed-only record.
+        assert len(openai_model_instance.provider_call_usages) == 1
+        call_usage = openai_model_instance.provider_call_usages[0]
+        assert call_usage.status == "completed"
+        assert call_usage.usage.input_tokens == 10
+        assert call_usage.usage.output_tokens == 5
+        assert call_usage.usage.total_tokens == 15
+        assert call_usage.to_dict()["schema_version"] == 3
+        assert tuple(openai_model_instance.provider_call_usages) == result.provider_call_usages
 
         # Verify observer calls
         openai_model_instance.observer.add_model_new_token.assert_any_call(
@@ -973,6 +986,56 @@ def test_call_rejects_reasoning_only_response_and_records_diagnostics(
     assert diagnostics["reasoning_char_count"] == len("Internal reasoning")
     assert diagnostics["output_tokens"] == 20
     assert "event=empty_model_response" in caplog.text
+
+
+def test_call_assembles_streamed_tool_calls_without_false_empty_response(
+    openai_model_instance,
+):
+    """A tool-only completion is a valid model response and preserves fragments."""
+    function_start = types.SimpleNamespace(name="marker_lookup", arguments='{"marker":"')
+    function_end = types.SimpleNamespace(name=None, arguments='acceptance"}')
+    first_delta = types.SimpleNamespace(
+        content=None,
+        role="assistant",
+        reasoning_content=None,
+        tool_calls=[types.SimpleNamespace(
+            index=0, id="call_123", type="function", function=function_start
+        )],
+    )
+    second_delta = types.SimpleNamespace(
+        content=None,
+        role=None,
+        reasoning_content=None,
+        tool_calls=[types.SimpleNamespace(
+            index=0, id=None, type=None, function=function_end
+        )],
+    )
+    chunks = [
+        types.SimpleNamespace(
+            choices=[types.SimpleNamespace(delta=first_delta, finish_reason=None)],
+            usage=None,
+        ),
+        types.SimpleNamespace(
+            choices=[types.SimpleNamespace(delta=second_delta, finish_reason="tool_calls")],
+            usage=types.SimpleNamespace(prompt_tokens=12, completion_tokens=7),
+        ),
+    ]
+
+    with patch.object(openai_model_instance, "_prepare_completion_kwargs", return_value={}):
+        openai_model_instance.client.chat.completions.create.return_value = chunks
+        result = openai_model_instance([{"role": "user", "content": "use tool"}])
+
+    assert result.content is None
+    assert result.tool_calls == [{
+        "id": "call_123",
+        "type": "function",
+        "function": {
+            "name": "marker_lookup",
+            "arguments": '{"marker":"acceptance"}',
+        },
+    }]
+    assert openai_model_instance.last_response_diagnostics["tool_call_count"] == 1
+    assert openai_model_instance.last_finish_reason == "tool_calls"
 
 
 def test_call_with_reasoning_content_and_content_together(openai_model_instance):
@@ -1539,7 +1602,7 @@ def test_call_with_snapshot_does_not_autofill_max_tokens_from_max_output_tokens(
         openai_model_instance.__call__(messages)
 
     create_kwargs = openai_model_instance.client.chat.completions.create.call_args.kwargs
-    assert create_kwargs["max_tokens"] == 8192
+    assert create_kwargs["max_tokens"] == 131072
 
 
 def test_dispatch_without_w2_snapshot_preserves_existing_max_tokens(openai_model_instance):
@@ -1557,6 +1620,7 @@ def test_dispatch_without_w2_snapshot_preserves_existing_max_tokens(openai_model
 
 
 def test_dispatch_with_w2_snapshot_sets_requested_output_tokens(openai_model_instance):
+    openai_model_instance.max_output_tokens = 8192
     openai_model_instance._dispatch_chat_completion(
         safe_input_budget_snapshot=_safe_input_budget_snapshot(256),
         stream=True,
@@ -1566,26 +1630,34 @@ def test_dispatch_with_w2_snapshot_sets_requested_output_tokens(openai_model_ins
     openai_model_instance.client.chat.completions.create.assert_called_once_with(
         stream=True,
         messages=[],
-        max_tokens=256,
+        max_tokens=8192,
+    )
+
+    dispatched = openai_model_instance.client.chat.completions.create.call_args.kwargs
+    assert (
+        openai_llm_module.build_final_request_shape(dispatched).fingerprint
+        == openai_model_instance.last_final_request_preflight.request_fingerprint
     )
 
 
 def test_dispatch_with_matching_caller_max_tokens_is_allowed(openai_model_instance):
+    openai_model_instance.max_output_tokens = 8192
     openai_model_instance._dispatch_chat_completion(
         safe_input_budget_snapshot=_safe_input_budget_snapshot(256),
         stream=True,
         messages=[],
-        max_tokens=256,
+        max_tokens=8192,
     )
 
     openai_model_instance.client.chat.completions.create.assert_called_once_with(
         stream=True,
         messages=[],
-        max_tokens=256,
+        max_tokens=8192,
     )
 
 
 def test_dispatch_rejects_caller_max_tokens_override(openai_model_instance):
+    openai_model_instance.max_output_tokens = 8192
     with pytest.raises(openai_llm_module.CallerMaxTokensOverrideForbidden):
         openai_model_instance._dispatch_chat_completion(
             safe_input_budget_snapshot=_safe_input_budget_snapshot(256),
@@ -1686,6 +1758,24 @@ def test_dispatch_rejects_cross_model_w2_snapshot(openai_model_instance):
     openai_model_instance.client.chat.completions.create.assert_not_called()
 
 
+def test_ac_p2_007_dispatch_rejects_model_switched_after_budget_resolution(
+    openai_model_instance,
+):
+    snapshot = _safe_input_budget_snapshot(256)
+    with pytest.raises(openai_llm_module.SafeInputBudgetCapacityMismatch) as exc_info:
+        openai_model_instance._dispatch_chat_completion(
+            safe_input_budget_snapshot=snapshot,
+            stream=True,
+            model="smaller-model",
+            messages=[],
+        )
+
+    assert exc_info.value.field == "model_name"
+    assert exc_info.value.expected == "gpt-test"
+    assert exc_info.value.actual == "smaller-model"
+    openai_model_instance.client.chat.completions.create.assert_not_called()
+
+
 def test_dispatch_skips_w1_w2_consistency_when_capacity_snapshot_absent(openai_model_instance):
     snapshot = _safe_input_budget_snapshot(256)
 
@@ -1713,6 +1803,334 @@ def test_safe_input_budget_trace_attributes_are_prefixed():
     assert attrs["w2.requested_output_tokens"] == 256
     assert attrs["w2.soft_input_budget_tokens"] == 800
     assert attrs["w2.hard_input_budget_tokens"] == 1000
+
+
+def _successful_stream(content="ok", prompt_tokens=10, finish_reason="stop"):
+    chunk = MagicMock()
+    chunk.choices = [MagicMock()]
+    chunk.choices[0].delta.content = content
+    chunk.choices[0].delta.reasoning_content = None
+    chunk.choices[0].delta.role = "assistant"
+    chunk.choices[0].finish_reason = finish_reason
+    chunk.usage = MagicMock()
+    chunk.usage.prompt_tokens = prompt_tokens
+    chunk.usage.completion_tokens = 1
+    return [chunk]
+
+
+def test_length_prose_continues_and_removes_repeated_boundary(openai_model_instance):
+    openai_model_instance.client.chat.completions.create.side_effect = [
+        _successful_stream("alpha beta", finish_reason="length"),
+        _successful_stream(" beta gamma"),
+    ]
+
+    with patch.object(
+        openai_model_instance, "_prepare_completion_kwargs", side_effect=_p2_prepare_kwargs
+    ):
+        result = openai_model_instance([{"role": "user", "content": "write"}])
+
+    assert result.content == "alpha beta gamma"
+    assert result.token_usage.input_tokens == 20
+    assert result.token_usage.output_tokens == 2
+    assert openai_model_instance.client.chat.completions.create.call_count == 2
+
+
+def test_length_prose_stops_after_two_continuations(openai_model_instance):
+    openai_model_instance.client.chat.completions.create.side_effect = [
+        _successful_stream("one", finish_reason="length"),
+        _successful_stream(" two", finish_reason="length"),
+        _successful_stream(" three", finish_reason="length"),
+        _successful_stream(" unexpected"),
+    ]
+
+    with patch.object(
+        openai_model_instance, "_prepare_completion_kwargs", side_effect=_p2_prepare_kwargs
+    ):
+        result = openai_model_instance([{"role": "user", "content": "write"}])
+
+    assert result.content == "one two three"
+    assert result.token_usage.input_tokens == 30
+    assert result.token_usage.output_tokens == 3
+    assert openai_model_instance.client.chat.completions.create.call_count == 3
+    assert openai_model_instance.last_finish_reason == "length"
+
+
+def test_length_tool_call_is_not_executed_or_continued(openai_model_instance):
+    function = types.SimpleNamespace(name="dangerous_tool", arguments='{"value":')
+    delta = types.SimpleNamespace(
+        content=None,
+        role="assistant",
+        reasoning_content=None,
+        tool_calls=[types.SimpleNamespace(
+            index=0, id="call_partial", type="function", function=function
+        )],
+    )
+    chunk = types.SimpleNamespace(
+        choices=[types.SimpleNamespace(delta=delta, finish_reason="length")],
+        usage=types.SimpleNamespace(prompt_tokens=10, completion_tokens=1),
+    )
+    openai_model_instance.client.chat.completions.create.return_value = [chunk]
+
+    with patch.object(
+        openai_model_instance, "_prepare_completion_kwargs", side_effect=_p2_prepare_kwargs
+    ), pytest.raises(openai_llm_module.IncompleteToolCallError):
+        openai_model_instance([{"role": "user", "content": "act"}])
+
+    assert openai_model_instance.client.chat.completions.create.call_count == 1
+
+
+def _p2_prepare_kwargs(messages=None, model=None, **kwargs):
+    return {
+        "model": "gpt-test",
+        "messages": [
+            message.model_dump()
+            if hasattr(message, "model_dump")
+            else {"role": getattr(message.role, "value", message.role), "content": message.content}
+            for message in (messages or [])
+        ],
+    }
+
+
+def _recorded_recovery_states(model):
+    return [
+        call.kwargs["context.final_request.recovery_state"]
+        for call in model._monitoring.set_span_attributes.call_args_list
+        if "context.final_request.recovery_state" in call.kwargs
+    ]
+
+
+def test_ac_p2_005_create_overflow_rebuilds_and_retries_once(openai_model_instance):
+    snapshot = _safe_input_budget_snapshot(128)
+    openai_model_instance.safe_input_budget_snapshot = snapshot
+    streams = [
+        Exception("context_length_exceeded: too many tokens"),
+        _successful_stream(),
+    ]
+    openai_model_instance.client.chat.completions.create.side_effect = streams
+    rebuild = MagicMock(return_value=[{"role": "user", "content": "short"}])
+
+    with patch.object(openai_model_instance, "_prepare_completion_kwargs", side_effect=_p2_prepare_kwargs):
+        result = openai_model_instance(
+            [{"role": "user", "content": "x" * 400}],
+            context_rebuild=rebuild,
+        )
+
+    assert result is not None
+    assert openai_model_instance.client.chat.completions.create.call_count == 2
+    rebuild.assert_called_once()
+    assert openai_model_instance.last_final_request_preflight.retry_ordinal == 1
+    assert _recorded_recovery_states(openai_model_instance)[-1] == "recovered"
+
+
+def test_ac_p6_001_third_overflow_is_terminal_after_two_recovery_requests(openai_model_instance):
+    snapshot = _safe_input_budget_snapshot(128)
+    openai_model_instance.safe_input_budget_snapshot = snapshot
+    openai_model_instance.client.chat.completions.create.side_effect = [
+        Exception("context_length_exceeded: first"),
+        Exception("context_length_exceeded: second"),
+        Exception("context_length_exceeded: third"),
+    ]
+    rebuild = MagicMock(side_effect=[
+        [{"role": "user", "content": "shorter first retry"}],
+        [{"role": "user", "content": "x"}],
+    ])
+
+    with pytest.raises(
+        openai_llm_module.ProviderContextOverflowRetryExhausted
+    ) as error:
+        with patch.object(openai_model_instance, "_prepare_completion_kwargs", side_effect=_p2_prepare_kwargs):
+            openai_model_instance(
+                [{"role": "user", "content": "x" * 400}],
+                context_rebuild=rebuild,
+            )
+
+    assert error.value.reason_code == "provider_context_overflow_retry_exhausted"
+    assert openai_model_instance.client.chat.completions.create.call_count == 3
+    assert rebuild.call_count == 2
+    assert rebuild.call_args_list[1].kwargs == {"emergency_archive": True}
+    assert _recorded_recovery_states(openai_model_instance)[-1] == "retry_exhausted"
+
+
+def test_ac_p6_002_local_first_rebuild_exhaustion_advances_to_emergency_archive(openai_model_instance):
+    snapshot = _safe_input_budget_snapshot(128)
+    openai_model_instance.safe_input_budget_snapshot = snapshot
+    openai_model_instance.client.chat.completions.create.side_effect = [
+        Exception("context_length_exceeded: first"),
+        _successful_stream(),
+    ]
+    rebuild = MagicMock(side_effect=[
+        openai_llm_module.ContextRebuildOverBudget(
+            failure_reason="compaction_no_reduction",
+            actual=900,
+            hard_budget=700,
+        ),
+        [{"role": "user", "content": "archive retry"}],
+    ])
+
+    with patch.object(openai_model_instance, "_prepare_completion_kwargs", side_effect=_p2_prepare_kwargs):
+        result = openai_model_instance(
+            [{"role": "user", "content": "x" * 400}],
+            context_rebuild=rebuild,
+        )
+
+    assert result.content == "ok"
+    assert openai_model_instance.client.chat.completions.create.call_count == 2
+    assert rebuild.call_count == 2
+    assert rebuild.call_args_list[0].kwargs == {}
+    assert rebuild.call_args_list[1].kwargs == {"emergency_archive": True}
+
+
+@pytest.mark.parametrize("failure_reason", ["fixed_context_over_budget", "single_context_item_oversize"])
+def test_ac_p6_002_protected_rebuild_failures_remain_terminal(
+    openai_model_instance, failure_reason
+):
+    snapshot = _safe_input_budget_snapshot(128)
+    openai_model_instance.safe_input_budget_snapshot = snapshot
+    openai_model_instance.client.chat.completions.create.side_effect = Exception(
+        "context_length_exceeded: first"
+    )
+    rebuild_error = openai_llm_module.ContextRebuildOverBudget(
+        failure_reason=failure_reason,
+        actual=900,
+        hard_budget=700,
+    )
+    rebuild = MagicMock(side_effect=rebuild_error)
+
+    with pytest.raises(openai_llm_module.ContextRebuildOverBudget) as error:
+        with patch.object(openai_model_instance, "_prepare_completion_kwargs", side_effect=_p2_prepare_kwargs):
+            openai_model_instance(
+                [{"role": "user", "content": "x" * 400}],
+                context_rebuild=rebuild,
+            )
+
+    assert error.value.failure_reason == failure_reason
+    rebuild.assert_called_once()
+
+
+def test_ac_p6_004_partial_prose_is_continued_into_one_message(openai_model_instance):
+    snapshot = _safe_input_budget_snapshot(128)
+    openai_model_instance.safe_input_budget_snapshot = snapshot
+
+    def partial_stream():
+        yield _successful_stream("partial")[0]
+        raise Exception("context_length_exceeded: late")
+
+    openai_model_instance.client.chat.completions.create.side_effect = [
+        partial_stream(), _successful_stream(" continuation"),
+    ]
+    rebuild = MagicMock(return_value=[{"role": "user", "content": "x"}])
+
+    with patch.object(openai_model_instance, "_prepare_completion_kwargs", side_effect=_p2_prepare_kwargs):
+        result = openai_model_instance(
+            [{"role": "user", "content": "hello " * 100}], context_rebuild=rebuild,
+        )
+
+    assert result.content == "partial continuation"
+    assert openai_model_instance.client.chat.completions.create.call_count == 2
+    rebuilt_messages = openai_model_instance.client.chat.completions.create.call_args.kwargs["messages"]
+    assert rebuilt_messages[-2]["content"] == "partial"
+    assert "Do not repeat" in rebuilt_messages[-1]["content"]
+
+
+def test_ac_p6_004_tool_fragments_prevent_automatic_continuation(openai_model_instance):
+    snapshot = _safe_input_budget_snapshot(128)
+    openai_model_instance.safe_input_budget_snapshot = snapshot
+    delta = types.SimpleNamespace(
+        content=None, role="assistant", reasoning_content=None,
+        tool_calls=[types.SimpleNamespace(
+            index=0, id="call_1", type="function",
+            function=types.SimpleNamespace(name="write_data", arguments='{'),
+        )],
+    )
+
+    def unsafe_stream():
+        yield types.SimpleNamespace(
+            choices=[types.SimpleNamespace(delta=delta, finish_reason=None)], usage=None,
+        )
+        raise Exception("context_length_exceeded: late")
+
+    openai_model_instance.client.chat.completions.create.return_value = unsafe_stream()
+    rebuild = MagicMock(return_value=[{"role": "user", "content": "short"}])
+    with patch.object(openai_model_instance, "_prepare_completion_kwargs", side_effect=_p2_prepare_kwargs):
+        with pytest.raises(openai_llm_module.ProviderContextOverflowRetryUnsafe):
+            openai_model_instance(
+                [{"role": "user", "content": "hello"}], context_rebuild=rebuild,
+            )
+
+    rebuild.assert_not_called()
+    assert openai_model_instance.client.chat.completions.create.call_count == 1
+
+
+def test_ac_p6_005_unknown_capacity_uses_run_local_provisional_32k(openai_model_instance):
+    openai_model_instance.safe_input_budget_snapshot = None
+    openai_model_instance.model_id = "gpt-test"
+    openai_model_instance.client.chat.completions.create.side_effect = [
+        Exception("context_length_exceeded: first"), _successful_stream("ok"),
+    ]
+    rebuild = MagicMock(return_value=[{"role": "user", "content": "x"}])
+
+    with patch.object(openai_model_instance, "_prepare_completion_kwargs", side_effect=_p2_prepare_kwargs):
+        result = openai_model_instance(
+            [{"role": "user", "content": "large " * 100}], context_rebuild=rebuild,
+        )
+
+    assert result.content == "ok"
+    assert openai_model_instance.safe_input_budget_snapshot is None
+    assert openai_model_instance.last_final_request_preflight.hard_budget == 32_768 - 4_096
+    assert openai_model_instance._using_provisional_capacity is True
+
+
+def test_ac_p2_004_soft_excess_rebuilds_before_provider_call(openai_model_instance):
+    snapshot = _safe_input_budget_snapshot(128)
+    openai_model_instance.safe_input_budget_snapshot = snapshot
+    openai_model_instance.client.chat.completions.create.return_value = _successful_stream()
+    rebuild = MagicMock(return_value=[{"role": "user", "content": "short"}])
+
+    with patch.object(openai_model_instance, "_prepare_completion_kwargs", side_effect=_p2_prepare_kwargs):
+        result = openai_model_instance(
+            [{"role": "user", "content": "x" * 3000}],
+            context_rebuild=rebuild,
+        )
+
+    assert result is not None
+    rebuild.assert_called_once()
+    assert openai_model_instance.client.chat.completions.create.call_count == 1
+    assert _recorded_recovery_states(openai_model_instance)[-1] == "soft_rebuilt"
+
+
+def test_ac_p2_010_preflight_telemetry_is_content_free(openai_model_instance):
+    snapshot = _safe_input_budget_snapshot(128)
+    openai_model_instance._dispatch_chat_completion(
+        safe_input_budget_snapshot=snapshot,
+        stream=True,
+        messages=[{"role": "user", "content": "private prompt value"}],
+    )
+
+    attributes = openai_model_instance._monitoring.set_span_attributes.call_args.kwargs
+    assert attributes["context.final_request.fingerprint"]
+    assert attributes["context.final_request.count_source"] == "estimated"
+    assert attributes["context.final_request.components.message_text"] > 0
+    assert attributes["context.final_request.recovery_state"] == "not_attempted"
+    assert "private prompt value" not in str(attributes)
+
+
+def test_ac_p2_003_verified_tokenizer_is_second_preflight_source(openai_model_instance):
+    snapshot = _safe_input_budget_snapshot(128)
+    openai_model_instance.tokenizer_family = "verified_family"
+    openai_model_instance.tokenizer_match_metadata = {"auto_applicable": True}
+    adapter = MagicMock()
+    adapter.count_tokens.return_value = 19
+
+    with patch.object(openai_llm_module, "resolve_tokenizer", return_value=(adapter, "exact")):
+        openai_model_instance._dispatch_chat_completion(
+            safe_input_budget_snapshot=snapshot,
+            stream=True,
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+    assert openai_model_instance.last_final_request_preflight.count_source == "tokenizer"
+    assert openai_model_instance.last_final_request_preflight.provider_count is None
+    adapter.count_tokens.assert_called_once()
 
 
 def test_call_without_tracker_creates_tracker(openai_model_instance):
@@ -1846,6 +2264,62 @@ def test_prompt_cache_usage_extracts_openai_cached_tokens(openai_model_instance)
     assert openai_model_instance.last_prompt_cache_usage.uncached_input_tokens == 60
     assert openai_model_instance.last_prompt_cache_usage.provider_cache_hit is True
     assert openai_model_instance.last_prompt_cache_usage.estimated_saved_input_tokens == 0
+
+
+def test_p8_feature_resolution_is_emitted_as_sanitized_span_attributes(
+    openai_model_instance,
+):
+    openai_model_instance.feature_capabilities = {
+        "source": "catalog_family",
+        "match_kind": "catalog_family",
+        "catalog_revision": "2026-09-01.2",
+        "profile_version": "dashscope/qwen3-hybrid-family@1",
+        "reasoning": {
+            "supported": True,
+            "mode": "effort",
+            "request_style": "openai_reasoning_effort",
+        },
+        "prompt_cache": {
+            "supported": True,
+            "mode": "provider_automatic",
+        },
+    }
+    openai_model_instance.prompt_cache = {
+        "mode": "provider_automatic",
+        "enabled": True,
+    }
+    mock_chunk = MagicMock()
+    mock_chunk.choices = [MagicMock()]
+    mock_chunk.choices[0].delta.content = "ok"
+    mock_chunk.choices[0].delta.role = "assistant"
+    mock_chunk.choices[0].delta.reasoning_content = None
+    mock_chunk.choices[0].finish_reason = "stop"
+    mock_chunk.usage = MagicMock(prompt_tokens=1, completion_tokens=1)
+
+    with patch.object(openai_model_instance, "_prepare_completion_kwargs", return_value={}):
+        openai_model_instance.client.chat.completions.create.return_value = [mock_chunk]
+        openai_model_instance([{"role": "user", "content": "verify"}])
+
+    feature_attributes = next(
+        call.kwargs
+        for call in reversed(
+            openai_model_instance._monitoring.set_span_attributes.call_args_list
+        )
+        if "llm.feature.source" in call.kwargs
+    )
+    assert feature_attributes == {
+        "llm.feature.source": "catalog_family",
+        "llm.feature.match_kind": "catalog_family",
+        "llm.feature.catalog_revision": "2026-09-01.2",
+        "llm.feature.profile_version": "dashscope/qwen3-hybrid-family@1",
+        "llm.reasoning.supported": True,
+        "llm.reasoning.mode": "effort",
+        "llm.reasoning.request_style": "openai_reasoning_effort",
+        "llm.prompt_cache.mode": "provider_automatic",
+        "llm.prompt_cache.supported": True,
+        "llm.prompt_cache.directive_reason": "provider_automatic_cache",
+        "llm.prompt_cache.profile_supported": True,
+    }
 
 
 def test_provider_adapter_preserves_context_manager_tool_order(openai_model_instance):

--- a/test/sdk/core/models/test_openai_llm.py
+++ b/test/sdk/core/models/test_openai_llm.py
@@ -2315,11 +2315,72 @@ def test_p8_feature_resolution_is_emitted_as_sanitized_span_attributes(
         "llm.reasoning.supported": True,
         "llm.reasoning.mode": "effort",
         "llm.reasoning.request_style": "openai_reasoning_effort",
+        "llm.reasoning.effective_enabled": True,
+        "llm.reasoning.effective_effort": "",
+        "llm.feature.policy_source": "nexent_default",
         "llm.prompt_cache.mode": "provider_automatic",
         "llm.prompt_cache.supported": True,
         "llm.prompt_cache.directive_reason": "provider_automatic_cache",
         "llm.prompt_cache.profile_supported": True,
     }
+
+
+def test_p8_014_supported_effort_defaults_are_sent_in_completion_payload(
+    openai_model_instance,
+):
+    openai_model_instance.feature_capabilities = {
+        "reasoning": {
+            "supported": True,
+            "mode": "effort",
+            "request_style": "openai_reasoning_effort",
+            "efforts": ["low", "medium", "high"],
+            "default_effort": "medium",
+        },
+        "prompt_cache": {"supported": False, "mode": "none"},
+    }
+    mock_chunk = MagicMock()
+    mock_chunk.choices = [MagicMock()]
+    mock_chunk.choices[0].delta.content = "ok"
+    mock_chunk.choices[0].delta.role = "assistant"
+    mock_chunk.choices[0].delta.reasoning_content = None
+    mock_chunk.choices[0].finish_reason = "stop"
+    mock_chunk.usage = MagicMock(prompt_tokens=1, completion_tokens=1)
+
+    with patch.object(openai_model_instance, "_prepare_completion_kwargs", return_value={}):
+        openai_model_instance.client.chat.completions.create.return_value = [mock_chunk]
+        openai_model_instance([{"role": "user", "content": "verify"}])
+
+    create_kwargs = openai_model_instance.client.chat.completions.create.call_args.kwargs
+    assert create_kwargs["reasoning_effort"] == "medium"
+
+
+def test_p8_014_supported_toggle_defaults_are_sent_in_provider_extra_body(
+    openai_model_instance,
+):
+    openai_model_instance.extra_body = {"logprobs": True}
+    openai_model_instance.feature_capabilities = {
+        "reasoning": {
+            "supported": True,
+            "mode": "toggle",
+            "request_style": "extra_body_enable_thinking",
+            "efforts": [],
+        },
+        "prompt_cache": {"supported": False, "mode": "none"},
+    }
+    mock_chunk = MagicMock()
+    mock_chunk.choices = [MagicMock()]
+    mock_chunk.choices[0].delta.content = "ok"
+    mock_chunk.choices[0].delta.role = "assistant"
+    mock_chunk.choices[0].delta.reasoning_content = None
+    mock_chunk.choices[0].finish_reason = "stop"
+    mock_chunk.usage = MagicMock(prompt_tokens=1, completion_tokens=1)
+
+    with patch.object(openai_model_instance, "_prepare_completion_kwargs", return_value={}):
+        openai_model_instance.client.chat.completions.create.return_value = [mock_chunk]
+        openai_model_instance([{"role": "user", "content": "verify"}])
+
+    create_kwargs = openai_model_instance.client.chat.completions.create.call_args.kwargs
+    assert create_kwargs["extra_body"] == {"logprobs": True, "enable_thinking": True}
 
 
 def test_provider_adapter_preserves_context_manager_tool_order(openai_model_instance):

--- a/test/sdk/core/models/test_provider_request_count.py
+++ b/test/sdk/core/models/test_provider_request_count.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from nexent.core.models.final_request_budget import build_final_request_shape
+from nexent.core.models.provider_request_count import count_final_request, endpoint_fingerprint
+
+
+BASE = "https://example.test/v1"
+
+
+def _metadata(**overrides):
+    value = {
+        "status": "supported",
+        "adapter_version": "1.0.0",
+        "selected_protocol": "openai_responses",
+        "endpoint_fingerprint": endpoint_fingerprint(BASE),
+        "model_identity": "dashscope:qwen",
+        "stale_at": (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat(),
+        "capabilities": {"text": "supported", "tools": "unknown", "media": "unknown"},
+    }
+    value.update(overrides)
+    return value
+
+
+def test_ac_p2_003_provider_count_precedence_for_matching_text_shape():
+    shape = build_final_request_shape({"model": "qwen", "messages": [{"role": "user", "content": "hello"}]})
+    response = MagicMock(status_code=200, content=b'{"input_tokens": 17}')
+    response.json.return_value = {"input_tokens": 17}
+    client = MagicMock()
+    client.__enter__.return_value.post.return_value = response
+    with patch("nexent.core.models.provider_request_count.httpx.Client", return_value=client) as client_type:
+        count, reason = count_final_request(
+            shape,
+            metadata=_metadata(),
+            base_url=BASE,
+            api_key="secret",
+            model_name="qwen",
+            canonical_model_id="dashscope:qwen",
+        )
+    assert (count, reason) == (17, None)
+    assert client_type.call_args.kwargs["follow_redirects"] is False
+    assert client.__enter__.return_value.post.call_args.kwargs["json"]["input"] == [
+        {"content": "hello", "role": "user"}
+    ]
+
+
+def test_ac_p2_003_text_capability_does_not_authorize_tools_shape():
+    shape = build_final_request_shape({"messages": [], "tools": [{"type": "function"}]})
+    count, reason = count_final_request(
+        shape,
+        metadata=_metadata(),
+        base_url=BASE,
+        api_key="secret",
+        model_name="qwen",
+        canonical_model_id="dashscope:qwen",
+    )
+    assert count is None
+    assert reason == "count_capability_shape_unsupported"
+
+
+def test_ac_p2_003_text_capability_does_not_authorize_reasoning_template():
+    shape = build_final_request_shape(
+        {
+            "messages": [],
+            "extra_body": {"chat_template_kwargs": {"enable_thinking": False}},
+        }
+    )
+    count, reason = count_final_request(
+        shape,
+        metadata=_metadata(),
+        base_url=BASE,
+        api_key="secret",
+        model_name="qwen",
+        canonical_model_id="dashscope:qwen",
+    )
+    assert count is None
+    assert reason == "count_capability_shape_unsupported"
+
+
+def test_ac_p2_003_temporary_count_failure_falls_back_with_reason():
+    shape = build_final_request_shape({"messages": []})
+    with patch(
+        "nexent.core.models.provider_request_count.httpx.Client",
+        side_effect=httpx.ReadTimeout("late"),
+    ):
+        count, reason = count_final_request(
+            shape,
+            metadata=_metadata(),
+            base_url=BASE,
+            api_key="secret",
+            model_name="qwen",
+            canonical_model_id="dashscope:qwen",
+        )
+    assert (count, reason) == (None, "count_timeout")
+
+
+def test_ac_p2_003_stale_or_cross_model_capability_is_not_used():
+    shape = build_final_request_shape({"messages": []})
+    count, reason = count_final_request(
+        shape,
+        metadata=_metadata(model_identity="other:model"),
+        base_url=BASE,
+        api_key="secret",
+        model_name="qwen",
+        canonical_model_id="dashscope:qwen",
+    )
+    assert count is None
+    assert reason == "count_capability_model_mismatch"
+
+
+def test_ac_p2_003_runtime_count_rejects_credentialed_or_queried_base_url():
+    shape = build_final_request_shape({"messages": []})
+    count, reason = count_final_request(
+        shape,
+        metadata=_metadata(),
+        base_url="https://user@example.test/v1?redirect=evil",
+        api_key="secret",
+        model_name="qwen",
+        canonical_model_id="dashscope:qwen",
+    )
+    assert count is None
+    assert reason == "count_ssrf_rejected"

--- a/test/sdk/core/models/test_provider_usage.py
+++ b/test/sdk/core/models/test_provider_usage.py
@@ -1,0 +1,145 @@
+from types import SimpleNamespace
+
+from nexent.core.models.provider_usage import (
+    PROVIDER_USAGE_SCHEMA_VERSION,
+    ProviderCallUsage,
+    normalize_provider_usage,
+)
+
+
+def test_ac_tu_001_normalizes_provider_totals_and_disjoint_details():
+    raw = SimpleNamespace(
+        prompt_tokens=100,
+        completion_tokens=30,
+        total_tokens=130,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=40, cache_creation_input_tokens=10),
+        completion_tokens_details=SimpleNamespace(reasoning_tokens=20),
+    )
+
+    usage, quality, source, metadata = normalize_provider_usage(
+        raw,
+        provider="siliconflow",
+        model="glm-5",
+        capability_profile={
+            "cache_partition_semantics": "disjoint_inclusive",
+            "reasoning_usage_semantics": "included",
+        },
+    )
+
+    assert source == "provider"
+    assert usage.input_tokens == 100
+    assert usage.fresh_input_tokens == 50
+    assert usage.cache_read_tokens == 40
+    assert usage.cache_write_tokens == 10
+    assert usage.visible_output_tokens == 10
+    assert usage.reasoning_tokens == 20
+    assert usage.total_tokens == 130
+    assert quality.degraded is False
+    assert metadata == {
+        "cached_tokens": 40,
+        "cache_creation_input_tokens": 10,
+        "reasoning_tokens": 20,
+    }
+
+
+def test_ac_tu_002_rejects_invalid_values_and_marks_conflicts():
+    raw = {
+        "prompt_tokens": 10,
+        "completion_tokens": 3,
+        "total_tokens": float("inf"),
+        "prompt_tokens_details": {"cached_tokens": 8, "cache_creation_input_tokens": 7},
+        "completion_tokens_details": {"reasoning_tokens": 5},
+    }
+
+    usage, quality, source, _ = normalize_provider_usage(
+        raw,
+        provider="dashscope",
+        model="qwen",
+        capability_profile={
+            "cache_partition_semantics": "disjoint_inclusive",
+            "reasoning_usage_semantics": "included",
+        },
+    )
+
+    assert source == "provider"
+    assert usage.fresh_input_tokens == 0
+    assert usage.visible_output_tokens == 0
+    assert usage.total_tokens == 13
+    assert usage.total_source == "derived"
+    assert quality.degraded is True
+    assert set(quality.reasons) == {
+        "invalid_total_tokens",
+        "cache_partition_exceeds_input",
+        "reasoning_exceeds_output",
+    }
+
+
+def test_ac_tu_003_preserves_missing_as_null_and_explicit_zero():
+    usage, quality, source, _ = normalize_provider_usage(
+        {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+        provider="modelengine",
+        model="model",
+    )
+
+    assert source == "provider"
+    assert usage.input_tokens == 0
+    assert usage.output_tokens == 0
+    assert usage.total_tokens == 0
+    assert usage.cache_read_tokens is None
+    assert usage.cache_write_tokens is None
+    assert usage.reasoning_tokens is None
+    assert usage.visible_output_tokens is None
+    assert quality.degraded is False
+
+
+def test_p10_ac_001_missing_provider_usage_stays_null():
+    usage, quality, source, _ = normalize_provider_usage(
+        None,
+        provider="unknown",
+        model="model",
+    )
+
+    assert source == "missing"
+    assert usage.input_tokens is None
+    assert usage.output_tokens is None
+    assert usage.total_tokens is None
+    assert usage.total_source == "missing"
+    assert usage.fresh_input_tokens is None
+    assert usage.reasoning_tokens is None
+    assert quality.degraded is False
+
+
+def test_ac_tu_004_call_record_contract_is_complete_and_versioned():
+    record = ProviderCallUsage(call_id="call-1", turn_id="turn-1", step_number=2)
+
+    payload = record.to_dict()
+
+    assert payload["schema_version"] == PROVIDER_USAGE_SCHEMA_VERSION
+    assert payload["call_id"] == "call-1"
+    assert payload["turn_id"] == "turn-1"
+    assert payload["usage"]["input_tokens"] is None
+    assert payload["quality"] == {"degraded": False, "reasons": ()}
+
+
+def test_ac_tu_002_siliconflow_hit_miss_conflict_is_not_silently_reconciled():
+    usage, quality, _, metadata = normalize_provider_usage(
+        {
+            "prompt_tokens": 100,
+            "completion_tokens": 1,
+            "prompt_cache_hit_tokens": 40,
+            "prompt_cache_miss_tokens": 50,
+        },
+        provider="siliconflow",
+        model="model",
+        capability_profile={
+            "cache_write_semantics": "unsupported",
+            "cache_hit_miss_semantics": "disjoint_inclusive",
+        },
+    )
+
+    assert usage.cache_read_tokens == 40
+    assert usage.cache_write_tokens == 0
+    assert usage.fresh_input_tokens is None
+    assert metadata["prompt_cache_hit_tokens"] == 40
+    assert metadata["prompt_cache_miss_tokens"] == 50
+    assert "cache_hit_miss_input_conflict" in quality.reasons

--- a/test/sdk/monitor/test_context_budget_evidence.py
+++ b/test/sdk/monitor/test_context_budget_evidence.py
@@ -1,0 +1,28 @@
+from nexent.monitor.monitoring import (
+    _enrich_record_with_final_request_evidence,
+    set_monitoring_final_request_evidence,
+    update_monitoring_final_request_evidence,
+)
+
+
+def test_physical_request_evidence_is_allowlisted_and_joins_own_usage():
+    set_monitoring_final_request_evidence({
+        "schema_version": 1,
+        "raw_estimate_tokens": 120,
+        "hard_count_tokens": 138,
+        "request_fingerprint": "hash",
+        "compression_attempted": True,
+    })
+    update_monitoring_final_request_evidence(recovery_attempted=True, recovery_succeeded=True)
+    record = {"input_tokens": 125}
+    _enrich_record_with_final_request_evidence(record)
+    assert record["context_budget_evidence"]["provider_prompt_usage_tokens"] == 125
+    assert record["context_budget_evidence"]["recovery_succeeded"] is True
+    assert "prompt" not in record["context_budget_evidence"]
+
+
+def test_missing_evidence_leaves_legacy_record_unchanged():
+    set_monitoring_final_request_evidence(None)
+    record = {"input_tokens": 10}
+    _enrich_record_with_final_request_evidence(record)
+    assert "context_budget_evidence" not in record

--- a/test/sdk/monitor/test_monitoring.py
+++ b/test/sdk/monitor/test_monitoring.py
@@ -1633,7 +1633,7 @@ class TestEnqueueMonitoringRecord:
             "output_reserve_source": "model_default",
             "provider_input_limit_tokens": 127000,
             "uncertainty_reserve_tokens": 12800,
-            "uncertainty_reserve_basis": "context_window_10pct",
+            "uncertainty_reserve_basis": "provider_input_limit_10pct",
             "soft_limit_ratio": 0.8,
             "soft_input_budget_tokens": 91360,
             "hard_input_budget_tokens": 114200,
@@ -1653,7 +1653,10 @@ class TestEnqueueMonitoringRecord:
         assert record["budget_output_reserve_source"] == "model_default"
         assert record["budget_provider_input_limit_tokens"] == 127000
         assert record["budget_uncertainty_reserve_tokens"] == 12800
-        assert record["budget_uncertainty_reserve_basis"] == "context_window_10pct"
+        assert (
+            record["budget_uncertainty_reserve_basis"]
+            == "provider_input_limit_10pct"
+        )
         assert record["budget_soft_limit_ratio"] == 0.8
         assert record["budget_soft_input_budget_tokens"] == 91360
         assert record["budget_hard_input_budget_tokens"] == 114200


### PR DESCRIPTION
## 概要

对实际待发送的完整请求进行计量，并以 Provider 响应状态驱动安全恢复；输入只观测和触发计划动作，输出始终使用模型 profile 的最大输出值。

## 新增能力

- 计量 messages、tools、response format、多模态和协议开销组成的最终请求。
- 保留 Provider 返回的 input/cache read/cache write/output/reasoning/total/finish reason。
- 支持受限次数的主动重建、Provider overflow 恢复和纯文本 `length` continuation。
- 增加上下文组成事件和监控证据。

## 对旧行为的调整

- 移除基于猜测供应商规则的 `input + max_tokens` 本地硬拒绝。
- API 请求的 `max_tokens` 始终采用模型 profile 的 `max_output_tokens`。
- 有潜在副作用或不完整工具调用的响应不会被盲目重试/续写。
- 中途调用错误不会覆盖最终成功 completion 的 usage 数据。

## 对 Nexent 的提升

避免预算策略导致模型异常截断，同时通过 compaction、overflow 重建和安全 continuation 支撑 Agent 长时间运行。

## 规模与依赖

- 15 个文件，3,915 行新增、300 行删除（4,215 行变更）。
- 前置 PR：#3849 模型配置治理集成（当前 base 分支）。
- SPEC：Final Request Budgeting and Recovery；Provider-observed Usage（底层归一化部分）。

## 验证

- 最终请求预算 13、请求计数 6、Provider usage 6、OpenAI 适配器 91 个测试通过。
- 上下文组成/事件、监控证据和监控回归共 103 个测试通过。
- 本地在前两层 squash 结果上模拟本 PR 的 `git merge --squash`；最终结果提交 `96cac2c15`，测试通过且文件树与本分支一致。
- 补充验证 OpenAI 长上下文模型 22、VLM 18 个兼容测试。

## 合并说明

这是堆叠变更的第三层；建议在前置 PR 合并后把 base 更新为 `develop`。
