### PR TITLE
🐛 Bugfix: The upload_to_s3 and download_from_s3 tools do not support user configuration.

### DIFF
--- a/backend/agents/create_agent_info.py
+++ b/backend/agents/create_agent_info.py
@@ -85,6 +85,7 @@ from consts.const import (
 )
 from consts.model import ToolParamsRequest
 from consts.exceptions import ValidationError
+from consts.tool_labels import SYSTEM_MANAGED_TOOL_NAMES
 
 logger = logging.getLogger("create_agent_info")
 logger.setLevel(logging.INFO)
@@ -1622,6 +1623,10 @@ async def create_tool_config_list(
     tool_keys_seen = set()
     for tool in tools_list:
         tool_identifier = tool.get("name") or tool.get("class_name")
+        # System-managed tools are injected below with run-scoped metadata. Ignore
+        # legacy agent bindings so they cannot create duplicate tool definitions.
+        if tool_identifier in SYSTEM_MANAGED_TOOL_NAMES:
+            continue
         if tool_identifier in tool_keys_seen:
             raise ValidationError(
                 f"Duplicate tool identifier '{tool_identifier}' found in agent '{agent_name or agent_id}'."

--- a/backend/consts/tool_labels.py
+++ b/backend/consts/tool_labels.py
@@ -56,4 +56,10 @@ BUILTIN_LABEL_MAP.update(_category_memory)
 BUILTIN_LABEL_MAP.update(_category_terminal)
 
 PARALLEL_EXECUTOR_TOOL_NAME = "parallel_executor"
-SYSTEM_MANAGED_TOOL_NAMES = frozenset({"store_memory", "search_memory", PARALLEL_EXECUTOR_TOOL_NAME})
+SYSTEM_MANAGED_TOOL_NAMES = frozenset({
+    "store_memory",
+    "search_memory",
+    "download_from_s3",
+    "upload_to_s3",
+    PARALLEL_EXECUTOR_TOOL_NAME,
+})

--- a/sdk/nexent/core/tools/download_from_s3_tool.py
+++ b/sdk/nexent/core/tools/download_from_s3_tool.py
@@ -18,6 +18,7 @@ class DownloadFromS3Tool(Tool):
     """Tool for downloading files from S3/MinIO storage to local workspace."""
 
     name = "download_from_s3"
+    is_user_selectable = False
     description = (
         "Download a file from S3/MinIO storage to the local workspace. "
         "Accepts s3://bucket/key, /bucket/key, or plain object key paths. "

--- a/sdk/nexent/core/tools/upload_to_s3_tool.py
+++ b/sdk/nexent/core/tools/upload_to_s3_tool.py
@@ -18,6 +18,7 @@ class UploadToS3Tool(Tool):
     """Tool for uploading files from local workspace to S3/MinIO storage."""
 
     name = "upload_to_s3"
+    is_user_selectable = False
     description = (
         "Upload a file from the local workspace to S3/MinIO storage. "
         "The file path must be within the workspace directory. A relative path such as "

--- a/test/backend/agents/test_create_agent_info.py
+++ b/test/backend/agents/test_create_agent_info.py
@@ -76,11 +76,22 @@ consts_exceptions_module.NotFoundException = NotFoundException
 consts_exceptions_module.ToolExecutionException = ToolExecutionException
 sys.modules["consts.exceptions"] = consts_exceptions_module
 
+consts_tool_labels_module = types.ModuleType("consts.tool_labels")
+consts_tool_labels_module.SYSTEM_MANAGED_TOOL_NAMES = frozenset({
+    "store_memory",
+    "search_memory",
+    "download_from_s3",
+    "upload_to_s3",
+    "parallel_executor",
+})
+sys.modules["consts.tool_labels"] = consts_tool_labels_module
+
 # Also add model and exceptions to consts module attributes
 consts_module = sys.modules.get("consts")
 if consts_module:
     setattr(consts_module, "model", consts_model_module)
     setattr(consts_module, "exceptions", consts_exceptions_module)
+    setattr(consts_module, "tool_labels", consts_tool_labels_module)
     setattr(
         consts_module,
         "capability_profiles",
@@ -1109,6 +1120,30 @@ class TestCreateToolConfigList:
                 source="local",
                 usage=None
             )
+
+    @pytest.mark.asyncio
+    async def test_create_tool_config_list_ignores_legacy_system_managed_bindings(self):
+        """Legacy S3 bindings are replaced by the run-scoped built-in tools."""
+        with patch(
+            "backend.agents.create_agent_info.discover_langchain_tools",
+            return_value=[],
+        ), patch(
+            "backend.agents.create_agent_info.search_tools_for_sub_agent",
+            return_value=[
+                {"tool_id": 1, "class_name": "DownloadFromS3Tool", "name": "download_from_s3"},
+                {"tool_id": 2, "class_name": "UploadToS3Tool", "name": "upload_to_s3"},
+            ],
+        ), patch(
+            "backend.agents.create_agent_info.skill_db.search_skills_for_agent",
+            return_value=[],
+        ), patch(
+            "backend.agents.create_agent_info.search_agent_info_by_agent_id",
+            return_value={"name": "legacy-agent"},
+        ), patch("backend.agents.create_agent_info.ToolConfig") as mock_tool_config:
+            result = await create_tool_config_list("agent_1", "tenant_1", "user_1")
+
+        assert result == []
+        mock_tool_config.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_create_tool_config_list_with_knowledge_base_tool(self):

--- a/test/backend/services/test_tool_configuration_service.py
+++ b/test/backend/services/test_tool_configuration_service.py
@@ -1168,6 +1168,10 @@ class TestListAllToolsWithLabels:
              "params": [], "inputs": "{}", "is_available": True, "create_time": "", "usage": ""},
             {"tool_id": 4, "name": "postgres_database", "description": "d4", "source": "local",
              "params": [], "inputs": "{}", "is_available": True, "create_time": "", "usage": ""},
+            {"tool_id": 5, "name": "download_from_s3", "description": "d5", "source": "local",
+             "params": [], "inputs": "{}", "is_available": True, "create_time": "", "usage": ""},
+            {"tool_id": 6, "name": "upload_to_s3", "description": "d6", "source": "local",
+             "params": [], "inputs": "{}", "is_available": True, "create_time": "", "usage": ""},
         ]
         mock_descriptions.return_value = {}
 
@@ -1177,6 +1181,8 @@ class TestListAllToolsWithLabels:
         result_names = [t["name"] for t in result]
         assert "store_memory" not in result_names
         assert "search_memory" not in result_names
+        assert "download_from_s3" not in result_names
+        assert "upload_to_s3" not in result_names
         assert "tavily_search" in result_names
         assert "postgres_database" in result_names
         assert len(result) == 2

--- a/test/sdk/core/tools/test_s3_tools.py
+++ b/test/sdk/core/tools/test_s3_tools.py
@@ -40,6 +40,9 @@ def temp_workspace():
 # ======================================================================
 
 class TestDownloadFromS3ToolInit:
+    def test_not_user_selectable(self):
+        assert DownloadFromS3Tool.is_user_selectable is False
+
     def test_init_defaults(self):
         tool = DownloadFromS3Tool()
         assert tool.workspace_path == os.path.abspath("/mnt/nexent")
@@ -254,6 +257,9 @@ class TestDownloadFromS3ToolForward:
 # ======================================================================
 
 class TestUploadToS3ToolInit:
+    def test_not_user_selectable(self):
+        assert UploadToS3Tool.is_user_selectable is False
+
     def test_init_defaults(self):
         tool = UploadToS3Tool()
         assert tool.workspace_path == os.path.abspath("/mnt/nexent")


### PR DESCRIPTION
🐛 Bugfix: The upload_to_s3 and download_from_s3 tools do not support user configuration.
[Specification Details]
1. 将两个工具放到SYSTEM_MANAGED_TOOL_NAMES的labels当中，前端不加载。
2. 前向适配，create_agent_info中如果之前用户选了这两个工具，跳过工具的加载。
[Test Results]
<img width="1116" height="567" alt="img_v3_0215a_9124046e-a4ee-4277-8f44-02445a0c5ccg" src="https://github.com/user-attachments/assets/2c60ce44-4e21-421c-9248-c2a8d3100884" />
