### PR TITLE
fix: generate conversation titles with session model

### DIFF
--- a/backend/apps/conversation_management_app.py
+++ b/backend/apps/conversation_management_app.py
@@ -292,11 +292,17 @@ async def generate_conversation_title_endpoint(
         user_id, tenant_id, language = get_current_user_info(
             authorization=authorization, request=http_request)
         title = await generate_conversation_title_service(
-            request.conversation_id, request.question, user_id, tenant_id=tenant_id, language=language)
+            request.conversation_id, request.question, user_id, tenant_id=tenant_id,
+            language=language, model_id=request.model_id)
         return ConversationResponse(code=0, message="success", data=title)
     except TokenExpiredError as e:
         logging.warning("Session expired")
         raise HTTPException(status_code=HTTPStatus.UNAUTHORIZED, detail=str(e))
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
     except Exception as e:
         logging.error(f"Failed to generate conversation title: {str(e)}")
         raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=str(e))

--- a/backend/apps/northbound_app.py
+++ b/backend/apps/northbound_app.py
@@ -611,9 +611,15 @@ async def generate_title(payload: GenerateTitleRequest, request: Request):
             conversation_id=payload.conversation_id,
             question=payload.question,
             language=get_user_language(request),
+            model_id=payload.model_id,
         )
     except ConversationNotFoundError as exc:
         raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail=str(exc)) from exc
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
     except HTTPException:
         raise
     except Exception as exc:

--- a/backend/consts/model.py
+++ b/backend/consts/model.py
@@ -708,6 +708,7 @@ class OptimizePromptFromDebugRequest(BaseModel):
 class GenerateTitleRequest(BaseModel):
     conversation_id: int
     question: str
+    model_id: Optional[int] = Field(default=None, gt=0)
 
 
 class AgentSkillInstanceRequest(BaseModel):

--- a/backend/services/conversation_management_service.py
+++ b/backend/services/conversation_management_service.py
@@ -43,6 +43,7 @@ from database.conversation_db import (
     update_message_unit_content,
     update_message_unit_status,
 )
+from database.model_management_db import get_model_by_model_id
 from nexent.monitor import set_monitoring_context, set_monitoring_operation
 from services.model_gateway_service import get_llm_adapter_from_config
 from utils.config_utils import tenant_config_manager
@@ -306,7 +307,8 @@ def save_conversation_assistant(request: AgentRequest, messages: List[str], user
     )
 
 
-def call_llm_for_title(question: str, tenant_id: str, language: str = LANGUAGE["ZH"]) -> str:
+def call_llm_for_title(question: str, tenant_id: str, language: str = LANGUAGE["ZH"],
+                       model_id: Optional[int] = None) -> str:
     """
     Call LLM to generate a title from a user question
 
@@ -314,6 +316,7 @@ def call_llm_for_title(question: str, tenant_id: str, language: str = LANGUAGE["
         question: User's question content
         tenant_id: Tenant ID
         language: Language code ('zh' for Chinese, 'en' for English)
+        model_id: Optional tenant-scoped LLM model ID
 
     Returns:
         str: Generated title
@@ -321,8 +324,15 @@ def call_llm_for_title(question: str, tenant_id: str, language: str = LANGUAGE["
     prompt_template = get_generate_title_prompt_template(language=language)
     set_monitoring_context(tenant_id=tenant_id, user_id=None)
 
-    model_config = tenant_config_manager.get_model_config(
-        key=MODEL_CONFIG_MAPPING["llm"], tenant_id=tenant_id)
+    if model_id is not None:
+        model_config = get_model_by_model_id(model_id, tenant_id)
+        if not model_config:
+            raise ValidationError("Selected model is unavailable")
+        if model_config.get("model_type") != "llm":
+            raise ValidationError("Selected model is not an LLM model")
+    else:
+        model_config = tenant_config_manager.get_model_config(
+            key=MODEL_CONFIG_MAPPING["llm"], tenant_id=tenant_id)
     display_name = model_config.get("display_name", "") if model_config else ""
     set_monitoring_operation("title_generation", display_name=display_name or None)
 
@@ -355,8 +365,12 @@ def call_llm_for_title(question: str, tenant_id: str, language: str = LANGUAGE["
     # Call the model (gateway adapter forwards to the wrapped OpenAIModel)
     response = llm(messages)
     if not response or not response.content or not response.content.strip():
-        return DEFAULT_EN_TITLE if language == LANGUAGE["EN"] else DEFAULT_ZH_TITLE
-    return remove_think_blocks(response.content.strip())
+        title = DEFAULT_EN_TITLE if language == LANGUAGE["EN"] else DEFAULT_ZH_TITLE
+    else:
+        title = remove_think_blocks(response.content.strip())
+
+    logger.info("title_generation: %s -> %s", display_name or "unknown", title)
+    return title
 
 
 def update_conversation_title(conversation_id: int, title: str, user_id: str = None) -> bool:
@@ -1018,7 +1032,9 @@ def get_sources_service(conversation_id: Optional[int], message_id: Optional[int
         }
 
 
-async def generate_conversation_title_service(conversation_id: int, question: str, user_id: str, tenant_id: str, language: str = LANGUAGE["ZH"]) -> str:
+async def generate_conversation_title_service(conversation_id: int, question: str, user_id: str, tenant_id: str,
+                                              language: str = LANGUAGE["ZH"],
+                                              model_id: Optional[int] = None) -> str:
     """
     Generate conversation title from user question
 
@@ -1031,19 +1047,22 @@ async def generate_conversation_title_service(conversation_id: int, question: st
         user_id: User ID
         tenant_id: Tenant ID
         language: Language code ('zh' for Chinese, 'en' for English)
+        model_id: Optional tenant-scoped LLM model ID
 
     Returns:
         str: Generated title
     """
     try:
         # Call LLM to generate title from question in a separate thread to avoid blocking
-        title = await asyncio.to_thread(call_llm_for_title, question, tenant_id, language)
+        title = await asyncio.to_thread(call_llm_for_title, question, tenant_id, language, model_id)
 
         # Update conversation title
         update_conversation_title(conversation_id, title, user_id)
 
         return title
 
+    except ValidationError:
+        raise
     except Exception as e:
         logging.error(f"Failed to generate conversation title: {str(e)}")
         raise Exception(str(e))

--- a/backend/services/northbound_service.py
+++ b/backend/services/northbound_service.py
@@ -866,6 +866,7 @@ async def generate_conversation_title(
     conversation_id: int,
     question: str,
     language: str,
+    model_id: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Generate and persist a conversation title from the user's question."""
     title = await generate_conversation_title_service(
@@ -874,5 +875,6 @@ async def generate_conversation_title(
         user_id=ctx.user_id,
         tenant_id=ctx.tenant_id,
         language=language,
+        model_id=model_id,
     )
     return {"message": "success", "data": title, "requestId": ctx.request_id}

--- a/frontend/app/[locale]/chat/internal/chatInterface.tsx
+++ b/frontend/app/[locale]/chat/internal/chatInterface.tsx
@@ -59,6 +59,7 @@ import {
   StreamingMessage,
 } from "@/app/chat/streaming/chatStreamHandler";
 import { formatConversationMessagesFromResponse } from "@/lib/chatMessageExtractor";
+import { createConversationTitleRequest } from "@/lib/conversationTitle";
 
 import { Button, Checkbox, Input, Layout, message, Modal } from "antd";
 import log from "@/lib/logger";
@@ -473,6 +474,7 @@ export function ChatInterface() {
     const selectedAgentIdForRun = selectedAgentId;
     const agentIdForRun =
       selectedAgentIdForRun !== null ? Number(selectedAgentIdForRun) : null;
+    const modelIdForRun = selectedModelId;
     let cid: number | null = null; // set after guard, used in try/catch/finally
 
     // Prepare attachment information
@@ -790,8 +792,8 @@ export function ChatInterface() {
       }
 
       // Add selected model_id for agent run
-      if (selectedModelId !== null) {
-        runAgentParams.model_id = selectedModelId;
+      if (modelIdForRun !== null) {
+        runAgentParams.model_id = modelIdForRun;
       }
 
       const reader = await conversationService.runAgent(
@@ -935,10 +937,13 @@ export function ChatInterface() {
           if (!titleGenerationConversationIdsRef.current.has(conversationId)) {
             titleGenerationConversationIdsRef.current.add(conversationId);
             void conversationService
-              .generateTitle({
-                conversation_id: conversationId,
-                question: userMessageContent,
-              })
+              .generateTitle(
+                createConversationTitleRequest(
+                  conversationId,
+                  userMessageContent,
+                  modelIdForRun
+                )
+              )
               .then((title) => {
                 if (title) {
                   conversationManagement.setConversationTitle(title);

--- a/frontend/lib/conversationTitle.ts
+++ b/frontend/lib/conversationTitle.ts
@@ -1,0 +1,15 @@
+export interface GenerateConversationTitleParams {
+  conversation_id: number;
+  question: string;
+  model_id?: number;
+}
+
+export const createConversationTitleRequest = (
+  conversationId: number,
+  question: string,
+  modelId: number | null
+): GenerateConversationTitleParams => ({
+  conversation_id: conversationId,
+  question,
+  ...(modelId !== null ? { model_id: modelId } : {}),
+});

--- a/frontend/services/conversationService.ts
+++ b/frontend/services/conversationService.ts
@@ -10,6 +10,7 @@ import type {
 } from "@/types/conversation";
 import { getAuthHeaders, fetchWithAuth } from "@/lib/auth";
 import log from "@/lib/logger";
+import type { GenerateConversationTitleParams } from "@/lib/conversationTitle";
 import type {
   ConversationKnowledgeScope,
   KnowledgeCapabilities,
@@ -1154,7 +1155,7 @@ export const conversationService = {
   },
 
   // Generate conversation title from user question
-  async generateTitle(params: { conversation_id: number; question: string }) {
+  async generateTitle(params: GenerateConversationTitleParams) {
     const response = await fetch(API_ENDPOINTS.conversation.generateTitle, {
       method: "POST",
       headers: getAuthHeaders(),

--- a/frontend/tests/conversationTitle.test.ts
+++ b/frontend/tests/conversationTitle.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createConversationTitleRequest,
+  // @ts-expect-error -- Node's built-in TypeScript runner needs the extension.
+} from "../lib/conversationTitle.ts";
+
+test("uses the model snapshot associated with the agent run", () => {
+  let selectedModelId: number | null = 7;
+  const modelIdForRun = selectedModelId;
+  const request = createConversationTitleRequest(42, "Question", modelIdForRun);
+
+  selectedModelId = 9;
+
+  assert.equal(selectedModelId, 9);
+  assert.deepEqual(request, {
+    conversation_id: 42,
+    question: "Question",
+    model_id: 7,
+  });
+});
+
+test("omits model_id for legacy default-model behavior", () => {
+  assert.deepEqual(createConversationTitleRequest(42, "Question", null), {
+    conversation_id: 42,
+    question: "Question",
+  });
+});

--- a/test/backend/app/test_conversation_management_app.py
+++ b/test/backend/app/test_conversation_management_app.py
@@ -8,6 +8,8 @@ import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
+from consts.exceptions import ValidationError
+
 # Dynamically determine the backend path
 current_dir = os.path.dirname(os.path.abspath(__file__))
 backend_dir = os.path.abspath(os.path.join(current_dir, "../../../backend"))
@@ -535,6 +537,7 @@ async def test_generate_title_success(conversation_mocks):
     request_obj = MagicMock()
     request_obj.conversation_id = conversation_id
     request_obj.question = question
+    request_obj.model_id = 7
 
     http_request = MagicMock()
 
@@ -542,7 +545,7 @@ async def test_generate_title_success(conversation_mocks):
 
     assert result.code == 0 and result.data == dummy_title
     conversation_mocks['generate_title_service'].assert_called_once_with(
-        conversation_id, question, "user_id", tenant_id="tenant_id", language="en")
+        conversation_id, question, "user_id", tenant_id="tenant_id", language="en", model_id=7)
 
 
 @pytest.mark.asyncio
@@ -551,6 +554,7 @@ async def test_generate_title_failure(conversation_mocks):
     request_obj = MagicMock()
     request_obj.conversation_id = 1
     request_obj.question = "Test question"
+    request_obj.model_id = None
     http_request = MagicMock()
 
     conversation_mocks['get_user_info'].side_effect = Exception("auth fail")
@@ -560,6 +564,20 @@ async def test_generate_title_failure(conversation_mocks):
 
     assert exc_info.value.status_code == 500
     conversation_mocks['logging'].error.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_generate_title_validation_error(conversation_mocks):
+    request_obj = MagicMock(conversation_id=1, question="Question", model_id=7)
+    conversation_mocks['get_user_info'].return_value = ("user_id", "tenant_id", "en")
+    conversation_mocks['generate_title_service'].side_effect = ValidationError(
+        "Selected model is unavailable")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await generate_conversation_title_endpoint(
+            request_obj, MagicMock(), authorization="Bearer test-token")
+
+    assert exc_info.value.status_code == 422
 
 
 # update_opinion_endpoint

--- a/test/backend/app/test_northbound_app.py
+++ b/test/backend/app/test_northbound_app.py
@@ -761,7 +761,7 @@ def test_generate_title_success():
         resp = client.post(
             "/nb/v1/generate_title",
             headers=_build_headers(),
-            json={"conversation_id": 42, "question": "Summarize this conversation"},
+            json={"conversation_id": 42, "question": "Summarize this conversation", "model_id": 7},
         )
 
     assert resp.status_code == 200
@@ -771,7 +771,23 @@ def test_generate_title_success():
         conversation_id=42,
         question="Summarize this conversation",
         language="en",
+        model_id=7,
     )
+
+
+def test_generate_title_validation_error():
+    with patch('apps.northbound_app._get_northbound_context', new_callable=AsyncMock) as mock_ctx, \
+            patch('apps.northbound_app.generate_conversation_title', new_callable=AsyncMock) as mock_generate:
+        mock_ctx.return_value = MagicMock()
+        mock_generate.side_effect = ValidationError("Selected model is unavailable")
+
+        resp = client.post(
+            "/nb/v1/generate_title",
+            headers=_build_headers(),
+            json={"conversation_id": 42, "question": "Question", "model_id": 7},
+        )
+
+    assert resp.status_code == 422
 
 
 # =============================================================================

--- a/test/backend/services/test_conversation_management_service.py
+++ b/test/backend/services/test_conversation_management_service.py
@@ -187,6 +187,7 @@ backend_database_mod.client = backend_database_client_mod
 sys.modules["backend.database"] = backend_database_mod
 
 from backend.consts.model import MessageRequest, AgentRequest, MessageUnit
+from consts.exceptions import ValidationError
 import unittest
 import json
 import asyncio
@@ -517,6 +518,67 @@ class TestConversationManagementService(unittest.TestCase):
         mock_openai.assert_called_once()
         mock_llm_instance.assert_called_once()
         mock_get_prompt_template.assert_called_once_with(language='zh')
+
+    @patch('backend.services.conversation_management_service.get_llm_adapter_from_config')
+    @patch('backend.services.conversation_management_service.get_generate_title_prompt_template')
+    @patch('backend.services.conversation_management_service.tenant_config_manager.get_model_config')
+    @patch('backend.services.conversation_management_service.get_model_by_model_id')
+    def test_call_llm_for_title_uses_selected_tenant_model(
+            self, mock_get_model, mock_get_default_model, mock_get_prompt, mock_adapter):
+        selected_config = {
+            "model_id": 7,
+            "model_type": "llm",
+            "display_name": "Selected LLM",
+            "model_factory": "openai",
+        }
+        mock_get_model.return_value = selected_config
+        mock_get_prompt.return_value = {
+            "SYSTEM_PROMPT": "Generate a short title",
+            "USER_PROMPT": "{{question}}",
+        }
+        mock_adapter.return_value.return_value = MagicMock(content="Selected title")
+
+        with self.assertLogs("conversation_management_service", level="INFO") as logs:
+            result = call_llm_for_title("Question", self.tenant_id, "en", model_id=7)
+
+        self.assertEqual(result, "Selected title")
+        self.assertIn(
+            "title_generation: Selected LLM -> Selected title",
+            "\n".join(logs.output),
+        )
+        mock_get_model.assert_called_once_with(7, self.tenant_id)
+        mock_get_default_model.assert_not_called()
+        mock_adapter.assert_called_once_with(
+            selected_config,
+            self.tenant_id,
+            temperature=0.7,
+            top_p=0.95,
+            stream=False,
+            timeout_seconds=None,
+            display_name="Selected LLM",
+        )
+
+    @patch('backend.services.conversation_management_service.get_llm_adapter_from_config')
+    @patch('backend.services.conversation_management_service.get_model_by_model_id')
+    def test_call_llm_for_title_rejects_unavailable_selected_model(
+            self, mock_get_model, mock_adapter):
+        mock_get_model.return_value = None
+
+        with self.assertRaisesRegex(ValidationError, "Selected model is unavailable"):
+            call_llm_for_title("Question", self.tenant_id, model_id=7)
+
+        mock_adapter.assert_not_called()
+
+    @patch('backend.services.conversation_management_service.get_llm_adapter_from_config')
+    @patch('backend.services.conversation_management_service.get_model_by_model_id')
+    def test_call_llm_for_title_rejects_non_llm_selected_model(
+            self, mock_get_model, mock_adapter):
+        mock_get_model.return_value = {"model_id": 7, "model_type": "embedding"}
+
+        with self.assertRaisesRegex(ValidationError, "Selected model is not an LLM model"):
+            call_llm_for_title("Question", self.tenant_id, model_id=7)
+
+        mock_adapter.assert_not_called()
 
     @patch('backend.services.conversation_management_service.rename_conversation')
     def test_update_conversation_title(self, mock_rename_conversation):
@@ -1076,9 +1138,35 @@ class TestConversationManagementService(unittest.TestCase):
         # Assert
         self.assertEqual(result, "Python Tips")
         mock_call_llm.assert_called_once_with(
-            "How to use Python effectively?", self.tenant_id, "en")
+            "How to use Python effectively?", self.tenant_id, "en", None)
         mock_update_title.assert_called_once_with(
             123, "Python Tips", self.user_id)
+
+    @patch('backend.services.conversation_management_service.call_llm_for_title')
+    @patch('backend.services.conversation_management_service.update_conversation_title')
+    def test_generate_conversation_title_service_forwards_model_id(
+            self, mock_update_title, mock_call_llm):
+        mock_call_llm.return_value = "Python Tips"
+
+        result = asyncio.run(generate_conversation_title_service(
+            123, "How to use Python?", self.user_id, self.tenant_id, "en", model_id=7))
+
+        self.assertEqual(result, "Python Tips")
+        mock_call_llm.assert_called_once_with(
+            "How to use Python?", self.tenant_id, "en", 7)
+        mock_update_title.assert_called_once_with(123, "Python Tips", self.user_id)
+
+    @patch('backend.services.conversation_management_service.call_llm_for_title')
+    @patch('backend.services.conversation_management_service.update_conversation_title')
+    def test_generate_conversation_title_service_does_not_persist_validation_failure(
+            self, mock_update_title, mock_call_llm):
+        mock_call_llm.side_effect = ValidationError("Selected model is unavailable")
+
+        with self.assertRaises(ValidationError):
+            asyncio.run(generate_conversation_title_service(
+                123, "Question", self.user_id, self.tenant_id, model_id=7))
+
+        mock_update_title.assert_not_called()
 
 
 class TestCallLlmForTitleMonitoring(unittest.TestCase):
@@ -1273,8 +1361,10 @@ class TestCallLlmForTitleEdgeCases(unittest.TestCase):
         mock_llm.return_value = MagicMock(content="  ")  # whitespace only
         mock_model.return_value = mock_llm
 
-        result = call_llm_for_title("test", "tenant-1", "zh")
+        with self.assertLogs("conversation_management_service", level="INFO") as logs:
+            result = call_llm_for_title("test", "tenant-1", "zh")
         self.assertEqual(result, "新对话")  # DEFAULT_ZH_TITLE
+        self.assertIn("title_generation: unknown -> 新对话", "\n".join(logs.output))
 
     @patch('backend.services.conversation_management_service.get_llm_adapter_from_config')
     @patch('backend.services.conversation_management_service.get_generate_title_prompt_template')

--- a/test/backend/services/test_northbound_service.py
+++ b/test/backend/services/test_northbound_service.py
@@ -1022,6 +1022,7 @@ class TestNorthboundModelAndGeneratedTitleServices:
             conversation_id=42,
             question="Summarize this conversation",
             language="en",
+            model_id=7,
         )
 
         assert result == {
@@ -1035,6 +1036,7 @@ class TestNorthboundModelAndGeneratedTitleServices:
             user_id="user-title",
             tenant_id="tenant-title",
             language="en",
+            model_id=7,
         )
 
 

--- a/test/backend/test_model_consts.py
+++ b/test/backend/test_model_consts.py
@@ -565,10 +565,29 @@ def test_generate_title_request():
     """Test GenerateTitleRequest"""
     req = model_consts.GenerateTitleRequest(
         conversation_id=42,
-        question="How do I learn Python?"
+        question="How do I learn Python?",
+        model_id=7,
     )
     assert req.conversation_id == 42
     assert "Python" in req.question
+    assert req.model_id == 7
+
+    legacy_req = model_consts.GenerateTitleRequest(
+        conversation_id=42,
+        question="How do I learn Python?",
+    )
+    assert legacy_req.model_id is None
+
+
+@pytest.mark.parametrize("model_id", [0, -1])
+def test_generate_title_request_rejects_non_positive_model_id(model_id):
+    """GenerateTitleRequest only accepts positive explicit model IDs."""
+    with pytest.raises(ValueError):
+        model_consts.GenerateTitleRequest(
+            conversation_id=42,
+            question="How do I learn Python?",
+            model_id=model_id,
+        )
 
 
 def test_agent_info_request():


### PR DESCRIPTION
## Summary

- pass the send-time session `model_id` from the chat UI to conversation title generation
- resolve and validate the selected tenant-scoped LLM for both regular and Northbound title APIs
- preserve the existing tenant-default LLM fallback when `model_id` is omitted
- log successful title generation as `title_generation: <model> -> <title>`

## Behavior

Explicit model selections must exist in the current tenant, be active, and have type `llm`. Invalid, deleted, cross-tenant, or non-LLM selections return HTTP 422 without generating or persisting a title. The frontend snapshots the model ID used for the Agent run, so a later selector change cannot alter the title model.

## Verification

- backend focused suites: 429 passed
  - `test/backend/test_model_consts.py`: 81
  - `test/backend/app/test_conversation_management_app.py`: 30
  - `test/backend/app/test_northbound_app.py`: 106
  - `test/backend/services/test_conversation_management_service.py`: 98
  - `test/backend/services/test_northbound_service.py`: 114
- frontend title request tests: 2 passed
- affected frontend Prettier check: passed
- `git diff --check`: passed
- ARM64 Docker image build: passed
- Multipass Docker E2E with infra + Nexent + Supabase and no data-process: passed
- tenant-admin E2E: Agent default `qwen3.8-flash`, session selected `deepseek-v4-flash`; Agent and title calls both logged `deepseek-v4-flash`; title persisted successfully
- runtime title log observed: `title_generation: deepseek-v4-flash -> 租户验证-134847`

<img width="966" height="833" alt="image" src="https://github.com/user-attachments/assets/1cf7e4ba-e7f9-4362-b959-8213902f77c4" />

