### PR TITLE
fix(nl2agent): filter knowledge tools by deployment

### DIFF
--- a/backend/services/nl2agent_service.py
+++ b/backend/services/nl2agent_service.py
@@ -28,7 +28,11 @@ from agents.create_agent_info import (
     join_minio_file_description_to_query,
 )
 from agents.nl2agent_agent import create_nl2agent_agent_config
-from consts.const import LOCAL_MCP_SERVER, MODEL_CONFIG_MAPPING
+from consts.const import (
+    ENABLE_AIDP_KNOWLEDGE,
+    LOCAL_MCP_SERVER,
+    MODEL_CONFIG_MAPPING,
+)
 from consts.model import HistoryItem, NL2AgentRunRequest, ToolSourceEnum
 from database.agent_db import update_agent_draft_fields
 from database.skill_db import query_enabled_skill_instances
@@ -63,6 +67,21 @@ logger = logging.getLogger(__name__)
 MINIMUM_RECOMMENDATION_SCORE = 0.45
 MAX_RECOMMENDATIONS = 5
 MAX_BINDING_CANDIDATES = 12
+
+_LOCAL_KNOWLEDGE_TOOL_NAMES = frozenset({
+    "knowledge_base_search",
+    "ind_aidp_search",
+})
+_AIDP_KNOWLEDGE_TOOL_NAME = "aidp_search"
+
+
+def _is_nl2agent_recommendable_tool(name: str) -> bool:
+    """Return whether a deployment permits NL2Agent to recommend a tool."""
+    if ENABLE_AIDP_KNOWLEDGE:
+        return name not in _LOCAL_KNOWLEDGE_TOOL_NAMES
+    return name != _AIDP_KNOWLEDGE_TOOL_NAME
+
+
 STRONG_RESOURCE_SCORE = 0.65
 MINIMUM_RESOURCE_SCORE = 0.50
 UNINSTALLED_SOURCE_PAGE_SIZE = 100
@@ -444,6 +463,7 @@ async def _load_installed_resource_catalog(
             source not in {ToolSourceEnum.LOCAL.value, ToolSourceEnum.MCP.value}
             or tool.get("is_available") is not True
             or name in internal_names
+            or not _is_nl2agent_recommendable_tool(name)
         ):
             continue
         tool_id = tool.get("tool_id")

--- a/backend/services/tool_configuration_service.py
+++ b/backend/services/tool_configuration_service.py
@@ -17,6 +17,7 @@ from consts.const import (
     AIDP_SERVER_URL,
     AIDP_TENANT_ID,
     DATA_PROCESS_SERVICE,
+    ENABLE_AIDP_KNOWLEDGE,
     LOCAL_MCP_SERVER,
     MCP_MANAGEMENT_API,
 )
@@ -70,6 +71,24 @@ from utils.tool_utils import get_local_tools_classes, get_local_tools_descriptio
 logger = logging.getLogger("tool_configuration_service")
 
 TOOL_PARAM_CONSTRAINT_ERROR_MESSAGES = ErrorMessage.get_param_constraint_messages()
+
+_ALWAYS_HIDDEN_KNOWLEDGE_TOOLS = frozenset({
+    "knowledge_base_search",
+    "aidp_search",
+})
+_INDEPENDENT_AIDP_SEARCH_TOOL = "ind_aidp_search"
+
+
+def _get_deployment_user_selectability(
+    tool_name: str,
+    default: bool,
+) -> bool:
+    """Return the deployment-controlled user selection state for a tool."""
+    if tool_name in _ALWAYS_HIDDEN_KNOWLEDGE_TOOLS:
+        return False
+    if tool_name == _INDEPENDENT_AIDP_SEARCH_TOOL:
+        return not ENABLE_AIDP_KNOWLEDGE
+    return default
 
 
 def _parse_kds_list(value: Any) -> list[str]:
@@ -283,7 +302,10 @@ def get_local_tools() -> List[ToolInfo]:
             output_type=getattr(tool_class, 'output_type'),
             category=getattr(tool_class, 'category'),
             labels=getattr(tool_class, 'labels', None),
-            is_user_selectable=getattr(tool_class, 'is_user_selectable', True),
+            is_user_selectable=_get_deployment_user_selectability(
+                getattr(tool_class, 'name'),
+                getattr(tool_class, 'is_user_selectable', True),
+            ),
             class_name=tool_class.__name__,
             usage=None,
             origin_name=getattr(tool_class, 'name')
@@ -872,7 +894,10 @@ async def list_all_tools(tenant_id: str, labels: Optional[List[str]] = None):
             "inputs": inputs_str,
             "category": tool.get("category"),
             "labels": tool.get("labels", []),
-            "is_user_selectable": tool.get("is_user_selectable", True),
+            "is_user_selectable": _get_deployment_user_selectability(
+                tool_name,
+                tool.get("is_user_selectable", True),
+            ),
             "updated_by": tool.get("updated_by", ""),
             "updated_by_name": updated_by_email_map.get(tool.get("updated_by"), ""),
         }

--- a/frontend/app/[locale]/newchat/adapter/conversation-thread-list-adapter.tsx
+++ b/frontend/app/[locale]/newchat/adapter/conversation-thread-list-adapter.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/services/conversationService";
 import { getConversationDateBoundaries } from "@/lib/conversationViewport";
 import { toMessageCreatedAt } from "@/lib/messageDate";
+import { buildHistoricalMessageTiming } from "@/lib/messageTiming";
 
 import { storageService } from "@/services/storageService";
 import { parseAutomationProposal } from "@/features/agentAutomation/parseProposal";
@@ -991,7 +992,12 @@ export class RemoteConversationHistoryAdapter implements ThreadHistoryAdapter {
       // always include the field and only set the token bucket when we have
       // historical step data.
       const createdAt = toMessageCreatedAt(msg.create_time);
+      const timing =
+        msg.role === "assistant"
+          ? buildHistoricalMessageTiming(stepTokenCounts)
+          : undefined;
       const metadata = {
+        ...(timing ? { timing } : {}),
         custom: {
           ...(stepTokenCounts.length > 0 ? { stepTokenCounts } : {}),
           ...(createdAt ? { databaseCreateTime: createdAt.getTime() } : {}),

--- a/frontend/app/[locale]/newchat/adapter/remote-chat-model-adapter.ts
+++ b/frontend/app/[locale]/newchat/adapter/remote-chat-model-adapter.ts
@@ -10,6 +10,7 @@ import type {
 
 import { conversationService } from "@/services/conversationService";
 import log from "@/lib/logger";
+import { completeTrailingToolCalls } from "@/lib/toolCallStatus";
 import { parseAutomationProposal } from "@/features/agentAutomation/parseProposal";
 import type { SkillParam, ToolParam } from "@/types/agentConfig";
 
@@ -2106,6 +2107,7 @@ export const remoteChatModelAdapter: ChatModelAdapter = {
           // uncorrelated logs so internal data is never rendered as chat text.
           if (chunk.type === "execution_logs") {
             attachExecutionLogsToTool(contentParts, chunk);
+            completeTrailingToolCalls(contentParts);
             yield buildStreamResult(contentParts);
             continue;
           }
@@ -2452,6 +2454,7 @@ export const remoteChatModelAdapter: ChatModelAdapter = {
             if (update) planRegistry.updateStep(update.stepId, update.status);
           } else if (chunk.type === "execution_logs") {
             attachExecutionLogsToTool(contentParts, chunk);
+            completeTrailingToolCalls(contentParts);
             yield buildStreamResult(contentParts);
           } else if (chunk.type === "nl2a") {
             if (acceptNl2aBoundary(chunk)) {

--- a/frontend/app/[locale]/newchat/ui/tool-fallback.tsx
+++ b/frontend/app/[locale]/newchat/ui/tool-fallback.tsx
@@ -135,7 +135,7 @@ function ToolFallbackResult({
 }: React.ComponentProps<"div"> & {
   result?: unknown;
 }) {
-  if (result === undefined) return null;
+  if (result === undefined || result === "") return null;
 
   return (
     <div className={cn("", className)} {...props}>

--- a/frontend/hooks/agent/useSaveGuard.ts
+++ b/frontend/hooks/agent/useSaveGuard.ts
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 
 import { checkAgentNameConflictBatch } from "@/services/agentConfigService";
 import { useAgentStore } from "@/stores/agentStore";
+import { trimAgentText } from "@/lib/agentText";
 
 const AGENT_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
@@ -30,15 +31,16 @@ type AgentNameConflictStatus =
 
 export async function checkAgentNameConflict(
   field: AgentNameField,
-  value: string,
+  value: string | undefined,
   agentId?: number
 ): Promise<AgentNameConflictStatus> {
-  if (!value.trim()) return "available";
+  const trimmed = trimAgentText(value);
+  if (!trimmed) return "available";
 
   const result = await checkAgentNameConflictBatch({
     items: [
       {
-        [field]: value.trim(),
+        [field]: trimmed,
         agent_id: agentId,
       },
     ],
@@ -85,9 +87,9 @@ export const useSaveGuard = () => {
     const { agentId, editedAgent } = useAgentStore.getState();
     if (!editedAgent || agentId === null) return false;
 
-    const name = editedAgent.name.trim();
-    const displayName = (editedAgent.display_name || "").trim();
-    const description = editedAgent.description.trim();
+    const name = trimAgentText(editedAgent.name);
+    const displayName = trimAgentText(editedAgent.display_name);
+    const description = trimAgentText(editedAgent.description);
 
     if (!displayName) {
       message.error(t("agent.validation.displayNameRequired"));

--- a/frontend/lib/agentText.ts
+++ b/frontend/lib/agentText.ts
@@ -1,0 +1,1 @@
+export const trimAgentText = (value?: string): string => value?.trim() ?? "";

--- a/frontend/lib/messageTiming.ts
+++ b/frontend/lib/messageTiming.ts
@@ -1,0 +1,28 @@
+export interface PersistedTokenCountTiming {
+  duration: number;
+  totalOutputTokens: number;
+}
+
+export const buildHistoricalMessageTiming = (
+  steps: readonly PersistedTokenCountTiming[]
+) => {
+  const completedSteps = steps.filter(
+    (step) => Number.isFinite(step.duration) && step.duration > 0
+  );
+  if (completedSteps.length === 0) return undefined;
+
+  const totalDuration = completedSteps.reduce(
+    (sum, step) => sum + step.duration,
+    0
+  );
+  const tokenCount = completedSteps.at(-1)?.totalOutputTokens ?? 0;
+
+  return {
+    streamStartTime: 0,
+    totalStreamTime: totalDuration * 1000,
+    tokenCount,
+    tokensPerSecond: tokenCount > 0 ? tokenCount / totalDuration : undefined,
+    totalChunks: 1,
+    toolCallCount: 0,
+  };
+};

--- a/frontend/lib/toolCallStatus.ts
+++ b/frontend/lib/toolCallStatus.ts
@@ -1,0 +1,19 @@
+type ToolCallPart = {
+  type?: string;
+  status?: { type?: string };
+};
+
+/**
+ * Marks the tool calls emitted by the most recently completed ReAct code
+ * block as complete. Tool calls in one code block are consecutive; a
+ * non-tool part is the boundary to the preceding block.
+ */
+export function completeTrailingToolCalls(parts: ToolCallPart[]): void {
+  for (let index = parts.length - 1; index >= 0; index -= 1) {
+    const part = parts[index];
+    if (part?.type !== "tool-call") break;
+
+    if (part.status?.type === "incomplete") continue;
+    part.status = { type: "complete" };
+  }
+}

--- a/frontend/lib/toolCallStatus.ts
+++ b/frontend/lib/toolCallStatus.ts
@@ -1,6 +1,7 @@
 type ToolCallPart = {
   type?: string;
   status?: { type?: string };
+  result?: unknown;
 };
 
 /**
@@ -15,5 +16,9 @@ export function completeTrailingToolCalls(parts: ToolCallPart[]): void {
 
     if (part.status?.type === "incomplete") continue;
     part.status = { type: "complete" };
+    // assistant-ui derives a tool call's status from the message while its
+    // result is undefined. An empty result records successful completion
+    // without inventing output for tools that did not emit any.
+    if (part.result === undefined) part.result = "";
   }
 }

--- a/frontend/tests/agentText.test.ts
+++ b/frontend/tests/agentText.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  trimAgentText,
+  // @ts-ignore -- Node's built-in TypeScript runner needs the extension.
+} from "../lib/agentText.ts";
+
+test("normalizes missing and blank agent text to an empty string", () => {
+  assert.equal(trimAgentText(undefined), "");
+  assert.equal(trimAgentText("   "), "");
+});
+
+test("trims agent text without changing its content", () => {
+  assert.equal(trimAgentText("  support-agent  "), "support-agent");
+});

--- a/frontend/tests/messageTiming.test.ts
+++ b/frontend/tests/messageTiming.test.ts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildHistoricalMessageTiming,
+  // @ts-expect-error -- Node's built-in TypeScript runner needs the extension.
+} from "../lib/messageTiming.ts";
+
+test("builds total timing from persisted token-count steps", () => {
+  assert.deepEqual(
+    buildHistoricalMessageTiming([
+      { duration: 1.25, totalOutputTokens: 100 },
+      { duration: 0.75, totalOutputTokens: 160 },
+    ]),
+    {
+      streamStartTime: 0,
+      totalStreamTime: 2000,
+      tokenCount: 160,
+      tokensPerSecond: 80,
+      totalChunks: 1,
+      toolCallCount: 0,
+    }
+  );
+});
+
+test("omits timing when persisted token-count steps have no duration", () => {
+  assert.equal(
+    buildHistoricalMessageTiming([
+      { duration: 0, totalOutputTokens: 100 },
+      { duration: -1, totalOutputTokens: 160 },
+    ]),
+    undefined
+  );
+});

--- a/frontend/tests/toolCallStatus.test.ts
+++ b/frontend/tests/toolCallStatus.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  completeTrailingToolCalls,
+  // @ts-expect-error -- Node's built-in TypeScript runner needs the extension.
+} from "../lib/toolCallStatus.ts";
+
+test("completes every running tool in the finished ReAct code block", () => {
+  const earlierTool = { type: "tool-call", status: { type: "running" } };
+  const parts = [
+    earlierTool,
+    { type: "reasoning", text: "next code block" },
+    { type: "tool-call", status: { type: "running" } },
+    { type: "tool-call" },
+    { type: "tool-call", status: { type: "incomplete", reason: "cancelled" } },
+  ];
+
+  completeTrailingToolCalls(parts);
+
+  assert.deepEqual(parts[2].status, { type: "complete" });
+  assert.deepEqual(parts[3].status, { type: "complete" });
+  assert.deepEqual(parts[4].status, { type: "incomplete", reason: "cancelled" });
+  assert.deepEqual(earlierTool.status, { type: "running" });
+});

--- a/frontend/tests/toolCallStatus.test.ts
+++ b/frontend/tests/toolCallStatus.test.ts
@@ -6,11 +6,20 @@ import {
   // @ts-expect-error -- Node's built-in TypeScript runner needs the extension.
 } from "../lib/toolCallStatus.ts";
 
+type TestToolCall = {
+  type: string;
+  status?: { type: string; reason?: string };
+  result?: unknown;
+};
+
 test("completes every running tool in the finished ReAct code block", () => {
-  const earlierTool = { type: "tool-call", status: { type: "running" } };
-  const parts = [
+  const earlierTool: TestToolCall = {
+    type: "tool-call",
+    status: { type: "running" },
+  };
+  const parts: TestToolCall[] = [
     earlierTool,
-    { type: "reasoning", text: "next code block" },
+    { type: "reasoning", status: { type: "complete" } },
     { type: "tool-call", status: { type: "running" } },
     { type: "tool-call" },
     { type: "tool-call", status: { type: "incomplete", reason: "cancelled" } },
@@ -20,6 +29,10 @@ test("completes every running tool in the finished ReAct code block", () => {
 
   assert.deepEqual(parts[2].status, { type: "complete" });
   assert.deepEqual(parts[3].status, { type: "complete" });
+  assert.equal(parts[2].result, "");
+  assert.equal(parts[3].result, "");
   assert.deepEqual(parts[4].status, { type: "incomplete", reason: "cancelled" });
+  assert.equal(parts[4].result, undefined);
   assert.deepEqual(earlierTool.status, { type: "running" });
+  assert.equal(earlierTool.result, undefined);
 });

--- a/test/backend/services/test_nl2agent_service.py
+++ b/test/backend/services/test_nl2agent_service.py
@@ -567,6 +567,10 @@ async def test_search_installed_resources_covers_visible_tools_and_skills(mocker
             }
         ],
     )
+    mocker.patch(
+        "services.nl2agent_service.ENABLE_AIDP_KNOWLEDGE",
+        False,
+    )
 
     catalog = await _load_installed_resource_catalog(
         tenant_id="tenant-a",
@@ -575,7 +579,7 @@ async def test_search_installed_resources_covers_visible_tools_and_skills(mocker
     catalog_by_name = {item["name"]: item for item in catalog}
     assert "wrapper" in catalog_by_name
     assert "knowledge_base_search" in catalog_by_name
-    assert "aidp_search" in catalog_by_name
+    assert "aidp_search" not in catalog_by_name
     assert catalog_by_name["knowledge_base_search"]["config"] == [
         {
             "name": "top_k",
@@ -586,8 +590,6 @@ async def test_search_installed_resources_covers_visible_tools_and_skills(mocker
             "description_zh": "",
         }
     ]
-    assert catalog_by_name["aidp_search"]["config"] == []
-
     result = await search_installed_resources_impl(
         requirements=[
             ResourceRequirement(
@@ -625,6 +627,58 @@ async def test_search_installed_resources_covers_visible_tools_and_skills(mocker
     )
     assert knowledge_result.candidates[0].candidate_ref == "tool:12"
     assert knowledge_result.uncovered_requirement_ids == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("enable_aidp_knowledge", "expected_knowledge_tools"),
+    [
+        (True, {"aidp_search"}),
+        (False, {"knowledge_base_search", "ind_aidp_search"}),
+    ],
+)
+async def test_installed_resource_catalog_filters_knowledge_tools_by_deployment(
+    mocker,
+    enable_aidp_knowledge,
+    expected_knowledge_tools,
+):
+    mocker.patch(
+        "services.tool_configuration_service.list_all_tools",
+        new=AsyncMock(
+            return_value=[
+                {
+                    "tool_id": tool_id,
+                    "name": name,
+                    "description": "Knowledge search",
+                    "source": "local",
+                    "is_available": True,
+                }
+                for tool_id, name in enumerate(
+                    (
+                        "knowledge_base_search",
+                        "ind_aidp_search",
+                        "aidp_search",
+                    ),
+                    start=1,
+                )
+            ]
+        ),
+    )
+    mocker.patch(
+        "services.skill_service.SkillService.list_visible_skills",
+        return_value=[],
+    )
+    mocker.patch(
+        "services.nl2agent_service.ENABLE_AIDP_KNOWLEDGE",
+        enable_aidp_knowledge,
+    )
+
+    catalog = await _load_installed_resource_catalog(
+        tenant_id="tenant-a",
+        user_id="user-a",
+    )
+
+    assert {item["name"] for item in catalog} == expected_knowledge_tools
 
 
 def test_resource_config_normalization_is_frontend_safe():

--- a/test/backend/services/test_tool_configuration_service.py
+++ b/test/backend/services/test_tool_configuration_service.py
@@ -4335,6 +4335,117 @@ class TestGetLocalToolsDescriptionZhCoverage:
         inputs = json.loads(result[0].inputs)
         assert inputs == {"query": "string"}
 
+    @pytest.mark.parametrize(
+        ("enable_aidp_knowledge", "expected_selectability"),
+        [
+            (
+                True,
+                {
+                    "knowledge_base_search": False,
+                    "aidp_search": False,
+                    "ind_aidp_search": False,
+                },
+            ),
+            (
+                False,
+                {
+                    "knowledge_base_search": False,
+                    "aidp_search": False,
+                    "ind_aidp_search": True,
+                },
+            ),
+        ],
+    )
+    @patch('backend.services.tool_configuration_service.get_local_tools_classes')
+    def test_get_local_tools_applies_knowledge_tool_selectability_by_deployment(
+        self,
+        mock_get_classes,
+        monkeypatch,
+        enable_aidp_knowledge,
+        expected_selectability,
+    ):
+        class KnowledgeTool:
+            name = "knowledge_base_search"
+            description = "Knowledge search"
+            output_type = "string"
+            category = "knowledge-base"
+            inputs = {}
+
+            def __init__(self):
+                pass
+
+        class AidpTool(KnowledgeTool):
+            name = "aidp_search"
+            is_user_selectable = False
+
+        class IndependentAidpTool(KnowledgeTool):
+            name = "ind_aidp_search"
+
+        mock_get_classes.return_value = [
+            KnowledgeTool,
+            AidpTool,
+            IndependentAidpTool,
+        ]
+        monkeypatch.setattr(
+            _tool_cfg_service,
+            "ENABLE_AIDP_KNOWLEDGE",
+            enable_aidp_knowledge,
+        )
+
+        result = _tool_cfg_service.get_local_tools()
+
+        assert {
+            tool.name: tool.is_user_selectable
+            for tool in result
+        } == expected_selectability
+
+    @pytest.mark.parametrize(
+        ("enable_aidp_knowledge", "expected_selectability"),
+        [
+            (True, [False, False, False]),
+            (False, [False, False, True]),
+        ],
+    )
+    @patch('backend.services.tool_configuration_service.get_local_tools_description_zh')
+    @patch('backend.services.tool_configuration_service.query_all_tools')
+    @pytest.mark.asyncio
+    async def test_list_all_tools_applies_deployment_selectability_to_stale_records(
+        self,
+        mock_query,
+        mock_get_descriptions,
+        monkeypatch,
+        enable_aidp_knowledge,
+        expected_selectability,
+    ):
+        mock_query.return_value = [
+            {
+                "tool_id": tool_id,
+                "name": name,
+                "description": "Knowledge search",
+                "source": "local",
+                "is_available": True,
+                "is_user_selectable": True,
+            }
+            for tool_id, name in enumerate(
+                (
+                    "knowledge_base_search",
+                    "aidp_search",
+                    "ind_aidp_search",
+                ),
+                start=1,
+            )
+        ]
+        mock_get_descriptions.return_value = {}
+        monkeypatch.setattr(
+            _tool_cfg_service,
+            "ENABLE_AIDP_KNOWLEDGE",
+            enable_aidp_knowledge,
+        )
+
+        result = await _tool_cfg_service.list_all_tools("tenant-a")
+
+        assert [tool["is_user_selectable"] for tool in result] == expected_selectability
+
     @patch('backend.services.tool_configuration_service.get_local_tools_description_zh')
     @patch('backend.services.tool_configuration_service.query_all_tools')
     @pytest.mark.asyncio


### PR DESCRIPTION
1. 根据ENABLE_AIDP_KNOWLEDGE判断nl2agent过滤knowlege_base_search/aidp_search
2. 修复创建智能体的时候，input为空时的报错
3. 历史会话支持渲染会话耗时
<img width="2560" height="1305" alt="image" src="https://github.com/user-attachments/assets/a4d03e36-bcbb-4146-823e-80b538c87df2" />
4. 调用parallel并行执行工具时，多个tool call的调用状态应该从loading->finished
<img width="1503" height="1305" alt="image" src="https://github.com/user-attachments/assets/a5b98ab8-35ba-4458-9ea3-ed4a0f477b7b" />
