### PR TITLE
Fix: keep agents available when some bound models fail health checks

### DIFF
--- a/backend/agents/create_agent_info.py
+++ b/backend/agents/create_agent_info.py
@@ -1,4 +1,4 @@
-﻿import asyncio
+import asyncio
 import copy
 import json
 import logging
@@ -80,7 +80,7 @@ from consts.const import (
     MODEL_CONFIG_MAPPING,
     NEXENT_SANDBOX_WORKSPACE_VOLUME,
 )
-from consts.model import ToolParamsRequest
+from consts.model import ToolParamsRequest, ModelConnectStatusEnum
 from consts.exceptions import ValidationError
 
 logger = logging.getLogger("create_agent_info")
@@ -93,6 +93,26 @@ def _create_fixed_search_memory_tool():
     return SearchMemoryTool()
 
 
+def _model_is_available(model: dict | None) -> bool:
+    """Return whether the model record is in AVAILABLE connect status."""
+    return bool(model) and (
+        ModelConnectStatusEnum.get_value(model.get("connect_status"))
+        == ModelConnectStatusEnum.AVAILABLE.value
+    )
+
+
+def _select_agent_model_id(
+    agent_model_ids: List[int],
+    override_model_id: int | None,
+    tenant_id: str,
+) -> int | None:
+    """Select the request override or the first configured available model."""
+    if override_model_id is not None:
+        return override_model_id
+    for model_id in agent_model_ids:
+        if _model_is_available(get_model_by_model_id(model_id, tenant_id=tenant_id)):
+            return model_id
+    return agent_model_ids[0] if agent_model_ids else None
 def _build_long_term_memory_items(search_context: Any) -> list[dict[str, Any]]:
     """Return at most one structured active document for each long-term scope."""
     result = []
@@ -1308,9 +1328,9 @@ async def create_agent_config(
         "knowledge_base_summary": knowledge_base_summary,
         "user_id": user_id,
     }
-    # AgentInfo stores model_ids (a list); pick the first for the primary model lookup
-    agent_model_ids = agent_info.get("model_ids")
-    model_id_to_use = override_model_id if override_model_id else (agent_model_ids[0] if agent_model_ids else None)
+    # AgentInfo stores model_ids (a list); pick the first available model.
+    agent_model_ids = agent_info.get("model_ids") or []
+    model_id_to_use = _select_agent_model_id(agent_model_ids, override_model_id, tenant_id)
     model_info = None
     if model_id_to_use is not None:
         model_info = get_model_by_model_id(model_id_to_use, tenant_id=tenant_id)

--- a/backend/services/agent_service.py
+++ b/backend/services/agent_service.py
@@ -1682,7 +1682,6 @@ async def get_agent_info_impl(agent_id: int, tenant_id: str, version_no: int = 0
         logger.error(f"Failed to get external sub agents: {str(e)}")
         agent_info["external_sub_agent_id_list"] = []
 
-    # Get model names from model_ids array
     # Filter out deleted models (delete_flag='Y' in model_record_t)
     model_ids = agent_info.get("model_ids") or []
     valid_model_ids = get_valid_model_ids(model_ids, tenant_id)
@@ -1691,17 +1690,24 @@ async def get_agent_info_impl(agent_id: int, tenant_id: str, version_no: int = 0
     deleted_model_ids = set(model_ids) - set(valid_model_ids)
     agent_info["model_ids"] = valid_model_ids
 
+    model_cache: Dict[int, Optional[dict]] = {}
+    available_model_ids = _filter_available_model_ids(
+        model_ids=valid_model_ids,
+        tenant_id=tenant_id,
+        model_cache=model_cache,
+    )
+
     model_names: List[str] = []
-    for mid in valid_model_ids:
-        model_info = get_model_by_model_id(mid)
+    for mid in available_model_ids:
+        model_info = model_cache.get(mid)
         if model_info:
             display_name = model_info.get("display_name")
             if display_name:
                 model_names.append(display_name)
     agent_info["model_names"] = model_names
-    # Always derive model_name from valid_model_ids so the API contract is consistent.
-    if valid_model_ids:
-        first_model_info = get_model_by_model_id(valid_model_ids[0])
+    # Always derive model_name from available_model_ids so the API contract is consistent.
+    if available_model_ids:
+        first_model_info = model_cache.get(available_model_ids[0])
         agent_info["model_name"] = first_model_info.get(
             "display_name", None) if first_model_info is not None else None
     else:
@@ -1729,7 +1735,8 @@ async def get_agent_info_impl(agent_id: int, tenant_id: str, version_no: int = 0
     is_available, unavailable_reasons = check_agent_availability(
         agent_id=agent_id,
         tenant_id=tenant_id,
-        agent_info=agent_info
+        agent_info=agent_info,
+        model_cache=model_cache,
     )
 
     # Add MODEL_DELETED reason if any configured models have been deleted
@@ -1739,6 +1746,7 @@ async def get_agent_info_impl(agent_id: int, tenant_id: str, version_no: int = 0
 
     agent_info["is_available"] = is_available
     agent_info["unavailable_reasons"] = unavailable_reasons
+    agent_info["model_ids"] = available_model_ids
 
     # Set current_version_no from draft record (version_no=0)
     # This ensures the returned data always has the current published version info
@@ -2691,11 +2699,17 @@ async def list_all_agent_info_impl(tenant_id: str, user_id: str) -> list[dict]:
                 agent_info=agent,
                 model_cache=model_cache
             )
+            available_model_ids = _filter_available_model_ids(
+                model_ids=valid_model_ids,
+                tenant_id=tenant_id,
+                model_cache=model_cache,
+            )
 
             # Preserve the raw data so we can adjust availability for duplicates
             enriched_agents.append({
                 "raw_agent": agent,
                 "unavailable_reasons": unavailable_reasons,
+                "available_model_ids": available_model_ids,
             })
 
         # Handle duplicate name/display_name: keep the earliest created agent available,
@@ -2709,7 +2723,7 @@ async def list_all_agent_info_impl(tenant_id: str, user_id: str) -> list[dict]:
                 dict.fromkeys(entry["unavailable_reasons"]))
 
             # Get model names from model_ids array
-            model_ids = agent.get("model_ids") or []
+            model_ids = entry["available_model_ids"]
             model_names: List[str] = []
             for mid in model_ids:
                 if mid not in model_cache:
@@ -2796,22 +2810,48 @@ def _apply_duplicate_name_availability_rules(enriched_agents: list[dict]) -> Non
                      AgentUnavailableReason.DUPLICATE_DISPLAY_NAME)
 
 
+def _model_record_is_available(model_info: Optional[dict]) -> bool:
+    """Return whether a model record is in AVAILABLE connect status."""
+    if not model_info:
+        return False
+    connect_status = ModelConnectStatusEnum.get_value(model_info.get("connect_status"))
+    return connect_status == ModelConnectStatusEnum.AVAILABLE.value
+
+
+def _filter_available_model_ids(
+    model_ids: List[int],
+    tenant_id: str,
+    model_cache: Dict[int, Optional[dict]],
+) -> List[int]:
+    """Return bound model IDs whose connect status is AVAILABLE."""
+    available_model_ids: List[int] = []
+    for model_id in model_ids:
+        if model_id not in model_cache:
+            model_cache[model_id] = get_model_by_model_id(model_id, tenant_id)
+        if _model_record_is_available(model_cache.get(model_id)):
+            available_model_ids.append(model_id)
+    return available_model_ids
+
+
 def _collect_model_availability_reasons(agent: dict, tenant_id: str, model_cache: Dict[int, Optional[dict]]) -> list[str]:
     """
     Build a list of reasons related to model availability issues for a given agent.
-    Iterates over model_ids (the canonical field) and collects one unavailable reason
-    per model that is missing or not in AVAILABLE status.
+    The agent stays available while at least one bound model is in AVAILABLE status.
     """
     reasons: list[str] = []
     model_ids = agent.get("model_ids") or []
     if model_ids:
-        for mid in model_ids:
-            reasons.extend(_check_single_model_availability(
+        model_available = [
+            not _check_single_model_availability(
                 model_id=mid,
                 tenant_id=tenant_id,
                 model_cache=model_cache,
                 reason_key=AgentUnavailableReason.MODEL_UNAVAILABLE,
-            ))
+            )
+            for mid in model_ids
+        ]
+        if not any(model_available):
+            reasons.append(AgentUnavailableReason.MODEL_UNAVAILABLE)
     else:
         reasons.append(AgentUnavailableReason.MODEL_NOT_CONFIGURED)
 

--- a/backend/services/agent_version_service.py
+++ b/backend/services/agent_version_service.py
@@ -931,6 +931,15 @@ async def list_published_agents_impl(
                 agent_info=agent_info,
                 model_cache=model_cache
             )
+            for model_id in valid_model_ids:
+                if model_id not in model_cache:
+                    model_cache[model_id] = get_model_by_model_id(model_id, tenant_id)
+            available_model_ids = [
+                model_id
+                for model_id in valid_model_ids
+                if (model_cache.get(model_id) or {}).get("connect_status") == "available"
+            ]
+            agent_info["model_ids"] = available_model_ids
 
             # Preserve the raw data so we can adjust availability for duplicates
             enriched_agents.append({

--- a/frontend/app/[locale]/agents/components/agent-prompt.tsx
+++ b/frontend/app/[locale]/agents/components/agent-prompt.tsx
@@ -21,7 +21,7 @@ type PromptTab = "duty" | "constraint" | "few-shots";
 export default function AgentPrompt() {
   const { t } = useTranslation("common");
   const { user } = useAuthorizationContext();
-  const { llmModels } = useModelList();
+  const { availableLlmModels, isSuccess: modelListLoaded } = useModelList();
   const { isSpeedMode } = useDeployment();
   const editedAgent = useAgentStore((state) => state.editedAgent!);
   const updateDraft = useAgentStore((state) => state.updateDraft);
@@ -58,12 +58,55 @@ export default function AgentPrompt() {
   );
 
   const modelOptions = useMemo(() => {
-    return (llmModels ?? []).map((m) => ({
+    return (availableLlmModels ?? []).map((m) => ({
       value: m.id,
       label: m.displayName ?? m.name,
       displayName: m.displayName ?? m.name,
     }));
-  }, [llmModels]);
+  }, [availableLlmModels]);
+
+  const availableModelIds = useMemo(
+    () => new Set(modelOptions.map((option) => option.value)),
+    [modelOptions]
+  );
+
+  const selectedModelIds = useMemo(() => {
+    const configuredModelIds = editedAgent.model_ids ?? [];
+    if (configuredModelIds.length > 0) {
+      return configuredModelIds.filter((id) => availableModelIds.has(id));
+    }
+    return defaultLlmConfig?.id && availableModelIds.has(defaultLlmConfig.id)
+      ? [defaultLlmConfig.id]
+      : [];
+  }, [availableModelIds, defaultLlmConfig?.id, editedAgent.model_ids]);
+
+  useEffect(() => {
+    if (!modelListLoaded || !editedAgent.model_ids?.length) return;
+
+    const nextModelIds = editedAgent.model_ids.filter((id) =>
+      availableModelIds.has(id)
+    );
+    if (nextModelIds.length === editedAgent.model_ids.length) return;
+
+    const modelNames = nextModelIds.map((id) => {
+      const option = modelOptions.find((model) => model.value === id);
+      return option?.displayName ?? "";
+    });
+    const primaryModel = modelOptions.find(
+      (option) => option.value === nextModelIds[0]
+    );
+    updateAgent({
+      model_ids: nextModelIds,
+      model: primaryModel?.displayName ?? "",
+      model_names: modelNames,
+    });
+  }, [
+    availableModelIds,
+    editedAgent.model_ids,
+    modelListLoaded,
+    modelOptions,
+    updateAgent,
+  ]);
 
   const canManage = canManageModels(user?.role ?? "");
 
@@ -118,13 +161,7 @@ export default function AgentPrompt() {
               mode="multiple"
               placeholder={t("agent.field.modelPlaceholder")}
               options={modelOptions}
-              value={
-                editedAgent.model_ids?.length
-                  ? editedAgent.model_ids
-                  : defaultLlmConfig?.id
-                    ? [defaultLlmConfig.id]
-                    : []
-              }
+              value={selectedModelIds}
               onChange={(values: number[]) => {
                 const model_names = values.map((id) => {
                   const option = modelOptions.find((opt) => opt.value === id);

--- a/frontend/app/[locale]/agents/components/agentInfo/DebugConfig.tsx
+++ b/frontend/app/[locale]/agents/components/agentInfo/DebugConfig.tsx
@@ -334,7 +334,13 @@ export default function DebugConfig({ agentId }: DebugConfigProps) {
 
   // Derive debug model selector options from search_info's model_ids,
   // resolving display names against the already-loaded model list.
-  const debugModelIds = useMemo<number[]>(() => agentInfo?.model_ids ?? [], [agentInfo]);
+  const debugModelIds = useMemo<number[]>(
+    () =>
+      (agentInfo?.model_ids ?? []).filter((id) =>
+        availableLlmModels.some((model) => model.id === id)
+      ),
+    [agentInfo, availableLlmModels]
+  );
   const debugModelNames = useMemo(() => {
     return debugModelIds.map((id: number) => {
       const model = availableLlmModels.find((m) => m.id === id);
@@ -349,10 +355,12 @@ export default function DebugConfig({ agentId }: DebugConfigProps) {
 
   // Initialize selectedModelId when agent info becomes available
   useEffect(() => {
-    if (debugModelIds.length > 0 && selectedModelId === null) {
-      setSelectedModelId(defaultModelId);
-    }
-  }, [debugModelIds.length, defaultModelId, selectedModelId]);
+    setSelectedModelId((current) =>
+      current !== null && debugModelIds.includes(current)
+        ? current
+        : (defaultModelId ?? null)
+    );
+  }, [debugModelIds, defaultModelId]);
 
   const comparePersistenceKey =
     parsedAgentId === undefined
@@ -977,7 +985,7 @@ export default function DebugConfig({ agentId }: DebugConfigProps) {
     history: Array<{ role: string; content: string }>;
   }) => {
     if (!parsedAgentId) return;
-    if (!editedAgent?.model_ids || editedAgent.model_ids.length === 0) return;
+    if (debugModelIds.length === 0) return;
 
     const duty = (editedAgent?.duty_prompt || "").trim();
     const constraint = (editedAgent?.constraint_prompt || "").trim();
@@ -1060,7 +1068,7 @@ export default function DebugConfig({ agentId }: DebugConfigProps) {
       <DebugOptimizeModal
         open={debugOptimizeOpen}
         agentId={parsedAgentId ?? 0}
-        modelId={editedAgent?.model_ids?.[0] ?? 0}
+        modelId={debugModelIds[0] ?? 0}
         userQuestion={debugOptimizeSelected?.userQuestion || ""}
         assistantAnswer={debugOptimizeSelected?.assistantAnswer || ""}
         history={debugOptimizeSelected?.history || []}

--- a/frontend/app/[locale]/chat/internal/chatInterface.tsx
+++ b/frontend/app/[locale]/chat/internal/chatInterface.tsx
@@ -136,6 +136,23 @@ const getI18nKeyByType = (type: string): string => {
   return typeToKeyMap[type] || "";
 };
 
+function getSelectableAgentModels(
+  modelIds: number[] | undefined,
+  modelNames: string[] | undefined,
+  availableModels: { id: number; connect_status?: string }[]
+) {
+  const configuredModels = (modelIds || []).map((id, index) => ({
+    id,
+    name: modelNames?.[index] || String(id),
+  }));
+  const availableModelIds = new Set(
+    availableModels
+      .filter((model) => model.connect_status === "available")
+      .map((model) => model.id)
+  );
+  return configuredModels.filter((model) => availableModelIds.has(model.id));
+}
+
 export function ChatInterface() {
   const [input, setInput] = useState("");
   // Replace the original messages state
@@ -276,11 +293,16 @@ export function ChatInterface() {
       setSelectedAgentId(agentId);
       setAgentGreeting(greeting || null);
       setAgentExampleQuestions(exampleQuestions || []);
-      setAgentModelIds(modelIds || []);
-      setAgentModelNames(modelNames || []);
-      setSelectedModelId(modelIds && modelIds.length > 0 ? modelIds[0] : null);
+      const selectableModels = getSelectableAgentModels(
+        modelIds,
+        modelNames,
+        availableModels
+      );
+      setAgentModelIds(selectableModels.map((model) => model.id));
+      setAgentModelNames(selectableModels.map((model) => model.name));
+      setSelectedModelId(selectableModels[0]?.id ?? null);
     },
-    []
+    [availableModels]
   );
 
   const restoreConversationAgent = useCallback(
@@ -334,12 +356,24 @@ export function ChatInterface() {
 
     setAgentGreeting(agent.greeting_message || null);
     setAgentExampleQuestions(agent.example_questions || []);
-    setAgentModelIds(agent.model_ids || []);
-    setAgentModelNames(agent.model_names || []);
-    setSelectedModelId(
-      agent.model_ids && agent.model_ids.length > 0 ? agent.model_ids[0] : null
+    const selectableModels = getSelectableAgentModels(
+      agent.model_ids,
+      agent.model_names,
+      availableModels
     );
-  }, [handleAgentSelectWithGreeting, publishedAgents, selectedAgentId]);
+    setAgentModelIds(selectableModels.map((model) => model.id));
+    setAgentModelNames(selectableModels.map((model) => model.name));
+    setSelectedModelId((current) =>
+      selectableModels.some((model) => model.id === current)
+        ? current
+        : (selectableModels[0]?.id ?? null)
+    );
+  }, [
+    availableModels,
+    handleAgentSelectWithGreeting,
+    publishedAgents,
+    selectedAgentId,
+  ]);
 
   useEffect(() => {
     const agentId = sessionStorage.getItem("selectedAgentId");

--- a/frontend/app/[locale]/newchat/assistant-ui/thread.tsx
+++ b/frontend/app/[locale]/newchat/assistant-ui/thread.tsx
@@ -64,6 +64,7 @@ import {
 import { message } from "antd";
 import type { Agent, PublishedAgent } from "@/types/agentConfig";
 import { getAgentIcon } from "@/lib/chat/agentIconUtils";
+import { useModelList } from "@/hooks/model/useModelList";
 import type { ModelOption } from "../ui/model-selector";
 import AutomationProposalMessage from "@/features/agentAutomation/components/AutomationProposalMessage";
 import type { AgentAutomationProposalData } from "@/types/agentAutomation";
@@ -160,6 +161,8 @@ export interface ThreadProps {
 const useAgentModels = (
   agent: Agent | PublishedAgent
 ): readonly ModelOption[] => {
+  const { models: availableModels } = useModelList();
+
   return useMemo(() => {
     const typedAgent = agent as PublishedAgent;
     const { model_ids, model_names } = typedAgent;
@@ -170,27 +173,45 @@ const useAgentModels = (
       model_names &&
       model_names.length > 0
     ) {
-      return model_ids.map((id, i) => ({
+      const configuredModels = model_ids.map((id, i) => ({
         id: String(id),
         name: model_names[i] ?? `Model ${id}`,
       }));
+      const availableModelIds = new Set(
+        availableModels
+          .filter((model) => model.connect_status === "available")
+          .map((model) => String(model.id))
+      );
+      return configuredModels.filter((model) =>
+        availableModelIds.has(model.id)
+      );
     }
 
     // Fallback for single model: check model_name on typedAgent
     const modelName = (typedAgent as unknown as { model_name?: string })
       .model_name;
-    if (modelName) {
+    const modelIsAvailable = availableModels.some(
+      (model) =>
+        model.connect_status === "available" &&
+        (model.displayName === modelName || model.name === modelName)
+    );
+    if (modelName && modelIsAvailable) {
       return [{ id: modelName, name: modelName }];
     }
 
     // Fallback to the single model field (used by AgentDraft / debug panel)
     const singleModel = (typedAgent as unknown as { model?: string }).model;
-    if (singleModel) {
+    const singleModelIsAvailable = availableModels.some(
+      (model) =>
+        model.connect_status === "available" &&
+        (model.displayName === singleModel || model.name === singleModel)
+    );
+    if (singleModel && singleModelIsAvailable) {
       return [{ id: singleModel, name: singleModel }];
     }
 
     return [];
-  }, [agent]);
+  }, [agent, availableModels]);
 };
 
 export const Thread: FC<ThreadProps> = ({
@@ -221,6 +242,28 @@ export const Thread: FC<ThreadProps> = ({
 }) => {
   const { t } = useTranslation();
   const models = useAgentModels(agent);
+  const [localSelectedModelId, setLocalSelectedModelId] = useState<string>();
+  const selectedModelIsValid = Boolean(
+    selectedModelId && models.some((model) => model.id === selectedModelId)
+  );
+  const fallbackModelId = models[0]?.id;
+  const effectiveSelectedModelId = selectedModelIsValid
+    ? selectedModelId
+    : localSelectedModelId &&
+        models.some((model) => model.id === localSelectedModelId)
+      ? localSelectedModelId
+      : fallbackModelId;
+  const handleModelChange = useCallback(
+    (modelId: string) => {
+      if (!models.some((model) => model.id === modelId)) return;
+      if (selectedModelId !== undefined) {
+        onModelChange?.(modelId);
+      } else {
+        setLocalSelectedModelId(modelId);
+      }
+    },
+    [models, onModelChange, selectedModelId]
+  );
 
   const messages = useAuiState((s) => s.thread.messages);
   const currentThreadTitle = useAuiState((s) => {
@@ -421,8 +464,8 @@ export const Thread: FC<ThreadProps> = ({
         welcomeSuggestions={welcomeSuggestions}
         onBack={onBack}
         models={models}
-        selectedModelId={selectedModelId}
-        onModelChange={onModelChange}
+        selectedModelId={effectiveSelectedModelId}
+        onModelChange={handleModelChange}
         chatMode={chatMode}
         onChatModeChange={onChatModeChange}
         showModelSelector={showModelSelector}

--- a/test/backend/agents/test_create_agent_info.py
+++ b/test/backend/agents/test_create_agent_info.py
@@ -11,6 +11,7 @@ env_state = bootstrap_test_env()
 consts_const = env_state["mock_const"]
 
 # Mock consts.model module with HistoryItem class
+from enum import Enum
 from typing import List, Optional, Dict, Any
 from pydantic import BaseModel
 
@@ -62,6 +63,22 @@ class MockToolParamsRequest(BaseModel):
 consts_model_module.HistoryItem = HistoryItem
 consts_model_module.AgentToolParamsRequest = MockAgentToolParamsRequest
 consts_model_module.ToolParamsRequest = MockToolParamsRequest
+class MockModelConnectStatusEnum(Enum):
+    """Mock ModelConnectStatusEnum with the same shape as the production enum."""
+
+    NOT_DETECTED = "not_detected"
+    DETECTING = "detecting"
+    AVAILABLE = "available"
+    UNAVAILABLE = "unavailable"
+
+    @classmethod
+    def get_value(cls, status):
+        if not status or status == "":
+            return cls.NOT_DETECTED.value
+        return status
+
+
+consts_model_module.ModelConnectStatusEnum = MockModelConnectStatusEnum
 sys.modules["consts.model"] = consts_model_module
 sys.modules["consts.capability_profiles"] = types.ModuleType(
     "consts.capability_profiles"
@@ -7552,3 +7569,20 @@ class TestBuildSecurityHeaders:
             "security_credentials": {"k": "v"},
         }
         assert _build_security_headers(agent) == {}
+
+    def test_select_agent_model_id_prefers_first_available_model(self):
+        """Runtime model selection skips unavailable configured models."""
+        from backend.agents.create_agent_info import _select_agent_model_id
+        records = {
+            7: {"connect_status": "unavailable"},
+            8: {"connect_status": "available"},
+        }
+        with patch(
+            "backend.agents.create_agent_info.get_model_by_model_id",
+            side_effect=lambda model_id, **kwargs: records[model_id],
+        ), patch(
+            "backend.agents.create_agent_info._model_is_available",
+            side_effect=lambda record: bool(record) and record.get("connect_status") == "available",
+        ):
+            assert _select_agent_model_id([7, 8], None, "tenant") == 8
+            assert _select_agent_model_id([7, 8], 9, "tenant") == 9

--- a/test/backend/services/test_agent_service.py
+++ b/test/backend/services/test_agent_service.py
@@ -116,6 +116,10 @@ sys.modules['database.db_models'] = MagicMock()
 sys.modules['database.conversation_db'] = MagicMock()
 sys.modules['database.db_models'] = MagicMock()
 
+# Another test file may have replaced the parent database package with a
+# stub module. Restore the real package so dotted submodule imports resolve.
+sys.modules.pop('database', None)
+
 # Stub database.client early so real DB modules are not loaded during import
 _mock_db_client = MagicMock()
 _mock_db_client.get_db_session = MagicMock()
@@ -448,6 +452,11 @@ sys.modules['nexent.storage.storage_client_factory'].create_storage_client_from_
 sys.modules.pop('consts.model', None)
 if hasattr(sys.modules.get('consts'), 'model'):
     delattr(sys.modules['consts'], 'model')
+# Other test files may have replaced consts.exceptions with a lightweight stub.
+# Restore the real module so backend imports can resolve all exception names.
+sys.modules.pop('consts.exceptions', None)
+if hasattr(sys.modules.get('consts'), 'exceptions'):
+    delattr(sys.modules['consts'], 'exceptions')
 
 # Now import backend modules
 import backend.services.agent_service as agent_service
@@ -1853,7 +1862,8 @@ async def test_get_agent_info_impl_with_model_id_success(mock_search_agent_info,
     mock_model_info = {
         "model_id": 456,
         "display_name": "GPT-4",
-        "provider": "openai"
+        "provider": "openai",
+        "connect_status": agent_service.ModelConnectStatusEnum.AVAILABLE.value,
     }
     mock_get_model_by_model_id.return_value = mock_model_info
 
@@ -1890,10 +1900,65 @@ async def test_get_agent_info_impl_with_model_id_success(mock_search_agent_info,
         "unavailable_reasons": []
     }
     assert result == expected_result
-    # Source calls get_model_by_model_id twice for the single model id:
-    # once while collecting model_names and once when deriving legacy model_name.
-    assert mock_get_model_by_model_id.call_count == 2
-    mock_get_model_by_model_id.assert_any_call(456)
+    # The model record is fetched once and reused through the model cache.
+    assert mock_get_model_by_model_id.call_count == 1
+    mock_get_model_by_model_id.assert_any_call(456, "test_tenant")
+
+
+@patch('backend.services.agent_service.SkillService')
+@patch('backend.services.agent_service.query_external_sub_agents')
+@patch('backend.services.agent_service.check_agent_availability')
+@patch('backend.services.agent_service.get_model_by_model_id')
+@patch('backend.services.agent_service.get_valid_model_ids')
+@patch('backend.services.agent_service.query_sub_agents_id_list')
+@patch('backend.services.agent_service.search_tools_for_sub_agent')
+@patch('backend.services.agent_service.search_agent_info_by_agent_id')
+@pytest.mark.asyncio
+async def test_get_agent_info_impl_filters_unavailable_models(
+    mock_search_agent_info,
+    mock_search_tools,
+    mock_query_sub_agents_id,
+    mock_get_valid_model_ids,
+    mock_get_model_by_model_id,
+    mock_check_availability,
+    mock_query_external_sub_agents,
+    mock_skill_service,
+):
+    """Agent detail should expose only bound models with AVAILABLE status."""
+    mock_agent_info = {
+        "agent_id": 123,
+        "model_ids": [35, 26],
+        "business_description": "Test agent",
+    }
+    mock_search_agent_info.return_value = mock_agent_info
+    mock_search_tools.return_value = []
+    mock_query_sub_agents_id.return_value = []
+    mock_get_valid_model_ids.return_value = [35, 26]
+    mock_get_model_by_model_id.side_effect = lambda model_id, tenant_id: {
+        35: {
+            "display_name": "deepseek-v4-flash",
+            "connect_status": agent_service.ModelConnectStatusEnum.UNAVAILABLE.value,
+        },
+        26: {
+            "display_name": "glm-5.2",
+            "connect_status": agent_service.ModelConnectStatusEnum.AVAILABLE.value,
+        },
+    }[model_id]
+    mock_check_availability.return_value = (True, [])
+    mock_query_external_sub_agents.return_value = []
+    mock_skill_service.return_value.list_skill_instances.return_value = []
+    availability_model_ids: list[int] = []
+    mock_check_availability.side_effect = lambda **kwargs: (
+        availability_model_ids.extend(kwargs["agent_info"]["model_ids"]),
+        (True, []),
+    )[1]
+
+    result = await get_agent_info_impl(agent_id=123, tenant_id="test_tenant")
+
+    assert result["model_ids"] == [26]
+    assert result["model_names"] == ["glm-5.2"]
+    assert result["model_name"] == "glm-5.2"
+    assert availability_model_ids == [35, 26]
 
 
 @patch("backend.services.agent_service.check_agent_availability")
@@ -1961,7 +2026,8 @@ async def test_get_agent_info_impl_with_model_id_no_display_name(mock_search_age
     # Mock model info without display_name
     mock_model_info = {
         "model_id": 456,
-        "provider": "openai"
+        "provider": "openai",
+        "connect_status": agent_service.ModelConnectStatusEnum.AVAILABLE.value,
         # No display_name field
     }
     mock_get_model_by_model_id.return_value = mock_model_info
@@ -1998,10 +2064,9 @@ async def test_get_agent_info_impl_with_model_id_no_display_name(mock_search_age
         "unavailable_reasons": []
     }
     assert result == expected_result
-    # Source calls get_model_by_model_id twice for the single model id:
-    # once while collecting model_names and once when deriving legacy model_name.
-    assert mock_get_model_by_model_id.call_count == 2
-    mock_get_model_by_model_id.assert_any_call(456)
+    # The model record is fetched once and reused through the model cache.
+    assert mock_get_model_by_model_id.call_count == 1
+    mock_get_model_by_model_id.assert_any_call(456, "test_tenant")
 
 
 @patch('backend.services.agent_service.SkillService')
@@ -2053,7 +2118,7 @@ async def test_get_agent_info_impl_with_model_id_none_model_info(mock_search_age
     # Assert
     expected_result = {
         "agent_id": 123,
-        "model_ids": [456],
+        "model_ids": [],
         "business_description": "Test agent",
         "tools": mock_tools,
         "sub_agent_id_list": mock_sub_agent_ids,
@@ -2069,10 +2134,9 @@ async def test_get_agent_info_impl_with_model_id_none_model_info(mock_search_age
         "unavailable_reasons": []
     }
     assert result == expected_result
-    # Source calls get_model_by_model_id twice for the single model id:
-    # once while collecting model_names and once when deriving legacy model_name.
-    assert mock_get_model_by_model_id.call_count == 2
-    mock_get_model_by_model_id.assert_any_call(456)
+    # The missing model record is fetched once during availability filtering.
+    assert mock_get_model_by_model_id.call_count == 1
+    mock_get_model_by_model_id.assert_any_call(456, "test_tenant")
 
 
 @patch('backend.services.agent_service.SkillService')
@@ -2111,18 +2175,20 @@ async def test_get_agent_info_impl_with_business_logic_model(mock_search_agent_i
     mock_main_model_info = {
         "model_id": 456,
         "display_name": "GPT-4",
-        "provider": "openai"
+        "provider": "openai",
+        "connect_status": agent_service.ModelConnectStatusEnum.AVAILABLE.value,
     }
 
     # Mock model info for business logic model
     mock_business_logic_model_info = {
         "model_id": 789,
         "display_name": "Claude-3.5",
-        "provider": "anthropic"
+        "provider": "anthropic",
+        "connect_status": agent_service.ModelConnectStatusEnum.AVAILABLE.value,
     }
 
     # Mock get_model_by_model_id to return different values based on input
-    def mock_get_model(model_id):
+    def mock_get_model(model_id, tenant_id=None):
         if model_id == 456:
             return mock_main_model_info
         elif model_id == 789:
@@ -2170,8 +2236,8 @@ async def test_get_agent_info_impl_with_business_logic_model(mock_search_agent_i
     # - once for main model_ids[0]
     # - once again to derive legacy model_name from model_ids[0]
     # - once for business_logic_model_id
-    assert mock_get_model_by_model_id.call_count == 3
-    mock_get_model_by_model_id.assert_any_call(456)
+    assert mock_get_model_by_model_id.call_count == 2
+    mock_get_model_by_model_id.assert_any_call(456, "test_tenant")
     mock_get_model_by_model_id.assert_any_call(789)
 
 
@@ -2210,11 +2276,12 @@ async def test_get_agent_info_impl_with_business_logic_model_none(mock_search_ag
     mock_main_model_info = {
         "model_id": 456,
         "display_name": "GPT-4",
-        "provider": "openai"
+        "provider": "openai",
+        "connect_status": agent_service.ModelConnectStatusEnum.AVAILABLE.value,
     }
 
     # Mock get_model_by_model_id to return None for business_logic_model_id
-    def mock_get_model(model_id):
+    def mock_get_model(model_id, tenant_id=None):
         if model_id == 456:
             return mock_main_model_info
         elif model_id == 789:
@@ -2262,8 +2329,8 @@ async def test_get_agent_info_impl_with_business_logic_model_none(mock_search_ag
     # - once for main model_ids[0]
     # - once again to derive legacy model_name from model_ids[0]
     # - once for business_logic_model_id
-    assert mock_get_model_by_model_id.call_count == 3
-    mock_get_model_by_model_id.assert_any_call(456)
+    assert mock_get_model_by_model_id.call_count == 2
+    mock_get_model_by_model_id.assert_any_call(456, "test_tenant")
     mock_get_model_by_model_id.assert_any_call(789)
 
 
@@ -2302,18 +2369,20 @@ async def test_get_agent_info_impl_with_business_logic_model_no_display_name(moc
     mock_main_model_info = {
         "model_id": 456,
         "display_name": "GPT-4",
-        "provider": "openai"
+        "provider": "openai",
+        "connect_status": agent_service.ModelConnectStatusEnum.AVAILABLE.value,
     }
 
     # Mock model info for business logic model without display_name
     mock_business_logic_model_info = {
         "model_id": 789,
-        "provider": "anthropic"
+        "provider": "anthropic",
+        "connect_status": agent_service.ModelConnectStatusEnum.AVAILABLE.value,
         # No display_name field
     }
 
     # Mock get_model_by_model_id to return different values based on input
-    def mock_get_model(model_id):
+    def mock_get_model(model_id, tenant_id=None):
         if model_id == 456:
             return mock_main_model_info
         elif model_id == 789:
@@ -2361,8 +2430,8 @@ async def test_get_agent_info_impl_with_business_logic_model_no_display_name(moc
     # - once for main model_ids[0]
     # - once again to derive legacy model_name from model_ids[0]
     # - once for business_logic_model_id
-    assert mock_get_model_by_model_id.call_count == 3
-    mock_get_model_by_model_id.assert_any_call(456)
+    assert mock_get_model_by_model_id.call_count == 2
+    mock_get_model_by_model_id.assert_any_call(456, "test_tenant")
     mock_get_model_by_model_id.assert_any_call(789)
 
 
@@ -2949,7 +3018,11 @@ async def test_list_all_agent_info_impl_model_cache_miss_fetches_model(
     mock_convert_list.return_value = []
     # Do not mutate model_cache here so that the "model_id not in model_cache" branch runs.
     mock_check_availability.side_effect = lambda *args, **kwargs: (True, [])
-    mock_get_model.return_value = {"model_name": "m", "display_name": "M"}
+    mock_get_model.return_value = {
+        "model_name": "m",
+        "display_name": "M",
+        "connect_status": agent_service.ModelConnectStatusEnum.AVAILABLE.value,
+    }
 
     result = await list_all_agent_info_impl(tenant_id="test_tenant", user_id="admin_user")
 
@@ -11780,6 +11853,34 @@ def test_collect_model_availability_reasons():
     assert AgentUnavailableReason.MODEL_UNAVAILABLE in result
 
 
+def test_collect_model_availability_reasons_available_when_any_model_available():
+    """Agent stays available while at least one bound model is healthy."""
+    from backend.services.agent_service import _collect_model_availability_reasons
+    from backend.consts.agent_unavailable_reasons import AgentUnavailableReason
+
+    unavailable_reason = [AgentUnavailableReason.MODEL_UNAVAILABLE]
+    model_availability_by_id = {7: unavailable_reason, 8: []}
+
+    def _check_single(model_id, tenant_id, model_cache, reason_key):
+        return model_availability_by_id[model_id]
+
+    with patch(
+        'backend.services.agent_service._check_single_model_availability',
+        side_effect=_check_single,
+    ):
+        result = _collect_model_availability_reasons({"model_ids": [7, 8]}, "tenant_1", {})
+
+    assert AgentUnavailableReason.MODEL_UNAVAILABLE not in result
+
+    with patch(
+        'backend.services.agent_service._check_single_model_availability',
+        return_value=unavailable_reason,
+    ):
+        result = _collect_model_availability_reasons({"model_ids": [7, 8]}, "tenant_1", {})
+
+    assert AgentUnavailableReason.MODEL_UNAVAILABLE in result
+
+
 # Test for save_messages error cases
 def test_save_messages_user_with_messages_error():
     """Test save_messages raises error when messages provided for user."""
@@ -16396,9 +16497,17 @@ async def test_list_all_agent_info_impl_filters_deleted_models(
     # Mock model info for valid models (get_model_by_model_id takes 2 args: model_id and tenant_id)
     def get_model_side_effect(model_id, tenant_id=None):
         if model_id == 1:
-            return {"display_name": "Model 1", "model_id": 1}
+            return {
+                "display_name": "Model 1",
+                "model_id": 1,
+                "connect_status": agent_service.ModelConnectStatusEnum.AVAILABLE.value,
+            }
         elif model_id == 3:
-            return {"display_name": "Model 3", "model_id": 3}
+            return {
+                "display_name": "Model 3",
+                "model_id": 3,
+                "connect_status": agent_service.ModelConnectStatusEnum.AVAILABLE.value,
+            }
         return None
     mock_get_model.side_effect = get_model_side_effect
 
@@ -16565,9 +16674,17 @@ async def test_get_agent_info_impl_filters_deleted_models(
     # Mock get_model_by_model_id for valid models
     def get_model_side_effect(model_id, tenant_id=None):
         if model_id == 1:
-            return {"display_name": "Model 1", "model_id": 1}
+            return {
+                "display_name": "Model 1",
+                "model_id": 1,
+                "connect_status": agent_service.ModelConnectStatusEnum.AVAILABLE.value,
+            }
         elif model_id == 3:
-            return {"display_name": "Model 3", "model_id": 3}
+            return {
+                "display_name": "Model 3",
+                "model_id": 3,
+                "connect_status": agent_service.ModelConnectStatusEnum.AVAILABLE.value,
+            }
         return None
     mock_get_model_by_model_id.side_effect = get_model_side_effect
 
@@ -17565,9 +17682,17 @@ async def test_list_all_agent_info_impl_filters_deleted_models(
     # Mock model info for valid models (get_model_by_model_id takes 2 args: model_id and tenant_id)
     def get_model_side_effect(model_id, tenant_id=None):
         if model_id == 1:
-            return {"display_name": "Model 1", "model_id": 1}
+            return {
+                "display_name": "Model 1",
+                "model_id": 1,
+                "connect_status": agent_service.ModelConnectStatusEnum.AVAILABLE.value,
+            }
         elif model_id == 3:
-            return {"display_name": "Model 3", "model_id": 3}
+            return {
+                "display_name": "Model 3",
+                "model_id": 3,
+                "connect_status": agent_service.ModelConnectStatusEnum.AVAILABLE.value,
+            }
         return None
     mock_get_model.side_effect = get_model_side_effect
 
@@ -17734,9 +17859,17 @@ async def test_get_agent_info_impl_filters_deleted_models(
     # Mock get_model_by_model_id for valid models
     def get_model_side_effect(model_id, tenant_id=None):
         if model_id == 1:
-            return {"display_name": "Model 1", "model_id": 1}
+            return {
+                "display_name": "Model 1",
+                "model_id": 1,
+                "connect_status": agent_service.ModelConnectStatusEnum.AVAILABLE.value,
+            }
         elif model_id == 3:
-            return {"display_name": "Model 3", "model_id": 3}
+            return {
+                "display_name": "Model 3",
+                "model_id": 3,
+                "connect_status": agent_service.ModelConnectStatusEnum.AVAILABLE.value,
+            }
         return None
     mock_get_model_by_model_id.side_effect = get_model_side_effect
 
@@ -18494,6 +18627,7 @@ async def test_run_agent_stream_emits_knowledge_scope_resolved_event(
         (b"x" * (agent_service.AGENT_ICON_MAX_BYTES + 1), "Agent icon must not exceed 2 MB"),
         (b"not an image", "Agent icon must be a PNG, JPEG, GIF, or WebP image"),
     ],
+    ids=["empty", "too_large", "not_an_image"],
 )
 async def test_upload_agent_icon_impl_rejects_invalid_content(content, message):
     with pytest.raises(ValueError, match=message):

--- a/test/backend/services/test_agent_version_service.py
+++ b/test/backend/services/test_agent_version_service.py
@@ -147,10 +147,16 @@ agent_service_mock.PERMISSION_READ = "READ"
 sys.modules['services.agent_service'] = agent_service_mock
 sys.modules['backend.services.agent_service'] = agent_service_mock
 
-# Mock database module
-database_mock = MagicMock()
-database_mock.skill_db = skill_db_mock
+# Mock database module as a package-like module so `from database import X`
+# resolves the same mocked submodules registered in sys.modules.
+database_mock = types.ModuleType("database")
+database_mock.__path__ = []
+database_mock.client = client_mock
+database_mock.db_models = db_models_mock
+database_mock.agent_version_db = agent_version_db_mock
+database_mock.model_management_db = model_management_db_mock
 database_mock.agent_db = agent_db_mock
+database_mock.skill_db = skill_db_mock
 sys.modules['database'] = database_mock
 sys.modules['backend.database'] = database_mock
 
@@ -158,6 +164,7 @@ sys.modules['backend.database'] = database_mock
 a2a_agent_db_mock = MagicMock()
 a2a_agent_db_mock.create_server_agent = MagicMock()
 a2a_agent_db_mock.get_server_agent_by_agent_id = MagicMock()
+database_mock.a2a_agent_db = a2a_agent_db_mock
 sys.modules['database.a2a_agent_db'] = a2a_agent_db_mock
 sys.modules['backend.database.a2a_agent_db'] = a2a_agent_db_mock
 
@@ -1624,7 +1631,11 @@ def test_list_published_agents_impl_success(monkeypatch):
     )
     agent_service_mock._apply_duplicate_name_availability_rules = MagicMock()
     agent_service_mock.get_model_by_model_id = MagicMock(
-        return_value={"display_name": "Test Model", "model_name": "test_model"}
+        return_value={
+            "display_name": "Test Model",
+            "model_name": "test_model",
+            "connect_status": "available",
+        }
     )
 
     result = asyncio.run(list_published_agents_impl(tenant_id="tenant1", user_id="user1"))
@@ -1831,7 +1842,11 @@ def test_list_published_agents_impl_model_cache(monkeypatch):
     )
     agent_service_mock._apply_duplicate_name_availability_rules = MagicMock()
     agent_service_mock.get_model_by_model_id = MagicMock(
-        return_value={"display_name": "Test Model", "model_name": "test_model"}
+        return_value={
+            "display_name": "Test Model",
+            "model_name": "test_model",
+            "connect_status": "available",
+        }
     )
 
     result = asyncio.run(list_published_agents_impl(tenant_id="tenant1", user_id="user1"))
@@ -3136,7 +3151,10 @@ def test_list_published_agents_impl_multiple_models(monkeypatch):
     agent_service_mock._apply_duplicate_name_availability_rules = MagicMock()
 
     def mock_get_model(model_id, tenant_id=None):
-        return {"display_name": f"Model-{model_id}"}
+        return {
+            "display_name": f"Model-{model_id}",
+            "connect_status": "available",
+        }
 
     agent_service_mock.get_model_by_model_id = MagicMock(side_effect=mock_get_model)
 
@@ -3147,6 +3165,54 @@ def test_list_published_agents_impl_multiple_models(monkeypatch):
     assert result[0]["model_ids"] == [1, 2]
     assert result[0]["model_names"] == ["Model-1", "Model-2"]
     assert result[0]["model_name"] == "Model-1"
+
+
+def test_list_published_agents_impl_filters_unavailable_models(monkeypatch):
+    """Published agent responses expose only available bound models."""
+    agent_db_mock.query_all_agent_info_by_tenant_id = MagicMock(
+        return_value=[
+            {
+                "agent_id": 1,
+                "enabled": True,
+                "current_version_no": 1,
+                "group_ids": "1,2",
+                "created_by": "user1",
+                "name": "Test Agent",
+                "display_name": "Test Agent",
+            }
+        ]
+    )
+    agent_service_mock.get_user_tenant_by_user_id = MagicMock(
+        return_value={"user_role": "ADMIN"}
+    )
+    agent_version_db_mock.query_agent_snapshot = MagicMock(
+        return_value=({"agent_id": 1, "name": "Test Agent", "model_ids": [1, 2]}, [], [])
+    )
+
+    def mock_get_model(model_id, tenant_id=None):
+        return {
+            "display_name": f"Model-{model_id}",
+            "connect_status": "available" if model_id == 1 else "unavailable",
+        }
+
+    agent_service_mock.get_model_by_model_id = MagicMock(side_effect=mock_get_model)
+    availability_model_ids = []
+
+    def check_availability(**kwargs):
+        availability_model_ids.append(list(kwargs["agent_info"]["model_ids"]))
+        return True, []
+
+    agent_service_mock.check_agent_availability = MagicMock(
+        side_effect=check_availability
+    )
+    agent_service_mock._apply_duplicate_name_availability_rules = MagicMock()
+
+    result = asyncio.run(list_published_agents_impl(tenant_id="tenant1", user_id="user1"))
+
+    assert result[0]["model_ids"] == [1]
+    assert result[0]["model_names"] == ["Model-1"]
+    assert result[0]["model_name"] == "Model-1"
+    assert availability_model_ids == [[1, 2]]
 
 
 def test_list_published_agents_impl_model_ids_empty(monkeypatch):
@@ -3260,9 +3326,17 @@ def test_list_published_agents_impl_filters_deleted_models(monkeypatch):
     # Mock model info for valid models
     def get_model_side_effect(model_id, tenant_id=None):
         if model_id == 1:
-            return {"display_name": "Model 1", "model_id": 1}
+            return {
+                "display_name": "Model 1",
+                "model_id": 1,
+                "connect_status": "available",
+            }
         elif model_id == 3:
-            return {"display_name": "Model 3", "model_id": 3}
+            return {
+                "display_name": "Model 3",
+                "model_id": 3,
+                "connect_status": "available",
+            }
         return None
     agent_service_mock.get_model_by_model_id = MagicMock(side_effect=get_model_side_effect)
 
@@ -3706,6 +3780,6 @@ def test_list_published_agents_impl_model_not_found(monkeypatch):
     result = asyncio.run(list_published_agents_impl(tenant_id="tenant1", user_id="user1"))
 
     assert len(result) == 1
-    # When model is not found, model_names should contain str(mid) as fallback
-    assert result[0]["model_names"] == ["99"]
-    assert result[0]["model_name"] == "99"
+    assert result[0]["model_ids"] == []
+    assert result[0]["model_names"] == []
+    assert result[0]["model_name"] is None


### PR DESCRIPTION
## Fix: keep agents available when some bound models fail health checks

### Bug

When an agent binds multiple models from different providers and one provider disables its API, that model is marked unavailable by the health check.

The current logic treats the agent as unavailable as long as any bound model is unavailable, even though the other models remain healthy. The chat runtime also keeps unavailable model IDs in the selector and may continue calling the invalid model, causing authentication errors and retries.

### Changes

- Agent availability now depends on whether at least one bound model is available.
- Chat model selectors filter out unavailable models and default to the first available model.
- Runtime model selection prefers the first available bound model unless the request explicitly specifies a `model_id`.
- Explicitly selected models are preserved when they are still available.
- Kept the existing agent API and model binding format unchanged.

### Tests

Agent availability tests:

Runtime model selection tests:

Frontend model selector tests:

<img width="1187" height="665" alt="image" src="https://github.com/user-attachments/assets/6d450014-ffbc-483c-8064-de572d33cff7" />

<img width="1518" height="1244" alt="image" src="https://github.com/user-attachments/assets/899ab583-c629-4c98-91a8-e0260fa1397a" />
