### PR TITLE
fix(deploy): include official skills in K8s offline packages

### DIFF
--- a/deploy/offline/build_offline_package.sh
+++ b/deploy/offline/build_offline_package.sh
@@ -701,7 +701,15 @@ copy_deployment_bundle() {
   rm -f "$OUTPUT_DIR/deploy/k8s/helm/nexent-infrastructure/generated-values.yaml" "$OUTPUT_DIR/deploy/k8s/helm/nexent-infrastructure/generated-runtime-values.yaml" "$OUTPUT_DIR/deploy/k8s/helm/nexent-infrastructure/generated-secrets-values.yaml" "$OUTPUT_DIR/deploy/k8s/helm/nexent-infrastructure/generated-persistence-values.yaml"
   case "$TARGET" in
     docker) rm -rf "$OUTPUT_DIR/deploy/k8s" ;;
-    k8s) rm -rf "$OUTPUT_DIR/deploy/docker" ;;
+    k8s)
+      rm -rf "$OUTPUT_DIR/deploy/docker"
+      if [ ! -d "$DEPLOY_ROOT/docker/assets/official-skills-zip" ]; then
+        echo "❌ Required K8s official skill assets not found: $DEPLOY_ROOT/docker/assets/official-skills-zip"
+        return 1
+      fi
+      mkdir -p "$OUTPUT_DIR/deploy/docker/assets"
+      cp -R "$DEPLOY_ROOT/docker/assets/official-skills-zip" "$OUTPUT_DIR/deploy/docker/assets/"
+      ;;
   esac
 
   create_offline_deploy_entrypoint

--- a/deploy/tests/test_build_offline_package.sh
+++ b/deploy/tests/test_build_offline_package.sh
@@ -225,6 +225,9 @@ for target in docker k8s all; do
     k8s)
       [ -f "$package_dir/deploy/k8s/deploy.sh" ] || fail "k8s package should include deploy/k8s/deploy.sh"
       [ ! -e "$package_dir/deploy/docker/deploy.sh" ] || fail "k8s package should not include docker deploy script"
+      [ -d "$package_dir/deploy/docker/assets/official-skills-zip" ] || fail "k8s package should include official skill archives"
+      [ "$(find "$package_dir/deploy/docker/assets/official-skills-zip" -type f -name '*.zip' | wc -l | tr -d ' ')" -gt 0 ] || fail "k8s package should include at least one official skill archive"
+      grep -Fq 'deploy/docker/assets/official-skills-zip/' "$package_dir/checksums.txt" || fail "k8s package checksums should include official skill archives"
       ;;
     all)
       [ -f "$package_dir/deploy/docker/deploy.sh" ] || fail "all package should include deploy/docker/deploy.sh"


### PR DESCRIPTION
## 问题说明

K8s 离线包构建时会删除整个 `deploy/docker` 目录，但 K8s 部署流程仍需要读取其中的 `deploy/docker/assets/official-skills-zip`，用于将官方技能同步到 workspace PVC。因此，原离线包虽然能够进入部署流程，却会因缺少官方技能资源而失败。

## 修改思路

- K8s 目标仍然裁剪与 Docker 部署有关的脚本和配置，避免引入无关内容。
- 裁剪完成后，仅将 K8s 实际依赖的 `official-skills-zip` 目录复制回离线包。
- 如果源码中的官方技能目录不存在，则立即终止构建，避免产出不完整的离线包。
- 通过离线包测试检查技能目录、ZIP 数量以及 `checksums.txt` 覆盖情况。

## 修改内容

- K8s-only 离线包保留 `deploy/docker/assets/official-skills-zip`。
- 其他 Docker 部署文件仍保持排除。
- 所有保留的官方技能归档均纳入 checksum。

## 验证结果

- `bash deploy/tests/test_build_offline_package.sh`：通过。
- 使用本地组合验证分支 `verify-four-deploy-fixes`，基于 `origin/develop` 按 Stack 顺序 squash 应用四项修复。
- 在 Multipass `external-memory-contract` 中重新构建四个 ARM64 应用镜像及 K8s 离线包。
- 离线包 194 项 checksum 全部通过；包含 28 个官方技能 ZIP，且全部被 checksum 覆盖。
- 在 kubeadm/containerd 环境中完成全新安装，12/12 Pod Ready，28 个官方技能成功同步到 workspace PVC。
- 使用相同参数重复部署成功，两个 Helm release 均升级到 revision 2。

## PR Stack

1. 当前 PR，base 为 `develop`
2. [#3876](https://github.com/ModelEngine-Group/nexent/pull/3876)
3. [#3878](https://github.com/ModelEngine-Group/nexent/pull/3878)
4. [#3877](https://github.com/ModelEngine-Group/nexent/pull/3877)

Fixes #3870
