### PR TITLE
fix(memory): allow external retrieval without embedding

### DIFF
--- a/sdk/nexent/core/tools/search_memory_tool.py
+++ b/sdk/nexent/core/tools/search_memory_tool.py
@@ -265,7 +265,7 @@ class SearchMemoryTool(Tool):
             top_k,
             self.memory_context_service is not None,
         )
-        if not self.embedding_configured:
+        if not self.embedding_configured and not self.external_results:
             logger.info(
                 "event=memory_tool_degraded tool=search_memory tenant_id=%s "
                 "reason=embedding_not_configured",

--- a/test/sdk/core/tools/test_search_memory_tool.py
+++ b/test/sdk/core/tools/test_search_memory_tool.py
@@ -244,6 +244,26 @@ class TestSearchMemoryToolPipelinePath:
 
         assert service.build_context.call_args.kwargs["external_results"] is external_results
 
+    def test_ac_p3_18_external_results_do_not_require_internal_embedding(self):
+        """AC-P3-18: external hits remain usable without internal embeddings."""
+        service = _async_context_service(_make_context({}))
+        external = _StubRecord(
+            "Deployment color is cobalt-42",
+            score=0.91,
+            source="mem0",
+        )
+        tool = _make_tool(
+            memory_context_service=service,
+            embedding_configured=False,
+            external_results=[external],
+        )
+
+        out = tool.forward(query="deployment color", top_k=5)
+
+        service.build_context.assert_called_once()
+        assert "#### External Memory" in out
+        assert "Deployment color is cobalt-42" in out
+
     def test_ac_p3_22_restores_external_results_dropped_by_global_top_k(self):
         """Mixed-source output keeps prefetched external hits after fusion truncation."""
         service = _async_context_service(_make_context({


### PR DESCRIPTION
## 问题说明

PR #3690 已将 Runtime 预取的外部记忆结果传入 `SearchMemoryTool`，但工具入口仍使用 `embedding_configured` 作为无条件前置门控。

因此，当租户没有配置 Nexent 内部 embedding、但 Mem0 等外部 provider 已返回命中时，工具会提前返回 `[]`，外部结果无法进入 `MemoryContextService`。这与现有 AC-P3-18 的“仅外部命中不得丢失”契约不一致。

## 修改思路

- 仅在“内部 embedding 未配置”且“没有外部预取结果”同时成立时保持原有降级行为。
- 只要存在外部结果，就继续执行既有上下文组装流程。
- 不改变内部向量检索、provider 协议、API、数据库结构或 `top_k` 策略。

## 修改内容

- 将入口门控条件改为 `not embedding_configured and not external_results`。
- 新增 AC-P3-18 回归测试，覆盖 `embedding_configured=False` 且 Mem0 外部结果非空的场景。
- 保留既有无 embedding、无外部结果时返回 `[]` 的兼容行为。

## 验证结果

- `PYTHONPATH=<当前 worktree>/sdk <backend venv>/python -m pytest -q test/sdk/core/tools/test_search_memory_tool.py`
- 结果：`14 passed`。
- 真实 K8s + Mem0 Agent 端到端复验将在包含本提交的新镜像中执行，结果完成后补充到本 PR。

## 关联

- 独立修复，基于最新 `develop`。
- 相关背景：#3690。

> 本 PR 由 AI 辅助完成，代码与测试结果已由提交者复核。