### PR TITLE
🐛 Bugfix: Changed ReAct recoverable exceptions to yellow warnings.

### DIFF
--- a/backend/services/nl2agent_service.py
+++ b/backend/services/nl2agent_service.py
@@ -99,7 +99,7 @@ class _Nl2AgentBoundaryObserver(MessageObserver):
     def add_message(self, agent_name, process_type, content, **kwargs):
         if self.boundary_reached and (
             (process_type == ProcessType.FINAL_ANSWER and content == self._STOP_FINAL_ANSWER)
-            or (process_type == ProcessType.ERROR and content == self._STOP_ERROR)
+            or (process_type == ProcessType.WARNING and content == self._STOP_ERROR)
         ):
             return
 

--- a/backend/utils/llm_utils.py
+++ b/backend/utils/llm_utils.py
@@ -157,8 +157,10 @@ def call_llm_for_system_prompt(
                 if delta is None:
                     logger.debug("Skipping LLM stream chunk without delta")
                     continue
- 
-                reasoning_content = getattr(delta, "reasoning_content", None)
+
+                reasoning_content = getattr(delta, "reasoning", None)
+                if reasoning_content is None:
+                    reasoning_content = getattr(delta, "reasoning_content", None)
                 new_token = getattr(delta, "content", None)
 
                 # Note: reasoning_content is separate metadata and doesn't affect content filtering

--- a/frontend/app/[locale]/newchat/adapter/conversation-thread-list-adapter.tsx
+++ b/frontend/app/[locale]/newchat/adapter/conversation-thread-list-adapter.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/services/conversationService";
 import { getConversationDateBoundaries } from "@/lib/conversationViewport";
 import { toMessageCreatedAt } from "@/lib/messageDate";
+import { stripAnsiControlSequences } from "@/lib/ansi";
 
 import { storageService } from "@/services/storageService";
 import { parseAutomationProposal } from "@/features/agentAutomation/parseProposal";
@@ -69,7 +70,8 @@ type HistoricalChatMode = "planning" | "execution";
 let activeHistoricalConversationId: string | undefined;
 let activeHistoricalChatModeConversationId: string | undefined;
 let historicalChatModeListener:
-  ((mode: HistoricalChatMode) => void) | undefined;
+  | ((mode: HistoricalChatMode) => void)
+  | undefined;
 const historicalChatModeCache = new Map<string, HistoricalChatMode>();
 
 export const restoreHistoricalPlan = (conversationId?: string): void => {
@@ -146,7 +148,8 @@ const toToolSearchItem = (value: unknown) => {
   const item = value as Record<string, unknown>;
   const url = typeof item.url === "string" ? item.url : "";
   const filename = typeof item.filename === "string" ? item.filename : "";
-  const sourceFile = typeof item.source_file === "string" ? item.source_file : "";
+  const sourceFile =
+    typeof item.source_file === "string" ? item.source_file : "";
   const imageMetadata = parseImageMetadata(item.text);
   const resolvedUrl = imageMetadata?.image_url || url;
   const title =
@@ -161,17 +164,24 @@ const toToolSearchItem = (value: unknown) => {
       : typeof item.citeIndex === "number"
         ? item.citeIndex
         : undefined;
-  const toolSign = typeof item.tool_sign === "string" ? item.tool_sign : undefined;
+  const toolSign =
+    typeof item.tool_sign === "string" ? item.tool_sign : undefined;
 
   return resolvedUrl || sourceFile
     ? {
         url: resolvedUrl,
         title,
-        text: imageMetadata ? undefined : typeof item.text === "string" ? item.text : undefined,
-        sourceType: typeof item.source_type === "string" ? item.source_type : undefined,
+        text: imageMetadata
+          ? undefined
+          : typeof item.text === "string"
+            ? item.text
+            : undefined,
+        sourceType:
+          typeof item.source_type === "string" ? item.source_type : undefined,
         filename: filename || undefined,
         sourceFile: sourceFile || imageMetadata?.source_file || undefined,
-        objectName: typeof item.object_name === "string" ? item.object_name : undefined,
+        objectName:
+          typeof item.object_name === "string" ? item.object_name : undefined,
         citeIndex,
         toolSign,
         isImage: Boolean(imageMetadata),
@@ -218,7 +228,7 @@ const buildBranchableHistory = (
   const branchableMessages: BranchableHistoryMessage[] = [];
   let visibleHeadId: string | null = null;
 
-  for (let groupStart = 0; groupStart < messages.length;) {
+  for (let groupStart = 0; groupStart < messages.length; ) {
     const role = messages[groupStart].role;
     let groupEnd = groupStart + 1;
     while (groupEnd < messages.length && messages[groupEnd].role === role) {
@@ -352,10 +362,19 @@ export class RemoteConversationHistoryAdapter implements ThreadHistoryAdapter {
       // Backend returns message as a string for user messages, but as an array of
       // ApiMessageItem for assistant messages. Normalize to array for consistent handling.
       const messageParts = Array.isArray(msg.message)
-        ? msg.message
+        ? msg.message.map((part) => ({
+            ...part,
+            content:
+              typeof part.content === "string"
+                ? stripAnsiControlSequences(part.content)
+                : part.content,
+          }))
         : typeof msg.message === "string"
           ? [{ type: "text", content: msg.message }]
           : [];
+      const runHasFinalAnswer = messageParts.some(
+        (part) => part.type === "final_answer"
+      );
       const persistedAnswerImageKeys = extractAidpImageKeys(
         messageParts.flatMap((part) =>
           (part.type === "final_answer" || part.type === "text") &&
@@ -627,7 +646,7 @@ export class RemoteConversationHistoryAdapter implements ThreadHistoryAdapter {
                     isImage: true,
                     imageKey: imagePart.imageKey,
                   },
-                  part.tool_call_id,
+                  part.tool_call_id
                 );
               }
             }
@@ -844,11 +863,28 @@ export class RemoteConversationHistoryAdapter implements ThreadHistoryAdapter {
               const errorPart: any = {
                 type: "text",
                 text: part.content,
-                isError: true,
+                ...(runHasFinalAnswer
+                  ? { isWarning: true }
+                  : { isError: true }),
               };
               const meta = buildMetadata(part.invocation_id);
               if (meta) errorPart.metadata = meta;
               content.push(errorPart);
+            }
+            continue;
+          }
+
+          if (part.type === "warning") {
+            flushReasoning(part.invocation_id);
+            if (part.content) {
+              const warningPart: any = {
+                type: "text",
+                text: part.content,
+                isWarning: true,
+              };
+              const meta = buildMetadata(part.invocation_id);
+              if (meta) warningPart.metadata = meta;
+              content.push(warningPart);
             }
             continue;
           }
@@ -929,7 +965,8 @@ export class RemoteConversationHistoryAdapter implements ThreadHistoryAdapter {
             if (typeof searchItem === "object" && searchItem !== null) {
               const item = searchItem as Record<string, unknown>;
               const scoreDetails = item.score_details as
-                Record<string, unknown> | undefined;
+                | Record<string, unknown>
+                | undefined;
               const searchImageKey = `${item.tool_sign ?? ""}${item.cite_index ?? ""}`;
               if (
                 scoreDetails?.chunk_type === "image" ||

--- a/frontend/app/[locale]/newchat/adapter/remote-chat-model-adapter.ts
+++ b/frontend/app/[locale]/newchat/adapter/remote-chat-model-adapter.ts
@@ -10,6 +10,7 @@ import type {
 
 import { conversationService } from "@/services/conversationService";
 import log from "@/lib/logger";
+import { stripAnsiControlSequences } from "@/lib/ansi";
 import { parseAutomationProposal } from "@/features/agentAutomation/parseProposal";
 import type { SkillParam, ToolParam } from "@/types/agentConfig";
 
@@ -188,7 +189,9 @@ export interface Nl2aResourceCandidate {
 }
 
 export type Nl2aInstallationFormKind =
-  "SKILL_CONFIG" | "MCP_REMOTE" | "MCP_CONTAINER";
+  | "SKILL_CONFIG"
+  | "MCP_REMOTE"
+  | "MCP_CONTAINER";
 
 export interface Nl2aResourceInstallationOption {
   option_id: string;
@@ -623,7 +626,12 @@ function parseSseChunk(line: string): SseChunk | null {
   if (!jsonStr) return null;
   try {
     const parsed = JSON.parse(jsonStr) as Record<string, unknown>;
-    if (typeof parsed.type === "string") return parsed as unknown as SseChunk;
+    if (typeof parsed.type === "string") {
+      if (typeof parsed.content === "string") {
+        parsed.content = stripAnsiControlSequences(parsed.content);
+      }
+      return parsed as unknown as SseChunk;
+    }
     if (typeof parsed.status === "string") {
       return { type: "status", content: parsed.status };
     }
@@ -653,7 +661,8 @@ function parseSseChunk(line: string): SseChunk | null {
  * | subagent_start               | subagent     | Opens a nested sub-agent card      |
  * | subagent_end                 | subagent     | Closes the most recent nested card |
  * | final_answer                 | text         | Final summary answer               |
- * | error                         | text         | Error message                      |
+ * | warning                       | text         | Recoverable step issue             |
+ * | error                         | text         | Terminal error message             |
  * | search_content               | text         | Search results content             |
  * | picture_web                  | text         | Web search image references        |
  * | card                         | text         | Card-rendered content              |
@@ -691,6 +700,7 @@ function mapChunkType(type: string): AssistantPartType | null {
     case "agent_finish":
     case "max_steps_reached":
     case "verification":
+    case "warning":
     case "error":
       return "text";
     case "search_content":
@@ -1417,7 +1427,8 @@ export const remoteChatModelAdapter: ChatModelAdapter = {
     const history = historyMessages.map((msg) => {
       const customMetadata = isNl2Agent
         ? (msg.metadata?.custom as
-            { nl2agentCardAction?: Nl2AgentCardAction } | undefined)
+            | { nl2agentCardAction?: Nl2AgentCardAction }
+            | undefined)
         : undefined;
       const text = customMetadata?.nl2agentCardAction
         ? JSON.stringify(customMetadata.nl2agentCardAction)
@@ -1513,7 +1524,8 @@ export const remoteChatModelAdapter: ChatModelAdapter = {
       if (abortHandled) return;
       abortHandled = true;
       const abortReason = abortSignal?.reason as
-        { detach?: boolean } | undefined;
+        | { detach?: boolean }
+        | undefined;
       if (abortReason?.detach) {
         log.log(
           `[ChatModelAdapter] Local stream detached from conversation ${backendConversationId ?? "unknown"}`
@@ -1541,7 +1553,8 @@ export const remoteChatModelAdapter: ChatModelAdapter = {
     };
 
     let agentResponse:
-      ReadableStreamDefaultReader<Uint8Array> | { type: "json"; data: unknown };
+      | ReadableStreamDefaultReader<Uint8Array>
+      | { type: "json"; data: unknown };
     let returnedRuntimeMetadataVersion: number | undefined;
     try {
       agentResponse = await conversationService.runAgent(
@@ -2184,6 +2197,24 @@ export const remoteChatModelAdapter: ChatModelAdapter = {
             completeVerificationPanel();
           }
 
+          if (chunk.type === "final_answer") {
+            // Backward compatibility for streams produced before the warning
+            // event existed. A later final answer proves those earlier step
+            // errors were recovered, so update their presentation in place.
+            for (const part of contentParts) {
+              if (part?.type === "text" && part.isError) {
+                delete part.isError;
+                part.isWarning = true;
+              }
+            }
+          }
+
+          if (chunk.type === "warning") {
+            // Preserve ordering without treating a recoverable issue as the
+            // end of the verification/run lifecycle.
+            flushOpenReasoning();
+          }
+
           // Sub-agent boundary handling. ``subagent_start`` registers a new
           // invocation in the per-id map (so parallel siblings stay
           // independent) and emits a stamp ``data`` part so the
@@ -2342,6 +2373,7 @@ export const remoteChatModelAdapter: ChatModelAdapter = {
             const textPart: any = {
               type: "text",
               text: chunk.content,
+              ...(chunk.type === "warning" && { isWarning: true }),
               ...(chunk.type === "error" && { isError: true }),
             };
             if (textMeta) {
@@ -2516,6 +2548,14 @@ export const remoteChatModelAdapter: ChatModelAdapter = {
               // in front of it.
               flushOpenReasoning();
               completeVerificationPanel();
+              for (const part of contentParts) {
+                if (part?.type === "text" && part.isError) {
+                  delete part.isError;
+                  part.isWarning = true;
+                }
+              }
+            } else if (chunk.type === "warning") {
+              flushOpenReasoning();
             }
             const partType = mapChunkType(chunk.type);
             if (partType === "reasoning") {
@@ -2572,6 +2612,7 @@ export const remoteChatModelAdapter: ChatModelAdapter = {
               const textPart: any = {
                 type: "text",
                 text: chunk.content,
+                ...(chunk.type === "warning" && { isWarning: true }),
                 ...(chunk.type === "error" && { isError: true }),
               };
               const textMeta = resolveSubAgent(chunk.invocation_id);

--- a/frontend/app/[locale]/newchat/assistant-ui/thread.tsx
+++ b/frontend/app/[locale]/newchat/assistant-ui/thread.tsx
@@ -53,6 +53,7 @@ import {
   MoreHorizontalIcon,
   RefreshCwIcon,
   ArrowLeft,
+  AlertTriangleIcon,
   SparklesIcon,
   type LucideIcon,
   PencilIcon,
@@ -873,9 +874,7 @@ const ThreadWelcomeContent: FC<ThreadWelcomeContentProps> = ({
                   <button
                     key={suggestion.id}
                     type="button"
-                    onClick={() =>
-                      handleSampleQuestionClick(suggestion.prompt)
-                    }
+                    onClick={() => handleSampleQuestionClick(suggestion.prompt)}
                     className="flex h-full min-h-20 items-center gap-3 rounded-lg border border-border bg-card px-4 py-3 text-left transition-colors hover:border-primary/40 hover:bg-accent/50"
                   >
                     <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
@@ -1268,11 +1267,13 @@ const AssistantMessage: FC<{
                 Boolean((part as { image?: string }).image)) ||
               (part.type === "text" &&
                 Boolean(
-                  (part as {
-                    isSearchImage?: boolean;
-                    imageSource?: SourcePartLike;
-                  }).isSearchImage &&
-                    (part as { imageSource?: SourcePartLike }).imageSource
+                  (
+                    part as {
+                      isSearchImage?: boolean;
+                      imageSource?: SourcePartLike;
+                    }
+                  ).isSearchImage &&
+                  (part as { imageSource?: SourcePartLike }).imageSource
                 ));
             const chainPath: `group-${string}`[] = isImagePart
               ? ["group-image"]
@@ -1381,6 +1382,7 @@ const AssistantMessage: FC<{
               case "text": {
                 const textPart = part as typeof part & {
                   isError?: boolean;
+                  isWarning?: boolean;
                   text?: string;
                   isSearchImage?: boolean;
                   imageSource?: SourcePartLike;
@@ -1392,6 +1394,14 @@ const AssistantMessage: FC<{
                   return (
                     <div className="mt-2 flex items-start gap-2 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
                       <XCircleIcon className="mt-0.5 size-4 shrink-0 text-red-500 dark:text-red-400" />
+                      <span className="break-all">{textPart.text}</span>
+                    </div>
+                  );
+                }
+                if (textPart.isWarning) {
+                  return (
+                    <div className="mt-2 flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
+                      <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-amber-500 dark:text-amber-400" />
                       <span className="break-all">{textPart.text}</span>
                     </div>
                   );

--- a/frontend/lib/ansi.ts
+++ b/frontend/lib/ansi.ts
@@ -1,0 +1,10 @@
+// Terminal/Jupyter output may contain console styling sequences. Browsers do
+// not interpret them, so leaving them in chat text exposes unreadable markers
+// such as "[31m" to users.
+export function stripAnsiControlSequences(value: string): string {
+  return value.replace(
+    // eslint-disable-next-line no-control-regex
+    /(?:\u001b\[[0-?]*[ -/]*[@-~]|\u001b\][^\u0007\u001b]*(?:\u0007|\u001b\\)|\u001b[@-_]|\u009b[0-?]*[ -/]*[@-~])/g,
+    ""
+  );
+}

--- a/frontend/tests/ansi.test.ts
+++ b/frontend/tests/ansi.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  stripAnsiControlSequences,
+  // @ts-expect-error -- Node's built-in TypeScript runner needs the extension.
+} from "../lib/ansi.ts";
+
+test("strips ANSI colours from a Jupyter traceback", () => {
+  const traceback =
+    "\u001b[31mHTTPError\u001b[39m: \u001b[32mHTTP Error 500\u001b[0m";
+
+  assert.equal(
+    stripAnsiControlSequences(traceback),
+    "HTTPError: HTTP Error 500"
+  );
+});
+
+test("strips OSC terminal metadata and preserves normal Unicode", () => {
+  const output = "\u001b]0;kernel\u0007沙箱错误";
+
+  assert.equal(stripAnsiControlSequences(output), "沙箱错误");
+});

--- a/sdk/nexent/core/agents/nexent_agent.py
+++ b/sdk/nexent/core/agents/nexent_agent.py
@@ -1116,7 +1116,11 @@ class NexentAgent:
                         observer.add_message("", ProcessType.TOKEN_COUNT, json.dumps(token_data))
 
                         if hasattr(step_log, "error") and step_log.error is not None:
-                            observer.add_message("", ProcessType.ERROR, str(step_log.error))
+                            # Action-step failures are observations in the ReAct loop:
+                            # the model receives them and can repair/retry on the next
+                            # step. Surface them as warnings so the UI does not imply
+                            # that the whole run has already failed.
+                            observer.add_message("", ProcessType.WARNING, str(step_log.error))
 
                     if step_log is None:
                         raise ValueError("Agent run produced no output")
@@ -1144,7 +1148,7 @@ class NexentAgent:
 
                     # Check if we need to stop from external stop_event
                     if self.agent.stop_event.is_set():
-                        observer.add_message(self.agent.agent_name, ProcessType.ERROR,
+                        observer.add_message(self.agent.agent_name, ProcessType.WARNING,
                                              "Agent execution interrupted by external stop signal")
                 except Exception as e:
                     observer.add_message(agent_name=self.agent.agent_name, process_type=ProcessType.ERROR,
@@ -1421,7 +1425,11 @@ class NexentAgent:
                 upload_tool.forward(str(path), relative.as_posix())
             except Exception as exc:
                 logger.error("Failed to upload workspace output %s: %s", path, exc)
-                self.observer.add_message("", ProcessType.ERROR, f"Failed to upload output file {relative}: {exc}")
+                self.observer.add_message(
+                    "",
+                    ProcessType.WARNING,
+                    f"Failed to upload output file {relative}: {exc}",
+                )
 
         if self._workspace_uploads:
             self.observer.add_message(

--- a/sdk/nexent/core/models/openai_llm.py
+++ b/sdk/nexent/core/models/openai_llm.py
@@ -391,9 +391,10 @@ class OpenAIModel(OpenAIServerModel):
                         if chunk_finish_reason is not None:
                             finish_reason = str(chunk_finish_reason)
 
-                        new_token = chunk.choices[0].delta.content
-                        reasoning_content = getattr(
-                            chunk.choices[0].delta, 'reasoning_content', None)
+                        new_token = getattr(chunk.choices[0].delta, "content", None)
+                        reasoning_content = getattr(chunk.choices[0].delta, "reasoning", None)
+                        if reasoning_content is None:
+                            reasoning_content = getattr(chunk.choices[0].delta, "reasoning_content", None)
 
                         # Handle reasoning_content if it exists and is not null
                         if reasoning_content is not None:

--- a/sdk/nexent/core/utils/observer.py
+++ b/sdk/nexent/core/utils/observer.py
@@ -14,6 +14,15 @@ _NL2A_STATE_PATTERN = re.compile(
     r"<nl2a_state>\s*(.*?)\s*</nl2a_state>",
     re.DOTALL,
 )
+# Terminal/Jupyter tracebacks contain ANSI SGR and other control sequences for
+# console colouring. They have no meaning in JSON/SSE clients and otherwise
+# surface as visible ``[31m`` garbage in the web UI.
+_ANSI_ESCAPE_PATTERN = re.compile(
+    r"(?:\x1b\[[0-?]*[ -/]*[@-~]"
+    r"|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)"
+    r"|\x1b[@-_]"
+    r"|\x9b[0-?]*[ -/]*[@-~])"
+)
 _NL2AGENT_DRAFT_SYNC_FIELDS = frozenset(
     {
         "description",
@@ -38,6 +47,7 @@ class ProcessType(Enum):
     AGENT_FINISH = "agent_finish"  # sub-agent end of run mark, mainly used for front-end display
     FINAL_ANSWER = "final_answer"  # final summary
     ERROR = "error"  # error field
+    WARNING = "warning"  # recoverable issue; execution can continue
     OTHER = "other"  # temporary other fields
     TOKEN_COUNT = "token_count"  # record the number of tokens used in each step
     HISTORY_SUMMARY = "history_summary"  # newly-created context compression checkpoint
@@ -226,6 +236,7 @@ class MessageObserver:
             ProcessType.EXECUTION_LOGS: ExecutionLogsTransformer(),
             ProcessType.FINAL_ANSWER: FinalAnswerTransformer(),
             ProcessType.ERROR: default_transformer,
+            ProcessType.WARNING: default_transformer,
             ProcessType.OTHER: default_transformer,
             ProcessType.SEARCH_CONTENT: default_transformer,
             ProcessType.TOKEN_COUNT: TokenCountTransformer(),
@@ -533,6 +544,8 @@ class MessageObserver:
             process_type, self.transformers[ProcessType.OTHER])
         formatted_content = transformer.transform(
             content=content, lang=self.lang, agent_name=agent_name, **kwargs)
+        if isinstance(formatted_content, str):
+            formatted_content = _ANSI_ESCAPE_PATTERN.sub("", formatted_content)
         nl2a_content = None
         nl2a_state_content = None
 

--- a/test/backend/services/test_nl2agent_service.py
+++ b/test/backend/services/test_nl2agent_service.py
@@ -78,7 +78,7 @@ def test_boundary_observer_stops_after_queuing_valid_nl2a_payload():
     observer.add_message("nl2agent", ProcessType.FINAL_ANSWER, "<user_break>")
     observer.add_message(
         "nl2agent",
-        ProcessType.ERROR,
+        ProcessType.WARNING,
         "Agent execution interrupted by external stop signal",
     )
     observer.add_message("nl2agent", ProcessType.ERROR, "real runtime failure")

--- a/test/backend/utils/test_llm_utils.py
+++ b/test/backend/utils/test_llm_utils.py
@@ -594,6 +594,7 @@ class TestAdditionalLLMUtilsTests:
 
     def test_call_llm_for_system_prompt_with_reasoning_content(self, mocker: MockFixture):
         """Test call_llm_for_system_prompt with reasoning_content"""
+        mock_logger = mocker.patch('backend.utils.llm_utils.logger')
         mock_get_model_by_id = mocker.patch('backend.utils.llm_utils.get_model_by_model_id')
         mock_adapter = mocker.patch('backend.utils.llm_utils.get_llm_adapter_from_config')
 
@@ -603,6 +604,7 @@ class TestAdditionalLLMUtilsTests:
         mock_chunk = MagicMock()
         mock_chunk.choices = [MagicMock()]
         mock_chunk.choices[0].delta.content = "Generated prompt"
+        mock_chunk.choices[0].delta.reasoning = None
         mock_chunk.choices[0].delta.reasoning_content = "Some reasoning"
 
         mock_llm_instance.client = MagicMock()
@@ -616,6 +618,39 @@ class TestAdditionalLLMUtilsTests:
         )
 
         assert result == "Generated prompt"
+        mock_logger.debug.assert_any_call(
+            "Received reasoning_content (metadata only, not filtering content)"
+        )
+
+    def test_call_llm_for_system_prompt_with_reasoning(self, mocker: MockFixture):
+        """Test call_llm_for_system_prompt with the alternate reasoning field."""
+        mock_logger = mocker.patch('backend.utils.llm_utils.logger')
+        mock_get_model_by_id = mocker.patch('backend.utils.llm_utils.get_model_by_model_id')
+        mock_adapter = mocker.patch('backend.utils.llm_utils.get_llm_adapter_from_config')
+
+        mock_get_model_by_id.return_value = {"base_url": "http://example.com", "api_key": "fake-key"}
+
+        mock_llm_instance = mock_adapter.return_value
+        mock_chunk = MagicMock()
+        mock_chunk.choices = [MagicMock()]
+        mock_chunk.choices[0].delta.content = "Generated prompt"
+        mock_chunk.choices[0].delta.reasoning = "Some reasoning"
+        mock_chunk.choices[0].delta.reasoning_content = None
+
+        mock_llm_instance.client = MagicMock()
+        mock_llm_instance.client.chat.completions.create.return_value = [mock_chunk]
+        mock_llm_instance._prepare_completion_kwargs.return_value = {}
+
+        result = call_llm_for_system_prompt(
+            1,
+            "user prompt",
+            "system prompt",
+        )
+
+        assert result == "Generated prompt"
+        mock_logger.debug.assert_any_call(
+            "Received reasoning_content (metadata only, not filtering content)"
+        )
 
     def test_call_llm_for_system_prompt_multiple_chunks(self, mocker: MockFixture):
         """Test call_llm_for_system_prompt with multiple chunks"""

--- a/test/sdk/core/agents/test_nexent_agent.py
+++ b/test/sdk/core/agents/test_nexent_agent.py
@@ -1955,9 +1955,9 @@ def test_agent_run_with_observer_with_error_in_step(nexent_agent_instance, mock_
     # Execute
     nexent_agent_instance.agent_run_with_observer("test query")
 
-    # Verify error message was added
+    # Recoverable action-step errors must not imply that the run terminated.
     mock_core_agent.observer.add_message.assert_any_call(
-        "", ProcessType.ERROR, "Test error occurred")
+        "", ProcessType.WARNING, "Test error occurred")
 
 
 def test_agent_run_with_observer_skips_non_action_step(nexent_agent_instance, mock_core_agent):
@@ -2007,7 +2007,7 @@ def test_agent_run_with_observer_with_stop_event_set(nexent_agent_instance, mock
 
     # Verify stop event message was added
     mock_core_agent.observer.add_message.assert_any_call(
-        "test_agent", ProcessType.ERROR, "Agent execution interrupted by external stop signal"
+        "test_agent", ProcessType.WARNING, "Agent execution interrupted by external stop signal"
     )
 
 
@@ -4998,7 +4998,7 @@ class TestCreateBuiltinToolAndFileWorkspaceLifecycle:
 
         upload_tool.forward.assert_called_once_with(str(failed_file), "outputs/failed.txt")
         assert any(
-            call_args.args[1] == ProcessType.ERROR
+            call_args.args[1] == ProcessType.WARNING
             for call_args in nexent_agent_instance.observer.add_message.call_args_list
         )
 

--- a/test/sdk/core/agents/test_nexent_agent.py
+++ b/test/sdk/core/agents/test_nexent_agent.py
@@ -120,6 +120,7 @@ class _MockProcessType:
     TOKEN_COUNT = "token_count"
     FINAL_ANSWER = "final_answer"
     ERROR = "error"
+    WARNING = "warning"
     NL2A = "nl2a"
     FILE_ARTIFACT = "file_artifact"
 

--- a/test/sdk/core/models/test_openai_llm.py
+++ b/test/sdk/core/models/test_openai_llm.py
@@ -790,12 +790,14 @@ def test_call_with_reasoning_content(openai_model_instance):
     mock_chunk1.choices = [MagicMock()]
     mock_chunk1.choices[0].delta.content = "Let me think about this"
     mock_chunk1.choices[0].delta.role = "assistant"
+    mock_chunk1.choices[0].delta.reasoning = None
     mock_chunk1.choices[0].delta.reasoning_content = "This is a reasoning step"
 
     mock_chunk2 = MagicMock()
     mock_chunk2.choices = [MagicMock()]
     mock_chunk2.choices[0].delta.content = "Response"
     mock_chunk2.choices[0].delta.role = None
+    mock_chunk2.choices[0].delta.reasoning = None
     mock_chunk2.choices[0].delta.reasoning_content = None
     mock_chunk2.usage = MagicMock()
     mock_chunk2.usage.prompt_tokens = 5
@@ -828,6 +830,36 @@ def test_call_with_reasoning_content(openai_model_instance):
             "Response")
 
 
+def test_call_with_reasoning_field(openai_model_instance):
+    """Test __call__ handles providers that stream reasoning in the reasoning field."""
+    messages = [{"role": "user", "content": [{"text": "Hello"}]}]
+
+    mock_chunk = MagicMock()
+    mock_chunk.choices = [MagicMock()]
+    mock_chunk.choices[0].delta.content = "Response"
+    mock_chunk.choices[0].delta.role = "assistant"
+    mock_chunk.choices[0].delta.reasoning = "Alternate reasoning field"
+    mock_chunk.usage = MagicMock()
+    mock_chunk.usage.prompt_tokens = 5
+    mock_chunk.usage.total_tokens = 8
+
+    mock_result_message = MagicMock()
+    mock_result_message.raw = [mock_chunk]
+    mock_result_message.role = MagicMock()
+
+    with patch.object(openai_model_instance, "_prepare_completion_kwargs", return_value={}), \
+            patch.object(mock_models_module.ChatMessage, "from_dict", return_value=mock_result_message):
+        openai_model_instance.client.chat.completions.create.return_value = [mock_chunk]
+
+        result = openai_model_instance.__call__(messages)
+
+        assert result == mock_result_message
+        openai_model_instance.observer.add_model_reasoning_content.assert_called_once_with(
+            "Alternate reasoning field"
+        )
+        openai_model_instance.observer.add_model_new_token.assert_called_once_with("Response")
+
+
 def test_call_with_multiple_reasoning_content_chunks(openai_model_instance):
     """Test __call__ method handles multiple chunks with reasoning_content"""
 
@@ -838,18 +870,21 @@ def test_call_with_multiple_reasoning_content_chunks(openai_model_instance):
     mock_chunk1.choices = [MagicMock()]
     mock_chunk1.choices[0].delta.content = "Let me"
     mock_chunk1.choices[0].delta.role = "assistant"
+    mock_chunk1.choices[0].delta.reasoning = None
     mock_chunk1.choices[0].delta.reasoning_content = "First reasoning step"
 
     mock_chunk2 = MagicMock()
     mock_chunk2.choices = [MagicMock()]
     mock_chunk2.choices[0].delta.content = " think"
     mock_chunk2.choices[0].delta.role = None
+    mock_chunk2.choices[0].delta.reasoning = None
     mock_chunk2.choices[0].delta.reasoning_content = "Second reasoning step"
 
     mock_chunk3 = MagicMock()
     mock_chunk3.choices = [MagicMock()]
     mock_chunk3.choices[0].delta.content = " about this"
     mock_chunk3.choices[0].delta.role = None
+    mock_chunk3.choices[0].delta.reasoning = None
     mock_chunk3.choices[0].delta.reasoning_content = None
     mock_chunk3.usage = MagicMock()
     mock_chunk3.usage.prompt_tokens = 5
@@ -896,12 +931,14 @@ def test_call_with_reasoning_content_only(openai_model_instance):
     mock_chunk1.choices = [MagicMock()]
     mock_chunk1.choices[0].delta.content = None
     mock_chunk1.choices[0].delta.role = "assistant"
+    mock_chunk1.choices[0].delta.reasoning = None
     mock_chunk1.choices[0].delta.reasoning_content = "Pure reasoning content"
 
     mock_chunk2 = MagicMock()
     mock_chunk2.choices = [MagicMock()]
     mock_chunk2.choices[0].delta.content = "Final response"
     mock_chunk2.choices[0].delta.role = None
+    mock_chunk2.choices[0].delta.reasoning = None
     mock_chunk2.choices[0].delta.reasoning_content = None
     mock_chunk2.usage = MagicMock()
     mock_chunk2.usage.prompt_tokens = 5
@@ -942,6 +979,7 @@ def test_call_rejects_reasoning_only_response_and_records_diagnostics(
     reasoning_chunk.choices = [MagicMock()]
     reasoning_chunk.choices[0].delta.content = None
     reasoning_chunk.choices[0].delta.role = "assistant"
+    reasoning_chunk.choices[0].delta.reasoning = None
     reasoning_chunk.choices[0].delta.reasoning_content = "Internal reasoning"
     reasoning_chunk.choices[0].finish_reason = None
     reasoning_chunk.usage = None
@@ -950,6 +988,7 @@ def test_call_rejects_reasoning_only_response_and_records_diagnostics(
     final_chunk.choices = [MagicMock()]
     final_chunk.choices[0].delta.content = None
     final_chunk.choices[0].delta.role = None
+    final_chunk.choices[0].delta.reasoning = None
     final_chunk.choices[0].delta.reasoning_content = None
     final_chunk.choices[0].finish_reason = "length"
     final_chunk.usage = MagicMock(prompt_tokens=10, completion_tokens=20)
@@ -985,6 +1024,7 @@ def test_call_with_reasoning_content_and_content_together(openai_model_instance)
     mock_chunk.choices = [MagicMock()]
     mock_chunk.choices[0].delta.content = "Response text"
     mock_chunk.choices[0].delta.role = "assistant"
+    mock_chunk.choices[0].delta.reasoning = None
     mock_chunk.choices[0].delta.reasoning_content = "Reasoning alongside content"
     mock_chunk.usage = MagicMock()
     mock_chunk.usage.prompt_tokens = 5
@@ -1067,18 +1107,21 @@ def test_call_with_monitoring_and_token_tracker(openai_model_instance):
     mock_chunk1.choices = [MagicMock()]
     mock_chunk1.choices[0].delta.content = "Hello"
     mock_chunk1.choices[0].delta.role = "assistant"
+    mock_chunk1.choices[0].delta.reasoning = None
     mock_chunk1.choices[0].delta.reasoning_content = None
 
     mock_chunk2 = MagicMock()
     mock_chunk2.choices = [MagicMock()]
     mock_chunk2.choices[0].delta.content = " world"
     mock_chunk2.choices[0].delta.role = None
+    mock_chunk2.choices[0].delta.reasoning = None
     mock_chunk2.choices[0].delta.reasoning_content = None
 
     mock_chunk3 = MagicMock()
     mock_chunk3.choices = [MagicMock()]
     mock_chunk3.choices[0].delta.content = None
     mock_chunk3.choices[0].delta.role = None
+    mock_chunk3.choices[0].delta.reasoning = None
     mock_chunk3.choices[0].delta.reasoning_content = None
     mock_chunk3.usage = MagicMock()
     mock_chunk3.usage.prompt_tokens = 10
@@ -1126,12 +1169,14 @@ def test_call_with_token_tracker_on_reasoning_content(openai_model_instance):
     mock_chunk1.choices = [MagicMock()]
     mock_chunk1.choices[0].delta.content = None
     mock_chunk1.choices[0].delta.role = "assistant"
+    mock_chunk1.choices[0].delta.reasoning = None
     mock_chunk1.choices[0].delta.reasoning_content = "Thinking..."
 
     mock_chunk2 = MagicMock()
     mock_chunk2.choices = [MagicMock()]
     mock_chunk2.choices[0].delta.content = "Response"
     mock_chunk2.choices[0].delta.role = None
+    mock_chunk2.choices[0].delta.reasoning = None
     mock_chunk2.choices[0].delta.reasoning_content = None
     mock_chunk2.usage = MagicMock()
     mock_chunk2.usage.prompt_tokens = 5
@@ -1170,6 +1215,7 @@ def test_call_with_stop_event_and_token_tracker(openai_model_instance):
     mock_chunk.choices = [MagicMock()]
     mock_chunk.choices[0].delta.content = "Response"
     mock_chunk.choices[0].delta.role = "assistant"
+    mock_chunk.choices[0].delta.reasoning = None
     mock_chunk.choices[0].delta.reasoning_content = None
 
     with patch.object(openai_model_instance, "_prepare_completion_kwargs", return_value={}):
@@ -1753,6 +1799,7 @@ def test_call_token_estimation_with_list_content(openai_model_instance):
     mock_chunk.choices = [MagicMock()]
     mock_chunk.choices[0].delta.content = "Response"
     mock_chunk.choices[0].delta.role = "assistant"
+    mock_chunk.choices[0].delta.reasoning = None
     mock_chunk.choices[0].delta.reasoning_content = None
     mock_chunk.usage = None  # No usage info to trigger token estimation
 
@@ -1801,6 +1848,7 @@ def test_prompt_cache_plan_records_unknown_capability_without_payload_directive(
     mock_chunk.choices = [MagicMock()]
     mock_chunk.choices[0].delta.content = "Response"
     mock_chunk.choices[0].delta.role = "assistant"
+    mock_chunk.choices[0].delta.reasoning = None
     mock_chunk.choices[0].delta.reasoning_content = None
     mock_chunk.usage = MagicMock()
     mock_chunk.usage.prompt_tokens = 10
@@ -1827,6 +1875,7 @@ def test_prompt_cache_usage_extracts_openai_cached_tokens(openai_model_instance)
     mock_chunk.choices = [MagicMock()]
     mock_chunk.choices[0].delta.content = "Response"
     mock_chunk.choices[0].delta.role = "assistant"
+    mock_chunk.choices[0].delta.reasoning = None
     mock_chunk.choices[0].delta.reasoning_content = None
     mock_chunk.usage = MagicMock()
     mock_chunk.usage.prompt_tokens = 100
@@ -1856,6 +1905,7 @@ def test_provider_adapter_preserves_context_manager_tool_order(openai_model_inst
     mock_chunk.choices = [MagicMock()]
     mock_chunk.choices[0].delta.content = "ok"
     mock_chunk.choices[0].delta.role = "assistant"
+    mock_chunk.choices[0].delta.reasoning = None
     mock_chunk.choices[0].delta.reasoning_content = None
     mock_chunk.choices[0].finish_reason = "stop"
     mock_chunk.usage = MagicMock(prompt_tokens=1, completion_tokens=1)
@@ -1891,6 +1941,7 @@ def _make_content_chunk(content: str = "hi"):
     chunk.choices = [MagicMock()]
     chunk.choices[0].delta.content = content
     chunk.choices[0].delta.role = "assistant"
+    chunk.choices[0].delta.reasoning = None
     chunk.choices[0].delta.reasoning_content = None
     chunk.usage = MagicMock()
     chunk.usage.prompt_tokens = 1
@@ -2274,6 +2325,7 @@ def test_streaming_without_usage_falls_back_to_input_text(openai_model_instance)
     clean_delta = types.SimpleNamespace()
     clean_delta.content = "ok"
     clean_delta.role = "assistant"
+    clean_delta.reasoning = None
     clean_delta.reasoning_content = None
     clean_choice.delta = clean_delta
     clean_chunk.choices = [clean_choice]

--- a/test/sdk/core/utils/test_observer.py
+++ b/test/sdk/core/utils/test_observer.py
@@ -274,6 +274,22 @@ class TestMessageObserver:
         assert message_data["type"] == ProcessType.STEP_COUNT.value
         assert "Step 3" in message_data["content"]
 
+    def test_add_message_strips_terminal_ansi_sequences(self):
+        """Console colour and title sequences must not leak into SSE text."""
+        observer = MessageObserver(lang="en")
+
+        observer.add_message(
+            "test_agent",
+            ProcessType.WARNING,
+            "\x1b[31mHTTPError\x1b[0m \x1b]0;kernel traceback\x07details",
+        )
+
+        message_data = json.loads(observer.get_cached_message()[0])
+        assert message_data == {
+            "type": ProcessType.WARNING.value,
+            "content": "HTTPError details",
+        }
+
     def test_add_message_uses_context_tool_call_id_when_explicit_value_is_none(self):
         """Preserve the active tool ID when a caller passes an empty override."""
         observer = MessageObserver(lang="en")


### PR DESCRIPTION
🐛 Bugfix: Changed ReAct recoverable exceptions to yellow warnings.
[Specification Details]
1. ReAct 可恢复异常改为黄色 warning，包括：代码块/JSON 解析失败，未生成可执行工具调用，Sandbox kernel watchdog 超时及自动重建，中间工具执行失败后继续重试，用户主动停止，输出文件上传失败但主流程已完成。
2. 实时消息和历史消息统一清理 ANSI 控制码，解决 �[31m、[39m 等乱码。
3. 新增黄色警告卡片及对应图标。
4. cherry pick新版openai的reasoning思考字段处理。
[Test Results]
<img width="854" height="120" alt="img_v3_0215c_cf711e2d-1257-464f-8ebe-9bed62de053g" src="https://github.com/user-attachments/assets/eec82cd9-ab0c-48cd-a3ff-42a637622bf6" />
<img width="846" height="607" alt="img_v3_0215c_bf3d9874-70fa-493f-adb9-d9b0067bfbdg" src="https://github.com/user-attachments/assets/8ca18680-47e0-4680-8459-7cabf2575bc9" />
