### PR TITLE
Fix: keep agents available when some bound models fail health checks

### DIFF
--- a/backend/agents/create_agent_info.py
+++ b/backend/agents/create_agent_info.py
@@ -37,7 +37,7 @@ from nexent.memory import models as memory_models
 from consts.capability_profiles import CATALOG as CAPABILITY_CATALOG
 
 from services.file_management_service import validate_urls_access
-from management.services.model.resolver import get_rerank_model
+from management.services.model.resolver import get_rerank_model, is_model_available
 from management.services.knowledge_base.service import (
     ElasticSearchService,
     get_vector_db_core,
@@ -94,6 +94,20 @@ def _create_fixed_search_memory_tool():
     from nexent.core.tools.search_memory_tool import SearchMemoryTool
 
     return SearchMemoryTool()
+
+
+def _select_agent_model_id(
+    agent_model_ids: List[int],
+    override_model_id: int | None,
+    tenant_id: str,
+) -> int | None:
+    """Select the request override or the first configured available model."""
+    if override_model_id is not None:
+        return override_model_id
+    for model_id in agent_model_ids:
+        if is_model_available(get_model_by_model_id(model_id, tenant_id=tenant_id)):
+            return model_id
+    return agent_model_ids[0] if agent_model_ids else None
 
 
 def _get_external_provider_service_for_search():
@@ -1378,9 +1392,9 @@ async def create_agent_config(
         "managed_agents": {agent.name: agent for agent in managed_agents},
         "external_a2a_agents": {agent.agent_id: agent for agent in external_a2a_agents},
     }
-    # AgentInfo stores model_ids (a list); pick the first for the primary model lookup
-    agent_model_ids = agent_info.get("model_ids")
-    model_id_to_use = override_model_id if override_model_id else (agent_model_ids[0] if agent_model_ids else None)
+    # AgentInfo stores model_ids (a list); pick the first available model.
+    agent_model_ids = agent_info.get("model_ids") or []
+    model_id_to_use = _select_agent_model_id(agent_model_ids, override_model_id, tenant_id)
     model_info = None
     if model_id_to_use is not None:
         model_info = get_model_by_model_id(model_id_to_use, tenant_id=tenant_id)

--- a/backend/management/services/agent/management.py
+++ b/backend/management/services/agent/management.py
@@ -809,6 +809,7 @@ async def list_all_agent_info_impl(tenant_id: str, user_id: str) -> list[dict]:
             # Filter out deleted models (delete_flag='Y' in model_record_t)
             model_projection = project_agent_models(agent, tenant_id, model_cache)
             agent.update(model_projection.fields)
+            agent["model_ids"] = model_projection.availability_model_ids
 
             # Use shared availability check function
             _, unavailable_reasons = check_agent_availability(
@@ -817,6 +818,7 @@ async def list_all_agent_info_impl(tenant_id: str, user_id: str) -> list[dict]:
                 agent_info=agent,
                 model_cache=model_cache
             )
+            agent["model_ids"] = model_projection.fields["model_ids"]
             _, unavailable_reasons = apply_deleted_model_reason(
                 not unavailable_reasons,
                 unavailable_reasons,

--- a/backend/management/services/agent/read.py
+++ b/backend/management/services/agent/read.py
@@ -17,6 +17,7 @@ class AgentModelProjection:
 
     fields: dict
     deleted_model_ids: frozenset[int]
+    availability_model_ids: list[int]
 
 
 def project_agent_models(
@@ -30,16 +31,29 @@ def project_agent_models(
     configured_model_ids = agent.get("model_ids") or []
     model_ids = get_valid_model_ids(configured_model_ids, tenant_id)
     records = [
-        resolve_model_record(mid, None if detail else tenant_id, model_cache)
+        (mid, resolve_model_record(mid, None if detail else tenant_id, model_cache))
         for mid in model_ids
     ]
-    names = [record["display_name"] for record in records if record and record.get("display_name")]
+    available_records = [
+        (mid, record) for mid, record in records if is_model_available(record)
+    ]
+    available_model_ids = [mid for mid, _ in available_records]
+    names = [
+        record["display_name"]
+        for _, record in available_records
+        if record and record.get("display_name")
+    ]
     legacy_name = names[0] if names else None
     if detail:
-        legacy_name = records[0].get("display_name") if records and records[0] is not None else None
+        legacy_name = (
+            available_records[0][1].get("display_name")
+            if available_records and available_records[0][1] is not None
+            else None
+        )
     return AgentModelProjection(
-        fields={"model_ids": model_ids, "model_names": names, "model_name": legacy_name},
+        fields={"model_ids": available_model_ids, "model_names": names, "model_name": legacy_name},
         deleted_model_ids=frozenset(configured_model_ids) - frozenset(model_ids),
+        availability_model_ids=model_ids,
     )
 
 
@@ -90,10 +104,9 @@ def check_agent_availability(
     if not model_ids:
         reasons.append(AgentUnavailableReason.MODEL_NOT_CONFIGURED)
     else:
-        reasons.extend(
-            AgentUnavailableReason.MODEL_UNAVAILABLE
-            for mid in model_ids if mid and not is_model_available(resolve_model_record(mid, tenant_id, cache))
-        )
+        model_records = [resolve_model_record(mid, tenant_id, cache) for mid in model_ids if mid]
+        if not any(is_model_available(record) for record in model_records):
+            reasons.append(AgentUnavailableReason.MODEL_UNAVAILABLE)
     return not reasons, reasons
 
 

--- a/backend/management/services/agent/service.py
+++ b/backend/management/services/agent/service.py
@@ -494,6 +494,7 @@ async def get_agent_info_impl(agent_id: int, tenant_id: str, version_no: int = 0
 
     model_projection = project_agent_models(agent_info, tenant_id, detail=True)
     agent_info.update(model_projection.fields)
+    agent_info["model_ids"] = model_projection.availability_model_ids
 
     # Get business logic model display name from model_id
     if agent_info.get("business_logic_model_id") is not None:
@@ -519,6 +520,7 @@ async def get_agent_info_impl(agent_id: int, tenant_id: str, version_no: int = 0
         tenant_id=tenant_id,
         agent_info=agent_info
     )
+    agent_info["model_ids"] = model_projection.fields["model_ids"]
 
     is_available, unavailable_reasons = apply_deleted_model_reason(
         is_available,

--- a/backend/services/agent_version_service.py
+++ b/backend/services/agent_version_service.py
@@ -930,6 +930,15 @@ async def list_published_agents_impl(
                 agent_info=agent_info,
                 model_cache=model_cache
             )
+            for model_id in valid_model_ids:
+                if model_id not in model_cache:
+                    model_cache[model_id] = get_model_by_model_id(model_id, tenant_id)
+            available_model_ids = [
+                model_id
+                for model_id in valid_model_ids
+                if (model_cache.get(model_id) or {}).get("connect_status") == "available"
+            ]
+            agent_info["model_ids"] = available_model_ids
 
             # Preserve the raw data so we can adjust availability for duplicates
             enriched_agents.append({

--- a/frontend/app/[locale]/agents/components/agent-prompt.tsx
+++ b/frontend/app/[locale]/agents/components/agent-prompt.tsx
@@ -21,7 +21,7 @@ type PromptTab = "duty" | "constraint" | "few-shots";
 export default function AgentPrompt() {
   const { t } = useTranslation("common");
   const { user } = useAuthorizationContext();
-  const { llmModels } = useModelList();
+  const { availableLlmModels, isSuccess: modelListLoaded } = useModelList();
   const { isSpeedMode } = useDeployment();
   const editedAgent = useAgentStore((state) => state.editedAgent!);
   const updateDraft = useAgentStore((state) => state.updateDraft);
@@ -58,12 +58,55 @@ export default function AgentPrompt() {
   );
 
   const modelOptions = useMemo(() => {
-    return (llmModels ?? []).map((m) => ({
+    return (availableLlmModels ?? []).map((m) => ({
       value: m.id,
       label: m.displayName ?? m.name,
       displayName: m.displayName ?? m.name,
     }));
-  }, [llmModels]);
+  }, [availableLlmModels]);
+
+  const availableModelIds = useMemo(
+    () => new Set(modelOptions.map((option) => option.value)),
+    [modelOptions]
+  );
+
+  const selectedModelIds = useMemo(() => {
+    const configuredModelIds = editedAgent.model_ids ?? [];
+    if (configuredModelIds.length > 0) {
+      return configuredModelIds.filter((id) => availableModelIds.has(id));
+    }
+    return defaultLlmConfig?.id && availableModelIds.has(defaultLlmConfig.id)
+      ? [defaultLlmConfig.id]
+      : [];
+  }, [availableModelIds, defaultLlmConfig?.id, editedAgent.model_ids]);
+
+  useEffect(() => {
+    if (!modelListLoaded || !editedAgent.model_ids?.length) return;
+
+    const nextModelIds = editedAgent.model_ids.filter((id) =>
+      availableModelIds.has(id)
+    );
+    if (nextModelIds.length === editedAgent.model_ids.length) return;
+
+    const modelNames = nextModelIds.map((id) => {
+      const option = modelOptions.find((model) => model.value === id);
+      return option?.displayName ?? "";
+    });
+    const primaryModel = modelOptions.find(
+      (option) => option.value === nextModelIds[0]
+    );
+    updateAgent({
+      model_ids: nextModelIds,
+      model: primaryModel?.displayName ?? "",
+      model_names: modelNames,
+    });
+  }, [
+    availableModelIds,
+    editedAgent.model_ids,
+    modelListLoaded,
+    modelOptions,
+    updateAgent,
+  ]);
 
   const canManage = canManageModels(user?.role ?? "");
 
@@ -118,13 +161,7 @@ export default function AgentPrompt() {
               mode="multiple"
               placeholder={t("agent.field.modelPlaceholder")}
               options={modelOptions}
-              value={
-                editedAgent.model_ids?.length
-                  ? editedAgent.model_ids
-                  : defaultLlmConfig?.id
-                    ? [defaultLlmConfig.id]
-                    : []
-              }
+              value={selectedModelIds}
               onChange={(values: number[]) => {
                 const model_names = values.map((id) => {
                   const option = modelOptions.find((opt) => opt.value === id);

--- a/frontend/app/[locale]/agents/components/agentInfo/DebugConfig.tsx
+++ b/frontend/app/[locale]/agents/components/agentInfo/DebugConfig.tsx
@@ -356,7 +356,9 @@ export default function DebugConfig({ agentId }: DebugConfigProps) {
   // Initialize selectedModelId when agent info becomes available
   useEffect(() => {
     setSelectedModelId((current) =>
-      debugModelIds.includes(current) ? current : (defaultModelId ?? null)
+      current !== null && debugModelIds.includes(current)
+        ? current
+        : (defaultModelId ?? null)
     );
   }, [debugModelIds, defaultModelId]);
 

--- a/frontend/app/[locale]/agents/components/agentInfo/DebugConfig.tsx
+++ b/frontend/app/[locale]/agents/components/agentInfo/DebugConfig.tsx
@@ -334,7 +334,13 @@ export default function DebugConfig({ agentId }: DebugConfigProps) {
 
   // Derive debug model selector options from search_info's model_ids,
   // resolving display names against the already-loaded model list.
-  const debugModelIds = useMemo<number[]>(() => agentInfo?.model_ids ?? [], [agentInfo]);
+  const debugModelIds = useMemo<number[]>(
+    () =>
+      (agentInfo?.model_ids ?? []).filter((id) =>
+        availableLlmModels.some((model) => model.id === id)
+      ),
+    [agentInfo, availableLlmModels]
+  );
   const debugModelNames = useMemo(() => {
     return debugModelIds.map((id: number) => {
       const model = availableLlmModels.find((m) => m.id === id);
@@ -349,10 +355,10 @@ export default function DebugConfig({ agentId }: DebugConfigProps) {
 
   // Initialize selectedModelId when agent info becomes available
   useEffect(() => {
-    if (debugModelIds.length > 0 && selectedModelId === null) {
-      setSelectedModelId(defaultModelId);
-    }
-  }, [debugModelIds.length, defaultModelId, selectedModelId]);
+    setSelectedModelId((current) =>
+      debugModelIds.includes(current) ? current : (defaultModelId ?? null)
+    );
+  }, [debugModelIds, defaultModelId]);
 
   const comparePersistenceKey =
     parsedAgentId === undefined
@@ -977,7 +983,7 @@ export default function DebugConfig({ agentId }: DebugConfigProps) {
     history: Array<{ role: string; content: string }>;
   }) => {
     if (!parsedAgentId) return;
-    if (!editedAgent?.model_ids || editedAgent.model_ids.length === 0) return;
+    if (debugModelIds.length === 0) return;
 
     const duty = (editedAgent?.duty_prompt || "").trim();
     const constraint = (editedAgent?.constraint_prompt || "").trim();
@@ -1060,7 +1066,7 @@ export default function DebugConfig({ agentId }: DebugConfigProps) {
       <DebugOptimizeModal
         open={debugOptimizeOpen}
         agentId={parsedAgentId ?? 0}
-        modelId={editedAgent?.model_ids?.[0] ?? 0}
+        modelId={debugModelIds[0] ?? 0}
         userQuestion={debugOptimizeSelected?.userQuestion || ""}
         assistantAnswer={debugOptimizeSelected?.assistantAnswer || ""}
         history={debugOptimizeSelected?.history || []}

--- a/frontend/app/[locale]/chat/internal/chatInterface.tsx
+++ b/frontend/app/[locale]/chat/internal/chatInterface.tsx
@@ -136,6 +136,23 @@ const getI18nKeyByType = (type: string): string => {
   return typeToKeyMap[type] || "";
 };
 
+function getSelectableAgentModels(
+  modelIds: number[] | undefined,
+  modelNames: string[] | undefined,
+  availableModels: { id: number; connect_status?: string }[]
+) {
+  const configuredModels = (modelIds || []).map((id, index) => ({
+    id,
+    name: modelNames?.[index] || String(id),
+  }));
+  const availableModelIds = new Set(
+    availableModels
+      .filter((model) => model.connect_status === "available")
+      .map((model) => model.id)
+  );
+  return configuredModels.filter((model) => availableModelIds.has(model.id));
+}
+
 export function ChatInterface() {
   const [input, setInput] = useState("");
   // Replace the original messages state
@@ -280,11 +297,16 @@ export function ChatInterface() {
       setSelectedAgentId(agentId);
       setAgentGreeting(greeting || null);
       setAgentExampleQuestions(exampleQuestions || []);
-      setAgentModelIds(modelIds || []);
-      setAgentModelNames(modelNames || []);
-      setSelectedModelId(modelIds && modelIds.length > 0 ? modelIds[0] : null);
+      const selectableModels = getSelectableAgentModels(
+        modelIds,
+        modelNames,
+        availableModels
+      );
+      setAgentModelIds(selectableModels.map((model) => model.id));
+      setAgentModelNames(selectableModels.map((model) => model.name));
+      setSelectedModelId(selectableModels[0]?.id ?? null);
     },
-    []
+    [availableModels]
   );
 
   const restoreConversationAgent = useCallback(
@@ -338,12 +360,24 @@ export function ChatInterface() {
 
     setAgentGreeting(agent.greeting_message || null);
     setAgentExampleQuestions(agent.example_questions || []);
-    setAgentModelIds(agent.model_ids || []);
-    setAgentModelNames(agent.model_names || []);
-    setSelectedModelId(
-      agent.model_ids && agent.model_ids.length > 0 ? agent.model_ids[0] : null
+    const selectableModels = getSelectableAgentModels(
+      agent.model_ids,
+      agent.model_names,
+      availableModels
     );
-  }, [handleAgentSelectWithGreeting, publishedAgents, selectedAgentId]);
+    setAgentModelIds(selectableModels.map((model) => model.id));
+    setAgentModelNames(selectableModels.map((model) => model.name));
+    setSelectedModelId((current) =>
+      selectableModels.some((model) => model.id === current)
+        ? current
+        : (selectableModels[0]?.id ?? null)
+    );
+  }, [
+    availableModels,
+    handleAgentSelectWithGreeting,
+    publishedAgents,
+    selectedAgentId,
+  ]);
 
   useEffect(() => {
     const agentId = sessionStorage.getItem("selectedAgentId");

--- a/frontend/app/[locale]/newchat/assistant-ui/thread.tsx
+++ b/frontend/app/[locale]/newchat/assistant-ui/thread.tsx
@@ -64,6 +64,7 @@ import {
 import { message } from "antd";
 import type { Agent, PublishedAgent } from "@/types/agentConfig";
 import { getAgentIcon } from "@/lib/chat/agentIconUtils";
+import { useModelList } from "@/hooks/model/useModelList";
 import type { ModelOption } from "../ui/model-selector";
 import AutomationProposalMessage from "@/features/agentAutomation/components/AutomationProposalMessage";
 import type { AgentAutomationProposalData } from "@/types/agentAutomation";
@@ -160,6 +161,8 @@ export interface ThreadProps {
 const useAgentModels = (
   agent: Agent | PublishedAgent
 ): readonly ModelOption[] => {
+  const { models: availableModels } = useModelList();
+
   return useMemo(() => {
     const typedAgent = agent as PublishedAgent;
     const { model_ids, model_names } = typedAgent;
@@ -170,27 +173,45 @@ const useAgentModels = (
       model_names &&
       model_names.length > 0
     ) {
-      return model_ids.map((id, i) => ({
+      const configuredModels = model_ids.map((id, i) => ({
         id: String(id),
         name: model_names[i] ?? `Model ${id}`,
       }));
+      const availableModelIds = new Set(
+        availableModels
+          .filter((model) => model.connect_status === "available")
+          .map((model) => String(model.id))
+      );
+      return configuredModels.filter((model) =>
+        availableModelIds.has(model.id)
+      );
     }
 
     // Fallback for single model: check model_name on typedAgent
     const modelName = (typedAgent as unknown as { model_name?: string })
       .model_name;
-    if (modelName) {
+    const modelIsAvailable = availableModels.some(
+      (model) =>
+        model.connect_status === "available" &&
+        (model.displayName === modelName || model.name === modelName)
+    );
+    if (modelName && modelIsAvailable) {
       return [{ id: modelName, name: modelName }];
     }
 
     // Fallback to the single model field (used by AgentDraft / debug panel)
     const singleModel = (typedAgent as unknown as { model?: string }).model;
-    if (singleModel) {
+    const singleModelIsAvailable = availableModels.some(
+      (model) =>
+        model.connect_status === "available" &&
+        (model.displayName === singleModel || model.name === singleModel)
+    );
+    if (singleModel && singleModelIsAvailable) {
       return [{ id: singleModel, name: singleModel }];
     }
 
     return [];
-  }, [agent]);
+  }, [agent, availableModels]);
 };
 
 export const Thread: FC<ThreadProps> = ({
@@ -221,6 +242,28 @@ export const Thread: FC<ThreadProps> = ({
 }) => {
   const { t } = useTranslation();
   const models = useAgentModels(agent);
+  const [localSelectedModelId, setLocalSelectedModelId] = useState<string>();
+  const selectedModelIsValid = Boolean(
+    selectedModelId && models.some((model) => model.id === selectedModelId)
+  );
+  const fallbackModelId = models[0]?.id;
+  const effectiveSelectedModelId = selectedModelIsValid
+    ? selectedModelId
+    : localSelectedModelId &&
+        models.some((model) => model.id === localSelectedModelId)
+      ? localSelectedModelId
+      : fallbackModelId;
+  const handleModelChange = useCallback(
+    (modelId: string) => {
+      if (!models.some((model) => model.id === modelId)) return;
+      if (selectedModelId !== undefined) {
+        onModelChange?.(modelId);
+      } else {
+        setLocalSelectedModelId(modelId);
+      }
+    },
+    [models, onModelChange, selectedModelId]
+  );
 
   const messages = useAuiState((s) => s.thread.messages);
   const currentThreadTitle = useAuiState((s) => {
@@ -421,8 +464,8 @@ export const Thread: FC<ThreadProps> = ({
         welcomeSuggestions={welcomeSuggestions}
         onBack={onBack}
         models={models}
-        selectedModelId={selectedModelId}
-        onModelChange={onModelChange}
+        selectedModelId={effectiveSelectedModelId}
+        onModelChange={handleModelChange}
         chatMode={chatMode}
         onChatModeChange={onChatModeChange}
         showModelSelector={showModelSelector}
@@ -876,9 +919,7 @@ const ThreadWelcomeContent: FC<ThreadWelcomeContentProps> = ({
                   <button
                     key={suggestion.id}
                     type="button"
-                    onClick={() =>
-                      handleSampleQuestionClick(suggestion.prompt)
-                    }
+                    onClick={() => handleSampleQuestionClick(suggestion.prompt)}
                     className="flex h-full min-h-20 items-center gap-3 rounded-lg border border-border bg-card px-4 py-3 text-left transition-colors hover:border-primary/40 hover:bg-accent/50"
                   >
                     <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
@@ -1271,11 +1312,13 @@ const AssistantMessage: FC<{
                 Boolean((part as { image?: string }).image)) ||
               (part.type === "text" &&
                 Boolean(
-                  (part as {
-                    isSearchImage?: boolean;
-                    imageSource?: SourcePartLike;
-                  }).isSearchImage &&
-                    (part as { imageSource?: SourcePartLike }).imageSource
+                  (
+                    part as {
+                      isSearchImage?: boolean;
+                      imageSource?: SourcePartLike;
+                    }
+                  ).isSearchImage &&
+                  (part as { imageSource?: SourcePartLike }).imageSource
                 ));
             const isExecutionCodePart =
               part.type === "data" &&

--- a/test/backend/agents/test_create_agent_info.py
+++ b/test/backend/agents/test_create_agent_info.py
@@ -7605,3 +7605,20 @@ class TestBuildSecurityHeaders:
             "security_credentials": {"k": "v"},
         }
         assert _build_security_headers(agent) == {}
+
+    def test_select_agent_model_id_prefers_first_available_model(self):
+        """Runtime model selection skips unavailable configured models."""
+        from backend.agents.create_agent_info import _select_agent_model_id
+        records = {
+            7: {"connect_status": "unavailable"},
+            8: {"connect_status": "available"},
+        }
+        with patch(
+            "backend.agents.create_agent_info.get_model_by_model_id",
+            side_effect=lambda model_id, **kwargs: records[model_id],
+        ), patch(
+            "backend.agents.create_agent_info.is_model_available",
+            side_effect=lambda record: bool(record) and record.get("connect_status") == "available",
+        ):
+            assert _select_agent_model_id([7, 8], None, "tenant") == 8
+            assert _select_agent_model_id([7, 8], 9, "tenant") == 9

--- a/test/backend/services/test_agent_service.py
+++ b/test/backend/services/test_agent_service.py
@@ -1851,7 +1851,8 @@ async def test_get_agent_info_impl_with_model_id_success(mock_search_agent_info,
     mock_model_info = {
         "model_id": 456,
         "display_name": "GPT-4",
-        "provider": "openai"
+        "provider": "openai",
+        "connect_status": "available"
     }
     mock_get_model_by_model_id.return_value = mock_model_info
 
@@ -1958,7 +1959,8 @@ async def test_get_agent_info_impl_with_model_id_no_display_name(mock_search_age
     # Mock model info without display_name
     mock_model_info = {
         "model_id": 456,
-        "provider": "openai"
+        "provider": "openai",
+        "connect_status": "available"
         # No display_name field
     }
     mock_get_model_by_model_id.return_value = mock_model_info
@@ -2050,7 +2052,7 @@ async def test_get_agent_info_impl_with_model_id_none_model_info(mock_search_age
     # Assert
     expected_result = {
         "agent_id": 123,
-        "model_ids": [456],
+        "model_ids": [],
         "business_description": "Test agent",
         "tools": mock_tools,
         "sub_agent_id_list": mock_sub_agent_ids,
@@ -2108,14 +2110,16 @@ async def test_get_agent_info_impl_with_business_logic_model(mock_search_agent_i
     mock_main_model_info = {
         "model_id": 456,
         "display_name": "GPT-4",
-        "provider": "openai"
+        "provider": "openai",
+        "connect_status": "available"
     }
 
     # Mock model info for business logic model
     mock_business_logic_model_info = {
         "model_id": 789,
         "display_name": "Claude-3.5",
-        "provider": "anthropic"
+        "provider": "anthropic",
+        "connect_status": "available"
     }
 
     # Mock get_model_by_model_id to return different values based on input
@@ -2207,7 +2211,8 @@ async def test_get_agent_info_impl_with_business_logic_model_none(mock_search_ag
     mock_main_model_info = {
         "model_id": 456,
         "display_name": "GPT-4",
-        "provider": "openai"
+        "provider": "openai",
+        "connect_status": "available"
     }
 
     # Mock get_model_by_model_id to return None for business_logic_model_id
@@ -2299,13 +2304,15 @@ async def test_get_agent_info_impl_with_business_logic_model_no_display_name(moc
     mock_main_model_info = {
         "model_id": 456,
         "display_name": "GPT-4",
-        "provider": "openai"
+        "provider": "openai",
+        "connect_status": "available"
     }
 
     # Mock model info for business logic model without display_name
     mock_business_logic_model_info = {
         "model_id": 789,
-        "provider": "anthropic"
+        "provider": "anthropic",
+        "connect_status": "available"
         # No display_name field
     }
 
@@ -2946,7 +2953,7 @@ async def test_list_all_agent_info_impl_model_cache_miss_fetches_model(
     mock_convert_list.return_value = []
     # Do not mutate model_cache here so that the "model_id not in model_cache" branch runs.
     mock_check_availability.side_effect = lambda *args, **kwargs: (True, [])
-    mock_get_model.return_value = {"model_name": "m", "display_name": "M"}
+    mock_get_model.return_value = {"model_name": "m", "display_name": "M", "connect_status": "available"}
 
     result = await list_all_agent_info_impl(tenant_id="test_tenant", user_id="admin_user")
 
@@ -17143,9 +17150,9 @@ async def test_list_all_agent_info_impl_filters_deleted_models(
     # Mock model info for valid models (get_model_by_model_id takes 2 args: model_id and tenant_id)
     def get_model_side_effect(model_id, tenant_id=None):
         if model_id == 1:
-            return {"display_name": "Model 1", "model_id": 1}
+            return {"display_name": "Model 1", "model_id": 1, "connect_status": "available"}
         elif model_id == 3:
-            return {"display_name": "Model 3", "model_id": 3}
+            return {"display_name": "Model 3", "model_id": 3, "connect_status": "available"}
         return None
     mock_get_model.side_effect = get_model_side_effect
 
@@ -17312,9 +17319,9 @@ async def test_get_agent_info_impl_filters_deleted_models(
     # Mock get_model_by_model_id for valid models
     def get_model_side_effect(model_id, tenant_id=None):
         if model_id == 1:
-            return {"display_name": "Model 1", "model_id": 1}
+            return {"display_name": "Model 1", "model_id": 1, "connect_status": "available"}
         elif model_id == 3:
-            return {"display_name": "Model 3", "model_id": 3}
+            return {"display_name": "Model 3", "model_id": 3, "connect_status": "available"}
         return None
     mock_get_model_by_model_id.side_effect = get_model_side_effect
 

--- a/test/backend/services/test_agent_version_service.py
+++ b/test/backend/services/test_agent_version_service.py
@@ -1625,7 +1625,11 @@ def test_list_published_agents_impl_success(monkeypatch):
     )
     agent_read_mock.apply_duplicate_name_availability_rules = MagicMock()
     model_management_db_mock.get_model_by_model_id = MagicMock(
-        return_value={"display_name": "Test Model", "model_name": "test_model"}
+        return_value={
+            "display_name": "Test Model",
+            "model_name": "test_model",
+            "connect_status": "available",
+        }
     )
 
     result = asyncio.run(list_published_agents_impl(tenant_id="tenant1", user_id="user1"))
@@ -1782,7 +1786,11 @@ def test_list_published_agents_impl_user_with_groups(monkeypatch):
     )
     agent_read_mock.apply_duplicate_name_availability_rules = MagicMock()
     model_management_db_mock.get_model_by_model_id = MagicMock(
-        return_value={"display_name": "Test Model", "model_name": "test_model"}
+        return_value={
+            "display_name": "Test Model",
+            "model_name": "test_model",
+            "connect_status": "available",
+        }
     )
 
     result = asyncio.run(list_published_agents_impl(tenant_id="tenant1", user_id="user1"))
@@ -1832,7 +1840,11 @@ def test_list_published_agents_impl_model_cache(monkeypatch):
     )
     agent_read_mock.apply_duplicate_name_availability_rules = MagicMock()
     model_management_db_mock.get_model_by_model_id = MagicMock(
-        return_value={"display_name": "Test Model", "model_name": "test_model"}
+        return_value={
+            "display_name": "Test Model",
+            "model_name": "test_model",
+            "connect_status": "available",
+        }
     )
 
     result = asyncio.run(list_published_agents_impl(tenant_id="tenant1", user_id="user1"))
@@ -3137,7 +3149,10 @@ def test_list_published_agents_impl_multiple_models(monkeypatch):
     agent_read_mock.apply_duplicate_name_availability_rules = MagicMock()
 
     def mock_get_model(model_id, tenant_id=None):
-        return {"display_name": f"Model-{model_id}"}
+        return {
+            "display_name": f"Model-{model_id}",
+            "connect_status": "available",
+        }
 
     model_management_db_mock.get_model_by_model_id = MagicMock(side_effect=mock_get_model)
 
@@ -3148,6 +3163,52 @@ def test_list_published_agents_impl_multiple_models(monkeypatch):
     assert result[0]["model_ids"] == [1, 2]
     assert result[0]["model_names"] == ["Model-1", "Model-2"]
     assert result[0]["model_name"] == "Model-1"
+
+
+def test_list_published_agents_impl_filters_unavailable_models(monkeypatch):
+    """Published agent responses expose only available bound models."""
+    agent_db_mock.query_all_agent_info_by_tenant_id = MagicMock(
+        return_value=[
+            {
+                "agent_id": 1,
+                "enabled": True,
+                "current_version_no": 1,
+                "group_ids": "1,2",
+                "created_by": "user1",
+                "name": "Test Agent",
+                "display_name": "Test Agent",
+            }
+        ]
+    )
+    user_tenant_db_mock.get_user_tenant_by_user_id = MagicMock(
+        return_value={"user_role": "ADMIN"}
+    )
+    agent_version_db_mock.query_agent_snapshot = MagicMock(
+        return_value=({"agent_id": 1, "name": "Test Agent", "model_ids": [1, 2]}, [], [])
+    )
+
+    def mock_get_model(model_id, tenant_id=None):
+        return {
+            "display_name": f"Model-{model_id}",
+            "connect_status": "available" if model_id == 1 else "unavailable",
+        }
+
+    model_management_db_mock.get_model_by_model_id = MagicMock(side_effect=mock_get_model)
+    availability_model_ids = []
+
+    def check_availability(**kwargs):
+        availability_model_ids.append(list(kwargs["agent_info"]["model_ids"]))
+        return True, []
+
+    agent_read_mock.check_agent_availability = MagicMock(side_effect=check_availability)
+    agent_read_mock.apply_duplicate_name_availability_rules = MagicMock()
+
+    result = asyncio.run(list_published_agents_impl(tenant_id="tenant1", user_id="user1"))
+
+    assert result[0]["model_ids"] == [1]
+    assert result[0]["model_names"] == ["Model-1"]
+    assert result[0]["model_name"] == "Model-1"
+    assert availability_model_ids == [[1, 2]]
 
 
 def test_list_published_agents_impl_model_ids_empty(monkeypatch):
@@ -3261,9 +3322,17 @@ def test_list_published_agents_impl_filters_deleted_models(monkeypatch):
     # Mock model info for valid models
     def get_model_side_effect(model_id, tenant_id=None):
         if model_id == 1:
-            return {"display_name": "Model 1", "model_id": 1}
+            return {
+                "display_name": "Model 1",
+                "model_id": 1,
+                "connect_status": "available",
+            }
         elif model_id == 3:
-            return {"display_name": "Model 3", "model_id": 3}
+            return {
+                "display_name": "Model 3",
+                "model_id": 3,
+                "connect_status": "available",
+            }
         return None
     model_management_db_mock.get_model_by_model_id = MagicMock(side_effect=get_model_side_effect)
 
@@ -3509,7 +3578,11 @@ def test_list_published_agents_impl_with_sub_agent_relations(monkeypatch):
     )
     agent_read_mock.apply_duplicate_name_availability_rules = MagicMock()
     model_management_db_mock.get_model_by_model_id = MagicMock(
-        return_value={"display_name": "Test Model", "model_name": "test_model"}
+        return_value={
+            "display_name": "Test Model",
+            "model_name": "test_model",
+            "connect_status": "available",
+        }
     )
 
     # Spy on _build_sub_agent_relations to verify it's called with the right relations
@@ -3707,6 +3780,6 @@ def test_list_published_agents_impl_model_not_found(monkeypatch):
     result = asyncio.run(list_published_agents_impl(tenant_id="tenant1", user_id="user1"))
 
     assert len(result) == 1
-    # When model is not found, model_names should contain str(mid) as fallback
-    assert result[0]["model_names"] == ["99"]
-    assert result[0]["model_name"] == "99"
+    assert result[0]["model_ids"] == []
+    assert result[0]["model_names"] == []
+    assert result[0]["model_name"] is None

--- a/test/backend/services/test_core_service_slimming.py
+++ b/test/backend/services/test_core_service_slimming.py
@@ -291,7 +291,10 @@ def agent_reader(monkeypatch, model_resolver):
 
 
 def test_ac007_projection_keeps_distinct_legacy_name_rules(agent_reader, monkeypatch, model_resolver):
-    records = {1: {"display_name": None}, 2: {"display_name": "Second"}}
+    records = {
+        1: {"display_name": None, "connect_status": "available"},
+        2: {"display_name": "Second", "connect_status": "available"},
+    }
     monkeypatch.setattr(model_resolver, "get_model_by_model_id", lambda mid, *args: records.get(mid))
     data = {"model_ids": [1, 9, 2, 2]}
     listed = agent_reader.project_agent_models(data, "tenant", {})
@@ -301,6 +304,21 @@ def test_ac007_projection_keeps_distinct_legacy_name_rules(agent_reader, monkeyp
     assert listed.fields["model_name"] == "Second"
     assert detail.fields["model_name"] is None
     assert listed.deleted_model_ids == detail.deleted_model_ids == frozenset({9})
+
+
+def test_ac007_projection_filters_unavailable_models(agent_reader, monkeypatch, model_resolver):
+    records = {
+        7: {"display_name": "Unavailable", "connect_status": "unavailable"},
+        8: {"display_name": "Available", "connect_status": "available"},
+    }
+    monkeypatch.setattr(model_resolver, "get_model_by_model_id", lambda mid, *args: records[mid])
+
+    projection = agent_reader.project_agent_models({"model_ids": [7, 8]}, "tenant", {})
+
+    assert projection.fields["model_ids"] == [8]
+    assert projection.fields["model_names"] == ["Available"]
+    assert projection.fields["model_name"] == "Available"
+    assert projection.availability_model_ids == [7, 8]
 
 
 def test_ac010_deleted_model_reason_is_added_once(agent_reader):
@@ -389,6 +407,21 @@ def test_ac007_availability_uses_real_shared_model_predicate(agent_reader, model
         else agent_reader.AgentUnavailableReason.MODEL_NOT_CONFIGURED
     ]
     assert reasons == expected
+
+
+def test_ac007_agent_available_when_any_configured_model_is_available(agent_reader, model_resolver, monkeypatch):
+    records = {
+        7: {"connect_status": "unavailable"},
+        8: {"connect_status": "available"},
+    }
+    monkeypatch.setattr(model_resolver, "get_model_by_model_id", lambda mid, *args: records[mid])
+
+    ok, reasons = agent_reader.check_agent_availability(
+        1, "tenant", {"agent_id": 1, "model_ids": [7, 8]}
+    )
+
+    assert ok is True
+    assert reasons == []
 
 
 def test_ac007_deleted_tool_model_and_duplicate_order(agent_reader, monkeypatch):


### PR DESCRIPTION
## Fix: keep agents available when some bound models fail health checks

### Bug

When an agent binds multiple models from different providers and one provider disables its API, that model is marked unavailable by the health check.

The current logic treats the agent as unavailable as long as any bound model is unavailable, even though the other models remain healthy. The chat runtime also keeps unavailable model IDs in the selector and may continue calling the invalid model, causing authentication errors and retries.

### Changes

- Agent availability now depends on whether at least one bound model is available.
- Chat model selectors filter out unavailable models and default to the first available model.
- Runtime model selection prefers the first available bound model unless the request explicitly specifies a `model_id`.
- Explicitly selected models are preserved when they are still available.
- Kept the existing agent API and model binding format unchanged.

### Tests

Agent availability tests:

Runtime model selection tests:

Frontend model selector tests: