### PR TITLE
bugfix(newchat): render parsed execution code

### DIFF
--- a/frontend/app/[locale]/newchat/adapter/conversation-thread-list-adapter.tsx
+++ b/frontend/app/[locale]/newchat/adapter/conversation-thread-list-adapter.tsx
@@ -37,6 +37,7 @@ import {
   attachExecutionLogsToTool,
   collapseSubAgentParts,
   attachSearchContentToTool,
+  buildExecutionCodePart,
   buildToolCallPart,
   conversationSourcesRegistry,
   extractAidpImageKeys,
@@ -843,6 +844,21 @@ export class RemoteConversationHistoryAdapter implements ThreadHistoryAdapter {
             const meta = buildMetadata(part.invocation_id);
             if (meta) toolCallPart.metadata = meta;
             content.push(toolCallPart);
+            continue;
+          }
+
+          if (part.type === "parse") {
+            flushReasoning(part.invocation_id);
+            if (part.content.trim()) {
+              const executionCodePart = buildExecutionCodePart({
+                type: "parse",
+                content: part.content,
+                unit_index: part.unit_index ?? partIndex,
+              });
+              const meta = buildMetadata(part.invocation_id);
+              if (meta) executionCodePart.metadata = meta;
+              content.push(executionCodePart);
+            }
             continue;
           }
 

--- a/frontend/app/[locale]/newchat/adapter/remote-chat-model-adapter.ts
+++ b/frontend/app/[locale]/newchat/adapter/remote-chat-model-adapter.ts
@@ -654,7 +654,7 @@ function parseSseChunk(line: string): SseChunk | null {
  * | model_output_deep_thinking    | reasoning    | Model deep thinking content         |
  * | model_output_code             | reasoning    | Model code output (streamed)        |
  * | step_count                   | text         | Current execution step number       |
- * | parse                         | tool-call    | Code parsing result                |
+ * | parse                         | execution-code | Parsed executable code             |
  * | execution_logs                | (attach)     | Attached to preceding tool result  |
  * | nl2a                          | (metadata)   | NL2Agent structured output         |
  * | agent_new_run                 | text         | Agent basic information            |
@@ -757,6 +757,18 @@ export function buildToolCallPart(chunk: SseChunk): any {
     argsText,
     unit_index: chunk.unit_index,
     tool_call_id: chunk.tool_call_id,
+  };
+}
+
+export function buildExecutionCodePart(chunk: SseChunk): any {
+  return {
+    type: "data" as const,
+    name: "execution-code",
+    data: {
+      code: chunk.content,
+      language: "python",
+    },
+    unit_index: chunk.unit_index,
   };
 }
 
@@ -2278,7 +2290,18 @@ export const remoteChatModelAdapter: ChatModelAdapter = {
 
           const partType = mapChunkType(chunk.type);
 
-          if (partType === "reasoning") {
+          if (chunk.type === "parse") {
+            flushOpenReasoning(chunk.invocation_id);
+            if (chunk.content.trim()) {
+              const executionCodePart = buildExecutionCodePart(chunk);
+              const executionMeta = resolveSubAgent(chunk.invocation_id);
+              if (executionMeta) {
+                executionCodePart.metadata = subAgentMetadataFor(executionMeta);
+              }
+              contentParts.push(executionCodePart);
+            }
+            yield buildStreamResult(contentParts);
+          } else if (partType === "reasoning") {
             // Update the streaming reasoning part in-place. Carry the
             // current sub-agent's metadata through to ``groupBy`` so the
             // part clusters inside the matching ``group-subagent-*`` card.
@@ -2538,7 +2561,19 @@ export const remoteChatModelAdapter: ChatModelAdapter = {
               completeVerificationPanel();
             }
             const partType = mapChunkType(chunk.type);
-            if (partType === "reasoning") {
+            if (chunk.type === "parse") {
+              flushOpenReasoning(chunk.invocation_id);
+              if (chunk.content.trim()) {
+                const executionCodePart = buildExecutionCodePart(chunk);
+                const executionMeta = resolveSubAgent(chunk.invocation_id);
+                if (executionMeta) {
+                  executionCodePart.metadata =
+                    subAgentMetadataFor(executionMeta);
+                }
+                contentParts.push(executionCodePart);
+              }
+              yield buildStreamResult(contentParts);
+            } else if (partType === "reasoning") {
               const top = resolveSubAgent(chunk.invocation_id);
               if (top) {
                 if (top.slot.reasoningIdx === null) {

--- a/frontend/app/[locale]/newchat/assistant-ui/thread.tsx
+++ b/frontend/app/[locale]/newchat/assistant-ui/thread.tsx
@@ -13,6 +13,7 @@ import type { CompleteAttachment } from "@assistant-ui/react";
 import { useTranslation } from "react-i18next";
 import { MarkdownText } from "../ui/markdown-text";
 import { Reasoning, GroupReasoningTrigger } from "../ui/reasoning";
+import { ExecutionCodeBlock } from "../ui/execution-code-block";
 import { SubAgentContainer } from "../ui/subagent";
 import { TooltipIconButton } from "../ui/tooltip-icon-button";
 import { Composer, type ChatMode } from "./composer";
@@ -1276,15 +1277,20 @@ const AssistantMessage: FC<{
                   }).isSearchImage &&
                     (part as { imageSource?: SourcePartLike }).imageSource
                 ));
+            const isExecutionCodePart =
+              part.type === "data" &&
+              (part as { name?: string }).name === "execution-code";
             const chainPath: `group-${string}`[] = isImagePart
               ? ["group-image"]
               : part.type === "reasoning"
                 ? ["group-chainOfThought", "group-reasoning"]
-                : part.type === "tool-call"
-                  ? ["group-chainOfThought", "group-tool"]
-                  : part.type === "source"
-                    ? ["group-source"]
-                    : ["group-default"];
+                : isExecutionCodePart
+                  ? ["group-chainOfThought", "group-execution-code"]
+                  : part.type === "tool-call"
+                    ? ["group-chainOfThought", "group-tool"]
+                    : part.type === "source"
+                      ? ["group-source"]
+                      : ["group-default"];
             if (subagentId !== undefined) {
               const groupKey =
                 `group-subagent-${subagentId}-${runId ?? "unknown"}` as const;
@@ -1369,6 +1375,8 @@ const AssistantMessage: FC<{
                   </Reasoning.Root>
                 );
               }
+              case "group-execution-code":
+                return <div data-slot="aui_execution-code">{children}</div>;
               case "group-source":
                 return (
                   <SourceGroupButton
@@ -1430,6 +1438,22 @@ const AssistantMessage: FC<{
                 }
                 return <Sources {...part} />;
               case "data":
+                if (
+                  (part as typeof part & { name?: string }).name ===
+                  "execution-code"
+                ) {
+                  const data = (
+                    part as typeof part & {
+                      data?: { code?: unknown; language?: string };
+                    }
+                  ).data;
+                  return (
+                    <ExecutionCodeBlock
+                      code={data?.code}
+                      language={data?.language}
+                    />
+                  );
+                }
                 if (
                   (part as typeof part & { name?: string }).name ===
                   "nl2skill-file"

--- a/frontend/app/[locale]/newchat/ui/execution-code-block.tsx
+++ b/frontend/app/[locale]/newchat/ui/execution-code-block.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { TerminalIcon } from "lucide-react";
+import { useState } from "react";
+import { ChevronDownIcon, TerminalIcon } from "lucide-react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+import { SyntaxHighlighter } from "./shiki-highlighter";
 
 type ExecutionCodeBlockProps = {
   code?: unknown;
@@ -11,20 +19,36 @@ export function ExecutionCodeBlock({
   code,
   language = "python",
 }: ExecutionCodeBlockProps) {
+  const [open, setOpen] = useState(true);
   if (typeof code !== "string" || !code.trim()) return null;
 
   return (
-    <section className="my-3 overflow-hidden rounded-xl border border-primary/20 bg-primary/[0.03]">
-      <header className="flex items-center gap-2 border-b border-primary/15 bg-primary/[0.06] px-3.5 py-2 text-xs font-medium text-muted-foreground">
-        <TerminalIcon className="size-3.5 text-primary" />
-        <span>Executed code</span>
-        <span className="ml-auto font-mono text-[11px] uppercase text-muted-foreground/80">
-          {language}
-        </span>
-      </header>
-      <pre className="overflow-x-auto p-3.5 font-mono text-[13px] leading-relaxed whitespace-pre-wrap">
-        <code>{code}</code>
-      </pre>
-    </section>
+    <Collapsible
+      open={open}
+      onOpenChange={setOpen}
+      className="my-3 overflow-hidden rounded-xl border border-primary/20 bg-primary/[0.03]"
+    >
+      <CollapsibleTrigger asChild>
+        <button
+          type="button"
+          className="flex w-full items-center gap-2 bg-primary/[0.06] px-3.5 py-2 text-left text-xs font-medium text-muted-foreground hover:bg-primary/[0.1]"
+        >
+          <TerminalIcon className="size-3.5 text-primary" />
+          <span>Executed code</span>
+          <span className="ml-auto font-mono text-[11px] uppercase text-muted-foreground/80">
+            {language}
+          </span>
+          <ChevronDownIcon
+            className={cn(
+              "size-3.5 transition-transform",
+              !open && "-rotate-90"
+            )}
+          />
+        </button>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <SyntaxHighlighter code={code} language={language} />
+      </CollapsibleContent>
+    </Collapsible>
   );
 }

--- a/frontend/app/[locale]/newchat/ui/execution-code-block.tsx
+++ b/frontend/app/[locale]/newchat/ui/execution-code-block.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { TerminalIcon } from "lucide-react";
+
+type ExecutionCodeBlockProps = {
+  code?: unknown;
+  language?: string;
+};
+
+export function ExecutionCodeBlock({
+  code,
+  language = "python",
+}: ExecutionCodeBlockProps) {
+  if (typeof code !== "string" || !code.trim()) return null;
+
+  return (
+    <section className="my-3 overflow-hidden rounded-xl border border-primary/20 bg-primary/[0.03]">
+      <header className="flex items-center gap-2 border-b border-primary/15 bg-primary/[0.06] px-3.5 py-2 text-xs font-medium text-muted-foreground">
+        <TerminalIcon className="size-3.5 text-primary" />
+        <span>Executed code</span>
+        <span className="ml-auto font-mono text-[11px] uppercase text-muted-foreground/80">
+          {language}
+        </span>
+      </header>
+      <pre className="overflow-x-auto p-3.5 font-mono text-[13px] leading-relaxed whitespace-pre-wrap">
+        <code>{code}</code>
+      </pre>
+    </section>
+  );
+}

--- a/frontend/app/[locale]/newchat/ui/reasoning.tsx
+++ b/frontend/app/[locale]/newchat/ui/reasoning.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useMemo } from "react";
+import { memo } from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { BrainIcon, ChevronDownIcon } from "lucide-react";
 import {
@@ -39,58 +39,6 @@ export function extractStepLabel(text: string | undefined): string | undefined {
  */
 export function stripStepLabel(text: string): string {
   return text.replace(STEP_LABEL_RE, "");
-}
-
-const CODE_TAG_RE = /<code>([\s\S]*?)(<\/code>|$)/gi;
-const BACKTICK_RUN_RE = /`+/g;
-
-export function normalizeReasoningCodeBlocks(text: string): string {
-  return text.replace(CODE_TAG_RE, (_, rawCode: string, closingTag: string) => {
-    let code = rawCode.replace(/^\r?\n/, "");
-    if (closingTag) {
-      code = code.replace(/\r?\n$/, "");
-    }
-    const longestBacktickRun = Math.max(
-      0,
-      ...Array.from(code.matchAll(BACKTICK_RUN_RE), (match) => match[0].length),
-    );
-    const fence = "`".repeat(Math.max(3, longestBacktickRun + 1));
-
-    return `\n\n${fence}\n${code}\n${fence}\n\n`;
-  });
-}
-
-interface StreamingReasoningSegment {
-  type: "text" | "code";
-  content: string;
-}
-
-function splitStreamingReasoning(text: string): StreamingReasoningSegment[] {
-  const segments: StreamingReasoningSegment[] = [];
-  let cursor = 0;
-  let match: RegExpExecArray | null;
-
-  CODE_TAG_RE.lastIndex = 0;
-  while ((match = CODE_TAG_RE.exec(text)) !== null) {
-    if (match.index > cursor) {
-      segments.push({
-        type: "text",
-        content: text.slice(cursor, match.index),
-      });
-    }
-
-    segments.push({
-      type: "code",
-      content: match[1].replace(/^\r?\n/, ""),
-    });
-    cursor = CODE_TAG_RE.lastIndex;
-  }
-
-  if (cursor < text.length) {
-    segments.push({ type: "text", content: text.slice(cursor) });
-  }
-
-  return segments;
 }
 
 const reasoningVariants = cva(
@@ -331,36 +279,19 @@ const StreamingReasoning = () => {
   const isRunning = useAuiState(
     (s) => s.part?.type === "reasoning" && s.part.status.type === "running",
   );
-  const segments = useMemo(() => splitStreamingReasoning(text), [text]);
-
   if (!isRunning) {
     return (
       <MarkdownTextPrimitive
         remarkPlugins={[remarkGfm]}
         className="aui-md prose prose-sm max-w-none dark:prose-invert"
         components={{ ...defaultComponents, img: () => null }}
-        preprocess={normalizeReasoningCodeBlocks}
       />
     );
   }
 
   return (
     <div className="aui-streaming-reasoning space-y-3 text-sm leading-relaxed text-muted-foreground/90">
-      {segments.map((segment, index) =>
-        segment.type === "code" ? (
-          <pre
-            key={`code-${index}`}
-            className="aui-md-pre border-border/50 bg-muted/30 overflow-x-auto rounded-xl border p-3.5 text-[13px] leading-relaxed whitespace-pre"
-          >
-            <code>{segment.content}</code>
-          </pre>
-        ) : (
-          <StreamingMarkdownSegment
-            key={`text-${index}`}
-            content={segment.content}
-          />
-        ),
-      )}
+      <StreamingMarkdownSegment content={text} />
     </div>
   );
 };

--- a/sdk/nexent/core/utils/observer.py
+++ b/sdk/nexent/core/utils/observer.py
@@ -91,17 +91,9 @@ class StepCountTransformer(MessageTransformer):
 
 
 class ParseTransformer(MessageTransformer):
-    # parse template
-    TEMPLATES = {"zh": "\n🛠️ 使用Python解释器执行代码\n",
-                 "en": "\n🛠️ Used tool python_interpreter\n"}
-
     def transform(self, **kwargs: Any) -> str:
         """convert the message of parse result"""
-        content = kwargs.get("content", "")
-        lang = kwargs.get("lang", "en")
-
-        template = self.TEMPLATES.get(lang, self.TEMPLATES["en"])
-        return template + f"```python\n{content}\n```\n"
+        return kwargs.get("content", "")
 
 
 class ExecutionLogsTransformer(MessageTransformer):

--- a/test/sdk/core/utils/test_observer.py
+++ b/test/sdk/core/utils/test_observer.py
@@ -150,7 +150,7 @@ class TestParseTransformer:
         code_content = "print('Hello World')"
 
         result = transformer.transform(content=code_content, lang="zh")
-        expected = "\n🛠️ 使用Python解释器执行代码\n```python\nprint('Hello World')\n```\n"
+        expected = "print('Hello World')"
         assert result == expected
 
     def test_parse_transformer_en(self):
@@ -159,7 +159,7 @@ class TestParseTransformer:
         code_content = "x = 42"
 
         result = transformer.transform(content=code_content, lang="en")
-        expected = "\n🛠️ Used tool python_interpreter\n```python\nx = 42\n```\n"
+        expected = "x = 42"
         assert result == expected
 
     def test_parse_transformer_default_lang(self):
@@ -168,7 +168,7 @@ class TestParseTransformer:
         code_content = "def test(): pass"
 
         result = transformer.transform(content=code_content)
-        expected = "\n🛠️ Used tool python_interpreter\n```python\ndef test(): pass\n```\n"
+        expected = "def test(): pass"
         assert result == expected
 
 


### PR DESCRIPTION
删除在思考过程中对代码块的渲染，汇总至思考结束后，符合ReAct逻辑
<img width="1373" height="1305" alt="image" src="https://github.com/user-attachments/assets/11438cb7-880d-442c-904e-5e88c8d8c806" />
