### PR TITLE
🐛bugfix:Fix saving of AIDP knowledge base information

### DIFF
--- a/backend/ext_components/aidp/apps/aidp_mgmt_app.py
+++ b/backend/ext_components/aidp/apps/aidp_mgmt_app.py
@@ -37,6 +37,7 @@ from ext_components.aidp.consts.aidp_exceptions import (
 )
 from ext_components.aidp.database import aidp_permission_db
 from ext_components.aidp.services import aidp_permission_service as perms
+from ext_components.aidp.services.aidp_kb_update_service import save_kb_settings
 from ext_components.aidp.services.aidp_access_service import (
     get_cached_aidp_doc_count,
     get_cached_aidp_kb_detail,
@@ -160,12 +161,10 @@ class UpdateKbRequest(BaseModel):
 
 
 class SetPermissionRequest(BaseModel):
-    """Request body for setting a KB's group-level permission.
+    """Save permissions and optionally synchronize explicitly changed metadata."""
 
-    The AIDP platform is not invoked; the change is purely a local table
-    write that controls who can see the KB in subsequent list/search calls.
-    """
-
+    name: Optional[str] = Field(None, min_length=1, description="Changed KB name; omit when unchanged")
+    description: Optional[str] = Field(None, description="Changed description; omit when unchanged")
     ingroup_permission: str = Field(..., description="EDIT / READ_ONLY / PRIVATE")
     group_ids: Optional[List[int]] = Field(
         None,
@@ -755,7 +754,7 @@ async def set_permission(
     kds_id: Annotated[str, Path(description="Knowledge base ID")],
     body: SetPermissionRequest,
 ) -> JSONResponse:
-    """Update the in-group permission for a KB (does not call AIDP)."""
+    """Save local permissions first, then synchronize supplied metadata changes."""
     user_id, tenant_id = await _auth(request)
     perms.require_permission(kds_id, user_id, tenant_id, required="EDIT")
 
@@ -787,14 +786,23 @@ async def set_permission(
                 detail=str(exc),
             )
 
-    perms.update_permission(
+    metadata = body.model_dump(include={"name", "description"}, exclude_none=True)
+    if "name" in metadata:
+        metadata["name"] = metadata["name"].strip()
+        if not metadata["name"]:
+            raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail="Name must not be blank")
+    result = await asyncio.to_thread(
+        save_kb_settings,
         kb_id=kds_id,
         tenant_id=tenant_id,
+        user_id=user_id,
         ingroup_permission=body.ingroup_permission,
         group_ids=final_group_ids,
-        updated_by=user_id,
+        metadata=metadata,
+        server_url=AIDP_SERVER_URL,
+        api_key=AIDP_API_KEY,
     )
-    return JSONResponse(status_code=HTTPStatus.OK, content={"success": True})
+    return JSONResponse(status_code=HTTPStatus.OK, content=result)
 
 
 @aidp_mgmt_router.get("/models")

--- a/backend/ext_components/aidp/services/aidp_kb_update_service.py
+++ b/backend/ext_components/aidp/services/aidp_kb_update_service.py
@@ -1,0 +1,46 @@
+"""Save local KB permissions before optionally synchronizing changed metadata."""
+
+import logging
+
+from consts.exceptions import AppException
+from ext_components.aidp.consts.aidp_exceptions import AidpKbNotFoundError
+from ext_components.aidp.services import aidp_permission_service as perms
+from ext_components.aidp.services.aidp_access_service import (
+    invalidate_aidp_catalog_cache,
+    invalidate_aidp_kb_detail_cache,
+)
+from ext_components.aidp.services.aidp_service import update_aidp_kb_impl
+
+logger = logging.getLogger(__name__)
+
+
+def save_kb_settings(
+    *, kb_id: str, tenant_id: str, user_id: str, ingroup_permission: str,
+    group_ids: list[int], metadata: dict, server_url: str, api_key: str,
+) -> dict:
+    """Commit permissions first; metadata contains only explicitly changed fields."""
+    if not perms.update_permission(
+        kb_id=kb_id, tenant_id=tenant_id, ingroup_permission=ingroup_permission,
+        group_ids=group_ids, updated_by=user_id,
+    ):
+        raise AidpKbNotFoundError(kb_id)
+
+    result = {"success": True, "permissions_saved": True, "metadata_status": "unchanged"}
+    if not metadata:
+        return result
+
+    try:
+        updated = update_aidp_kb_impl(server_url, api_key, kb_id, metadata)
+    except AppException:
+        logger.exception("AIDP metadata update failed after permissions were saved for %s", kb_id)
+        return {**result, "success": False, "metadata_status": "failed"}
+    finally:
+        invalidate_aidp_catalog_cache(server_url, api_key)
+        invalidate_aidp_kb_detail_cache(server_url, api_key, kb_id)
+
+    new_name = updated.get("kds_name") or metadata.get("name")
+    if new_name:
+        perms.update_permission(
+            kb_id=kb_id, tenant_id=tenant_id, kds_name=new_name, updated_by=user_id,
+        )
+    return {**result, "metadata_status": "updated", "metadata": updated}

--- a/frontend/ext_components/aidp/components/AidpUpdateKbModal.tsx
+++ b/frontend/ext_components/aidp/components/AidpUpdateKbModal.tsx
@@ -76,19 +76,12 @@ const AidpUpdateKbModal: React.FC<AidpUpdateKbModalProps> = ({
       const values = await form.validateFields();
       setLoading(true);
 
-      // Update AIDP-side metadata (name + description).
-      const updated = await aidpKnowledgeService.updateKb(
-        knowledgeBase.kds_id,
-        {
-          name: values.name.trim(),
-          description: values.description?.trim() || "",
-        }
-      );
+      const name = values.name.trim();
+      const description = values.description?.trim() || "";
+      const nameChanged = name !== knowledgeBase.kds_name.trim();
+      const descriptionChanged =
+        description !== (knowledgeBase.description || "").trim();
 
-      // Update Nexent-side permissions only when something actually
-      // changed. Skipping the PATCH call when values match the original
-      // row avoids an unnecessary DB write and sidesteps backend
-      // validation for rows where the user hasn't touched permissions.
       const newPermission = isUser ? "PRIVATE" : values.ingroup_permission;
       const newGroupIds: number[] = isUser
         ? []
@@ -111,24 +104,46 @@ const AidpUpdateKbModal: React.FC<AidpUpdateKbModalProps> = ({
             (id, idx) => id !== [...originalGroupIds].sort((a, b) => a - b)[idx]
           );
 
-      if (permissionChanged) {
-        await aidpKnowledgeService.setPermission(knowledgeBase.kds_id, {
-          ingroup_permission: newPermission,
-          group_ids: normalizedNewGroupIds,
-        });
+      if (!nameChanged && !descriptionChanged && !permissionChanged) {
+        form.resetFields();
+        onSuccess(knowledgeBase);
+        return;
       }
 
-      message.success(t("aidpKnowledge.updateKbSuccess"));
+      // Omitted metadata fields must never trigger an upstream AIDP request.
+      const result = await aidpKnowledgeService.setPermission(
+        knowledgeBase.kds_id,
+        {
+          ingroup_permission: newPermission,
+          group_ids: normalizedNewGroupIds,
+          ...(nameChanged ? { name } : {}),
+          ...(descriptionChanged ? { description } : {}),
+        }
+      );
+      const metadataFailed = result.metadata_status === "failed";
+      if (metadataFailed) {
+        message.warning(t("aidpKnowledge.updateKbMetadataFailed"));
+      } else {
+        message.success(t("aidpKnowledge.updateKbSuccess"));
+      }
+      const updated = result.metadata;
       form.resetFields();
       onSuccess({
         ...knowledgeBase,
-        ...updated,
-        kds_id: knowledgeBase.kds_id,
-        kds_name: updated.kds_name || values.name.trim(),
-        description: updated.description ?? values.description?.trim() ?? "",
+        kds_name:
+          !metadataFailed && nameChanged
+            ? updated?.kds_name || name
+            : knowledgeBase.kds_name,
+        description:
+          !metadataFailed && descriptionChanged
+            ? (updated?.description ?? description)
+            : knowledgeBase.description,
         ingroup_permission: newPermission,
         group_ids: normalizedNewGroupIds,
-        resource_status: "ACTIVE",
+        resource_status:
+          result.metadata_status === "updated"
+            ? "ACTIVE"
+            : knowledgeBase.resource_status,
       });
     } catch (error) {
       if (error && typeof error === "object" && "errorFields" in error) {

--- a/frontend/ext_components/aidp/services/aidpKnowledgeService.ts
+++ b/frontend/ext_components/aidp/services/aidpKnowledgeService.ts
@@ -138,6 +138,16 @@ export interface AidpCreateKbPayload {
 export interface AidpSetPermissionPayload {
   ingroup_permission: "EDIT" | "READ_ONLY" | "PRIVATE";
   group_ids?: number[];
+  /** Only include metadata fields when their values have changed. */
+  name?: string;
+  description?: string;
+}
+
+export interface AidpSaveSettingsResult {
+  success: boolean;
+  permissions_saved: boolean;
+  metadata_status: "unchanged" | "updated" | "failed";
+  metadata?: AidpKbDetail;
 }
 
 export interface AidpUpdateKbPayload {
@@ -393,16 +403,15 @@ class AidpKnowledgeService {
   }
 
   /**
-   * Update the in-group permission for a KB (does not call AIDP).
-   * Required when a Nexent user with EDIT permission changes who can see the KB.
+   * Save local permissions first, then synchronize supplied metadata changes.
    */
   async setPermission(
     id: string,
     payload: AidpSetPermissionPayload
-  ): Promise<void> {
+  ): Promise<AidpSaveSettingsResult> {
     const url = buildUrl(API_ENDPOINTS.aidpMgmt.kbPermission(id), {});
 
-    await fetchWithErrorHandling(url, {
+    const response = await fetchWithErrorHandling(url, {
       method: "PATCH",
       headers: {
         ...getAuthHeaders(),
@@ -410,6 +419,7 @@ class AidpKnowledgeService {
       },
       body: JSON.stringify(payload),
     });
+    return response.json();
   }
 
   /**

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -4188,6 +4188,8 @@
   "aidpKnowledge.updateKb": "Update Knowledge Base",
   "aidpKnowledge.updateKbSuccess": "Knowledge base updated",
   "aidpKnowledge.updateKbFailed": "Failed to update knowledge base",
+  "aidpKnowledge.updateKbPermissionFailed": "Name and description saved, but permissions failed to update. Reopen the editor to retry.",
+  "aidpKnowledge.updateKbMetadataFailed": "Permissions saved, but name and description failed to update. Reopen the editor to retry.",
   "aidpKnowledge.kbName": "Name",
   "aidpKnowledge.kbNamePlaceholder": "Knowledge base name",
   "aidpKnowledge.kbNameRequired": "Name is required",

--- a/frontend/public/locales/zh/common.json
+++ b/frontend/public/locales/zh/common.json
@@ -3919,6 +3919,8 @@
   "aidpKnowledge.updateKb": "更新知识库",
   "aidpKnowledge.updateKbSuccess": "知识库已更新",
   "aidpKnowledge.updateKbFailed": "更新知识库失败",
+  "aidpKnowledge.updateKbPermissionFailed": "名称和描述已保存，但权限更新失败，请重新编辑并重试",
+  "aidpKnowledge.updateKbMetadataFailed": "权限已保存，但名称和描述更新失败，请重新编辑并重试",
   "aidpKnowledge.kbName": "名称",
   "aidpKnowledge.kbNamePlaceholder": "知识库名称",
   "aidpKnowledge.kbNameRequired": "名称是必填项",

--- a/test/backend/database/test_conversation_knowledge_scope_migration.py
+++ b/test/backend/database/test_conversation_knowledge_scope_migration.py
@@ -1,9 +1,8 @@
 from pathlib import Path
 
 
-MIGRATION = Path(
-    "deploy/sql/migrations/v2.5.0_0806_add_conversation_knowledge_scope.sql"
-)
+ROOT = Path(__file__).resolve().parents[3]
+MIGRATION = ROOT / "deploy/sql/migrations/v2.5.0_merged_migrations.sql"
 
 
 def test_conversation_knowledge_scope_migration_is_repeatable():
@@ -15,6 +14,6 @@ def test_conversation_knowledge_scope_migration_is_repeatable():
 
 
 def test_init_sql_is_not_used_for_conversation_knowledge_scope():
-    init_sql = Path("deploy/sql/init.sql").read_text(encoding="utf-8")
+    init_sql = (ROOT / "deploy/sql/init.sql").read_text(encoding="utf-8")
 
     assert "knowledge_scope" not in init_sql

--- a/test/backend/database/test_memory_dreaming_schema.py
+++ b/test/backend/database/test_memory_dreaming_schema.py
@@ -11,6 +11,13 @@ from database.db_models import (
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 
 
+def _read_dreaming_migration(migrations):
+    sql = (migrations / "v2.5.0_merged_migrations.sql").read_text(encoding="utf-8")
+    marker = "-- Source migration: v2.5.0_0813_versioned_markdown_long_term_memory.sql\n"
+    assert sql.count(marker) == 1
+    return sql.split(marker, 1)[1].split("-- Source migration:", 1)[0]
+
+
 def test_final_orm_contract_has_only_shared_long_term_versions():
     assert MemoryDreamingAudit.__tablename__ == "memory_dreaming_audit_t"
     assert MemoryDreamingDecision.__tablename__ == "memory_dreaming_decision_t"
@@ -36,8 +43,8 @@ def test_final_orm_contract_has_only_shared_long_term_versions():
 def test_final_migration_is_the_only_dreaming_schema_source():
     root = Path(__file__).resolve().parents[3]
     migrations = root / "deploy/sql/migrations"
-    final = (migrations / "v2.5.0_0813_versioned_markdown_long_term_memory.sql").read_text()
-    init_sql = (root / "deploy/sql/init.sql").read_text()
+    final = _read_dreaming_migration(migrations)
+    init_sql = (root / "deploy/sql/init.sql").read_text(encoding="utf-8")
     for token in (
         "memory_dreaming_audit_t", "memory_dreaming_decision_t", "memory_dreaming_schedule_t",
         "memory_long_term_version_t",
@@ -72,8 +79,8 @@ def test_final_migration_is_the_only_dreaming_schema_source():
 def test_final_migration_upgrades_v24_without_intermediate_v25_schema():
     root = Path(__file__).resolve().parents[3]
     migrations = root / "deploy/sql/migrations"
-    v24 = (migrations / "v2.4_merged_migrations.sql").read_text()
-    final = (migrations / "v2.5.0_0813_versioned_markdown_long_term_memory.sql").read_text()
+    v24 = (migrations / "v2.4_merged_migrations.sql").read_text(encoding="utf-8")
+    final = _read_dreaming_migration(migrations)
 
     assert "CREATE TABLE IF NOT EXISTS nexent.memory_records_t" in v24
     for table_name in (

--- a/test/ext_components/aidp/test_aidp_mgmt_app.py
+++ b/test/ext_components/aidp/test_aidp_mgmt_app.py
@@ -85,6 +85,62 @@ USER_ID = "user-test"
 TENANT_ID = "tenant-test"
 
 
+@pytest.mark.parametrize("metadata,remote_fails", [
+    ({}, False),
+    ({"name": "Renamed"}, False),
+    ({"description": ""}, False),
+    ({"description": "New description"}, True),
+])
+def test_unified_save_commits_permissions_before_optional_aidp(monkeypatch, metadata, remote_fails):
+    from consts.error_code import ErrorCode
+    from consts.exceptions import AppException
+    from ext_components.aidp.apps import aidp_mgmt_app
+    from ext_components.aidp.services import aidp_kb_update_service as service
+
+    events = []
+    monkeypatch.setattr(aidp_mgmt_app.perms, "require_permission", lambda *a, **kw: None)
+
+    def save_local(**kwargs):
+        events.append(("local", kwargs))
+        return True
+
+    def save_remote(server_url, api_key, kb_id, payload):
+        assert events[0][0] == "local"
+        assert events[0][1]["ingroup_permission"] == "PRIVATE"
+        events.append(("remote", payload))
+        if remote_fails:
+            raise AppException(ErrorCode.AIDP_CONNECTION_ERROR, "Unavailable")
+        return {"kds_name": payload.get("name", "Original"), **payload}
+
+    monkeypatch.setattr(service.perms, "update_permission", save_local)
+    monkeypatch.setattr(service, "update_aidp_kb_impl", save_remote)
+    response = _client().patch(
+        "/aidp-mgmt/aidp-permissions/kb-1", headers=_bearer(),
+        json={"ingroup_permission": "PRIVATE", "group_ids": [], **metadata},
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result["permissions_saved"] is True
+    assert result["metadata_status"] == ("failed" if remote_fails else "updated" if metadata else "unchanged")
+    assert [payload for kind, payload in events if kind == "remote"] == ([metadata] if metadata else [])
+
+
+def test_unified_save_local_failure_prevents_aidp(monkeypatch):
+    from ext_components.aidp.apps import aidp_mgmt_app
+    from ext_components.aidp.services import aidp_kb_update_service as service
+
+    monkeypatch.setattr(aidp_mgmt_app.perms, "require_permission", lambda *a, **kw: None)
+    monkeypatch.setattr(service.perms, "update_permission", lambda **kw: False)
+    remote_calls = []
+    monkeypatch.setattr(service, "update_aidp_kb_impl", lambda *a: remote_calls.append(a))
+    response = _client().patch(
+        "/aidp-mgmt/aidp-permissions/kb-1", headers=_bearer(),
+        json={"ingroup_permission": "PRIVATE", "description": "Changed"},
+    )
+    assert response.status_code == 404
+    assert remote_calls == []
+
+
 # --- Fixtures -------------------------------------------------------------
 
 


### PR DESCRIPTION
1.前端只调用 PATCH /aidp-mgmt/aidp-permissions/{id}，仅携带发生变化的名称／描述。
2. 后端先保存 Nexent 权限表。
3. 请求包含名称／描述变更时，再调用 AIDP。
4. AIDP 失败不回滚权限，界面提示“权限已保存，名称和描述更新失败”。