### PR TITLE
fix(k8s): correct shared storage PV rendering

### DIFF
--- a/deploy/k8s/helm/nexent/charts/nexent-common/templates/shared-storage.yaml
+++ b/deploy/k8s/helm/nexent/charts/nexent-common/templates/shared-storage.yaml
@@ -67,7 +67,7 @@ spec:
   storageClassName: {{ $storageClassName | quote }}
   capacity:
     storage: {{ $skillsSize }}
-    accessModes:
+  accessModes:
 {{ toYaml $accessModes | indent 4 }}
   persistentVolumeReclaimPolicy: Retain
   hostPath:

--- a/deploy/tests/test_common.sh
+++ b/deploy/tests/test_common.sh
@@ -15,6 +15,8 @@ DEPLOYMENT_ROOT_ENV="$TMP_DIR/root.env"
 : > "$DEPLOYMENT_ROOT_ENV"
 export DEPLOYMENT_LANG=en
 
+SHARED_STORAGE_TEMPLATE="$(cat "$SCRIPT_DIR/../k8s/helm/nexent/charts/nexent-common/templates/shared-storage.yaml")"
+
 assert_eq() {
   local expected="$1"
   local actual="$2"
@@ -70,6 +72,9 @@ assert_success() {
     exit 1
   fi
 }
+
+assert_contains "$SHARED_STORAGE_TEMPLATE" $'  capacity:\n    storage: {{ $skillsSize }}\n  accessModes:' "skills PV accessModes should be a sibling of capacity"
+assert_not_contains "$SHARED_STORAGE_TEMPLATE" $'    storage: {{ $skillsSize }}\n    accessModes:' "skills PV accessModes should not be nested under capacity"
 
 write_full_config() {
   local file="$1"


### PR DESCRIPTION
## 问题说明

Skills PersistentVolume 模板中的 `accessModes` 缩进在 `capacity` 内部，导致渲染结果不符合 Kubernetes PersistentVolume 结构。Helm 安装时无法按预期创建 skills PV，进而阻断 K8s 部署。

## 修改思路

- 参照同一模板中 workspace、logs 和 memory plugins PV 的结构修正缩进。
- 让 `capacity` 与 `accessModes` 成为 `spec` 下的同级字段。
- 增加回归断言，同时检查正确结构存在、错误嵌套结构不存在。

## 修改内容

- 修正 `nexent-skills-pv` 的 Helm YAML 缩进。
- 为 shared storage 模板增加结构回归测试。

## 验证结果

- `bash deploy/tests/test_common.sh`：通过。
- Multipass 全新安装中，Helm 成功创建修正后的 skills PV。
- 实际 PV 属性：`capacity=5Gi`、`accessModes=[ReadWriteMany]`。
- 12/12 Pod 全部 Ready；重复部署时两个 Helm release 均成功升级。
- 完整部署证据来自包含四项修复的组合验证分支，用于模拟四个 PR 按顺序 squash merge 后的结果。

## PR Stack

- 依赖 [#3875](https://github.com/ModelEngine-Group/nexent/pull/3875)。
- 下游为 [#3878](https://github.com/ModelEngine-Group/nexent/pull/3878)。

Fixes #3871
