### PR TITLE
docs: update offline deployment package download instructions

### DIFF
--- a/doc/docs/en/quick-start/installation.md
+++ b/doc/docs/en/quick-start/installation.md
@@ -105,13 +105,11 @@ delete from nexent.user_tenant_t where user_id = 'your_user_id';
 
 ### Offline Deployment
 
-When the target host cannot access public image registries, download a prebuilt offline deployment package from GitHub Actions:
+When the target host cannot access public image registries, download a prebuilt offline deployment package from Nexent Releases:
 
-1. Sign in to GitHub and open [Build Offline Deployment Package](https://github.com/ModelEngine-Group/nexent/actions/workflows/build-offline-package.yml).
-2. Select a successful run for the required version and download the artifact matching the server architecture from **Artifacts** at the bottom of the run page.
+1. Open [Nexent Releases](https://github.com/ModelEngine-Group/nexent/releases).
+2. Find the required version in the release list and download the archive matching the server architecture from that release's **Assets**.
 3. Download `nexent-<version>-amd64.zip` for AMD64 or `nexent-<version>-arm64.zip` for ARM64.
-
-GitHub Actions artifacts are retained for 30 days. If the required artifact has expired, ask a maintainer to rerun the workflow.
 
 Copy the downloaded archive to the offline host and extract it. The downloaded artifact contains the package files directly, with no nested archive:
 

--- a/doc/docs/en/quick-start/installation.md
+++ b/doc/docs/en/quick-start/installation.md
@@ -108,7 +108,7 @@ delete from nexent.user_tenant_t where user_id = 'your_user_id';
 When the target host cannot access public image registries, download a prebuilt offline deployment package from Nexent Releases:
 
 1. Open [Nexent Releases](https://github.com/ModelEngine-Group/nexent/releases).
-2. Find the required version in the release list and download the archive matching the server architecture from that release's **Assets**.
+2. Find the required version in the release list and download the archive matching the server architecture from that release's **Assets** (Versions v2.6.0 and later support this offline deployment method).
 3. Download `nexent-<version>-amd64.zip` for AMD64 or `nexent-<version>-arm64.zip` for ARM64.
 
 Copy the downloaded archive to the offline host and extract it. The downloaded artifact contains the package files directly, with no nested archive:

--- a/doc/docs/en/quick-start/kubernetes-installation.md
+++ b/doc/docs/en/quick-start/kubernetes-installation.md
@@ -106,11 +106,11 @@ bash deploy.sh k8s
 
 ### Offline Deployment
 
-When the target cluster cannot access public image registries, download a prebuilt offline deployment package from GitHub Actions:
+When the target cluster cannot access public image registries, download a prebuilt offline deployment package from Nexent Releases:
 
-1. Sign in to GitHub and open [Build Offline Deployment Package](https://github.com/ModelEngine-Group/nexent/actions/workflows/build-offline-package.yml).
-2. Select a successful run for the required version and download `nexent-<version>-<platform>.zip` matching the cluster node architecture from **Artifacts**.
-3. Copy the archive to a management host that can access the target cluster and extract it. Workflow artifacts are retained for 30 days; if one has expired, ask a maintainer to rerun the workflow.
+1. Open [Nexent Releases](https://github.com/ModelEngine-Group/nexent/releases).
+2. Find the required version in the release list and download `nexent-<version>-<platform>.zip` matching the cluster node architecture from that release's **Assets**.
+3. Copy the archive to a management host that can access the target cluster and extract it.
 
 Extract the offline deployment package:
 

--- a/doc/docs/en/quick-start/kubernetes-installation.md
+++ b/doc/docs/en/quick-start/kubernetes-installation.md
@@ -110,7 +110,7 @@ When the target cluster cannot access public image registries, download a prebui
 
 1. Open [Nexent Releases](https://github.com/ModelEngine-Group/nexent/releases).
 2. Find the required version in the release list and download `nexent-<version>-<platform>.zip` matching the cluster node architecture from that release's **Assets**.
-3. Copy the archive to a management host that can access the target cluster and extract it.
+3. Copy the archive to a management host that can access the target cluster and extract it (Versions v2.6.0 and later support this offline deployment method).
 
 Extract the offline deployment package:
 

--- a/doc/docs/zh/quick-start/installation.md
+++ b/doc/docs/zh/quick-start/installation.md
@@ -106,7 +106,7 @@ delete from nexent.user_tenant_t where user_id = 'your_user_id';
 目标服务器无法访问公网镜像仓库时，可从 Nexent Releases 下载已经打包好的离线部署包：
 
 1. 打开 [Nexent Releases](https://github.com/ModelEngine-Group/nexent/releases)。
-2. 在 Release 列表中找到需要的版本，并在该版本的 **Assets** 中下载与服务器架构匹配的压缩包。
+2. 在 Release 列表中找到需要的版本，并在该版本的 **Assets** 中下载与服务器架构匹配的压缩包（v2.6.0及以后的版本支持此离线部署方法）。
 3. `amd64` 服务器下载 `nexent-<version>-amd64.zip`，ARM64 服务器下载 `nexent-<version>-arm64.zip`。
 
 下载后，将压缩包复制到离线服务器并解压。压缩包内直接包含离线包文件，无需再次解压内层归档：

--- a/doc/docs/zh/quick-start/installation.md
+++ b/doc/docs/zh/quick-start/installation.md
@@ -103,13 +103,11 @@ delete from nexent.user_tenant_t where user_id = 'your_user_id';
 ```
 ### 离线部署
 
-目标服务器无法访问公网镜像仓库时，可从 GitHub Actions 获取已经打包好的离线部署包：
+目标服务器无法访问公网镜像仓库时，可从 Nexent Releases 下载已经打包好的离线部署包：
 
-1. 登录 GitHub，打开 [Build Offline Deployment Package](https://github.com/ModelEngine-Group/nexent/actions/workflows/build-offline-package.yml)。
-2. 选择目标版本对应的成功运行记录，在页面底部的 **Artifacts** 中下载与服务器架构匹配的压缩包。
+1. 打开 [Nexent Releases](https://github.com/ModelEngine-Group/nexent/releases)。
+2. 在 Release 列表中找到需要的版本，并在该版本的 **Assets** 中下载与服务器架构匹配的压缩包。
 3. `amd64` 服务器下载 `nexent-<version>-amd64.zip`，ARM64 服务器下载 `nexent-<version>-arm64.zip`。
-
-GitHub Actions 构建产物默认保留 30 天。如果目标版本的产物已过期，请联系维护者重新运行工作流。
 
 下载后，将压缩包复制到离线服务器并解压。压缩包内直接包含离线包文件，无需再次解压内层归档：
 

--- a/doc/docs/zh/quick-start/kubernetes-installation.md
+++ b/doc/docs/zh/quick-start/kubernetes-installation.md
@@ -106,11 +106,11 @@ bash deploy.sh k8s
 
 ### 离线部署
 
-目标集群无法访问公网镜像仓库时，可从 GitHub Actions 获取已经打包好的离线部署包：
+目标集群无法访问公网镜像仓库时，可从 Nexent Releases 下载已经打包好的离线部署包：
 
-1. 登录 GitHub，打开 [Build Offline Deployment Package](https://github.com/ModelEngine-Group/nexent/actions/workflows/build-offline-package.yml)。
-2. 选择目标版本对应的成功运行记录，在 **Artifacts** 中下载与集群节点架构匹配的 `nexent-<version>-<platform>.zip`。
-3. 将压缩包复制到可以访问目标集群的管理节点并解压。工作流产物默认保留 30 天；产物过期时，可联系维护者重新运行工作流。
+1. 打开 [Nexent Releases](https://github.com/ModelEngine-Group/nexent/releases)。
+2. 在 Release 列表中找到需要的版本，并在该版本的 **Assets** 中下载与集群节点架构匹配的 `nexent-<version>-<platform>.zip`。
+3. 将压缩包复制到可以访问目标集群的管理节点并解压。
 
 解压离线部署包：
 

--- a/doc/docs/zh/quick-start/kubernetes-installation.md
+++ b/doc/docs/zh/quick-start/kubernetes-installation.md
@@ -110,7 +110,7 @@ bash deploy.sh k8s
 
 1. 打开 [Nexent Releases](https://github.com/ModelEngine-Group/nexent/releases)。
 2. 在 Release 列表中找到需要的版本，并在该版本的 **Assets** 中下载与集群节点架构匹配的 `nexent-<version>-<platform>.zip`。
-3. 将压缩包复制到可以访问目标集群的管理节点并解压。
+3. 将压缩包复制到可以访问目标集群的管理节点并解压（v2.6.0及以后的版本支持此离线部署方法）。
 
 解压离线部署包：
 


### PR DESCRIPTION
## 修改说明

更新 Docker 和 Kubernetes 离线部署文档中的安装包下载说明。

## 主要修改

- 将离线部署包的下载入口从 GitHub Actions 调整为 Nexent Releases。
- 引导用户在 Release 列表中选择所需版本，并从该版本的 Assets 下载对应架构的压缩包。
- 删除 GitHub Actions Artifacts 保留期限及重新运行工作流的相关说明。
- 同步更新中文和英文文档。
- 下载后的解压与部署操作保持不变。

## 涉及文件

- `doc/docs/zh/quick-start/installation.md`
- `doc/docs/zh/quick-start/kubernetes-installation.md`
- `doc/docs/en/quick-start/installation.md`
- `doc/docs/en/quick-start/kubernetes-installation.md`

## 验证
- 本次仅修改文档内容，不涉及代码和部署逻辑。