### PR TITLE
fix(deploy): load K8s images into containerd first

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -347,7 +347,11 @@ if [ "$LOAD_IMAGES" = "true" ] && [ "$PUSH_IMAGES" != "true" ]; then
     fi
     exit 1
   fi
-  bash "$LOAD_SCRIPT"
+  if ! DEPLOYMENT_TARGET="$(detect_deployment_target)"; then
+    echo "Error: --load-images requires a docker or k8s deployment target." >&2
+    exit 1
+  fi
+  bash "$LOAD_SCRIPT" "$DEPLOYMENT_TARGET"
 fi
 
 if [ "$PUSH_IMAGES" = "true" ]; then

--- a/deploy/offline/load-images.sh
+++ b/deploy/offline/load-images.sh
@@ -1,16 +1,44 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 IMAGES_DIR="$SCRIPT_DIR/images"
 
-echo "Loading Docker images from $IMAGES_DIR..."
+TARGET="${1:-docker}"
+
+if [[ "$TARGET" != "docker" && "$TARGET" != "k8s" ]]; then
+  echo "Error: target must be 'docker' or 'k8s': $TARGET" >&2
+  exit 1
+fi
+
+loader=(docker load -i)
+loader_name="Docker"
+if [ "$TARGET" = "k8s" ]; then
+  if command -v ctr >/dev/null 2>&1; then
+    loader=(ctr -n k8s.io images import)
+    if [ "$(id -u)" -ne 0 ]; then
+      if command -v sudo >/dev/null 2>&1 && sudo -n ctr -n k8s.io namespaces list >/dev/null 2>&1; then
+        loader=(sudo -n ctr -n k8s.io images import)
+      elif ! ctr -n k8s.io namespaces list >/dev/null 2>&1; then
+        echo "Error: ctr is installed but the containerd socket is not accessible." >&2
+        echo "Run this command as root or grant non-interactive sudo access to ctr." >&2
+        exit 1
+      fi
+    fi
+    loader_name="containerd (k8s.io namespace)"
+  else
+    echo "Warning: ctr is unavailable; falling back to Docker image loading." >&2
+    echo "Warning: verify that the Kubernetes container runtime can access Docker-loaded images." >&2
+  fi
+fi
+
+echo "Loading images into $loader_name from $IMAGES_DIR..."
 
 for tar_file in "$IMAGES_DIR"/*.tar; do
   if [[ -f "$tar_file" ]]; then
     echo "Loading: $tar_file"
-    docker load -i "$tar_file"
+    "${loader[@]}" "$tar_file"
   fi
 done
 

--- a/deploy/tests/test_build_offline_package.sh
+++ b/deploy/tests/test_build_offline_package.sh
@@ -281,7 +281,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ -n "${DEPLOY_WRAPPER_EXPECT_ENV:-}" ]; then
   grep -Fqx "$DEPLOY_WRAPPER_EXPECT_ENV" "$script_dir/deploy/env/.env" || exit 1
 fi
-printf 'load-images\n' >> "$DEPLOY_WRAPPER_LOG"
+printf 'load-images:%s\n' "$*" >> "$DEPLOY_WRAPPER_LOG"
 SH
 chmod +x "$deploy_wrapper_dir/load-images.sh"
 cat > "$deploy_wrapper_dir/push-images.sh" <<'SH'
@@ -308,7 +308,7 @@ deploy_wrapper_log="$TMP_DIR/deploy-wrapper.log"
 DEPLOY_WRAPPER_LOG="$deploy_wrapper_log" \
   DEPLOY_WRAPPER_EXPECT_ENV='WRAPPER_NEW_DEFAULT=merged-before-actions' \
   bash "$deploy_wrapper_dir/deploy.sh" docker --foo bar
-if grep -q '^load-images$' "$deploy_wrapper_log"; then
+if grep -q '^load-images:' "$deploy_wrapper_log"; then
   fail "deploy.sh should not load images by default"
 fi
 grep -q '^deploy::false:docker --foo bar$' "$deploy_wrapper_log" || fail "deploy.sh should forward args and mark an online deployment"
@@ -321,7 +321,7 @@ DEPLOY_WRAPPER_LOG="$deploy_wrapper_log" \
   bash "$deploy_wrapper_dir/deploy.sh" --load-images docker --foo bar
 first_line="$(sed -n '1p' "$deploy_wrapper_log")"
 second_line="$(sed -n '2p' "$deploy_wrapper_log")"
-[ "$first_line" = "load-images" ] || fail "deploy.sh --load-images should load images before deploy"
+[ "$first_line" = "load-images:docker" ] || fail "deploy.sh --load-images should pass the docker target to the loader"
 [ "$second_line" = "deploy::false:docker --foo bar" ] || fail "deploy.sh --load-images should strip only the wrapper flag"
 
 mv "$deploy_wrapper_dir/deploy/env/.env.example" "$deploy_wrapper_dir/deploy/env/.env.example.saved"
@@ -442,7 +442,7 @@ fi
 if [ -n "${DEPLOY_WRAPPER_EXPECT_MERGED_ENV:-}" ]; then
   grep -Fqx "$DEPLOY_WRAPPER_EXPECT_MERGED_ENV" "$script_dir/deploy/env/.env" || exit 1
 fi
-printf 'load-images\n' >> "$DEPLOY_WRAPPER_LOG"
+printf 'load-images:%s\n' "$*" >> "$DEPLOY_WRAPPER_LOG"
 SH
 chmod +x "$latest_package_dir/load-images.sh"
 cat > "$latest_package_dir/push-images.sh" <<'SH'
@@ -509,7 +509,7 @@ DEPLOY_WRAPPER_LOG="$offline_deploy_log" \
   bash "$latest_package_dir/deploy.sh" docker --reuse-from "$reuse_source" --load-images --foo bar >"$TMP_DIR/reuse-docker.log" 2>&1
 first_line="$(sed -n '1p' "$offline_deploy_log")"
 second_line="$(sed -n '2p' "$offline_deploy_log")"
-[ "$first_line" = "load-images" ] || fail "--reuse-from should import files before loading images"
+[ "$first_line" = "load-images:docker" ] || fail "--reuse-from should import files before loading images with the target"
 [ "$second_line" = "deploy:defaults:true:docker --foo bar" ] || fail "--reuse-from should be consumed before forwarding Docker deploy arguments"
 grep -q '^REUSED_SECRET=do-not-print-this-value$' "$latest_package_dir/deploy/env/.env" || fail "Docker reuse should copy deploy/env/.env"
 grep -q '^OFFLINE_TEMPLATE_ONLY=merged-before-actions$' "$latest_package_dir/deploy/env/.env" || fail "Docker reuse should merge variables from the current .env.example"
@@ -585,7 +585,7 @@ grep -q '^deploy:defaults:true:docker --foo bar$' "$offline_deploy_log" || fail 
 DEPLOY_WRAPPER_LOG="$offline_deploy_log" bash "$latest_package_dir/deploy.sh" --load-images docker --foo bar
 first_line="$(sed -n '1p' "$offline_deploy_log")"
 second_line="$(sed -n '2p' "$offline_deploy_log")"
-[ "$first_line" = "load-images" ] || fail "offline deploy.sh --load-images should load images before deploy"
+[ "$first_line" = "load-images:docker" ] || fail "offline deploy.sh --load-images should load images with the target before deploy"
 [ "$second_line" = "deploy:defaults:true:docker --foo bar" ] || fail "offline deploy.sh --load-images should preserve defaults mode"
 
 : > "$offline_deploy_log"

--- a/deploy/tests/test_load_images.sh
+++ b/deploy/tests/test_load_images.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOAD_SCRIPT="$SCRIPT_DIR/../offline/load-images.sh"
+TMP_DIR="${TMPDIR:-/tmp}/nexent-load-images-test-$$"
+trap 'rm -rf "$TMP_DIR"' EXIT
+mkdir -p "$TMP_DIR/package/images" "$TMP_DIR/bin"
+cp "$LOAD_SCRIPT" "$TMP_DIR/package/load-images.sh"
+: > "$TMP_DIR/package/images/nexent.tar"
+
+fail() { echo "FAIL: $*"; exit 1; }
+
+cat > "$TMP_DIR/bin/docker" <<'SH'
+#!/usr/bin/env bash
+printf 'docker:%s\n' "$*" >> "$IMAGE_LOADER_LOG"
+SH
+cat > "$TMP_DIR/bin/ctr" <<'SH'
+#!/usr/bin/env bash
+printf 'ctr:%s\n' "$*" >> "$IMAGE_LOADER_LOG"
+SH
+chmod +x "$TMP_DIR/bin/docker" "$TMP_DIR/bin/ctr"
+
+: > "$TMP_DIR/loader.log"
+PATH="$TMP_DIR/bin:/usr/bin:/bin" IMAGE_LOADER_LOG="$TMP_DIR/loader.log" bash "$TMP_DIR/package/load-images.sh" k8s >/dev/null
+grep -Fq 'ctr:-n k8s.io images import' "$TMP_DIR/loader.log" || fail "K8s loading should import with ctr in k8s.io"
+! grep -Fq 'docker:' "$TMP_DIR/loader.log" || fail "K8s loading should prefer ctr"
+
+rm "$TMP_DIR/bin/ctr"
+: > "$TMP_DIR/loader.log"
+PATH="$TMP_DIR/bin:/usr/bin:/bin" IMAGE_LOADER_LOG="$TMP_DIR/loader.log" bash "$TMP_DIR/package/load-images.sh" k8s >/dev/null 2>"$TMP_DIR/fallback.log"
+grep -Fq 'docker:load -i' "$TMP_DIR/loader.log" || fail "missing ctr should fall back to Docker"
+grep -Fq 'falling back to Docker' "$TMP_DIR/fallback.log" || fail "Docker fallback should be visible"
+
+: > "$TMP_DIR/loader.log"
+PATH="$TMP_DIR/bin:/usr/bin:/bin" IMAGE_LOADER_LOG="$TMP_DIR/loader.log" bash "$TMP_DIR/package/load-images.sh" docker >/dev/null
+grep -Fq 'docker:load -i' "$TMP_DIR/loader.log" || fail "Docker target should use Docker"
+
+echo "Offline image loader tests passed."

--- a/deploy/tests/test_load_images.sh
+++ b/deploy/tests/test_load_images.sh
@@ -18,6 +18,9 @@ SH
 cat > "$TMP_DIR/bin/ctr" <<'SH'
 #!/usr/bin/env bash
 printf 'ctr:%s\n' "$*" >> "$IMAGE_LOADER_LOG"
+if [ "${FAKE_CTR_FAIL_IMPORT:-false}" = "true" ] && [ "$4" = "import" ]; then
+  exit 42
+fi
 SH
 chmod +x "$TMP_DIR/bin/docker" "$TMP_DIR/bin/ctr"
 
@@ -25,6 +28,12 @@ chmod +x "$TMP_DIR/bin/docker" "$TMP_DIR/bin/ctr"
 PATH="$TMP_DIR/bin:/usr/bin:/bin" IMAGE_LOADER_LOG="$TMP_DIR/loader.log" bash "$TMP_DIR/package/load-images.sh" k8s >/dev/null
 grep -Fq 'ctr:-n k8s.io images import' "$TMP_DIR/loader.log" || fail "K8s loading should import with ctr in k8s.io"
 ! grep -Fq 'docker:' "$TMP_DIR/loader.log" || fail "K8s loading should prefer ctr"
+
+: > "$TMP_DIR/loader.log"
+if PATH="$TMP_DIR/bin:/usr/bin:/bin" IMAGE_LOADER_LOG="$TMP_DIR/loader.log" FAKE_CTR_FAIL_IMPORT=true bash "$TMP_DIR/package/load-images.sh" k8s >/dev/null 2>&1; then
+  fail "a failing ctr import should fail image loading"
+fi
+! grep -Fq 'docker:' "$TMP_DIR/loader.log" || fail "a failing ctr import should not fall back to Docker"
 
 rm "$TMP_DIR/bin/ctr"
 : > "$TMP_DIR/loader.log"


### PR DESCRIPTION
## 问题说明

原离线镜像加载脚本始终执行 `docker load`。但 kubeadm 环境通常由 containerd 提供 CRI，Docker 中存在的镜像不一定对 kubelet 可见，因此脚本可能显示加载成功，而 Pod 仍然尝试从远端拉取镜像或进入 `ImagePullBackOff`。

## 修改思路

- 离线部署入口将用户选择的 `docker` 或 `k8s` 目标显式传给镜像加载脚本。
- K8s 目标优先使用 `ctr -n k8s.io images import`，将镜像导入 kubelet 可见的 containerd namespace。
- 普通用户运行时，先尝试直接访问 containerd；必要时使用非交互 `sudo -n ctr`。
- 只有系统完全没有 `ctr` 时才回落到 Docker，并输出可见性风险警告。
- 如果 `ctr` 已安装但权限不足或导入失败，则直接返回失败，不回落 Docker，避免产生“加载成功但 kubelet 不可见”的假成功。
- Docker 部署和镜像推送场景仍保持原有 Docker 加载行为。

## 修改内容

- 部署 wrapper 将目标类型传入 `load-images.sh`。
- 增加 K8s containerd-first 导入逻辑，固定使用 `k8s.io` namespace。
- 增加缺少 `ctr` 时的兼容回落与警告。
- 增加 containerd 导入失败时禁止 Docker fallback 的测试。
- 保持直接调用脚本时默认使用 Docker，兼容旧用法。

## 验证结果

- image loader 与离线包测试：通过，包括 `ctr` 导入失败且不得回落 Docker 的场景。
- 真实验证环境：Multipass、kubeadm Kubernetes v1.32.13、containerd 2.2.1。
- 脚本实际选择 `containerd (k8s.io namespace)`，8 个离线镜像归档全部成功导入。
- 应用镜像 digest 与本次新构建结果一致：main `89069601…`、web `d13a7a3c…`、MCP `e22b1052…`、sandbox `85da58a8…`。
- 全新安装及重复部署均成功，12/12 Pod Ready。

## PR Stack

- 依赖 [#3878](https://github.com/ModelEngine-Group/nexent/pull/3878)、[#3876](https://github.com/ModelEngine-Group/nexent/pull/3876) 和 [#3875](https://github.com/ModelEngine-Group/nexent/pull/3875)。

Fixes #3873
