### PR TITLE
bugfix(agent-debug): preserve chat history across compare-mode toggle

### DIFF
--- a/frontend/app/[locale]/agents/agent-debug.tsx
+++ b/frontend/app/[locale]/agents/agent-debug.tsx
@@ -120,15 +120,16 @@ const AgentDebugPanel: FC<AgentDebugPanelProps> = ({ isCompareMode = false }) =>
     );
   }
 
-  if (isCompareMode) {
-    return (
-      <div className="h-full w-full">
+  return (
+    <div className="h-full w-full">
+      <div className={isCompareMode ? "hidden h-full w-full" : "h-full w-full"}>
+        <AgentDebugChat agent={debugAgent} agentId={agentId} />
+      </div>
+      <div className={isCompareMode ? "h-full w-full" : "hidden h-full w-full"}>
         <AgentDebugComparePanel agentId={agentId} />
       </div>
-    );
-  }
-
-  return <AgentDebugChat agent={debugAgent} agentId={agentId} />;
+    </div>
+  );
 };
 
 export default AgentDebugPanel;


### PR DESCRIPTION
    Keep AgentDebugChat mounted alongside AgentDebugComparePanel and toggle
    visibility with CSS instead of conditional rendering. The prior approach
    destroyed the useLocalRuntime on each toggle, wiping the debug thread.

Send test messages in debug mode
<img width="561" height="1059" alt="img_v3_0215b_dd724c2f-c6b9-4607-b8fb-103108c0631g" src="https://github.com/user-attachments/assets/d40a7f8f-3d4a-493f-9c4b-b266a74da556" />

Switch to comparison mode to send messages
<img width="552" height="1039" alt="img_v3_0215b_0650602e-eede-4bca-8a14-af239c191fdg" src="https://github.com/user-attachments/assets/849d5c24-3742-4f56-afa1-358769c62d15" />

Then switch back to debug mode, and historical messages are still displayed
<img width="547" height="1129" alt="img_v3_0215b_cd2ff82f-d3d0-46bc-b827-d9060fa4feag" src="https://github.com/user-attachments/assets/ae3dee0c-0cd6-4092-b2fb-ab2b2ff375fa" />
