### PR TITLE
🐛 Fix: align AIDP knowledge base name validation

### DIFF
--- a/frontend/const/knowledgeBase.ts
+++ b/frontend/const/knowledgeBase.ts
@@ -1,5 +1,9 @@
 // Knowledge base related constants
 
+// Keep this pattern in sync with AIDP's knowledge-base name validation.
+export const AIDP_KNOWLEDGE_BASE_NAME_PATTERN =
+  /^[\u4e00-\u9fa5a-zA-Z][\u4e00-\u9fa5a-zA-Z0-9_]{0,255}$/;
+
 // Document status constants
 export const DOCUMENT_STATUS = {
   WAIT_FOR_PROCESSING: "WAIT_FOR_PROCESSING",

--- a/frontend/ext_components/aidp/components/AidpCreateKbModal.tsx
+++ b/frontend/ext_components/aidp/components/AidpCreateKbModal.tsx
@@ -36,7 +36,10 @@ import { USER_ROLES } from "@/const/auth";
  * compatibility.
  */
 type RcFileLike = File & { uid: string; lastModifiedDate: Date };
-import { AIDP_ACCEPT_STRING } from "@/const/knowledgeBase";
+import {
+  AIDP_ACCEPT_STRING,
+  AIDP_KNOWLEDGE_BASE_NAME_PATTERN,
+} from "@/const/knowledgeBase";
 import {
   partitionAidpFiles,
   validateAidpFiles,
@@ -444,6 +447,10 @@ const AidpCreateKbModal: React.FC<AidpCreateKbModalProps> = ({
           label={t("aidpKnowledge.kbName")}
           rules={[
             { required: true, message: t("aidpKnowledge.kbNameRequired") },
+            {
+              pattern: AIDP_KNOWLEDGE_BASE_NAME_PATTERN,
+              message: t("aidpKnowledge.kbNameInvalid"),
+            },
           ]}
         >
           <Input placeholder={t("aidpKnowledge.kbNamePlaceholder")} />

--- a/frontend/ext_components/aidp/components/AidpUpdateKbModal.tsx
+++ b/frontend/ext_components/aidp/components/AidpUpdateKbModal.tsx
@@ -7,6 +7,7 @@ import { Modal, Form, Input, Select, message } from "antd";
 
 import type { AidpKnowledgeBaseItem } from "@/types/agentConfig";
 import aidpKnowledgeService from "@/ext_components/aidp/services/aidpKnowledgeService";
+import { AIDP_KNOWLEDGE_BASE_NAME_PATTERN } from "@/const/knowledgeBase";
 import { useGroupList } from "@/hooks/group/useGroupList";
 import { useAuthorizationContext } from "@/components/providers/AuthorizationProvider";
 import { USER_ROLES } from "@/const/auth";
@@ -163,6 +164,10 @@ const AidpUpdateKbModal: React.FC<AidpUpdateKbModalProps> = ({
           label={t("aidpKnowledge.kbName")}
           rules={[
             { required: true, message: t("aidpKnowledge.kbNameRequired") },
+            {
+              pattern: AIDP_KNOWLEDGE_BASE_NAME_PATTERN,
+              message: t("aidpKnowledge.kbNameInvalid"),
+            },
           ]}
         >
           <Input placeholder={t("aidpKnowledge.kbNamePlaceholder")} />

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -4191,6 +4191,7 @@
   "aidpKnowledge.kbName": "Name",
   "aidpKnowledge.kbNamePlaceholder": "Knowledge base name",
   "aidpKnowledge.kbNameRequired": "Name is required",
+  "aidpKnowledge.kbNameInvalid": "Invalid name format: the name must start with a Chinese character or English letter, followed only by Chinese or English letters, digits, or underscores, and be 1–256 characters long.",
   "aidpKnowledge.kbDescription": "Description",
   "aidpKnowledge.kbDescriptionPlaceholder": "Optional description",
   "aidpKnowledge.kbDescriptionRequired": "Please enter a description",

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -3922,6 +3922,7 @@
   "aidpKnowledge.kbName": "名称",
   "aidpKnowledge.kbNamePlaceholder": "知识库名称",
   "aidpKnowledge.kbNameRequired": "名称是必填项",
+  "aidpKnowledge.kbNameInvalid": "名称格式不正确：必须以中文或英文字母开头，后续只能包含中文、英文字母、数字或下划线，长度为 1-256 个字符",
   "aidpKnowledge.kbDescription": "描述",
   "aidpKnowledge.kbDescriptionPlaceholder": "可选描述信息",
   "aidpKnowledge.kbDescriptionRequired": "请输入知识库描述",


### PR DESCRIPTION
## Problem

AIDP introduced validation for knowledge base names, but Nexent did not synchronize the frontend validation rules.

The name must:

- Start with a Chinese character or an English letter
- Contain only Chinese characters, English letters, digits, or underscores afterward
- Be between 1 and 256 characters long

The previous frontend regex also contained a typo: `1-z` should be `a-z`.

## Fix

- Corrected the knowledge base name regex
- Added validation to the create and update knowledge base forms
- Added detailed Chinese and English validation messages

## Verification

<img width="693" height="867" alt="img_v3_0215a_d48aa9f3-b34d-4164-9588-5411a75ad03g" src="https://github.com/user-attachments/assets/079aed13-f633-4789-83a4-3280fa0315c1" />
