### PR TITLE
fix(memory): let enabled providers drive external search

### DIFF
--- a/backend/agents/create_agent_info.py
+++ b/backend/agents/create_agent_info.py
@@ -75,7 +75,6 @@ from consts.const import (
     AIDP_SERVER_URL,
     AIDP_TENANT_ID,
     DATA_PROCESS_SERVICE,
-    EXTERNAL_MEMORY_SEARCH_ENABLED,
     LANGUAGE,
     LLM_INCLUDE_LOGPROBS,
     LOCAL_MCP_SERVER,
@@ -98,9 +97,7 @@ def _create_fixed_search_memory_tool():
 
 
 def _get_external_provider_service_for_search():
-    """Resolve the external provider service only when the search kill switch is on."""
-    if not EXTERNAL_MEMORY_SEARCH_ENABLED:
-        return None
+    """Resolve the external provider service used to search enabled providers."""
     return get_memory_external_provider_service()
 
 

--- a/backend/consts/const.py
+++ b/backend/consts/const.py
@@ -426,12 +426,8 @@ PROVIDER_REQUEST_TIMEOUT_SECONDS = int(
     os.getenv("PROVIDER_REQUEST_TIMEOUT_SECONDS", "30")
 )
 
-# External memory transparent proxy master switches
-EXTERNAL_MEMORY_SEARCH_ENABLED = os.getenv(
-    "EXTERNAL_MEMORY_SEARCH_ENABLED", "false"
-).lower() in ("true", "1", "yes")
-# External provider toggles (configured per provider elsewhere; these constants
-# describe protocol-level defaults)
+# External provider protocol defaults. Provider records control whether each
+# configured integration participates in search and ingest.
 EXTERNAL_MEMORY_DEFAULT_ALLOWED_UNIT_TYPES = (
     "agent",
     "model_output",

--- a/backend/services/memory_context_service.py
+++ b/backend/services/memory_context_service.py
@@ -28,7 +28,6 @@ from nexent.memory.policy import MemoryRetrievalPolicy
 
 from consts.const import (
     AGENT_SHORT_TERM_HALF_LIFE_DAYS,
-    EXTERNAL_MEMORY_SEARCH_ENABLED,
     MMR_CANDIDATE_TOP_K,
     MMR_DUPLICATE_THRESHOLD,
     MMR_FINAL_TOP_K,
@@ -106,9 +105,8 @@ class MemoryContextService:
                 transparent proxy.  Signature:
                 ``async (query, tenant_id, user_id, agent_id, conversation_id)
                 -> List[ExternalMemoryItem]``.
-                When set and ``EXTERNAL_MEMORY_SEARCH_ENABLED`` is True,
-                ``build_context`` auto-queries external providers if
-                ``external_results`` was not explicitly passed.
+                When set, ``build_context`` auto-queries enabled external
+                providers if ``external_results`` was not explicitly passed.
         """
         self.retrieval_service = retrieval_service or get_memory_retrieval_service()
         self.pipeline_enabled = pipeline_enabled
@@ -208,11 +206,7 @@ class MemoryContextService:
             external_results is not None,
         )
 
-        if (
-            external_results is None
-            and EXTERNAL_MEMORY_SEARCH_ENABLED
-            and self._external_search_hook is not None
-        ):
+        if external_results is None and self._external_search_hook is not None:
             try:
                 external_results = await self._external_search_hook(
                     query=query or "",

--- a/deploy/k8s/helm/nexent/charts/nexent-common/templates/configmap.yaml
+++ b/deploy/k8s/helm/nexent/charts/nexent-common/templates/configmap.yaml
@@ -151,7 +151,6 @@ data:
   UMASK: {{ .Values.config.umask | quote }}
   SKILLS_PATH: {{ .Values.config.skillsPath | quote }}
   MEMORY_PROVIDER_PLUGINS_DIR: {{ .Values.config.memoryProviderPluginsDir | quote }}
-  EXTERNAL_MEMORY_SEARCH_ENABLED: {{ .Values.config.externalMemorySearchEnabled | quote }}
   LOG_DIR: {{ .Values.config.logDir | quote }}
 
   # MCP Container Image

--- a/deploy/k8s/helm/nexent/charts/nexent-common/values.yaml
+++ b/deploy/k8s/helm/nexent/charts/nexent-common/values.yaml
@@ -70,7 +70,6 @@ config:
   isDeployedByKubernetes: "true"
   skillsPath: "/mnt/nexent-data/skills"
   memoryProviderPluginsDir: "/mnt/nexent-data/memory-provider-plugins"
-  externalMemorySearchEnabled: "false"
   logDir: "/mnt/nexent-data/logs"
   modelEngine:
     enabled: "false"

--- a/test/backend/agents/test_create_agent_info.py
+++ b/test/backend/agents/test_create_agent_info.py
@@ -548,20 +548,10 @@ from backend.agents.create_agent_info import (
 )
 
 
-def test_ac_p3_25_external_search_switch_skips_provider_factory(monkeypatch):
-    factory = MagicMock()
-    monkeypatch.setattr(create_agent_info_module, "get_memory_external_provider_service", factory)
-    monkeypatch.setattr(create_agent_info_module, "EXTERNAL_MEMORY_SEARCH_ENABLED", False)
-
-    assert _get_external_provider_service_for_search() is None
-    factory.assert_not_called()
-
-
-def test_ac_p3_25_external_search_switch_uses_provider_factory(monkeypatch):
+def test_ac_ext_001_external_search_always_resolves_provider_service(monkeypatch):
     service = object()
     factory = MagicMock(return_value=service)
     monkeypatch.setattr(create_agent_info_module, "get_memory_external_provider_service", factory)
-    monkeypatch.setattr(create_agent_info_module, "EXTERNAL_MEMORY_SEARCH_ENABLED", True)
 
     assert _get_external_provider_service_for_search() is service
     factory.assert_called_once_with()

--- a/test/backend/services/test_memory_context_service.py
+++ b/test/backend/services/test_memory_context_service.py
@@ -337,7 +337,6 @@ consts_mod.MMR_LAMBDA = 0.7
 consts_mod.MEMORY_TOKEN_BUDGET = 2000
 consts_mod.W_AGENT_SHORT_TERM = 1.0
 consts_mod.W_EXTERNAL = 0.8
-consts_mod.EXTERNAL_MEMORY_SEARCH_ENABLED = True
 consts_mod.ES_API_KEY = ""
 consts_mod.ES_HOST = ""
 

--- a/test/backend/services/test_memory_transparent_proxy.py
+++ b/test/backend/services/test_memory_transparent_proxy.py
@@ -7,7 +7,6 @@ import pytest
 sys.path.insert(0, __import__("os").path.join(__import__("os").path.dirname(__file__), "../../.."))
 
 consts_const = types.ModuleType("consts.const")
-consts_const.EXTERNAL_MEMORY_SEARCH_ENABLED = True
 consts_const.AGENT_SHORT_TERM_HALF_LIFE_DAYS = 7.0
 consts_const.MMR_CANDIDATE_TOP_K = 10
 consts_const.MMR_DUPLICATE_THRESHOLD = 0.92
@@ -239,8 +238,7 @@ async def test_build_context_with_external_search_hook_called(mock_retrieval):
         external_search_hook=hook,
     )
 
-    with patch("backend.services.memory_context_service.EXTERNAL_MEMORY_SEARCH_ENABLED", True):
-        await svc.build_context(tenant_id="t1", user_id="u1", query="hello")
+    await svc.build_context(tenant_id="t1", user_id="u1", query="hello")
 
     hook.assert_awaited_once()
 
@@ -256,11 +254,10 @@ async def test_build_context_hook_not_called_when_external_results_provided(mock
 
     ext_items = [ExternalMemoryItem(id="ext1", content="ext", score=0.9)]
 
-    with patch("backend.services.memory_context_service.EXTERNAL_MEMORY_SEARCH_ENABLED", True):
-        await svc.build_context(
-            tenant_id="t1", user_id="u1", query="hello",
-            external_results=ext_items,
-        )
+    await svc.build_context(
+        tenant_id="t1", user_id="u1", query="hello",
+        external_results=ext_items,
+    )
 
     hook.assert_not_awaited()
 
@@ -274,8 +271,7 @@ async def test_build_context_hook_failure_doesnt_break(mock_retrieval):
         external_search_hook=hook,
     )
 
-    with patch("backend.services.memory_context_service.EXTERNAL_MEMORY_SEARCH_ENABLED", True):
-        ctx = await svc.build_context(tenant_id="t1", user_id="u1", query="hello")
+    ctx = await svc.build_context(tenant_id="t1", user_id="u1", query="hello")
 
     assert ctx is not None
 
@@ -288,25 +284,9 @@ async def test_build_context_no_hook_configured(mock_retrieval):
         external_search_hook=None,
     )
 
-    with patch("backend.services.memory_context_service.EXTERNAL_MEMORY_SEARCH_ENABLED", True):
-        ctx = await svc.build_context(tenant_id="t1", user_id="u1", query="hello")
+    ctx = await svc.build_context(tenant_id="t1", user_id="u1", query="hello")
 
     assert ctx is not None
-
-
-@pytest.mark.asyncio
-async def test_build_context_search_disabled(mock_retrieval):
-    hook = AsyncMock(return_value=[])
-    svc = MemoryContextService(
-        retrieval_service=mock_retrieval,
-        pipeline_enabled=False,
-        external_search_hook=hook,
-    )
-
-    with patch("backend.services.memory_context_service.EXTERNAL_MEMORY_SEARCH_ENABLED", False):
-        await svc.build_context(tenant_id="t1", user_id="u1", query="hello")
-
-    hook.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 问题

外部记忆写入已经以租户下 provider 的 `enabled` 状态为准，但外部记忆检索还额外受 `EXTERNAL_MEMORY_SEARCH_ENABLED` 环境变量控制。该变量默认是 `false`，导致用户即使已经安装 Mem0 插件并启用 provider，Agent 也不会执行外部检索；未配置内部 embedding 时，最终还会表现为 `embedding_not_configured`，误导问题定位。

## 修改思路

让检索与 ingest 使用同一套启用语义：

- Agent 预检索始终取得外部 provider service。
- provider service 继续通过租户下已启用的 provider 配置决定实际搜索对象；没有启用 provider 时自然返回空结果。
- `MemoryContextService` 在存在 external search hook 且调用方没有预传结果时直接执行 hook。
- 删除后端环境变量读取及 K8s Helm 中对应的 value/ConfigMap 注入，避免保留无效的第二套开关。
- 保留 provider 失败隔离、降级以及预传结果不重复查询的原有行为。

## 验证

### 单元测试

受影响的测试文件分别独立执行，合计 **317 passed**：

- `test/backend/agents/test_create_agent_info.py`：228 passed
- `test/backend/services/test_memory_transparent_proxy.py`：7 passed
- `test/backend/services/test_memory_context_service.py`：26 passed
- `test/backend/services/test_memory_external_provider_service.py`：25 passed
- `test/backend/services/test_memory_provider_config_service.py`：31 passed

### 真实端到端验证

- 基于 `origin/develop@27beec188` 和本 PR 修改构建 ARM64 `nexent/nexent:latest`。
- 通过 `ctr` 导入 Multipass 中的 kubeadm Kubernetes v1.32.13 / containerd v2.2.1 环境。
- 从运行时 ConfigMap 删除 `EXTERNAL_MEMORY_SEARCH_ENABLED`，并确认新容器中该变量不存在。
- 不配置内部 embedding，安装并启用 Mem0 Cloud provider。
- 第一轮真实 Agent 会话提供唯一标记，由 `turn_completed` fanout 自动写入 Mem0。
- 第二轮新 Agent 会话不携带标记，只询问之前的标记；真实模型最终答案完整召回该标记。
- runtime 日志出现 `external_provider_search_started/completed` 与 `memory_tool_invoked/completed`，本轮没有 `embedding_not_configured` 降级。

## 兼容性说明

原先通过全局环境变量关闭所有外部搜索的方式将不再生效；需要关闭时，应禁用相应租户的 provider。该变化使搜索和写入统一由 provider 的 `enabled` 状态管理。
