### PR TITLE
fix(database): make bootstrap and suadmin initialization idempotent

### DIFF
--- a/deploy/sql/migrations/v2.5.3_database_bootstrap_idempotency.sql
+++ b/deploy/sql/migrations/v2.5.3_database_bootstrap_idempotency.sql
@@ -1,0 +1,31 @@
+BEGIN;
+
+-- Explicit seeded IDs do not advance SERIAL sequences. Re-synchronize the
+-- sequence after every currently shipped migration and keep re-runs safe.
+SELECT setval(
+    pg_get_serial_sequence('nexent.role_permission_t', 'role_permission_id'),
+    COALESCE(MAX(role_permission_id), 1),
+    MAX(role_permission_id) IS NOT NULL
+)
+FROM nexent.role_permission_t;
+
+-- The platform super-admin mapping intentionally uses an empty tenant ID. It
+-- is not a tenant to provision, so ignore only that reserved mapping while
+-- retaining normal provisioning for active tenant rows.
+CREATE OR REPLACE FUNCTION nexent.provision_unified_tag_management_after_user_tenant_insert()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF COALESCE(NEW.delete_flag, 'N') <> 'Y'
+       AND NULLIF(btrim(NEW.tenant_id), '') IS NOT NULL THEN
+        PERFORM nexent.provision_unified_tag_management(
+            NEW.tenant_id,
+            COALESCE(NEW.created_by, 'system')
+        );
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+COMMIT;

--- a/deploy/tests/test_database_bootstrap_idempotency.sh
+++ b/deploy/tests/test_database_bootstrap_idempotency.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGRATION="$SCRIPT_DIR/../sql/migrations/v2.5.3_database_bootstrap_idempotency.sql"
+
+fail() { echo "FAIL: $*"; exit 1; }
+
+[ -f "$MIGRATION" ] || fail "corrective migration missing"
+grep -Fq "pg_get_serial_sequence('nexent.role_permission_t', 'role_permission_id')" "$MIGRATION" || fail "permission sequence is not synchronized"
+grep -Fq "COALESCE(MAX(role_permission_id), 1)" "$MIGRATION" || fail "sequence does not use the current maximum"
+grep -Fq "NULLIF(btrim(NEW.tenant_id), '') IS NOT NULL" "$MIGRATION" || fail "reserved empty tenant mapping is not skipped"
+[ "$(grep -Fc 'CREATE OR REPLACE FUNCTION nexent.provision_unified_tag_management_after_user_tenant_insert()' "$MIGRATION")" -eq 1 ] || fail "trigger function correction is not idempotent"
+grep -Fq 'BEGIN;' "$MIGRATION" || fail "migration transaction missing"
+grep -Fq 'COMMIT;' "$MIGRATION" || fail "migration commit missing"
+
+echo "Database bootstrap idempotency contract passed."


### PR DESCRIPTION
## 问题说明

K8s 全新安装期间存在两个数据库初始化问题：

1. 历史迁移会显式插入 `role_permission_id`，但 PostgreSQL 的 `SERIAL` sequence 不会随显式 ID 自动前进，后续使用默认 ID 插入时可能发生主键冲突。
2. 平台 suadmin 映射按现有约定使用空 `tenant_id`。`user_tenant_t` 的统一标签触发器会把它当作普通租户进行初始化，导致 suadmin 创建或 reconcile 失败。

## 修改思路

- 不修改任何已经发布的 SQL，通过新增 forward-only migration 修复现有数据库和全新数据库。
- 使用 `pg_get_serial_sequence` 获取实际 sequence，并通过 `setval(MAX(role_permission_id))` 将其同步到当前最大 ID。
- 重定义 tenant insert trigger function：只对未删除且 tenant ID 非空的普通租户执行统一标签初始化。
- suadmin 的空 tenant 映射只跳过租户级标签初始化，不改变普通租户的原有行为。
- 所有修改放在同一个事务中，保证原子性；使用 `CREATE OR REPLACE FUNCTION` 保证重复执行安全。

## 修改内容

- 新增 `v2.5.3_database_bootstrap_idempotency.sql`。
- 校准 `role_permission_t.role_permission_id` sequence。
- 兼容 suadmin 保留的空 tenant 映射。
- 新增数据库 bootstrap 幂等性契约测试。

## 验证结果

- tag-library permission 与 bootstrap idempotency 测试：通过。
- Multipass 全新数据库初始化成功，新迁移状态为 `applied`。
- suadmin 初始化成功；数据库中存在且仅存在一条有效的 `SU + 空 tenant` 映射。
- sequence 实测：`last_value=1604`、`is_called=true`、表内最大 ID 为 `1604`，下一次默认生成的 ID 会继续递增，不会发生冲突。
- 使用相同参数重复完整部署成功；suadmin 已存在分支正确跳过密码初始化，tenant 映射 reconcile 成功。

## PR Stack

- 依赖 [#3876](https://github.com/ModelEngine-Group/nexent/pull/3876) 和 [#3875](https://github.com/ModelEngine-Group/nexent/pull/3875)。
- 下游为 [#3877](https://github.com/ModelEngine-Group/nexent/pull/3877)。

Fixes #3872
